### PR TITLE
fix: do not allow adding ISO, PXE nodes running different Talos version

### DIFF
--- a/client/pkg/omni/resources/omni/machine_status.go
+++ b/client/pkg/omni/resources/omni/machine_status.go
@@ -212,6 +212,10 @@ func MachineStatusReconcileLabels(machineStatus *MachineStatus) {
 
 // GetMachineStatusSystemDisk looks up a system disk for the Talos machine.
 func GetMachineStatusSystemDisk(res *MachineStatus) string {
+	if res == nil || res.TypedSpec().Value.Hardware == nil {
+		return ""
+	}
+
 	for _, disk := range res.TypedSpec().Value.Hardware.Blockdevices {
 		if disk.SystemDisk {
 			return disk.LinuxName

--- a/frontend/src/views/omni/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterMachineItem.vue
@@ -122,10 +122,10 @@ const props = defineProps<{
   item: ResourceTyped<MachineStatusSpec & SiderolinkSpec & MachineConfigGenOptionsSpec>,
   reset?: number,
   searchQuery?: string,
-  talosVersionNotAllowed: boolean
+  versionMismatch: string | null
 }>();
 
-const { item, reset, talosVersionNotAllowed } = toRefs(props);
+const { item, reset, versionMismatch } = toRefs(props);
 
 const machineSetNode = ref<MachineSetNode>({
   patches: {},
@@ -173,7 +173,7 @@ computeState();
 watch(item, computeState);
 watch(state.value, computeMachineAssignment);
 
-watch(talosVersionNotAllowed, (value: boolean) => {
+watch(versionMismatch, (value: string | null) => {
   if (value) {
     machineSetIndex.value = undefined;
   }
@@ -240,9 +240,9 @@ const options: Ref<PickerOption[]> = computed(() => {
       tooltip = `The machine class ${ms.id} is using machine class so no manual allocation is possible`
     }
 
-    if (talosVersionNotAllowed.value) {
+    if (versionMismatch.value) {
       disabled = true;
-      tooltip = `The machine has newer Talos version installed: downgrade is not allowed. Upgrade the machine or change Talos cluster version`
+      tooltip = versionMismatch.value
     }
 
     return {

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
@@ -281,6 +281,13 @@ func (ctrl *MachineSetNodeController) createNodes(
 				continue
 			}
 
+			// do not try to allocate the machine if it's running Talos from an ISO or PXE and it's major and minor version do not match.
+			installed := omni.GetMachineStatusSystemDisk(machine) != ""
+
+			if !installed && (machineVersion.Major != clusterVersion.Major || machineVersion.Minor != clusterVersion.Minor) {
+				continue
+			}
+
 			id := machine.Metadata().ID()
 
 			if err := r.Create(ctx, omni.NewMachineSetNode(resources.DefaultNamespace, id, machineSet)); err != nil {

--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -465,6 +465,14 @@ func machineSetNodeValidationOptions(st state.State) []validated.StateOption {
 			)
 		}
 
+		installed := omni.GetMachineStatusSystemDisk(machineStatus) != ""
+
+		if !installed && (machineTalosVersion.Major != clusterTalosVersion.Major || machineTalosVersion.Minor != clusterTalosVersion.Minor) {
+			return errors.New(
+				"machines which are running Talos without installation can be added only to Talos clusters with the same major and minor versions",
+			)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Adding them to cluster will no longer work. Validation and the UI won't allow that.

We can not upgrade the node which doesn't have Talos installed yet. So the config generated for a different version of Talos will make this node never join the cluster. That's why we disable that.

Fixes: https://github.com/siderolabs/omni/issues/43