### PR TITLE
feat: add Cache-Control header for head requests

### DIFF
--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -320,7 +320,7 @@ const download = async () => {
 
     phase.value = Phase.Generating;
 
-    await doRequest(url, { signal: controller.signal, method: "HEAD" });
+    await doRequest(url, { signal: controller.signal, method: "HEAD", headers: { "Cache-Control": "no-store" } });
 
     phase.value = Phase.Loading;
 


### PR DESCRIPTION
Added `Cache-Control: no-store` header to all `HEAD` requests in `/image` path.

Close #324 