### PR TITLE
fix: do not expect LB to be healthy when scaling down workers

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/workers_handler.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/workers_handler.go
@@ -24,10 +24,6 @@ func ReconcileWorkers(rc *ReconciliationContext) []Operation {
 		operations = append(operations, &Create{ID: id})
 	}
 
-	if !rc.LBHealthy() {
-		return operations
-	}
-
 	for _, id := range toTeardown {
 		operations = append(operations, &Teardown{ID: id, Quota: &quota})
 	}

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_status_test.go
@@ -284,7 +284,7 @@ func (suite *MachineSetStatusSuite) TestScaleUp() {
 
 // TestScaleDown create a machine set with 3 machines
 // which are not running. Immediately try to scale down.
-// Scale down should be blocked until the machines become ready.
+// Scale down should remove the first machine.
 // Make all machines ready, check that machines count went to 2 and the machine set is ready.
 func (suite *MachineSetStatusSuite) TestScaleDown() {
 	clusterName := "scale-down"
@@ -304,7 +304,7 @@ func (suite *MachineSetStatusSuite) TestScaleDown() {
 
 	suite.assertMachineSetPhase(machineSet, specs.MachineSetPhase_ScalingUp)
 
-	expectedMachines := []string{"scaledown-1", "scaledown-2", "scaledown-3"}
+	expectedMachines := []string{"scaledown-2", "scaledown-3"}
 
 	suite.assertMachinesState(expectedMachines, clusterName, machineSet.Metadata().ID())
 
@@ -324,7 +324,7 @@ func (suite *MachineSetStatusSuite) TestScaleDown() {
 	suite.Require().NoError(err)
 
 	suite.Assert().NoError(retry.Constant(5*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-		suite.assertNoResource(*omni.NewClusterMachine(resources.DefaultNamespace, expectedMachines[0]).Metadata()),
+		suite.assertNoResource(*omni.NewClusterMachine(resources.DefaultNamespace, machines[0]).Metadata()),
 	))
 
 	suite.assertMachineSetPhase(machineSet, specs.MachineSetPhase_Running)


### PR DESCRIPTION
As we now have node audit and discovery service cleanup we don't have a strong requirement for LB to be healthy at the point of the node deletion.

This change will speed up nodes deletion and will not block the node deletion for the unhealthy clusters.