### PR TITLE
chore: bump deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/go-tail v0.1.1
 	github.com/siderolabs/go-talos-support v0.1.0
-	github.com/siderolabs/grpc-proxy v0.4.0
+	github.com/siderolabs/grpc-proxy v0.4.1
 	github.com/siderolabs/image-factory v0.4.1
 	github.com/siderolabs/kms-client v0.1.0
 	github.com/siderolabs/omni/client v0.0.0-00010101000000-000000000000

--- a/go.sum
+++ b/go.sum
@@ -434,8 +434,8 @@ github.com/siderolabs/go-tail v0.1.1 h1:3XeJgd97OHyFAIE7nQEMcRhOfnv7DvXbu0BRKbtT
 github.com/siderolabs/go-tail v0.1.1/go.mod h1:IihAL39acadXHfb5fEAOKK2DaDFIrG2+VD3b2H/ziZ0=
 github.com/siderolabs/go-talos-support v0.1.0 h1:ulf+RI0Wo6UGzKQJZog1uvdQE/zstogs1R46jZpAmvU=
 github.com/siderolabs/go-talos-support v0.1.0/go.mod h1:hiYQrdQSBH6ap7LZHyHUZLbYnL2KhC6hPrJ7utqm+P8=
-github.com/siderolabs/grpc-proxy v0.4.0 h1:zYrhqLYs8JlYoLHYeel7/XwXDZ4OJ5XyP9wX7JlbPew=
-github.com/siderolabs/grpc-proxy v0.4.0/go.mod h1:QDurYOwQD4H8BKyvCuUxMiuG/etYnb/++xaQB644NdU=
+github.com/siderolabs/grpc-proxy v0.4.1 h1:UTYviMqb65oKjnH7dy5D+U4zMJ6iCTjAN6x6K/Ss120=
+github.com/siderolabs/grpc-proxy v0.4.1/go.mod h1:QwQuLUpJrlN08kpP0m63oO/SEeoz0dEhU9ndlBafc0Y=
 github.com/siderolabs/image-factory v0.4.1 h1:qyTbK7ZTCZ4hg/rRVfmwkEMWSoltRpCL/YUAPje4UaA=
 github.com/siderolabs/image-factory v0.4.1/go.mod h1:XrH8VJfOBYEJrH0eB7Tru30MPKouT9BDFQfo6hQgA3U=
 github.com/siderolabs/kms-client v0.1.0 h1:rCDWzcDDsNlp6zdyLngOuuhchVILn+vwUQy3tk6rQps=

--- a/internal/backend/grpc/router/router.go
+++ b/internal/backend/grpc/router/router.go
@@ -83,9 +83,11 @@ func NewRouter(
 			return transport.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithCodec(proxy.Codec()), //nolint:staticcheck
-		// we are proxying requests to ourselves, so we don't need to impose a limit
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(math.MaxInt32)),
+		grpc.WithDefaultCallOptions(
+			// we are proxying requests to ourselves, so we don't need to impose a limit
+			grpc.MaxCallRecvMsgSize(math.MaxInt32),
+			grpc.ForceCodec(proxy.Codec()),
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial omni backend: %w", err)
@@ -279,7 +281,7 @@ func (r *Router) getConn(ctx context.Context, contextName string) (*grpc.ClientC
 			MinConnectTimeout: 20 * time.Second,
 		}),
 		grpc.WithTransportCredentials(creds),
-		grpc.WithCodec(proxy.Codec()), //nolint:staticcheck
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(proxy.Codec())),
 		grpc.WithSharedWriteBuffer(true),
 	}
 

--- a/internal/backend/grpc/router/server.go
+++ b/internal/backend/grpc/router/server.go
@@ -28,7 +28,7 @@ type Director interface {
 func NewServer(router Director, options ...grpc.ServerOption) *grpc.Server {
 	opts := append(
 		[]grpc.ServerOption{
-			grpc.CustomCodec(proxy.Codec()), //nolint:staticcheck
+			grpc.ForceServerCodec(proxy.Codec()),
 			grpc.UnknownServiceHandler(
 				proxy.TransparentHandler(
 					router.Director,

--- a/internal/backend/grpc/router/talos_backend_test.go
+++ b/internal/backend/grpc/router/talos_backend_test.go
@@ -205,7 +205,7 @@ func dial(serverEndpoint string) (*grpc.ClientConn, error) {
 			MinConnectTimeout: 20 * time.Second,
 		}),
 		grpc.WithTransportCredentials(creds),
-		grpc.WithCodec(proxy.Codec()), //nolint:staticcheck
+		grpc.WithDefaultCallOptions(grpc.ForceCodec(proxy.Codec())),
 	}
 
 	return grpc.NewClient(serverEndpoint, opts...)


### PR DESCRIPTION
Bump github.com/siderolabs/grpc-proxy to v0.4.1 and replace deprecated calls to `grpc.CustomCodec`.

Same as in https://github.com/siderolabs/talos/pull/8999