### PR TITLE
add basic helm chart

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,0 +1,233 @@
+# Omni Helm chart
+
+## Prerequisites
+
+To run Omni using this Helm chart the following additional components are required:
+
+- An ingress controller e.g. [ingress-nginx](https://github.com/kubernetes/ingress-nginx)
+- SSL certificates e.g. created via [cert-manager](https://cert-manager.io/)
+- An Authentication provider. e.g. See [Configure Authentication](https://omni.siderolabs.com/how-to-guides/self_hosted/index#configure-authentication) for using Auth0.
+- A GPG key. See [Create Etcd Encryption Key](https://omni.siderolabs.com/how-to-guides/self_hosted/index#create-etcd-encryption-key)
+  The GPG key can be added to a Secret like:
+
+  ```sh
+  kubectl create secret -n omni generic gpg --from-file=omni.asc=./omni.asc
+  ```
+
+- A PV for etcd storage. See [Local Storage](https://www.talos.dev/v1.8/kubernetes-guides/configuration/local-storage/) for a simple storage setup or [Storage](https://www.talos.dev/v1.8/kubernetes-guides/configuration/storage/) for more advanced options.
+
+## Example Walkthrough
+
+This example assumes 3 separate DNS entries will be used:
+
+| Example URL                 | Purpose          |
+| --------------------------- | ---------------- |
+| omni.example.com            | UI and API       |
+| kubernetes.omni.example.com | Kubernetes proxy |
+| siderolink.omni.example.com | SideroLink       |
+
+Assuming the above URLs and an Auth0 account the only values that need
+to be modified are:
+
+```yaml
+domainName: omni.example.com 
+accountUuid: <UUID> # This can be created using uuidgen
+name: "MyOmniInstance"
+auth:
+  auth0:
+    clientId: <AUTH0_CLIENT_ID>
+    domain: <AUTH0_DOMAIN>
+initialUsers:
+  - <EMAIL>
+service:
+  siderolink:
+    domainName: siderolink.omni.example.com
+    wireguard:
+      # The Helm chart currently assumes that Omni will be bound on a particular Node.
+      address: <IP address of worker node>
+  k8sProxy:
+    domainName: kubernetes.omni.example.com
+```
+
+### Ingresses
+
+Example Ingresses are given below for ingress-nginx. N.B. They also require SSL certs to exist.
+
+#### api
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    nginx.ingress.kubernetes.io/proxy-body-size: 32m
+    nginx.ingress.kubernetes.io/service-upstream: "true"
+  labels:
+    app.kubernetes.io/name: omni
+  name: api
+  namespace: omni
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: omni.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: omni-internal-grpc
+            port:
+              number: 8080
+        path: /cosi.resource.State
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /management.ManagementService
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /machine.MachineService
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /cluster.ClusterService
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /inspect.InspectService
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /resource.ResourceService
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /storage.StorageService
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /time.TimeService
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /auth.AuthService
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8080
+        path: /oicd.
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - omni.example.com
+    secretName: omni.example.com-tls
+```
+
+#### kubernetes-proxy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kubernetes-proxy
+  namespace: omni
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: kubernetes.omni.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: internal
+            port:
+              number: 8095
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - kubernetes.omni.example.com
+    secretName: kubernetes.omni.example.com-tls
+```
+
+#### siderolink
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+  name: siderolink
+  namespace: omni
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: siderolink.omni.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: internal-grpc
+            port:
+              number: 8090
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - siderolink.omni.example.com
+    secretName: siderolink.omni.example.com-tls
+```
+
+#### ui
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ui
+  namespace: omni
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: omni.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: internal
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - omni.example.com
+    secretName: omni.example.com-tls
+```

--- a/deploy/helm/omni/.helmignore
+++ b/deploy/helm/omni/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: omni
+description: A helm chart to deploy Omni on a Kubernetes cluster
+type: application
+version: 0.0.1
+appVersion: "0.32.2"

--- a/deploy/helm/omni/templates/_helpers.tpl
+++ b/deploy/helm/omni/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "omni.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "omni.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "omni.labels" -}}
+helm.sh/chart: {{ include "omni.chart" . }}
+{{ include "omni.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "omni.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "omni.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/deploy/helm/omni/templates/deployment.yaml
+++ b/deploy/helm/omni/templates/deployment.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "omni.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "omni.labels" . | nindent 4 }}
+    app.kubernetes.io/component: omni
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.deployment.annotations | nindent 4 }}
+spec:
+  strategy:
+    type: Recreate
+  replicas: {{ .Values.deployment.replicaCount }}
+  selector:
+    matchLabels: {{- include "omni.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- if .Values.deployment.podAnnotations }}
+      annotations:
+      {{- toYaml .Values.deployment.annotations | nindent 6 }}
+    {{- end }}
+      labels: 
+      {{- include "omni.labels" . | nindent 8 }}
+      app.kubernetes.io/component: omni
+      {{- with .Values.deployment.labels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      - name: omni
+        image: {{ .Values.deployment.image }}:{{ .Values.deployment.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+        resources:
+          {{- with .Values.resources }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+        ports:
+          - name: omni
+            containerPort: 8080
+            protocol: TCP
+          - name: siderolink
+            containerPort: 8090
+            protocol: TCP
+          - name: k8s-proxy
+            containerPort: 8095
+            protocol: TCP
+          - name: wireguard
+            containerPort: 50180
+            protocol: UDP
+        resources:
+          limits:
+            # Required for /dev/net/tun
+            # https://www.talos.dev/v1.8/kubernetes-guides/configuration/device-plugins/
+            squat.ai/tun: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_ADMIN
+        volumeMounts:
+          {{- if .Values.volumeMounts.tls.mountPath }}
+          - name: tls
+            mountPath: {{ .Values.volumeMounts.tls.mountPath }}
+            readOnly: {{ .Values.volumeMounts.tls.readOnly }}
+          {{- end }}
+          - name: omni-asc
+            mountPath: {{ .Values.volumeMounts.omniAsc.mountPath }}
+            subPath: {{ .Values.volumeMounts.omniAsc.subPath }}
+            readOnly: {{ .Values.volumeMounts.omniAsc.readOnly }}
+          - name: etcd
+            mountPath: /_out
+        args:
+          - --account-id="{{ .Values.accountUuid }}"
+          - --advertised-api-url={{ printf "https://%s/" .Values.domainName }} 
+          - --advertised-kubernetes-proxy-url={{ printf "https://%s/" .Values.service.k8sProxy.domainName }}
+        {{- if .Values.auth.auth0.enabled }}
+          - --auth-auth0-enabled=true
+          - --auth-auth0-client-id={{ .Values.auth.auth0.clientId | toString}}
+          - --auth-auth0-domain={{ .Values.auth.auth0.domain }}
+        {{- end }}
+        {{- if .Values.auth.saml.enabled }}
+          - --auth-saml-enabled=true
+        {{- if .Values.auth.saml.url }}
+          - --auth-saml-url="{{ .Values.auth.saml.url }}"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.volumes.tls.secretName }}
+          - --cert=/etc/omni/tls/tls.crt
+          - --key=/etc/omni/tls/tls.key
+        {{- end }}
+          - --etcd-embedded=true
+        {{- if and .Values.initialUsers (gt (len .Values.initialUsers) 0) }}
+          - --initial-users={{ join "," .Values.initialUsers }}
+        {{- end }}
+          - --name={{ .Values.name}}
+          - --private-key-source={{ .Values.privateKeySource }}
+          - --siderolink-api-advertised-url={{ printf "https://%s" .Values.service.siderolink.domainName }}
+          - --siderolink-wireguard-advertised-addr={{ .Values.service.siderolink.wireguard.address }}:{{ .Values.service.siderolink.wireguard.port }}
+        {{- range $value := .Values.extraArgs }}
+          - {{ $value }}
+        {{- end }}
+      volumes:
+        {{- if .Values.volumes.tls.secretName }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.volumes.tls.secretName }}
+        {{- end }}
+        - name: omni-asc
+          secret:
+            secretName: {{ .Values.volumes.gpg.secretName }}
+        - name: etcd
+          persistentVolumeClaim:
+            claimName: {{ .Values.volumes.etcd.persistentVolumeClaimName }}

--- a/deploy/helm/omni/templates/generic-device-plugin.yaml
+++ b/deploy/helm/omni/templates/generic-device-plugin.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.includeGenericDevicePlugin }}
+# Required for /dev/net/tun
+# https://www.talos.dev/v1.8/kubernetes-guides/configuration/device-plugins/
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: generic-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: generic-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: generic-device-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: generic-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - image: squat/generic-device-plugin
+        args:
+        - --device
+        - |
+          name: tun
+          groups:
+            - count: 1000
+              paths:
+                - path: /dev/net/tun          
+        name: generic-device-plugin
+        resources:
+          requests:
+            cpu: 50m
+            memory: 10Mi
+          limits:
+            cpu: 50m
+            memory: 20Mi
+        ports:
+        - containerPort: 8080
+          name: http
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/device-plugins
+        - name: dev
+          mountPath: /dev
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+      - name: dev
+        hostPath:
+          path: /dev
+  updateStrategy:
+    type: RollingUpdate
+{{- end }}

--- a/deploy/helm/omni/templates/service.yaml
+++ b/deploy/helm/omni/templates/service.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: internal
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+  {{- end }}
+  labels:
+    {{- include "omni.labels" . | nindent 4 }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  ports:
+    - name: omni
+      port: 8080
+      targetPort: omni
+      protocol: TCP
+    - name: k8s-proxy
+      port: 8095
+      targetPort: k8s-proxy
+      protocol: TCP
+    - name: siderolink
+      port: 8090
+      targetPort: siderolink
+      protocol: TCP
+  selector:
+    {{- include "omni.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: internal-grpc
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+  {{- end }}
+  labels:
+    {{- include "omni.labels" . | nindent 4 }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  ports:
+    - name: omni
+      port: 8080
+      targetPort: omni
+      protocol: TCP
+    - name: siderolink
+      port: 8090
+      targetPort: siderolink
+      protocol: TCP
+  selector:
+    {{- include "omni.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wireguard
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+  {{- end }}
+  labels:
+    {{- include "omni.labels" . | nindent 4 }}
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
+spec:
+  type: NodePort
+  clusterIP: {{ .Values.service.clusterIP }}
+  ports:
+    - name: wireguard
+      nodePort: {{ .Values.service.siderolink.wireguard.port }}
+      port: {{ .Values.service.siderolink.wireguard.port }}
+      targetPort: wireguard
+      protocol: UDP
+  selector:
+    {{- include "omni.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -1,0 +1,55 @@
+# nameOverride: omni  # optional, if omitted the Chart name will be used
+domainName: omni.example.com
+accountUuid:
+privateKeySource: "file:///omni.asc"
+deployment:
+  image: ghcr.io/siderolabs/omni
+  tag: "latest"
+  replicaCount: 1
+  annotations: {}
+  imagePullPolicy: IfNotPresent
+auth:
+  auth0:
+    enabled: true
+    clientId: "123456"
+    domain: "https://www.auth0.example"
+  saml:
+    enabled: false
+    url: "https://www.saml.example"
+includeGenericDevicePlugin: true # 
+initialUsers: []
+name: "My Omni instance"
+service:
+  type: ClusterIP # currently only ClusterIP is supported by this Helm Chart
+  siderolink:
+    domainName: omni.siderolink.example.com
+    wireguard:
+      address: "" #<ip address of the host running Omni>
+      port: 30180
+  k8sProxy:
+    domainName: omni.kubernetes.example.com
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
+extraArgs:
+  # - --debug
+  # - --image-factory-address=factory.talos.dev
+volumeMounts:
+  tls:
+    mountPath: null # "/etc/omni/tls"
+    readOnly: true
+  omniAsc:
+    mountPath: "/omni.asc"
+    subPath: "omni.asc"
+    readOnly: true
+volumes:
+  etcd:
+    persistentVolumeClaimName: omni-pvc
+  tls:
+    secretName: null # tls
+  gpg:
+    secretName: gpg


### PR DESCRIPTION
This PR adds a basic helm chart to deploy Omni in an existing Kubernetes cluster. It does not take care of gpg keys, certificates, etcetera, leaving that to the user's own devices. 