### PR TITLE
feat: allow setting some url params for api endpoint

### DIFF
--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -292,6 +292,7 @@ func init() {
 		config.Config.SiderolinkWireguardAdvertisedAddress,
 		"advertised wireguard address which is passed down to the nodes.")
 	rootCmd.Flags().StringVar(&config.Config.SiderolinkWireguardBindAddress, "siderolink-wireguard-bind-addr", config.Config.SiderolinkWireguardBindAddress, "Siderolink wireguard bind address.")
+	rootCmd.Flags().BoolVar(&config.Config.SiderolinkUseGRPCTunnel, "siderolink-use-grpc-tunnel", false, "use gRPC tunnel to wrap wireguard traffic instead of UDP")
 
 	rootCmd.Flags().StringVar(&config.Config.MachineAPIBindAddress, "siderolink-api-bind-addr", config.Config.MachineAPIBindAddress, "SideroLink provision bind address.")
 	rootCmd.Flags().StringVar(&config.Config.MachineAPICertFile, "siderolink-api-cert", config.Config.MachineAPICertFile, "SideroLink TLS cert file path.")

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -48,6 +48,7 @@ type Params struct {
 	SiderolinkWireguardBindAddress       string `yaml:"siderolinkWireguardBindAddress"`
 	SiderolinkWireguardAdvertisedAddress string `yaml:"siderolinkWireguardAdvertisedAddress"`
 	SiderolinkDisableLastEndpoint        bool   `yaml:"siderolinkDisableLastEndpoint"`
+	SiderolinkUseGRPCTunnel              bool   `yaml:"siderolinkUseGRPCTunnel"`
 
 	EventSinkPort    int                `yaml:"eventSinkPort"`
 	SideroLinkAPIURL string             `yaml:"siderolinkAPIURL"`


### PR DESCRIPTION
# feat: Accept apiendpoint url params

## Description

This lets the operator define url params for the api endpoint. For example https://<endpoint>/?grpc_tunnel=true. Instead of only appending the jointoken, we are parsing the url and adding it using Query.Set.

## Why

When configuring an ingress in front of omni, it is easier to use the grpc tunnel instead of opening an UDP port. But there is currently no way of setting grpc_tunnel to true by default. This change has a minimal effect on how the endpoint is handled while allowing an operator to set default param values.