### PR TITLE
fix: ignore unknown machine version on the cluster create page

### DIFF
--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -266,6 +266,10 @@ const canAddMachine = (machine: Resource<MachineStatusSpec>) => {
   const clusterVersion = semver.parse(state.value.cluster.talosVersion);
   const machineVersion = semver.parse(machine.spec.talos_version);
 
+  if (!machineVersion || !clusterVersion) {
+    return false;
+  }
+
   return machineVersion.major <= clusterVersion.major && machineVersion.minor <= clusterVersion.minor;
 }
 


### PR DESCRIPTION
The machine can have no Talos version if Omni couldn't collect it.