### PR TITLE
fix: get rid of the issue with `MachineSets` stuck in `Reconfiguring`

### DIFF
--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -132,6 +132,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: fixClusterTalosVersionOwnership,
 				name:     "fixClusterTalosVersionOwnership",
 			},
+			{
+				callback: updateClusterMachineConfigPatchesLabels,
+				name:     "updateClusterMachineConfigPatchesLabels",
+			},
 		},
 	}
 }


### PR DESCRIPTION
`ClusterMachineConfigPatches` resources of old clusters are missing label `omni.sidero.dev/machine-set` and the controller always thinks that the machines are not configured yet.