### PR TITLE
feat: don't allow downgrades of the machines when adding to a cluster

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,8 +66,8 @@
     "postcss": "^8.4.14",
     "tailwindcss": "^3.1.4",
     "ts-jest": "^27.1.5",
-    "ts-loader": "^9.3.1",
     "typescript": "^4.7.4",
+    "ts-loader": "^9.3.1",
     "vue-cli-plugin-tailwind": "^3.0.0"
   }
 }

--- a/frontend/src/views/cluster/Config/Patches.vue
+++ b/frontend/src/views/cluster/Config/Patches.vue
@@ -109,10 +109,7 @@ type Props = {
   currentCluster?: ResourceTyped<ClusterSpec>,
 };
 
-const props = defineProps<Props>();
-
-  console.log("PATCHES currentCluster", props.currentCluster);
-
+defineProps<Props>();
 
 const updateSelectors = () => {
   patchListSelectors.value = [`!${LabelSystemPatch}`];

--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -98,6 +98,7 @@ included in the LICENSE file.
         <template #default="{ items, searchQuery }">
           <cluster-machine-item
             v-for="item in items"
+            :talos-version-not-allowed="!canAddMachine(item)"
             :key="itemID(item)"
             :reset="reset"
             :item="item"
@@ -140,7 +141,7 @@ import {
 PatchBaseWeightMachineSet,
 PatchBaseWeightCluster,
 } from "@/api/resources";
-import { TalosVersionSpec } from "@/api/omni/specs/omni.pb";
+import { MachineStatusSpec, TalosVersionSpec } from "@/api/omni/specs/omni.pb";
 import WatchResource, { itemID } from "@/api/watch";
 import { showError, showSuccess } from "@/notification";
 import { Resource, ResourceTyped } from "@/api/grpc";
@@ -260,6 +261,13 @@ const createCluster = async () => {
     await createCluster_(false);
   }
 };
+
+const canAddMachine = (machine: Resource<MachineStatusSpec>) => {
+  const clusterVersion = semver.parse(state.value.cluster.talosVersion);
+  const machineVersion = semver.parse(machine.spec.talos_version);
+
+  return machineVersion.major <= clusterVersion.major && machineVersion.minor <= clusterVersion.minor;
+}
 
 const createCluster_ = async (untaint: boolean) => {
   if (typeof state.value.controlPlanesCount === 'number' && (state.value.controlPlanesCount - 1) % 2 !== 0) {

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
@@ -55,6 +55,8 @@ func (suite *MachineSetNodeSuite) createMachines(labels ...map[string]string) []
 			}
 		})
 
+		machineStatus.TypedSpec().Value.TalosVersion = "v1.6.0"
+
 		res = append(res, machineStatus)
 
 		suite.Require().NoError(suite.state.Create(suite.ctx, machineStatus))
@@ -109,7 +111,12 @@ func (suite *MachineSetNodeSuite) TestReconcile() {
 		)
 	}
 
-	machineSet.Metadata().Labels().Set(omni.LabelCluster, "cluster1")
+	cluster := omni.NewCluster(resources.DefaultNamespace, "cluster1")
+	cluster.TypedSpec().Value.TalosVersion = "1.6.0"
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cluster))
+
+	machineSet.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
 	machineSet.Metadata().Labels().Set(omni.LabelWorkerRole, "")
 
 	machineClass := newMachineClass(fmt.Sprintf("%s==amd64", omni.MachineStatusLabelArch))


### PR DESCRIPTION
Make `MachineClass` selector skip them.
Disable them in the UI.
Do not allow adding them as the resources, validate on the backend level.
Fixes: https://github.com/siderolabs/omni/issues/46