### PR TITLE
fix: ignore not found `ClusterMachine` in the migrations

### DIFF
--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -1553,6 +1553,9 @@ func (suite *MigrationSuite) TestMigrateInstallImageConfigIntoGenOptions() {
 
 	for _, res := range []resource.Resource{
 		clusterMachine, clusterMachineConfig, configPatches, genOptions, clusterSecrets, lbConfig, cluster,
+		omni.NewMachineStatus(resources.DefaultNamespace, "test2"),
+		omni.NewMachineConfigGenOptions(resources.DefaultNamespace, "test2"),
+		omni.NewClusterMachineTalosVersion(resources.DefaultNamespace, "test2"),
 	} {
 		suite.Require().NoError(suite.state.Create(ctx, res, state.WithCreateOwner(res.Metadata().Owner())))
 	}

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1288,6 +1288,10 @@ func migrateInstallImageConfigIntoGenOptions(ctx context.Context, st state.State
 		var clusterMachine *omni.ClusterMachine
 
 		if clusterMachine, err = safe.StateGetByID[*omni.ClusterMachine](ctx, st, genOptions.Metadata().ID()); err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
 			return err
 		}
 


### PR DESCRIPTION
`migrateInstallImageConfigIntoGenOptions` was missing that check.
Add the check and add the test.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
(cherry picked from commit https://github.com/siderolabs/omni/commit/2e64c3152fd0d0275418ed32ecf5a9662755eab4)