### PR TITLE
feat: forbid `*.acceptedCAs` fields in config patches

### DIFF
--- a/client/pkg/omni/resources/omni/config_patch.go
+++ b/client/pkg/omni/resources/omni/config_patch.go
@@ -30,10 +30,12 @@ var forbiddenFields = []string{
 	"cluster.secret",
 	"cluster.aescbcEncryptionSecret",
 	"cluster.secretboxEncryptionSecret",
+	"cluster.acceptedCAs",
 	"machine.token",
 	"machine.ca",
 	"machine.type",
 	"machine.install.extensions",
+	"machine.acceptedCAs",
 }
 
 var forbiddenSliceElements = map[string]map[any]struct{}{

--- a/client/pkg/omni/resources/omni/config_patch_test.go
+++ b/client/pkg/omni/resources/omni/config_patch_test.go
@@ -39,11 +39,23 @@ machine:
 			name: "several fields",
 			config: strings.TrimSpace(`
 machine:
+  acceptedCAs:
+    - crt: YWFhCg==
   token: bab
   ca:
     crt: YWFhCg==
+cluster:
+  acceptedCAs:
+    - crt: YWFhCg==
+    - crt: YmJiCg==
 `),
-			expectedError: "2 errors occurred:\n\t* overriding \"machine.token\" is not allowed in the config patch\n\t* overriding \"machine.ca\" is not allowed in the config patch\n\n",
+			expectedError: `4 errors occurred:
+	* overriding "cluster.acceptedCAs" is not allowed in the config patch
+	* overriding "machine.token" is not allowed in the config patch
+	* overriding "machine.ca" is not allowed in the config patch
+	* overriding "machine.acceptedCAs" is not allowed in the config patch
+
+`,
 		},
 		{
 			name: "different configs",


### PR DESCRIPTION
Add the new fields `cluster.acceptedCAs` and `machine.acceptedCAs`, which are introduced by Talos 1.7, to the list forbidden fields in config patches.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>