### PR TITLE
fix: properly handle upgrades for the machines with invalid schematics

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status.go
@@ -129,7 +129,7 @@ func NewClusterMachineConfigStatusController() *ClusterMachineConfigStatusContro
 					machineStatus.TypedSpec().Value.Schematic.Id != expectedSchematic
 
 				// don't run the upgrade check if the running version and expected versions match
-				if versionMismatch && talosVersion.TypedSpec().Value.TalosVersion != "" && talosVersion.TypedSpec().Value.SchematicId != "" {
+				if versionMismatch && talosVersion.TypedSpec().Value.TalosVersion != "" {
 					inSync, err := handler.syncTalosVersionAndSchematic(ctx, configStatus, machineStatus, machineConfig, statusSnapshot, talosVersion)
 					if err != nil {
 						return err


### PR DESCRIPTION
Simple fix to not skip updating Talos if the machine schematic is empty.

Verified that on a cluster running on the nodes with the invalid schematics. Upgrades work.