### PR TITLE
test: do not use epoch millis in service account names

### DIFF
--- a/cmd/integration-test/pkg/tests/auth.go
+++ b/cmd/integration-test/pkg/tests/auth.go
@@ -164,7 +164,7 @@ func AssertRegisterPublicKeyWithUnknownEmail(testCtx context.Context, cli *clien
 // AssertServiceAccountAPIFlow tests the service account lifecycle and API calls using it.
 func AssertServiceAccountAPIFlow(testCtx context.Context, cli *client.Client) TestFunc {
 	return func(t *testing.T) {
-		name := fmt.Sprintf("test-%d", time.Now().UnixMilli())
+		name := "test-" + uuid.NewString()
 
 		saCli, armoredPublicKey, err := newServiceAccountClient(testCtx, cli, name)
 		require.NoError(t, err)

--- a/cmd/integration-test/pkg/tests/cli.go
+++ b/cmd/integration-test/pkg/tests/cli.go
@@ -14,9 +14,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/google/uuid"
 	"github.com/siderolabs/go-api-signature/pkg/pgp"
 	"github.com/siderolabs/go-api-signature/pkg/serviceaccount"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -60,7 +60,7 @@ func AssertDownloadUsingCLI(testCtx context.Context, client *client.Client, omni
 
 		require.Greater(t, len(images), 2)
 
-		name := fmt.Sprintf("test-%d", time.Now().UnixMilli())
+		name := "test-" + uuid.NewString()
 
 		key := createServiceAccount(testCtx, t, client, name)
 


### PR DESCRIPTION
To avoid any potential collisions based on timing.

Closes siderolabs/omni#303.