### PR TITLE
chore: always build frontend on BUILDPLATFORM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-05-21T13:03:14Z by kres 0290180.
+# Generated on 2024-05-22T17:52:27Z by kres 5fac898-dirty.
 
 # common variables
 

--- a/internal/frontend/frontend.go
+++ b/internal/frontend/frontend.go
@@ -5,7 +5,7 @@
 
 // THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 //
-// Generated on 2024-05-21T15:42:13Z by kres 04ecdaf.
+// Generated on 2024-05-22T18:31:05Z by kres 5fac898-dirty.
 
 package frontend
 


### PR DESCRIPTION
To avoid crosscompilation of the frontend tasks.