### PR TITLE
fix: properly detect `authcode-keyboard` oidc mode

### DIFF
--- a/internal/backend/grpc/oidc.go
+++ b/internal/backend/grpc/oidc.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/omni/client/api/omni/oidc"
+	"github.com/siderolabs/omni/internal/backend/oidc/external"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 )
 
@@ -60,7 +61,7 @@ func (s *oidcServer) Authenticate(ctx context.Context, req *oidc.AuthenticateReq
 		return nil, status.Errorf(codes.PermissionDenied, "failed to authenticate request: %s", err)
 	}
 
-	if challenge := request.GetCodeChallenge(); challenge != nil {
+	if request.GetRedirectURI() == external.KeyCodeRedirectURL {
 		var code string
 
 		code, err = encodeToString(6)

--- a/internal/backend/oidc/external/external.go
+++ b/internal/backend/oidc/external/external.go
@@ -22,3 +22,6 @@ const ServiceAccountTokenLifetime = 10 * 365 * 24 * time.Hour
 
 // KeyRotationInterval specifies the interval in which the keys are rotated.
 const KeyRotationInterval = 30 * 24 * time.Hour
+
+// KeyCodeRedirectURL is the redirect URL for the keycode authentication method.
+const KeyCodeRedirectURL = "urn:ietf:wg:oauth:2.0:oob"

--- a/internal/backend/oidc/internal/client/client.go
+++ b/internal/backend/oidc/internal/client/client.go
@@ -35,7 +35,7 @@ func (Client) RedirectURIs() []string {
 	return []string{
 		"http://localhost:8000",
 		"http://localhost:18000",
-		"urn:ietf:wg:oauth:2.0:oob",
+		external.KeyCodeRedirectURL,
 	}
 }
 


### PR DESCRIPTION
Looks like my assumption wasn't correct.