### PR TITLE
fix: use proper name for fetching existing extension configuration

### DIFF
--- a/frontend/src/views/omni/Modals/UpdateExtensions.vue
+++ b/frontend/src/views/omni/Modals/UpdateExtensions.vue
@@ -161,7 +161,7 @@ const updateExtensionsConfig = async () => {
 
   try {
     const existing: Resource<ExtensionsConfigurationSpec> = await ResourceService.Get({
-      id: `schematic-${extensionsConfiguration.metadata.id}`,
+      id: extensionsConfiguration.metadata.id,
       namespace: extensionsConfiguration.metadata.namespace,
       type: extensionsConfiguration.metadata.type,
     }, withRuntime(Runtime.Omni));


### PR DESCRIPTION
The bug was leading to fetching `schematic-schematic-<machine-uuid>`, which is the incorrect name and it was always trying to create the resources instead of the update.