### PR TITLE
fix: get rid of the issue with MachineSets stuck in Reconfiguring

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -12,7 +12,7 @@ policies:
           gitHubOrganization: siderolabs
       spellcheck:
         locale: US
-      maximumOfOneCommit: true
+      maximumOfOneCommit: false
       header:
         length: 89
         imperative: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-28T11:30:58Z by kres latest.
+# Generated on 2024-03-14T17:43:23Z by kres latest.
 
 name: default
 concurrency:
@@ -50,8 +50,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: js
         run: |
           make js
@@ -198,8 +198,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -251,8 +251,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -304,8 +304,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -357,8 +357,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -410,8 +410,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/e2e-backups-cron.yaml
+++ b/.github/workflows/e2e-backups-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-28T11:30:58Z by kres latest.
+# Generated on 2024-03-14T17:43:23Z by kres latest.
 
 name: e2e-backups-cron
 concurrency:
@@ -33,8 +33,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: run-integration-test
         env:
           AUTH0_TEST_PASSWORD: ${{ secrets.AUTH0_TEST_PASSWORD }}

--- a/.github/workflows/e2e-scaling-cron.yaml
+++ b/.github/workflows/e2e-scaling-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-28T11:30:58Z by kres latest.
+# Generated on 2024-03-14T17:43:23Z by kres latest.
 
 name: e2e-scaling-cron
 concurrency:
@@ -33,8 +33,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: run-integration-test
         env:
           AUTH0_TEST_PASSWORD: ${{ secrets.AUTH0_TEST_PASSWORD }}

--- a/.github/workflows/e2e-short-cron.yaml
+++ b/.github/workflows/e2e-short-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-28T11:30:58Z by kres latest.
+# Generated on 2024-03-14T17:43:23Z by kres latest.
 
 name: e2e-short-cron
 concurrency:
@@ -33,8 +33,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: run-integration-test
         env:
           AUTH0_TEST_PASSWORD: ${{ secrets.AUTH0_TEST_PASSWORD }}

--- a/.github/workflows/e2e-templates-cron.yaml
+++ b/.github/workflows/e2e-templates-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-28T11:30:58Z by kres latest.
+# Generated on 2024-03-14T17:43:23Z by kres latest.
 
 name: e2e-templates-cron
 concurrency:
@@ -33,8 +33,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: run-integration-test
         env:
           AUTH0_TEST_PASSWORD: ${{ secrets.AUTH0_TEST_PASSWORD }}

--- a/.github/workflows/e2e-upgrades-cron.yaml
+++ b/.github/workflows/e2e-upgrades-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-28T11:30:58Z by kres latest.
+# Generated on 2024-03-14T17:43:23Z by kres latest.
 
 name: e2e-upgrades-cron
 concurrency:
@@ -33,8 +33,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: run-integration-test
         env:
           AUTH0_TEST_PASSWORD: ${{ secrets.AUTH0_TEST_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax = docker/dockerfile-upstream:1.6.0-labs
+# syntax = docker/dockerfile-upstream:1.7.0-labs
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-26T21:35:48Z by kres latest.
+# Generated on 2024-03-14T17:43:23Z by kres latest.
 
 ARG JS_TOOLCHAIN
 ARG TOOLCHAIN
@@ -21,7 +21,7 @@ ENV GOPATH /go
 ENV PATH ${PATH}:/usr/local/go/bin
 
 # runs markdownlint
-FROM docker.io/node:21.6.2-alpine3.19 AS lint-markdown
+FROM docker.io/node:21.7.1-alpine3.19 AS lint-markdown
 WORKDIR /src
 RUN npm i -g markdownlint-cli@0.39.0
 RUN npm i sentences-per-line@0.2.1

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-26T21:35:48Z by kres latest.
+# Generated on 2024-03-14T17:43:23Z by kres latest.
 
 # common variables
 
 SHA := $(shell git describe --match=none --always --abbrev=8 --dirty)
-TAG := $(shell git describe --tag --always --dirty)
+TAG := $(shell git describe --tag --always --dirty --match v[0-9]\*)
 ABBREV_TAG := $(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\* --abbrev=0 || echo 'undefined')
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
@@ -17,15 +17,15 @@ REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 PROTOBUF_GRPC_GATEWAY_TS_VERSION ?= 1.2.1
 TESTPKGS ?= ./...
 NODE_BUILD_ARGS ?=
-PROTOBUF_GO_VERSION ?= 1.32.0
+PROTOBUF_GO_VERSION ?= 1.33.0
 GRPC_GO_VERSION ?= 1.3.0
 GRPC_GATEWAY_VERSION ?= 2.19.1
 VTPROTOBUF_VERSION ?= 0.6.0
 DEEPCOPY_VERSION ?= v0.5.6
 GOLANGCILINT_VERSION ?= v1.56.2
 GOFUMPT_VERSION ?= v0.6.0
-GO_VERSION ?= 1.22.0
-GOIMPORTS_VERSION ?= v0.18.0
+GO_VERSION ?= 1.22.1
+GOIMPORTS_VERSION ?= v0.19.0
 GO_BUILDFLAGS ?=
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
@@ -69,7 +69,7 @@ COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION="$(GOLANGCILINT_VERSION)"
 COMMON_ARGS += --build-arg=GOIMPORTS_VERSION="$(GOIMPORTS_VERSION)"
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION="$(GOFUMPT_VERSION)"
 COMMON_ARGS += --build-arg=TESTPKGS="$(TESTPKGS)"
-JS_TOOLCHAIN ?= docker.io/node:21.6.2-alpine3.19
+JS_TOOLCHAIN ?= docker.io/node:21.7.1-alpine3.19
 TOOLCHAIN ?= docker.io/golang:1.22-alpine
 
 # extra variables

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -132,6 +132,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: fixClusterTalosVersionOwnership,
 				name:     "fixClusterTalosVersionOwnership",
 			},
+			{
+				callback: updateClusterMachineConfigPatchesLabels,
+				name:     "updateClusterMachineConfigPatchesLabels",
+			},
 		},
 	}
 }

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -5,7 +5,7 @@
 
 // THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 //
-// Generated on 2024-02-28T17:18:34Z by kres latest.
+// Generated on 2024-03-14T17:43:23Z by kres latest.
 
 package frontend
 


### PR DESCRIPTION
`ClusterMachineConfigPatches` resources of old clusters are missing
label `omni.sidero.dev/machine-set` and the controller always thinks
that the machines are not configured yet.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
(cherry picked from commit https://github.com/siderolabs/omni/commit/5a8abf584edd605ac7bfc6f72b31142c857128c4)