### PR TITLE
fix: enable etcd client keep-alives by default

### DIFF
--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -393,6 +393,10 @@ func init() {
 	rootCmd.Flags().BoolVar(&config.Config.Storage.Etcd.EmbeddedUnsafeFsync, "etcd-embedded-unsafe-fsync", config.Config.Storage.Etcd.EmbeddedUnsafeFsync,
 		"disable fsync in the embedded etcd server (dangerous).")
 	rootCmd.Flags().StringSliceVar(&config.Config.Storage.Etcd.Endpoints, "etcd-endpoints", config.Config.Storage.Etcd.Endpoints, "external etcd endpoints.")
+	rootCmd.Flags().DurationVar(&config.Config.Storage.Etcd.DialKeepAliveTime,
+		"etcd-dial-keepalive-time", config.Config.Storage.Etcd.DialKeepAliveTime, "external etcd client keep-alive time (interval).")
+	rootCmd.Flags().DurationVar(&config.Config.Storage.Etcd.DialKeepAliveTimeout,
+		"etcd-dial-keepalive-timeout", config.Config.Storage.Etcd.DialKeepAliveTimeout, "external etcd client keep-alive timeout.")
 	rootCmd.Flags().StringVar(&config.Config.Storage.Etcd.CAPath, "etcd-ca-path", config.Config.Storage.Etcd.CAPath, "external etcd CA path.")
 	rootCmd.Flags().StringVar(&config.Config.Storage.Etcd.CertPath, "etcd-client-cert-path", config.Config.Storage.Etcd.CertPath, "external etcd client cert path.")
 	rootCmd.Flags().StringVar(&config.Config.Storage.Etcd.KeyPath, "etcd-client-key-path", config.Config.Storage.Etcd.KeyPath, "external etcd client key path.")

--- a/internal/backend/runtime/omni/state_etcd.go
+++ b/internal/backend/runtime/omni/state_etcd.go
@@ -272,10 +272,11 @@ func getExternalEtcdClient(ctx context.Context, params *config.EtcdParams, logge
 	}
 
 	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   params.Endpoints,
-		DialTimeout: 5 * time.Second,
+		Endpoints:            params.Endpoints,
+		DialKeepAliveTime:    params.DialKeepAliveTime,
+		DialKeepAliveTimeout: params.DialKeepAliveTimeout,
+		DialTimeout:          5 * time.Second,
 		DialOptions: []grpc.DialOption{
-			grpc.WithBlock(), //nolint:staticcheck
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize)),
 			grpc.WithSharedWriteBuffer(true),
 		},

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -166,10 +166,12 @@ type BoltDBParams struct {
 // EtcdParams defines etcd storage configs.
 type EtcdParams struct { ///nolint:govet
 	// External etcd: list of endpoints, as host:port pairs.
-	Endpoints []string `yaml:"endpoints"`
-	CAPath    string   `yaml:"caPath"`
-	CertPath  string   `yaml:"certPath"`
-	KeyPath   string   `yaml:"keyPath"`
+	Endpoints            []string      `yaml:"endpoints"`
+	DialKeepAliveTime    time.Duration `yaml:"dialKeepAliveTime"`
+	DialKeepAliveTimeout time.Duration `yaml:"dialKeepAliveTimeout"`
+	CAPath               string        `yaml:"caPath"`
+	CertPath             string        `yaml:"certPath"`
+	KeyPath              string        `yaml:"keyPath"`
 
 	// Use embedded etcd server (no clustering).
 	Embedded            bool   `yaml:"embedded"`
@@ -248,10 +250,12 @@ var (
 				Path: "_out/omni.db",
 			},
 			Etcd: EtcdParams{
-				Endpoints: []string{"http://localhost:2379"},
-				CAPath:    "etcd/ca.crt",
-				CertPath:  "etcd/client.crt",
-				KeyPath:   "etcd/client.key",
+				Endpoints:            []string{"http://localhost:2379"},
+				DialKeepAliveTime:    30 * time.Second,
+				DialKeepAliveTimeout: 5 * time.Second,
+				CAPath:               "etcd/ca.crt",
+				CertPath:             "etcd/client.crt",
+				KeyPath:              "etcd/client.key",
 
 				Embedded:       true,
 				EmbeddedDBPath: "_out/etcd/",


### PR DESCRIPTION
Make them configurable, but provide sane defaults out of the box.

Part of #427