### PR TITLE
test: fix flaky test by longer k8s node checks and retries

### DIFF
--- a/cmd/integration-test/pkg/tests/blocks.go
+++ b/cmd/integration-test/pkg/tests/blocks.go
@@ -66,7 +66,7 @@ func TestBlockProxyAPIAccessShouldWork(ctx context.Context, rootClient *client.C
 	return []subTest{
 		{
 			"ClusterKubernetesAPIShouldBeAccessibleViaOmni",
-			AssertKubernetesAPIAccessViaOmni(ctx, rootClient, clusterName, true, 30*time.Second),
+			AssertKubernetesAPIAccessViaOmni(ctx, rootClient, clusterName, true, 5*time.Minute),
 		},
 		{
 			"ClusterTalosAPIShouldBeAccessibleViaOmni",

--- a/hack/generate-certs/main.go
+++ b/hack/generate-certs/main.go
@@ -132,7 +132,7 @@ func generate() (err error) {
 		port = ""
 	}
 
-	data := struct { 
+	data := struct {
 		ClientID         string
 		Auth0Domain      string
 		Host             string


### PR DESCRIPTION
Fix the flakiness in `ReplaceControlPlanes` test that was introduced by the recently added `KubernetesNodeAuditController`. This controller changed the Kubernetes node deletion logic to not block the `ClusterMachineTeardownController` for node deletions, as itself would take care of it later.

This causes the replaced control plane node in this test to be removed with a delay, as it is now removed by the audit controller after a grace period.

Improve the assertion between k8s<>Omni nodes by:
- not only asserting the number of nodes but also their names
- adding retries to this assertion, so it would keep trying until the audit controller does its job and removes the node from Kubernetes
- increasing its timeout to give the audit controller enough time (as it gives nodes a grace period of a minute) to remove the node