### PR TITLE
feat: show service events on the node overview page

### DIFF
--- a/frontend/src/components/common/Status/TStatus.vue
+++ b/frontend/src/components/common/Status/TStatus.vue
@@ -95,6 +95,7 @@ const iconData = computed((): { iconColor?: string, iconTypeValue?: IconType } =
           iconTypeValue: "time",
           iconColor: "#FF5C56",
         };
+      case TCommonStatuses.WAITING:
       case TCommonStatuses.LOADING:
         return {
           iconTypeValue: "time",
@@ -160,6 +161,11 @@ const iconData = computed((): { iconColor?: string, iconTypeValue?: IconType } =
           iconTypeValue: "time",
           iconColor: "#FFB200",
         };
+      default:
+        return {
+          iconTypeValue: "unknown",
+          iconColor: "#FF8B59",
+        }
     }
   }
 

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -54,4 +54,5 @@ export enum TCommonStatuses {
   OUTDATED = 'Outdated',
   APPLIED = 'Applied',
   LOADING = "Loading...",
+  WAITING = "Waiting",
 }

--- a/frontend/src/views/cluster/Nodes/NodeLogs.vue
+++ b/frontend/src/views/cluster/Nodes/NodeLogs.vue
@@ -11,7 +11,7 @@ included in the LICENSE file.
         class="logs-container"
     />
     <div v-else class="logs-container">
-      <div class="w-1/4 mb-4">
+      <div class="mb-4">
         <t-input
           placeholder="Search..."
           v-model="inputValue"

--- a/frontend/src/views/cluster/Nodes/NodeServiceEvents.vue
+++ b/frontend/src/views/cluster/Nodes/NodeServiceEvents.vue
@@ -1,0 +1,58 @@
+<!--
+Copyright (c) 2024 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<template>
+  <div class="pl-1 mt-4 -mb-2">
+    <div class="w-full h-full border-l-2 border-naturals-N4 flex flex-col gap-4">
+      <div v-for="event in events" :key="event.ts" class="grid grid-cols-6 gap-3">
+        <div class="flex items-center gap-3">
+          <div class="rounded-full p-1 max-w-min " :class="eventStyle(event.state!).color" style="margin-left: -11px">
+            <t-icon :icon="eventStyle(event.state!).icon" class="w-3 h-3 text-white"/>
+          </div>
+          <div class="font-bold">{{ event.state }}</div>
+        </div>
+        <div class="col-span-5">{{ time.relativeISO(event.ts!) }} {{ event.msg }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ServiceEvent } from "@/api/talos/machine/machine.pb";
+
+import TIcon, { IconType } from "@/components/common/Icon/TIcon.vue";
+import { time } from "@/methods/time";
+
+defineProps<{
+  events?: ServiceEvent[],
+}>();
+
+const eventStyle = (state: string) => {
+  let color = "bg-naturals-N7";
+  let icon: IconType = "question";
+
+  switch (state) {
+  case "Running":
+    color = "bg-green-G2";
+    icon = "check"
+
+    break;
+  case "Starting":
+  case "Waiting":
+    color = "bg-yellow-Y2";
+    icon = "loading"
+
+    break;
+  case "Preparing":
+    icon = "time"
+  }
+
+  return {
+    color,
+    icon
+  }
+}
+</script>

--- a/frontend/src/views/cluster/SideBarNode.vue
+++ b/frontend/src/views/cluster/SideBarNode.vue
@@ -16,56 +16,66 @@ included in the LICENSE file.
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, Ref } from "vue";
+import { ref, onMounted, computed } from "vue";
 import { useRoute } from "vue-router";
 import { getContext } from "@/context";
 import { ResourceService, Resource } from "@/api/grpc";
 import { Runtime } from "@/api/common/omni.pb";
-import { TalosK8sNamespace, TalosNodenameID, TalosNodenameType, TalosRuntimeNamespace, TalosServiceType } from "@/api/resources"
-import { withContext, withRuntime } from "@/api/options";
+import { ClusterMachineIdentityType, DefaultNamespace, TalosRuntimeNamespace, TalosServiceType } from "@/api/resources"
+import { withRuntime } from "@/api/options";
 
 import TSidebarList, { SideBarItem } from "@/components/SideBar/TSideBarList.vue";
 import ClusterSideBar from "@/views/cluster/SideBar.vue";
+import Watch from "@/api/watch";
 
-const items: Ref<SideBarItem[]> = ref([]);
 const node = ref();
 const context = getContext();
 const route = useRoute();
 
-onMounted(async () => {
-  const response: Resource[] = await ResourceService.List(
-    {
+const services = ref<Resource[]>([]);
+
+const serviceWatch = new Watch(services);
+
+serviceWatch.setup(computed(() => {
+  return {
+    resource: {
       type: TalosServiceType,
       namespace: TalosRuntimeNamespace,
     },
-    withRuntime(Runtime.Talos),
-    withContext(context),
-  );
+    runtime: Runtime.Talos,
+    context: context,
+  }
+}));
 
-  const nodename: Resource<{ nodename: string }> = await ResourceService.Get(
-    {
-      type: TalosNodenameType,
-      id: TalosNodenameID,
-      namespace: TalosK8sNamespace,
-    },
-    withRuntime(Runtime.Talos),
-    withContext(context),
-  );
-  node.value = nodename.spec.nodename;
+const items = computed(() => {
+  const res: SideBarItem[] = [];
 
-  items.value = [];
-
-  for (const service of response) {
-    items.value.push({
-      name: service.metadata.id!,
+  for (const service of ['controller-runtime'].concat(services.value.map(item => item.metadata.id!))) {
+    res.push({
+      name: service,
       route: {
         name: "NodeLogs",
         params: {
           machine: route.params.machine as string,
-          service: service.metadata.id!
-        },
+          service: service
+        }
       },
     })
   }
+
+  return res;
+});
+
+onMounted(async () => {
+  const nodename: Resource<{ nodename: string }> = await ResourceService.Get(
+    {
+      type: ClusterMachineIdentityType,
+      id: route.params.machine as string,
+      namespace: DefaultNamespace,
+    },
+    withRuntime(Runtime.Omni),
+  );
+
+  node.value = nodename.spec.nodename;
 });
 </script>

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -347,7 +347,7 @@ func (suite *OmniSuite) newServer(suffix string, opts ...grpc.ServerOption) (*ma
 }
 
 func (suite *OmniSuite) SetupTest() {
-	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 20*time.Second)
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 60*time.Second)
 
 	suite.stateBuilder = dynamicStateBuilder{m: map[resource.Namespace]state.CoreState{}}
 


### PR DESCRIPTION
Also pull the service list from the `MachineService.ServiceList` API as it has more data than the resource and has services which haven't started yet.

The list is dynamically updated by subscribing on the machine events and filtering the events of type `ServiceStateEvent`.

Additionally make the sidebar service list dynamically update for consistency.

Fixes: https://github.com/siderolabs/omni/issues/21