### PR TITLE
fix: add missing `return err` in the maintenance config drop migration

### DIFF
--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1274,6 +1274,8 @@ func dropGeneratedMaintenanceConfigs(ctx context.Context, st state.State, _ *zap
 			if state.IsNotFoundError(err) {
 				return nil
 			}
+
+			return err
 		}
 
 		// remove finalizers and destroy the resource


### PR DESCRIPTION
Otherwise we might miss the errors.