### PR TITLE
fix: use un-cached list in the `MachineSetNodeController`

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -13,7 +13,7 @@ replace (
 require (
 	github.com/adrg/xdg v0.4.0
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/cosi-project/runtime v0.4.5
+	github.com/cosi-project/runtime v0.4.6
 	github.com/fatih/color v1.17.0
 	github.com/google/uuid v1.6.0
 	github.com/gosuri/uiprogress v0.0.1

--- a/client/go.sum
+++ b/client/go.sum
@@ -26,8 +26,8 @@ github.com/containerd/go-cni v1.1.9 h1:ORi7P1dYzCwVM6XPN4n3CbkuOx/NZ2DOqy+SHRdo9
 github.com/containerd/go-cni v1.1.9/go.mod h1:XYrZJ1d5W6E2VOvjffL3IZq0Dz6bsVlERHbekNK90PM=
 github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
-github.com/cosi-project/runtime v0.4.5 h1:WNEuUa6TDOhWMU3vno1/a1WErZNFrPzqNzwcoR4Aw8I=
-github.com/cosi-project/runtime v0.4.5/go.mod h1:fucT88LYFzORKoXQ1SzITQ11nq0HlR10RAXW5jkPWHQ=
+github.com/cosi-project/runtime v0.4.6 h1:LEyU/+5JkYihGbMnfNiFHvBVUBKsMjYLzbpTHBJf3dc=
+github.com/cosi-project/runtime v0.4.6/go.mod h1:fucT88LYFzORKoXQ1SzITQ11nq0HlR10RAXW5jkPWHQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/containers/image/v5 v5.31.0
-	github.com/cosi-project/runtime v0.4.5
+	github.com/cosi-project/runtime v0.4.6
 	github.com/cosi-project/state-etcd v0.2.9
 	github.com/crewjam/saml v0.4.14
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cosi-project/runtime v0.4.5 h1:WNEuUa6TDOhWMU3vno1/a1WErZNFrPzqNzwcoR4Aw8I=
-github.com/cosi-project/runtime v0.4.5/go.mod h1:fucT88LYFzORKoXQ1SzITQ11nq0HlR10RAXW5jkPWHQ=
+github.com/cosi-project/runtime v0.4.6 h1:LEyU/+5JkYihGbMnfNiFHvBVUBKsMjYLzbpTHBJf3dc=
+github.com/cosi-project/runtime v0.4.6/go.mod h1:fucT88LYFzORKoXQ1SzITQ11nq0HlR10RAXW5jkPWHQ=
 github.com/cosi-project/state-etcd v0.2.9 h1:jPYLHvQEjAksqPxku7gcfX7o+a0cw289dAQfr58lWfE=
 github.com/cosi-project/state-etcd v0.2.9/go.mod h1:9PAv45buB5kWEGB+TuAk8FZxyRYxcB3198W/JndzcbA=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
@@ -98,10 +98,12 @@ func (ctrl *MachineSetNodeController) Run(ctx context.Context, r controller.Runt
 			return fmt.Errorf("error listing machine sets: %w", err)
 		}
 
-		allMachineSetNodes, err := safe.ReaderListAll[*omni.MachineSetNode](ctx, r)
+		machineSetNodes, err := r.ListUncached(ctx, resource.NewMetadata(resources.DefaultNamespace, omni.MachineSetNodeType, "", resource.VersionUndefined))
 		if err != nil {
 			return err
 		}
+
+		allMachineSetNodes := safe.NewList[*omni.MachineSetNode](machineSetNodes)
 
 		allMachines, err := safe.ReaderListAll[*omni.Machine](ctx, r)
 		if err != nil {


### PR DESCRIPTION
This change fixes race during machine allocation in the machine class based machine sets, which was happening due to the eventual consistency of the in-memory cache.