### PR TITLE
fix: skip empty config patches in `ClusterMachineConfigPatches`

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/operations.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/operations.go
@@ -8,6 +8,7 @@ package machineset
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -203,13 +204,15 @@ func (d *Destroy) Apply(ctx context.Context, r controller.ReaderWriter, logger *
 	return nil
 }
 
-func setPatches(
-	clusterMachineConfigPatches *omni.ClusterMachineConfigPatches,
-	patches []*omni.ConfigPatch,
-) {
+func setPatches(clusterMachineConfigPatches *omni.ClusterMachineConfigPatches, patches []*omni.ConfigPatch) {
 	patchesRaw := make([]string, 0, len(patches))
-	for _, p := range patches {
-		patchesRaw = append(patchesRaw, p.TypedSpec().Value.Data)
+
+	for _, patch := range patches {
+		data := patch.TypedSpec().Value.Data
+
+		if strings.TrimSpace(data) != "" {
+			patchesRaw = append(patchesRaw, data)
+		}
 	}
 
 	clusterMachineConfigPatches.TypedSpec().Value.Patches = patchesRaw

--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_patch.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_patch.go
@@ -43,6 +43,10 @@ func NewMaintenanceConfigPatchController() *MaintenanceConfigPatchController {
 					return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("maintenance config is not ready")
 				}
 
+				if strings.TrimSpace(maintenanceConfig.GetConfig()) == "" {
+					return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("maintenance config is empty")
+				}
+
 				configPatch.Metadata().Labels().Set(omni.LabelSystemPatch, "")
 				configPatch.Metadata().Labels().Set(omni.LabelMachine, machineStatus.Metadata().ID())
 

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -136,6 +136,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: updateClusterMachineConfigPatchesLabels,
 				name:     "updateClusterMachineConfigPatchesLabels",
 			},
+			{
+				callback: clearEmptyConfigPatches,
+				name:     "clearEmptyConfigPatches",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Empty config patches are detected as JSON6902 patches which are not supported by Omni and by the Talos machine config patcher when the config is multidoc.

Empty system-level config patches can be generated at the moment by `MaintenanceConfigPatchController`.