### PR TITLE
chore: add request label to the links created by the cloud provider

### DIFF
--- a/client/pkg/omni/resources/omni/labels.go
+++ b/client/pkg/omni/resources/omni/labels.go
@@ -59,6 +59,10 @@ const (
 
 	// LabelMachineClassName is the name of the machine class.
 	LabelMachineClassName = SystemLabelPrefix + "machine-class-name"
+
+	// LabelMachineRequest is the machine request label.
+	// tsgen:LabelMachineRequest
+	LabelMachineRequest = SystemLabelPrefix + "machine-request"
 )
 
 const (

--- a/frontend/src/views/omni/ItemLabels/ItemLabels.vue
+++ b/frontend/src/views/omni/ItemLabels/ItemLabels.vue
@@ -36,6 +36,7 @@ const { resource } = toRefs(props);
 defineEmits(['filterLabel']);
 
 const labelOrder = {
+  "machine-request": -1,
   "reporting-events": -1,
   "invalid-state": 0,
   "cluster": 0,

--- a/frontend/src/views/omni/Machines/MachineItem.vue
+++ b/frontend/src/views/omni/Machines/MachineItem.vue
@@ -166,8 +166,8 @@ const openMaintenanceUpdate = () => {
 const processors = computed(() => {
   const processors = machine?.value?.spec?.message_status?.hardware?.processors || [];
 
-  const format = (proc: { frequency: number; core_count: number; description: string }) => {
-    return `${proc.frequency / 1000} GHz, ${pluralize("core", proc.core_count, true)}, ${proc.description}`;
+  const format = (proc: { frequency?: number; core_count?: number; description?: string }) => {
+    return `${proc.frequency! / 1000} GHz, ${pluralize("core", proc.core_count, true)}, ${proc.description}`;
   };
 
   return processors.map(format);
@@ -176,16 +176,16 @@ const processors = computed(() => {
 const memorymodules = computed(() => {
   const memorymodules = machine?.value?.spec?.message_status?.hardware?.memory_modules || [];
 
-  const format = (mem: { description: string; size_mb: number; }) => {
+  const format = (mem: { description?: string; size_mb?: number; }) => {
     let description = mem.description;
 
     if (mem.description === undefined) {
       description = "";
     }
-    return `${formatBytes(mem.size_mb * 1024 * 1024)} ${description}`;
+    return `${formatBytes(mem.size_mb! * 1024 * 1024)} ${description}`;
   };
 
-  return memorymodules.filter((mem: { size_mb: number; }) => mem.size_mb !== 0).map(format);
+  return memorymodules.filter((mem: { size_mb?: number; }) => mem.size_mb !== 0).map(format);
 });
 
 const clusterName = computed(() => machine.value?.spec?.message_status?.cluster);

--- a/frontend/src/views/omni/Modals/MachineRemove.vue
+++ b/frontend/src/views/omni/Modals/MachineRemove.vue
@@ -25,7 +25,7 @@ included in the LICENSE file.
       </p>
 
       <p class="py-2">
-        If you want to remove the machine from the cluster, please use the <router-link :to="{ name: 'ClusterOverview', params: { cluster: $route.query.cluster }}">cluster overview page</router-link>.
+        If you want to remove the machine from the cluster, please use the <router-link :to="{ name: 'ClusterOverview', params: { cluster: $route.query.cluster as string }}">cluster overview page</router-link>.
       </p>
     </div>
 
@@ -67,9 +67,13 @@ const remove = async () => {
   disabled.value = true;
 
   try {
-    await removeMachine(route.query.machine as string)
+    await removeMachine(route.query.machine as string);
   } catch (e) {
-    showError("Failed to remove the machine", e.message)
+    close();
+
+    showError("Failed to remove the machine", e.message);
+
+    return;
   }
 
   close();

--- a/internal/backend/runtime/omni/controllers/omni/machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine.go
@@ -16,6 +16,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 )
 
 // MachineController creates omni.Machines based on siderolink.Link resources.
@@ -40,6 +41,8 @@ func NewMachineController() *MachineController {
 				if err != nil {
 					return err
 				}
+
+				helpers.CopyLabels(link, machine, omni.LabelMachineRequest)
 
 				spec := machine.TypedSpec().Value
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_request_link_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_request_link_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/cloud"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
+	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+)
+
+type MachineRequestLinkSuite struct {
+	OmniSuite
+}
+
+func (suite *MachineRequestLinkSuite) TestReconcile() {
+	require := suite.Require()
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
+	defer cancel()
+
+	suite.startRuntime()
+
+	require.NoError(suite.runtime.RegisterQController(omnictrl.NewMachineRequestLinkController(suite.state)))
+
+	uuid := "aabb"
+	requestID := "request-1"
+
+	status := cloud.NewMachineRequestStatus(requestID)
+	status.TypedSpec().Value.Id = uuid
+
+	suite.Require().NoError(suite.state.Create(ctx, status))
+	suite.Require().NoError(suite.state.Create(ctx, siderolink.NewLink(resources.DefaultNamespace, uuid, nil)))
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{uuid}, func(link *siderolink.Link, assert *assert.Assertions) {
+		request, ok := link.Metadata().Labels().Get(omni.LabelMachineRequest)
+
+		assert.True(ok)
+		assert.Equal(requestID, request)
+	})
+}
+
+func TestMachineRequestLinkSuite(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, new(MachineRequestLinkSuite))
+}

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -249,6 +249,8 @@ func (ctrl *MachineStatusController) reconcileRunning(ctx context.Context, r con
 
 		spec.Connected = connected
 
+		helpers.CopyLabels(machine, m, omni.LabelMachineRequest)
+
 		if connected {
 			m.Metadata().Labels().Set(omni.MachineStatusLabelConnected, "")
 			m.Metadata().Labels().Delete(omni.MachineStatusLabelDisconnected)

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -245,6 +245,7 @@ func New(talosClientFactory *talos.ClientFactory, dnsService *dns.Service, workl
 		omnictrl.NewTalosExtensionsController(imageFactoryClient),
 		omnictrl.NewTalosUpgradeStatusController(),
 		omnictrl.NewMachineStatusSnapshotController(siderolinkEventsCh),
+		omnictrl.NewMachineRequestLinkController(resourceState),
 	}
 
 	if config.Config.Auth.SAML.Enabled {


### PR DESCRIPTION
The controller handles all `MachineRequestStatuses` and adds labels to the links which IDs is specified in the `MachineRequestStatus` spec.

This flow should help to identify which links are managed by the machine requests.