### PR TITLE
fix: do not re-create peer on the remote addr change

### DIFF
--- a/internal/backend/grpc/router/router.go
+++ b/internal/backend/grpc/router/router.go
@@ -362,11 +362,13 @@ func (r *Router) ResourceWatcher(ctx context.Context, s state.State, logger *zap
 			case state.Bootstrapped:
 				// ignore
 			case state.Created, state.Updated, state.Destroyed:
-				if e.Type == state.Destroyed && e.Resource.Metadata().Type() == omni.MachineType {
-					id := fmt.Sprintf("machine-%s", e.Resource.Metadata().ID())
-					r.removeBackend(id)
+				if e.Resource.Metadata().Type() == omni.MachineType {
+					if e.Type == state.Destroyed {
+						id := fmt.Sprintf("machine-%s", e.Resource.Metadata().ID())
+						r.removeBackend(id)
 
-					logger.Info("remove machine talos backend", zap.String("id", id))
+						logger.Info("remove machine talos backend", zap.String("id", id))
+					}
 
 					continue
 				}

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status.go
@@ -188,8 +188,7 @@ func NewClusterMachineStatusController() *ClusterMachineStatusController {
 				case machineapi.MachineStatusEvent_RUNNING:
 					cmsVal.Stage = specs.ClusterMachineStatusSpec_RUNNING
 				case machineapi.MachineStatusEvent_MAINTENANCE:
-					// shouldn't happen as machine config should be submitted
-					cmsVal.Stage = specs.ClusterMachineStatusSpec_UNKNOWN
+					cmsVal.Stage = specs.ClusterMachineStatusSpec_CONFIGURING
 				}
 
 				clusterMachineIdentity, err := safe.ReaderGet[*omni.ClusterMachineIdentity](ctx, r, omni.NewClusterMachineIdentity(


### PR DESCRIPTION
And exclude port from the saved address.

Additionally fix Talos backends cache to not to
react on the `MachineType` `Create` and `Update` events.