### PR TITLE
fix: properly render download installation media page in Safari

### DIFF
--- a/frontend/src/components/common/TInput/TInput.vue
+++ b/frontend/src/components/common/TInput/TInput.vue
@@ -132,7 +132,7 @@ onMounted(() => {
 
 <style scoped>
 .input-box {
-  @apply flex justify-start items-center p-2 border border-naturals-N8 rounded transition-colors gap-2 min-w-fit;
+  @apply flex justify-start items-center p-2 border border-naturals-N8 rounded transition-colors gap-2;
 }
 
 .compact {
@@ -140,11 +140,11 @@ onMounted(() => {
 }
 
 .input-box-icon {
-  @apply fill-current text-naturals-N8 transition-colors cursor-pointer w-4 h-4 min-w-max;
+  @apply fill-current text-naturals-N8 transition-colors cursor-pointer w-4 h-4;
 }
 
 .input-box-input {
-  @apply bg-transparent border-none outline-none w-full text-naturals-N13 focus:outline-none  focus:border-transparent text-xs transition-colors placeholder-naturals-N7;
+  @apply bg-transparent border-none outline-none flex-1 text-naturals-N13 focus:outline-none  focus:border-transparent text-xs transition-colors placeholder-naturals-N7;
 
   min-width: 0.5rem;
 }

--- a/frontend/src/views/cluster/Nodes/NodeOverview.vue
+++ b/frontend/src/views/cluster/Nodes/NodeOverview.vue
@@ -403,6 +403,6 @@ const status = computed(() => getStatus(node.value));
   width: auto;
 }
 .overview-item-button {
-  @apply min-w-max;
+  @apply min-w-min;
 }
 </style>

--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -128,10 +128,10 @@ included in the LICENSE file.
       </h3>
 
       <div class="cursor-pointer px-1.5 py-1.5 rounded border border-naturals-N8 text-xs flex gap-2 items-center">
-        <icon-button class="min-w-max" icon="refresh" @click="createSchematic" :icon-classes="{'animate-spin': creatingSchematic}"/>
+        <icon-button class="min-w-min" icon="refresh" @click="createSchematic" :icon-classes="{'animate-spin': creatingSchematic}"/>
         <span v-if="copiedPXEURL" class="flex-1 text-sm">Copied!</span>
         <span v-else class="flex-1 break-all" @click="createSchematic">{{ pxeURL ? pxeURL : 'Click to generate' }}</span>
-        <icon-button class="min-w-max" icon="copy" @click="copyPXEURL"/>
+        <icon-button class="min-w-min" icon="copy" @click="copyPXEURL"/>
       </div>
 
       <div>


### PR DESCRIPTION
Looks like `min-w-max` works differently there, so it messes up the layout.
Fixes: https://github.com/siderolabs/omni/issues/42