### PR TITLE
feat: generate overlay info by extracting board kernel args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/siderolabs/go-kubernetes v0.2.8
 	github.com/siderolabs/go-loadbalancer v0.3.3
 	github.com/siderolabs/go-pointer v1.0.0
+	github.com/siderolabs/go-procfs v0.1.2
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/go-tail v0.1.0
 	github.com/siderolabs/go-talos-support v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -473,6 +473,8 @@ github.com/siderolabs/go-loadbalancer v0.3.3 h1:D6ONnP9Erlh4TS6kV9L7ocnfrNYCA/58
 github.com/siderolabs/go-loadbalancer v0.3.3/go.mod h1:7j4Q9peU/UFuTNSFfwhKLQ028CNkyMkAdGnSi1Dm7Jw=
 github.com/siderolabs/go-pointer v1.0.0 h1:6TshPKep2doDQJAAtHUuHWXbca8ZfyRySjSBT/4GsMU=
 github.com/siderolabs/go-pointer v1.0.0/go.mod h1:HTRFUNYa3R+k0FFKNv11zgkaCLzEkWVzoYZ433P3kHc=
+github.com/siderolabs/go-procfs v0.1.2 h1:bDs9hHyYGE2HO1frpmUsD60yg80VIEDrx31fkbi4C8M=
+github.com/siderolabs/go-procfs v0.1.2/go.mod h1:dBzQXobsM7+TWRRI3DS9X7vAuj8Nkfgu3Z/U9iY3ZTY=
 github.com/siderolabs/go-retry v0.3.3 h1:zKV+S1vumtO72E6sYsLlmIdV/G/GcYSBLiEx/c9oCEg=
 github.com/siderolabs/go-retry v0.3.3/go.mod h1:Ff/VGc7v7un4uQg3DybgrmOWHEmJ8BzZds/XNn/BqMI=
 github.com/siderolabs/go-tail v0.1.0 h1:U+ZClt7BXLGsxDNU/XQ12sz7lQElfFZBYEPdkW78Qro=

--- a/internal/backend/runtime/omni/controllers/omni/installation_media.go
+++ b/internal/backend/runtime/omni/controllers/omni/installation_media.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/boards"
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
@@ -245,10 +246,9 @@ var installationMedia = []installationMediaSpec{
 	{
 		Name:         "Banana Pi BPI-M64 (arm64)",
 		Architecture: arm64Arch,
+		Profile:      constants.BoardBananaPiM64,
 		Type:         rawType,
 		SBC:          true,
-		Overlay:      "bananapi_m64",
-		Profile:      constants.BoardBananaPiM64,
 		ContentType:  "application/x-xz",
 	},
 	{
@@ -257,7 +257,6 @@ var installationMedia = []installationMediaSpec{
 		Profile:      constants.BoardJetsonNano,
 		Type:         rawType,
 		SBC:          true,
-		Overlay:      "jetson_nano",
 		ContentType:  "application/x-xz",
 	},
 	{
@@ -266,7 +265,6 @@ var installationMedia = []installationMediaSpec{
 		Profile:      constants.BoardLibretechAllH3CCH5,
 		Type:         rawType,
 		SBC:          true,
-		Overlay:      "libretech_all_h3_cc_h5",
 		ContentType:  "application/x-xz",
 	},
 	{
@@ -275,7 +273,6 @@ var installationMedia = []installationMediaSpec{
 		Profile:      constants.BoardPine64,
 		Type:         rawType,
 		SBC:          true,
-		Overlay:      "pine64",
 		ContentType:  "application/x-xz",
 	},
 	{
@@ -284,7 +281,6 @@ var installationMedia = []installationMediaSpec{
 		Profile:      constants.BoardRock64,
 		Type:         rawType,
 		SBC:          true,
-		Overlay:      "rock64",
 		ContentType:  "application/x-xz",
 	},
 	{
@@ -293,7 +289,6 @@ var installationMedia = []installationMediaSpec{
 		Profile:      constants.BoardRockpi4,
 		Type:         rawType,
 		SBC:          true,
-		Overlay:      "rockpi4",
 		ContentType:  "application/x-xz",
 	},
 	{
@@ -302,7 +297,6 @@ var installationMedia = []installationMediaSpec{
 		Profile:      constants.BoardRockpi4c,
 		Type:         rawType,
 		SBC:          true,
-		Overlay:      "rockpi4c",
 		ContentType:  "application/x-xz",
 	},
 	{
@@ -311,7 +305,14 @@ var installationMedia = []installationMediaSpec{
 		Profile:      constants.BoardRPiGeneric,
 		Type:         rawType,
 		SBC:          true,
-		Overlay:      "rpi_generic",
+		ContentType:  "application/x-xz",
+	},
+	{
+		Name:         "Nano Pi R4S",
+		Architecture: arm64Arch,
+		Profile:      constants.BoardNanoPiR4S,
+		Type:         rawType,
+		SBC:          true,
 		ContentType:  "application/x-xz",
 	},
 }
@@ -360,7 +361,12 @@ func (ctrl *InstallationMediaController) Run(ctx context.Context, r controller.R
 			newMedia.TypedSpec().Value.DestFilePrefix = fmt.Sprintf("%s-omni-%s", fname.srcPrefix, config.Config.Name)
 			newMedia.TypedSpec().Value.Extension = fname.extension
 			newMedia.TypedSpec().Value.NoSecureBoot = m.SBC
-			newMedia.TypedSpec().Value.Overlay = m.Overlay
+
+			overlay := boards.GetOverlay(m.Profile)
+
+			if overlay != nil {
+				newMedia.TypedSpec().Value.Overlay = overlay.Name
+			}
 
 			tracker.keep(newMedia)
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/boards/boards.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/boards/boards.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2024 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package boards contains helpers for mapping board types to the overlays.
+package boards
+
+import (
+	"github.com/siderolabs/image-factory/pkg/schematic"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
+
+// GetOverlay converts board constant to it's overlay.
+func GetOverlay(board string) *schematic.Overlay {
+	switch board {
+	case constants.BoardBananaPiM64:
+		return &schematic.Overlay{
+			Name:  "bananapi_m64",
+			Image: "siderolabs/sbc-allwinner",
+		}
+	case constants.BoardJetsonNano:
+		return &schematic.Overlay{
+			Name:  "jetson_nano",
+			Image: "siderolabs/sbc-jetson",
+		}
+	case constants.BoardLibretechAllH3CCH5:
+		return &schematic.Overlay{
+			Name:  "libretech_all_h3_cc_h5",
+			Image: "siderolabs/sbc-allwinner",
+		}
+	case constants.BoardPine64:
+		return &schematic.Overlay{
+			Name:  "pine64",
+			Image: "siderolabs/sbc-allwinner",
+		}
+	case constants.BoardRock64:
+		return &schematic.Overlay{
+			Name:  "bananapi_m64",
+			Image: "siderolabs/sbc-allwinner",
+		}
+	case constants.BoardRockpi4:
+		return &schematic.Overlay{
+			Name:  "rockpi4",
+			Image: "siderolabs/sbc-rockchip",
+		}
+	case constants.BoardRockpi4c:
+		return &schematic.Overlay{
+			Name:  "rockpi4c",
+			Image: "siderolabs/sbc-rockchip",
+		}
+	case constants.BoardNanoPiR4S:
+		return &schematic.Overlay{
+			Name:  "nanopi-r4s",
+			Image: "siderolabs/sbc-rockchip",
+		}
+	case constants.BoardRPiGeneric:
+		return &schematic.Overlay{
+			Name:  "rpi_generic",
+			Image: "siderolabs/sbc-raspberrypi",
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is compatibility code for SBCs running Talos < 1.7.x. With this change it's possible to do seamless upgrade of SBCs running without overlays.

Fixes: https://github.com/siderolabs/omni/issues/145