### PR TITLE
fix: properly delete the item from the cached items slice

### DIFF
--- a/internal/backend/runtime/cosi/cosi.go
+++ b/internal/backend/runtime/cosi/cosi.go
@@ -171,7 +171,7 @@ func WatchLegacy(ctx context.Context, st state.State, md resource.Metadata, out 
 				}
 
 				if items != nil {
-					slices.Delete(items, index, index+1) //nolint:govet
+					items = slices.Delete(items, index, index+1)
 				}
 
 				channel.SendWithContext(ctx, out, responseFromResource(ev, r))


### PR DESCRIPTION
Should fix nil reference errors.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
(cherry picked from commit https://github.com/siderolabs/omni/commit/6286340e38363aefadada987e9ac865fedab38d1)