### PR TITLE
fix: detect the old vs. new URL format correctly on workload proxying

### DIFF
--- a/internal/backend/workloadproxy/handler.go
+++ b/internal/backend/workloadproxy/handler.go
@@ -174,7 +174,7 @@ func (h *HTTPHandler) parseServiceAliasFromHost(request *http.Request) string {
 		return ""
 	}
 
-	if isNewFormat := len(proxyServiceHostPrefixParts) == 2; isNewFormat {
+	if isNewFormat := proxyServiceHostPrefixParts[0] != LegacyHostPrefix; isNewFormat {
 		return proxyServiceHostPrefixParts[0]
 	}
 


### PR DESCRIPTION
Requests targeting workload proxies were incorrectly detected to be in the old URL format with the `p-` prefix when the instance name had a dash (`-`) in it.

Fix it by checking explicitly for the `p-` prefix in the logic.

Add a test to cover this case.