### PR TITLE
fix: make cluster machine install disk selector pick correct disk

### DIFF
--- a/frontend/src/views/omni/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterMachineItem.vue
@@ -29,7 +29,7 @@ included in the LICENSE file.
                 title="Install Disk"
                 @checkedValue="setInstallDisk"
                 :values="disks"
-                :defaultValue="disks[0]"/>
+                :defaultValue="item.spec.install_disk ?? disks[0]"/>
             </div>
           </template>
           <div>


### PR DESCRIPTION
The UI does not create install disk config patch if the user does not touch disk dropdown.
It works correctly if the default disk is shown initially there, then it works as intended.
But the bug was that we were showing the first install disk as the selected option instead of the default one.

Fixes: https://github.com/siderolabs/omni/issues/154