### PR TITLE
feat: improve auth flow when user email is not verified

### DIFF
--- a/internal/pkg/auth/auth0/token.go
+++ b/internal/pkg/auth/auth0/token.go
@@ -101,8 +101,18 @@ func (a *CustomIDClaims) Validate(_ context.Context) error {
 	}
 
 	if !a.EmailVerified {
-		return errors.New("email is not verified")
+		return &EmailNotVerifiedError{Email: a.Email}
 	}
 
 	return nil
+}
+
+// EmailNotVerifiedError is an error that occurs when the email address is not verified.
+type EmailNotVerifiedError struct {
+	Email string
+}
+
+// Error implements the error interface.
+func (e EmailNotVerifiedError) Error() string {
+	return "email not verified: " + e.Email
 }


### PR DESCRIPTION
If the user has their email not verified, instead of failing with a generic error message of "invalid JWT", print an error message asking user to verify their email and try again.

In Auth0 mode, if the JWT validation has failed on the backend at the moment of clicking "Login", get a new ID token from Auth0 on the next click. This way, the user will not have to reload the page after validating their email - they can simply click "Login" again to get in.

Part of siderolabs/omni#114.

After this change is rolled out, we need to configure our Auth0 app to allow username/password auth.

**Demo:**
![auth](https://github.com/siderolabs/omni/assets/1465819/718738ee-1496-4fce-97fe-3b66957b5766)
