### PR TITLE
fix: do not divide by 0 on the machine stats page

### DIFF
--- a/frontend/src/views/omni/Machines/Machines.vue
+++ b/frontend/src/views/omni/Machines/Machines.vue
@@ -76,6 +76,10 @@ const watchOpts = computed<WatchOptions>(() => {
 
 const getCapacity = (item: Resource<MachineStatusMetricsSpec>) => {
   const registered = item?.spec.registered_machines_count ?? 0;
+  if (registered == 0) {
+    return 0;
+  }
+
   const allocated = item?.spec.allocated_machines_count ?? 0;
   const free = registered - allocated;
 


### PR DESCRIPTION
If the number of registered machines is 0 just return 0 capacity.