### PR TITLE
fix: fix error handling in image pre pull task

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/task/image/pulltask.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/image/pulltask.go
@@ -98,8 +98,9 @@ func (p PullTaskSpec) RunTask(ctx context.Context, _ *zap.Logger, pullStatusCh P
 
 			if nodeImageInfoMap.shouldPull(imageList.Node, img) {
 				currentError = p.pullImage(ctx, clusterID, imageList.Node, img)
-
-				errs = multierror.Append(errs, currentError)
+				if currentError != nil {
+					errs = multierror.Append(errs, currentError)
+				}
 
 				skipFinalEvent = true // we are already sending an event, so no need to send one at the end
 


### PR DESCRIPTION
If no error occurs during pulling an image, do not gather it in multi-error, causing the task to be wrongly marked as failed.