### PR TITLE
fix: validate user email on creation

### DIFF
--- a/frontend/src/notification.ts
+++ b/frontend/src/notification.ts
@@ -11,29 +11,37 @@ export type Notification = {
 
 export const notification: Ref<Notification | null> = shallowRef(null);
 
-export const showError = (title: string, body?: string) => {
+export const showError = (title: string, body?: string, ref?: Ref<Notification | null>) => {
   console.error(`error occurred: title: ${title}, body: ${body}`)
 
-  notification.value = {
+  if (!ref) {
+    ref = notification;
+  }
+
+  ref.value = {
     props: {
       title: title,
       body: body,
       type: "error",
       close: () => {
-        notification.value = null;
+        ref.value = null;
       }
     }
   }
 };
 
-export const showSuccess = (title: string, body?: string) => {
-  notification.value = {
+export const showSuccess = (title: string, body?: string, ref?: Ref<Notification | null>) => {
+  if (!ref) {
+    ref = notification;
+  }
+
+  ref.value = {
     props: {
       title: title,
       body: body,
       type: "success",
       close: () => {
-        notification.value = null;
+        ref.value = null;
       }
     }
   }

--- a/frontend/src/views/omni/Modals/UserCreate.vue
+++ b/frontend/src/views/omni/Modals/UserCreate.vue
@@ -13,24 +13,29 @@ included in the LICENSE file.
       <close-button @click="close"/>
     </div>
 
-    <div class="flex gap-2 items-center">
-      <t-input title="User Email" class="flex-1 h-full" placeholder="..." v-model="identity"/>
-      <t-select-list
-          class="h-full"
-          title="Role"
-          :values="roles"
-          :defaultValue="RoleReader"
-          @checkedValue="value => role = value"
-      />
-      <t-button type="highlighted" @click="handleUserCreate" :disabled="!canManageUsers && authType !== AuthType.SAML" class="w-32 h-9">Create User</t-button>
+    <div class="flex flex-col w-full h-full gap-4">
+      <t-notification v-if="notification" v-bind="notification.props"/>
+
+      <div class="flex gap-2 items-center">
+        <t-input title="User Email" class="flex-1 h-full" placeholder="..." v-model="identity"/>
+        <t-select-list
+            class="h-full"
+            title="Role"
+            :values="roles"
+            :defaultValue="RoleReader"
+            @checkedValue="value => role = value"
+        />
+        <t-button type="highlighted" @click="handleUserCreate" :disabled="!canManageUsers && authType !== AuthType.SAML" class="w-32 h-9">Create User</t-button>
+      </div>
     </div>
+
   </div>
 </template>
 
 <script setup lang="ts">
-import { Ref, ref } from "vue";
+import { Ref, ref, shallowRef } from "vue";
 import { createUser } from "@/methods/user";
-import { showError, showSuccess } from "@/notification";
+import { Notification, showError, showSuccess } from "@/notification";
 import { useRouter } from "vue-router";
 import { RoleNone, RoleReader, RoleOperator, RoleAdmin } from "@/api/resources";
 
@@ -40,17 +45,20 @@ import { canManageUsers } from "@/methods/auth";
 import TSelectList from "@/components/common/SelectList/TSelectList.vue";
 import TInput from "@/components/common/TInput/TInput.vue";
 import { AuthType, authType } from "@/methods";
+import TNotification from "@/components/common/Notification/TNotification.vue";
+
+const notification: Ref<Notification | null> = shallowRef(null);
 
 const identity = ref("");
 const router = useRouter();
 
 const roles = [RoleNone, RoleReader, RoleOperator, RoleAdmin]
 
-const role: Ref<string> = ref(RoleReader);
+const role: Ref<string> = ref(RoleReader)
 
 const handleUserCreate = async () => {
   if (identity.value === "") {
-    showError("Failed to Create User", "User email is not defined");
+    showError("Failed to Create User", "User email is not defined", notification);
 
     return;
   }
@@ -58,7 +66,7 @@ const handleUserCreate = async () => {
   try {
     await createUser(identity.value, role.value);
   } catch (e) {
-    showError("Failed to Create User", e.message);
+    showError("Failed to Create User", e.message, notification);
 
     return;
   }

--- a/internal/backend/runtime/omni/export_test.go
+++ b/internal/backend/runtime/omni/export_test.go
@@ -30,8 +30,8 @@ func EtcdElections(ctx context.Context, client *clientv3.Client, electionKey str
 	return etcdElections(ctx, client, electionKey, logger, f)
 }
 
-func ClusterValidationOptions(st state.State, config *config.Params) []validated.StateOption {
-	return clusterValidationOptions(st, config)
+func ClusterValidationOptions(st state.State, etcdBackupConfig config.EtcdBackupParams, embeddedDiscoveryServiceConfig config.EmbeddedDiscoveryServiceParams) []validated.StateOption {
+	return clusterValidationOptions(st, etcdBackupConfig, embeddedDiscoveryServiceConfig)
 }
 
 func RelationLabelsValidationOptions() []validated.StateOption {
@@ -46,8 +46,8 @@ func MachineSetNodeValidationOptions(st state.State) []validated.StateOption {
 	return machineSetNodeValidationOptions(st)
 }
 
-func IdentityValidationOptions() []validated.StateOption {
-	return identityValidationOptions()
+func IdentityValidationOptions(samlConfig config.SAMLParams) []validated.StateOption {
+	return identityValidationOptions(samlConfig)
 }
 
 func ExposedServiceValidationOptions() []validated.StateOption {

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -270,14 +270,14 @@ func New(talosClientFactory *talos.ClientFactory, dnsService *dns.Service, workl
 
 	metricsRegistry.MustRegister(expvarCollector)
 
-	validationOptions := clusterValidationOptions(resourceState, config.Config)
+	validationOptions := clusterValidationOptions(resourceState, config.Config.EtcdBackup, config.Config.EmbeddedDiscoveryService)
 	validationOptions = append(validationOptions, relationLabelsValidationOptions()...)
 	validationOptions = append(validationOptions, accessPolicyValidationOptions()...)
 	validationOptions = append(validationOptions, aclValidationOptions(resourceState)...)
 	validationOptions = append(validationOptions, roleValidationOptions()...)
 	validationOptions = append(validationOptions, machineSetNodeValidationOptions(resourceState)...)
 	validationOptions = append(validationOptions, machineSetValidationOptions(resourceState, storeFactory)...)
-	validationOptions = append(validationOptions, identityValidationOptions()...)
+	validationOptions = append(validationOptions, identityValidationOptions(config.Config.Auth.SAML)...)
 	validationOptions = append(validationOptions, exposedServiceValidationOptions()...)
 	validationOptions = append(validationOptions, configPatchValidationOptions(resourceState)...)
 	validationOptions = append(validationOptions, etcdManualBackupValidationOptions()...)


### PR DESCRIPTION
Validate the user email when creating a new identity.

Closes siderolabs/omni#312.

**Preview**

<img width="952" alt="preview" src="https://github.com/siderolabs/omni/assets/1465819/e7b941dd-8688-45cc-837c-6f836ec1ac57">