### PR TITLE
fix: generate schematics with the extensions, meta and kernel args

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/machine.go
@@ -28,8 +28,15 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	talosschematic "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/talos"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 )
+
+// SchematicInfo contains all collected schematic information.
+type SchematicInfo struct {
+	talosschematic.SchematicInfo
+	Invalid bool
+}
 
 // Info contains information gathered about a machine.
 type Info struct { //nolint:govet
@@ -49,7 +56,7 @@ type Info struct { //nolint:govet
 	Blockdevices  []*specs.MachineStatusSpec_HardwareStatus_BlockDevice
 
 	PlatformMetadata *specs.MachineStatusSpec_PlatformMetadata
-	Schematic        *specs.MachineStatusSpec_Schematic
+	Schematic        *SchematicInfo
 
 	LastError       error
 	MachineID       string


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/omni/issues/378

That should fix the migration from the vanilla Talos images which do not exist in the image factory.