### PR TITLE
fix: ignore not found in the `MachineStatus` and `MachineStatusSnapshot`

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -282,6 +282,10 @@ func (ctrl *MachineStatusController) reconcileTearingDown(ctx context.Context, r
 
 	ready, err := r.Teardown(ctx, md)
 	if err != nil {
+		if state.IsNotFoundError(err) {
+			return r.RemoveFinalizer(ctx, machine.Metadata(), ctrl.Name())
+		}
+
 		return err
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot.go
@@ -201,6 +201,10 @@ func (ctrl *MachineStatusSnapshotController) reconcileTearingDown(ctx context.Co
 
 	ready, err := r.Teardown(ctx, md)
 	if err != nil {
+		if state.IsNotFoundError(err) {
+			return r.RemoveFinalizer(ctx, machine.Metadata(), ctrl.Name())
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Otherwise the controller might get stuck trying to destroy the resource forever.