### PR TITLE
fix: use proper types in the machine status and snapshot controllers

### DIFF
--- a/internal/backend/runtime/omni/controllers/helpers/helpers.go
+++ b/internal/backend/runtime/omni/controllers/helpers/helpers.go
@@ -175,7 +175,11 @@ func HandleInput[T generic.ResourceWithRD, S generic.ResourceWithRD](ctx context
 			return zero, err
 		}
 
-		return zero, nil
+		if res.Metadata().Phase() == resource.PhaseTearingDown {
+			return zero, nil
+		}
+
+		return res, nil
 	}
 
 	if !res.Metadata().Finalizers().Has(finalizer) {

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
@@ -93,6 +93,7 @@ func (suite *MachineSetNodeSuite) TestReconcile() {
 		map[string]string{
 			omni.MachineStatusLabelCPU:       "AMD",
 			omni.MachineStatusLabelAvailable: "",
+			"userlabel":                      "value",
 		},
 	)
 
@@ -127,7 +128,7 @@ func (suite *MachineSetNodeSuite) TestReconcile() {
 	machineSet.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
 	machineSet.Metadata().Labels().Set(omni.LabelWorkerRole, "")
 
-	machineClass := newMachineClass(fmt.Sprintf("%s==amd64", omni.MachineStatusLabelArch))
+	machineClass := newMachineClass(fmt.Sprintf("%s==amd64", omni.MachineStatusLabelArch), "userlabel=value")
 
 	machineSet.TypedSpec().Value.MachineClass = &specs.MachineSetSpec_MachineClass{
 		Name:         machineClass.Metadata().ID(),
@@ -138,6 +139,9 @@ func (suite *MachineSetNodeSuite) TestReconcile() {
 	suite.Require().NoError(suite.state.Create(ctx, machineSet))
 
 	assertMachineSetNode(machines[0])
+	assertNoMachineSetNode(machines[1])
+	assertNoMachineSetNode(machines[2])
+	assertNoMachineSetNode(machines[3])
 
 	machineClass = newMachineClass(fmt.Sprintf("%s==AMD", omni.MachineStatusLabelCPU))
 

--- a/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status_test.go
@@ -194,7 +194,7 @@ func (suite *TalosUpgradeStatusSuite) TestUpdateVersionsMaintenance() {
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineSetStatusController()))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewSchematicConfigurationController(&imageFactoryClientMock{})))
 
-	clusterName := "talos-upgrade-cluster"
+	clusterName := "talos-upgrade-cluster-2"
 
 	cluster, machines := suite.createCluster(clusterName, 3, 1)
 


### PR DESCRIPTION
The return type should be input type, not the output type. Also leverage runner equality functions to not to restart the collectors if nothing changed.