### PR TITLE
test: use Talos nodes with partial config in integration tests

### DIFF
--- a/hack/test/freeze-a-vm.sh
+++ b/hack/test/freeze-a-vm.sh
@@ -7,6 +7,16 @@
 
 set -eoux pipefail
 
-# freeze a VM UUID $1 in talosctl cluster created cluster 'talos-default'
+dir=""
 
-echo "s" | socat - unix-connect:${HOME}/.talos/clusters/talos-default/machine-$1.monitor
+# find the cluster machine $1 belongs to
+for d in "${HOME}"/.talos/clusters/*; do
+  if [ -e "${d}/machine-$1.monitor" ]; then
+    dir="${d}"
+
+    break
+  fi
+done
+
+# freeze the VM $1
+echo "s" | socat - "unix-connect:${dir}/machine-$1.monitor"

--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -110,12 +110,54 @@ nice -n 10 ${ARTIFACTS}/omni-linux-amd64 \
     "${REGISTRY_MIRROR_FLAGS[@]}" \
     &
 
-# Launch empty Talos VMs.
+# Prepare partial machine config
+PARTIAL_CONFIG=$(cat <<EOF
+apiVersion: v1alpha1
+kind: SideroLinkConfig
+apiUrl: grpc://$LOCAL_IP:8090?jointoken=${JOIN_TOKEN}
+---
+apiVersion: v1alpha1
+kind: EventSinkConfig
+endpoint: '[fdae:41e4:649b:9303::1]:8090'
+---
+apiVersion: v1alpha1
+kind: KmsgLogConfig
+name: omni-kmsg
+url: 'tcp://[fdae:41e4:649b:9303::1]:8092'
+EOF
+)
+PARTIAL_CONFIG_DIR="${ARTIFACTS}/partial-config"
+mkdir -p "${PARTIAL_CONFIG_DIR}"
+echo "${PARTIAL_CONFIG}" > "${PARTIAL_CONFIG_DIR}/controlplane.yaml"
+echo "${PARTIAL_CONFIG}" > "${PARTIAL_CONFIG_DIR}/worker.yaml"
+
+# Launch half of the Talos VMs with partial config to join Omni
 ${ARTIFACTS}/talosctl cluster create \
+    --name test-1 \
     --provisioner=qemu \
     --cidr=172.20.0.0/24 \
+    --no-masquerade-cidrs=172.21.0.0/24 \
     --controlplanes=1 \
-    --workers=7 \
+    --workers=3 \
+    --input-dir="${PARTIAL_CONFIG_DIR}" \
+    --vmlinuz-path="https://factory.talos.dev/image/${SCHEMATIC_ID}/v${TALOS_VERSION}/kernel-amd64" \
+    --initrd-path="https://factory.talos.dev/image/${SCHEMATIC_ID}/v${TALOS_VERSION}/initramfs-amd64.xz" \
+    --wait=false \
+    --mtu=1430 \
+    --memory=3072 \
+    --memory-workers=3072 \
+    --cpus=3 \
+    --cpus-workers=3 \
+    --with-uuid-hostnames
+
+# Launch the other half of the Talos VMs with the kernel args to join Omni
+${ARTIFACTS}/talosctl cluster create \
+    --name test-2 \
+    --provisioner=qemu \
+    --cidr=172.21.0.0/24 \
+    --no-masquerade-cidrs=172.20.0.0/24 \
+    --controlplanes=1 \
+    --workers=3 \
     --skip-injecting-config \
     --extra-boot-kernel-args "siderolink.api=grpc://$LOCAL_IP:8090?jointoken=${JOIN_TOKEN} talos.events.sink=[fdae:41e4:649b:9303::1]:8090 talos.logging.kernel=tcp://[fdae:41e4:649b:9303::1]:8092" \
     --vmlinuz-path="https://factory.talos.dev/image/${SCHEMATIC_ID}/v${TALOS_VERSION}/kernel-amd64" \

--- a/hack/test/restart-a-vm.sh
+++ b/hack/test/restart-a-vm.sh
@@ -7,6 +7,16 @@
 
 set -eoux pipefail
 
-# restart a VM UUID $1 in talosctl cluster created cluster 'talos-default'
+dir=""
 
-echo "q" | socat - unix-connect:${HOME}/.talos/clusters/talos-default/machine-$1.monitor
+# find the cluster machine $1 belongs to
+for d in "${HOME}"/.talos/clusters/*; do
+  if [ -e "${d}/machine-$1.monitor" ]; then
+    dir="${d}"
+
+    break
+  fi
+done
+
+# restart the VM $1
+echo "q" | socat - "unix-connect:${dir}/machine-$1.monitor"

--- a/hack/test/wipe-a-vm.sh
+++ b/hack/test/wipe-a-vm.sh
@@ -7,11 +7,21 @@
 
 set -eoux pipefail
 
-# wipe a VM UUID $1 in talosctl cluster created cluster 'talos-default'
+dir=""
 
-echo "s" | socat - unix-connect:${HOME}/.talos/clusters/talos-default/machine-$1.monitor
+# find the cluster machine $1 belongs to
+for d in "${HOME}"/.talos/clusters/*; do
+  if [ -e "${d}/machine-$1.monitor" ]; then
+    dir="${d}"
 
-disk="${HOME}/.talos/clusters/talos-default/machine-$1-0.disk"
+    break
+  fi
+done
+
+# wipe the VM $1
+echo "s" | socat - "unix-connect:${dir}/machine-$1.monitor"
+
+disk="${dir}/machine-$1-0.disk"
 
 size=$(du -bs "${disk}" | cut -f1)
 
@@ -19,4 +29,4 @@ rm "${disk}"
 
 truncate -s "${size}" "${disk}"
 
-echo "q" | socat - unix-connect:${HOME}/.talos/clusters/talos-default/machine-$1.monitor
+echo "q" | socat - "unix-connect:${dir}/machine-$1.monitor"


### PR DESCRIPTION
Make half of the Talos nodes used in the integration tests to use a partial machine config to join Omni instead of kernel args. This would allow us to test more real use cases and catch more issues.