### PR TITLE
fix: make `MachineSetNode` controller select only connected machines

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
@@ -269,6 +269,12 @@ func (ctrl *MachineSetNodeController) createNodes(
 		selector.Terms = append(selector.Terms, resource.LabelTerm{
 			Key: omni.MachineStatusLabelAvailable,
 			Op:  resource.LabelOpExists,
+		}, resource.LabelTerm{
+			Key: omni.MachineStatusLabelConnected,
+			Op:  resource.LabelOpExists,
+		}, resource.LabelTerm{
+			Key: omni.MachineStatusLabelReportingEvents,
+			Op:  resource.LabelOpExists,
 		})
 
 		availableMachineClassMachines := allMachineStatuses.FilterLabelQuery(resource.RawLabelQuery(selector))

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
@@ -82,18 +82,24 @@ func (suite *MachineSetNodeSuite) TestReconcile() {
 
 	machines := suite.createMachines(
 		map[string]string{
-			omni.MachineStatusLabelArch:      "amd64",
-			omni.MachineStatusLabelAvailable: "",
+			omni.MachineStatusLabelArch:            "amd64",
+			omni.MachineStatusLabelAvailable:       "",
+			omni.MachineStatusLabelConnected:       "",
+			omni.MachineStatusLabelReportingEvents: "",
 		},
 		map[string]string{
-			omni.MachineStatusLabelAvailable: "",
-			omni.MachineStatusLabelArch:      "amd64",
+			omni.MachineStatusLabelAvailable:       "",
+			omni.MachineStatusLabelArch:            "amd64",
+			omni.MachineStatusLabelConnected:       "",
+			omni.MachineStatusLabelReportingEvents: "",
 		},
 		map[string]string{},
 		map[string]string{
-			omni.MachineStatusLabelCPU:       "AMD",
-			omni.MachineStatusLabelAvailable: "",
-			"userlabel":                      "value",
+			omni.MachineStatusLabelCPU:             "AMD",
+			omni.MachineStatusLabelAvailable:       "",
+			"userlabel":                            "value",
+			omni.MachineStatusLabelConnected:       "",
+			omni.MachineStatusLabelReportingEvents: "",
 		},
 	)
 
@@ -186,15 +192,21 @@ func (suite *MachineSetNodeSuite) TestReconcile() {
 	// add more machines and wait for the controller to scale up
 	machines = append(machines, suite.createMachines(
 		map[string]string{
-			omni.MachineStatusLabelCPU:       "AMD",
-			omni.MachineStatusLabelAvailable: "",
+			omni.MachineStatusLabelCPU:             "AMD",
+			omni.MachineStatusLabelAvailable:       "",
+			omni.MachineStatusLabelConnected:       "",
+			omni.MachineStatusLabelReportingEvents: "",
 		},
 		map[string]string{
-			omni.MachineStatusLabelCPU: "AMD",
+			omni.MachineStatusLabelCPU:             "AMD",
+			omni.MachineStatusLabelConnected:       "",
+			omni.MachineStatusLabelReportingEvents: "",
 		},
 		map[string]string{
-			omni.MachineStatusLabelCPU:       "AMD",
-			omni.MachineStatusLabelAvailable: "",
+			omni.MachineStatusLabelCPU:             "AMD",
+			omni.MachineStatusLabelAvailable:       "",
+			omni.MachineStatusLabelConnected:       "",
+			omni.MachineStatusLabelReportingEvents: "",
 		},
 	)...)
 


### PR DESCRIPTION
Filter them in the same way as in manual allocation: available, connected and reporting events.