### PR TITLE
fix: improve wording in authentication error messages

### DIFF
--- a/internal/backend/grpc/auth.go
+++ b/internal/backend/grpc/auth.go
@@ -214,7 +214,7 @@ func (s *authServer) ConfirmPublicKey(ctx context.Context, request *authpb.Confi
 	identity, err := safe.StateGet[*authres.Identity](ctx, s.state, authres.NewIdentity(resources.DefaultNamespace, email).Metadata())
 	if err != nil {
 		if state.IsNotFoundError(err) {
-			return nil, status.Errorf(codes.PermissionDenied, "The identity %q is not authorized to this instance", email)
+			return nil, status.Errorf(codes.PermissionDenied, "The identity %q is not authorized for this instance", email)
 		}
 
 		return nil, err

--- a/internal/pkg/auth/interceptor/jwt.go
+++ b/internal/pkg/auth/interceptor/jwt.go
@@ -82,7 +82,9 @@ func (i *JWT) intercept(ctx context.Context) (context.Context, error) {
 		var errEmailNotVerified *auth0.EmailNotVerifiedError
 
 		if errors.As(err, &errEmailNotVerified) {
-			return nil, status.Error(codes.Unauthenticated, fmt.Sprintf("Email address %q is not verified, please verify it and try again.", errEmailNotVerified.Email))
+			return nil, status.Error(codes.Unauthenticated,
+				fmt.Sprintf(`Email address %q is not verified. Please check your email for a message to verify it, then click "Log In" again.`,
+					errEmailNotVerified.Email))
 		}
 
 		return nil, errGRPCInvalidJWT


### PR DESCRIPTION
Fix the grammar and improve the error messages about authentication.