### PR TITLE
test: fix a data race in `MachineStatusSnapshotController` unit tests

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot_test.go
@@ -27,12 +27,16 @@ type MachineStatusSnapshotControllerSuite struct {
 }
 
 func (suite *MachineStatusSnapshotControllerSuite) TestReconcile() {
-	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
-	defer cancel()
-
 	require := suite.Require()
 
 	suite.startRuntime()
+
+	// wait for the runtime to stop, including all controllers and the tasks they started.
+	// this is necessary to prevent a data race on the test logger when a task finishes after the test ends.
+	suite.T().Cleanup(suite.wg.Wait)
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
+	suite.T().Cleanup(cancel)
 
 	siderolinkEventsCh := make(chan *omni.MachineStatusSnapshot)
 


### PR DESCRIPTION
Fix the flaky test due to the race caused by the test ending before the last log, `task finished`, is written by the task runner.