### PR TITLE
fix: properly set `Cache-Control` header

### DIFF
--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -320,7 +320,7 @@ const download = async () => {
 
     phase.value = Phase.Generating;
 
-    await doRequest(url, { signal: controller.signal, method: "HEAD", headers: { "Cache-Control": "no-store" } });
+    await doRequest(url, { signal: controller.signal, method: "HEAD", headers: new Headers({ "Cache-Control": "no-store" }) });
 
     phase.value = Phase.Loading;
 


### PR DESCRIPTION
Looks like setting headers as `Record<string, string>` doesn't work. Should use `new Headers()` instead.