### PR TITLE
fix: ignore not existing cluster in `MachineSet` teardown flow

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/control_planes_handler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/control_planes_handler_test.go
@@ -187,6 +187,7 @@ func TestControlPlanesHandler(t *testing.T) {
 			require := require.New(t)
 
 			machineSet.TypedSpec().Value = tt.machineSet
+			machineSet.Metadata().Labels().Set(omni.LabelCluster, tt.name)
 
 			cluster := omni.NewCluster(resources.DefaultNamespace, tt.name)
 			cluster.TypedSpec().Value.TalosVersion = "v1.5.4"

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/operations_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/operations_test.go
@@ -85,6 +85,7 @@ func TestCreate(t *testing.T) {
 	cluster.TypedSpec().Value.KubernetesVersion = "v1.6.2"
 
 	machineSet := omni.NewMachineSet(resources.DefaultNamespace, "machineset")
+	machineSet.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
 
 	create := machineset.Create{ID: "aa"}
 
@@ -157,6 +158,7 @@ func TestUpdate(t *testing.T) {
 	cluster.TypedSpec().Value.KubernetesVersion = "v1.6.4"
 
 	machineSet := omni.NewMachineSet(resources.DefaultNamespace, "machineset")
+	machineSet.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
 
 	quota := &machineset.ChangeQuota{
 		Update: 2,
@@ -292,6 +294,7 @@ func TestTeardown(t *testing.T) {
 	cluster.TypedSpec().Value.KubernetesVersion = "v1.6.3"
 
 	machineSet := omni.NewMachineSet(resources.DefaultNamespace, "machineset")
+	machineSet.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
 
 	quota := machineset.ChangeQuota{
 		Teardown: 1,
@@ -358,6 +361,7 @@ func TestDestroy(t *testing.T) {
 	cluster.TypedSpec().Value.KubernetesVersion = "v1.6.3"
 
 	machineSet := omni.NewMachineSet(resources.DefaultNamespace, "machineset")
+	machineSet.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
 
 	require := require.New(t)
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/reconciliation_context_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/reconciliation_context_test.go
@@ -312,6 +312,7 @@ func TestReconciliationContext(t *testing.T) {
 
 			machineSet := omni.NewMachineSet(resources.DefaultNamespace, tt.name)
 			machineSet.TypedSpec().Value = tt.machineSet
+			machineSet.Metadata().Labels().Set(omni.LabelCluster, tt.name)
 
 			cluster := omni.NewCluster(resources.DefaultNamespace, tt.name)
 			cluster.TypedSpec().Value.TalosVersion = "v1.6.4"

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/status_handler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/status_handler_test.go
@@ -329,6 +329,8 @@ func TestStatusHandler(t *testing.T) {
 				machineSet = omni.NewMachineSet(resources.DefaultNamespace, "test")
 			}
 
+			machineSet.Metadata().Labels().Set(omni.LabelCluster, "test")
+
 			require := require.New(t)
 
 			clusterMachineConfigStatuses := make([]*omni.ClusterMachineConfigStatus, 0, len(tt.clusterMachines))

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/workers_handler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/workers_handler_test.go
@@ -173,6 +173,7 @@ func TestWorkersHandler(t *testing.T) {
 			require := require.New(t)
 
 			machineSet.TypedSpec().Value = tt.machineSet
+			machineSet.Metadata().Labels().Set(omni.LabelCluster, tt.name)
 
 			cluster := omni.NewCluster(resources.DefaultNamespace, tt.name)
 			cluster.TypedSpec().Value.TalosVersion = "v1.6.0"


### PR DESCRIPTION
If the cluster is not found it's not critical for teardown flow, so we shouldn't skip reconcile in that case.