### PR TITLE
fix: start watch before delete in `omnictl delete`

### DIFF
--- a/hack/generate-certs/main.go
+++ b/hack/generate-certs/main.go
@@ -132,7 +132,7 @@ func generate() (err error) {
 		port = ""
 	}
 
-	data := struct { //nolint:govet
+	data := struct { 
 		ClientID         string
 		Auth0Domain      string
 		Host             string


### PR DESCRIPTION
Start the watch before sending the destroy call to not miss events.

Add support for passing more than a single resource to the call, e.g., `omnictl delete link link-1 link-2 link-3`.

Additionally, bring back the "WatchKind" behavior when `--all` or `--selector` is used, or when the number of resources to be deleted is above a certain size.