### PR TITLE
fix: use proper check for the machine set teardown flow

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_set_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_status.go
@@ -213,7 +213,7 @@ func (handler *machineSetStatusHandler) reconcileTearingDown(ctx context.Context
 
 	clusterMachinesCount := uint32(len(rc.GetClusterMachines()))
 	// no cluster machines release the finalizer
-	if clusterMachinesCount == 0 {
+	if clusterMachinesCount == 0 && len(rc.GetMachineSetNodes()) == 0 {
 		logger.Info("machineset torn down", zap.String("machineset", machineSet.Metadata().ID()))
 
 		return nil


### PR DESCRIPTION
The condition was buggy: the controller wasn't removing finalizers from the `MachineSetNode`s if the machine set had 0 cluster machines.