### PR TITLE
fix: properly do rolling update on control plane nodes

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/control_planes_handler.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/control_planes_handler.go
@@ -59,7 +59,14 @@ func ReconcileControlPlanes(ctx context.Context, rc *ReconciliationContext, etcd
 
 	// do a single update
 	toUpdate := rc.GetMachinesToUpdate()
+
 	if len(toUpdate) > 0 {
+		// if the count of outdated machines > 0 do update if the machine is already outdated
+		// e.g.: allow applying the config change for the same machine multiple times
+		if len(rc.GetOutdatedMachines()) > 0 && !rc.GetOutdatedMachines().Contains(toUpdate[0]) {
+			return nil, nil
+		}
+
 		return []Operation{&Update{ID: toUpdate[0]}}, nil
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/omni/issues/244

There was an error in the logic that allowed updates of the machines even if the machine set has outdated machines already.