### PR TITLE
fix: ignore `modules.dep` virtual extension on schematic id calculation

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
@@ -55,6 +55,10 @@ func GetSchematicInfo(ctx context.Context, c *client.Client) (SchematicInfo, err
 			return
 		}
 
+		if name == "modules.dep" { // ignore the virtual extension used for kernel modules dependencies
+			return
+		}
+
 		if !strings.HasPrefix(name, officialExtensionPrefix) {
 			name = officialExtensionPrefix + name
 		}


### PR DESCRIPTION
The extension `modules.dep` is a virtual extension, used for the Kernel module dependencies. Therefore, it must not be used when computing the machine schematic - it causes a miscalculation, resulting in failing installer pull attempts from the image factory.

Closes #122.