### PR TITLE
fix: properly generate maintenance config patches

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/data/maintenance-config-patch.yaml
+++ b/internal/backend/runtime/omni/controllers/omni/data/maintenance-config-patch.yaml
@@ -4,7 +4,7 @@ apiUrl: {{ .APIURL }}
 ---
 apiVersion: v1alpha1
 kind: EventSinkConfig
-endpoint: '[fdae:41e4:649b:9303::1]:8090'
+endpoint: '[fdae:41e4:649b:9303::1]:{{ .EventSinkPort }}'
 ---
 apiVersion: v1alpha1
 kind: KmsgLogConfig

--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_patch_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_patch_test.go
@@ -32,7 +32,7 @@ func (suite *MaintenanceConfigPatchSuite) TestReconcile() {
 	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
 	defer cancel()
 
-	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMaintenanceConfigPatchController()))
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMaintenanceConfigPatchController(9999)))
 
 	machineID := "test-machine"
 
@@ -55,7 +55,7 @@ apiUrl: grpc://127.0.0.1:8080?grpc_tunnel=false&jointoken=tttt
 ---
 apiVersion: v1alpha1
 kind: EventSinkConfig
-endpoint: '[fdae:41e4:649b:9303::1]:8090'
+endpoint: '[fdae:41e4:649b:9303::1]:9999'
 ---
 apiVersion: v1alpha1
 kind: KmsgLogConfig

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -1449,7 +1449,7 @@ func (suite *MigrationSuite) TestGenerateAllMaintenanceConfigs() {
 	runtime, err := runtime.NewRuntime(suite.state, suite.logger)
 	suite.Require().NoError(err)
 
-	suite.Require().NoError(runtime.RegisterQController(omnictrl.NewMaintenanceConfigPatchController()))
+	suite.Require().NoError(runtime.RegisterQController(omnictrl.NewMaintenanceConfigPatchController(8090)))
 	suite.Require().NoError(runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil)))
 
 	runCtx, cancel := context.WithTimeout(ctx, time.Second)

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -31,6 +31,7 @@ import (
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/auth/scope"
+	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/image"
 )
 
@@ -1203,8 +1204,8 @@ func generateAllMaintenanceConfigs(ctx context.Context, st state.State, _ *zap.L
 		configPatch := omni.NewConfigPatch(resources.DefaultNamespace, omnictrl.MaintenanceConfigPatchPrefix+machineStatus.Metadata().ID())
 
 		if err = createOrUpdate(ctx, st, configPatch, func(res *omni.ConfigPatch) error {
-			return omnictrl.UpdateMaintenanceConfigPatch(res, machineStatus, connectionParams)
-		}, omnictrl.NewMaintenanceConfigPatchController().Name()); err != nil {
+			return omnictrl.UpdateMaintenanceConfigPatch(res, machineStatus, connectionParams, config.Config.EventSinkPort)
+		}, omnictrl.NewMaintenanceConfigPatchController(0).Name()); err != nil {
 			return err
 		}
 

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -213,7 +213,7 @@ func New(talosClientFactory *talos.ClientFactory, dnsService *dns.Service, workl
 		omnictrl.NewMachineExtensionsController(),
 		omnictrl.NewMachineSetStatusController(),
 		omnictrl.NewMachineSetEtcdAuditController(talosClientFactory, time.Minute),
-		omnictrl.NewMaintenanceConfigPatchController(),
+		omnictrl.NewMaintenanceConfigPatchController(config.Config.EventSinkPort),
 		omnictrl.NewRedactedClusterMachineConfigController(),
 		omnictrl.NewSchematicConfigurationController(imageFactoryClient),
 		omnictrl.NewSecretsController(storeFactory),


### PR DESCRIPTION
Accidentally hardcoded `8090` there :facepalm:

Fixes: https://github.com/siderolabs/omni/issues/310