### PR TITLE
feat: add `Equinix metal` option in the download installation media

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/installation_media.go
+++ b/internal/backend/runtime/omni/controllers/omni/installation_media.go
@@ -144,6 +144,20 @@ var installationMedia = []installationMediaSpec{
 		ContentType:  "application/x-xz",
 	},
 	{
+		Name:         "Equinix Metal (amd64)",
+		Architecture: amd64Arch,
+		Profile:      "equinixMetal",
+		Type:         rawType,
+		ContentType:  "application/x-xz",
+	},
+	{
+		Name:         "Equinix Metal (arm64)",
+		Architecture: arm64Arch,
+		Profile:      "equinixMetal",
+		Type:         rawType,
+		ContentType:  "application/x-xz",
+	},
+	{
 		Name:         "NoCloud (amd64)",
 		Architecture: amd64Arch,
 		Profile:      "nocloud",


### PR DESCRIPTION
It looks like it was missing there.