### PR TITLE
fix: properly generate machine config input versions in the migration

### DIFF
--- a/internal/backend/runtime/omni/migration/helpers.go
+++ b/internal/backend/runtime/omni/migration/helpers.go
@@ -18,7 +18,7 @@ import (
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 )
 
-func reconcileConfigInputs(ctx context.Context, st state.State, item *omni.ClusterMachine, withGenOptions bool) error {
+func reconcileConfigInputs(ctx context.Context, st state.State, item *omni.ClusterMachine, withGenOptions, withTalosVersion bool) error {
 	config := omni.NewClusterMachineConfig(resources.DefaultNamespace, item.Metadata().ID())
 
 	_, err := st.Get(ctx, config.Metadata())
@@ -46,6 +46,10 @@ func reconcileConfigInputs(ctx context.Context, st state.State, item *omni.Clust
 
 	if withGenOptions {
 		res = append(res, omni.NewMachineConfigGenOptions(resources.DefaultNamespace, item.Metadata().ID()))
+	}
+
+	if withTalosVersion {
+		res = append(res, omni.NewClusterMachineTalosVersion(resources.DefaultNamespace, item.Metadata().ID()))
 	}
 
 	inputs := make([]resource.Resource, 0, len(res))

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -1056,6 +1056,9 @@ func (suite *MigrationSuite) TestInstallDiskPatchMigration() {
 			},
 		},
 	}
+	m1Status.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+		Id: "id",
+	}
 
 	lbStatus := omni.NewLoadBalancerStatus(resources.DefaultNamespace, clusterName)
 	lbStatus.TypedSpec().Value.Healthy = true
@@ -1375,9 +1378,15 @@ func (suite *MigrationSuite) TestGenerateAllMaintenanceConfigs() {
 
 	m1Status := omni.NewMachineStatus(resources.DefaultNamespace, m1)
 	m1Status.TypedSpec().Value.TalosVersion = "v1.4.0"
+	m1Status.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+		Id: "id",
+	}
 
 	m2Status := omni.NewMachineStatus(resources.DefaultNamespace, m2)
 	m2Status.TypedSpec().Value.TalosVersion = "v1.5.0"
+	m2Status.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+		Id: "id",
+	}
 
 	lbStatus := omni.NewLoadBalancerStatus(resources.DefaultNamespace, clusterName)
 	lbStatus.TypedSpec().Value.Healthy = true
@@ -1403,6 +1412,10 @@ func (suite *MigrationSuite) TestGenerateAllMaintenanceConfigs() {
 		pair.MakePair[string, resource.Resource]("", omni.NewMachineSetNode(resources.DefaultNamespace, m1, machineSet)),
 		pair.MakePair[string, resource.Resource]("", omni.NewMachineSetNode(resources.DefaultNamespace, m2, machineSet)),
 		pair.MakePair[string, resource.Resource]("", clusterConfigVersion),
+		pair.MakePair[string, resource.Resource]("", omni.NewMachineConfigGenOptions(resources.DefaultNamespace, m1)),
+		pair.MakePair[string, resource.Resource]("", omni.NewMachineConfigGenOptions(resources.DefaultNamespace, m2)),
+		pair.MakePair[string, resource.Resource]("", omni.NewClusterMachineTalosVersion(resources.DefaultNamespace, m1)),
+		pair.MakePair[string, resource.Resource]("", omni.NewClusterMachineTalosVersion(resources.DefaultNamespace, m2)),
 	}
 
 	createResources = append(createResources, xslices.Map(machines, func(m machine) pair.Pair[string, resource.Resource] {

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -923,7 +923,7 @@ func removeConfigPatchesFromClusterMachines(ctx context.Context, st state.State,
 			return err
 		}
 
-		return reconcileConfigInputs(ctx, st, item, false)
+		return reconcileConfigInputs(ctx, st, item, false, false)
 	})
 }
 
@@ -957,7 +957,7 @@ func machineInstallDiskPatches(ctx context.Context, st state.State, _ *zap.Logge
 			return err
 		}
 
-		return reconcileConfigInputs(ctx, st, item, true)
+		return reconcileConfigInputs(ctx, st, item, true, false)
 	})
 }
 
@@ -1208,7 +1208,7 @@ func generateAllMaintenanceConfigs(ctx context.Context, st state.State, _ *zap.L
 			return err
 		}
 
-		return reconcileConfigInputs(ctx, st, item, true)
+		return reconcileConfigInputs(ctx, st, item, true, true)
 	})
 }
 


### PR DESCRIPTION
Looks like the test was broken in two places too and wasn't verifying anything:
- the status was missing the schematic and so the resources were just skipped by the `ClusterMachineConfig` controller.
- the `ClusterMachineTalosVersion` resources were ignored in the migration method and not created in the test.

So basically it was a bit outdated. Now it's in sync and I've checked that the test is failing with the buggy code.