### PR TITLE
fix: make `MachineSetNodeController` handle machinesets without clusters

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
@@ -227,6 +227,7 @@ func (ctrl *MachineSetNodeController) reconcileMachineSet(
 	return nil
 }
 
+//nolint:gocognit
 func (ctrl *MachineSetNodeController) createNodes(
 	ctx context.Context,
 	r controller.Runtime,
@@ -249,6 +250,10 @@ func (ctrl *MachineSetNodeController) createNodes(
 
 	cluster, err := safe.ReaderGetByID[*omni.Cluster](ctx, r, clusterName)
 	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Ignore such machine sets instead of failing, as fail leads to all other machine sets being skipped.

Fixes: https://github.com/siderolabs/omni/issues/208