### PR TITLE
fix: fix nil pointer dereference in workload proxy reconciler

### DIFF
--- a/internal/backend/workloadproxy/reconciler.go
+++ b/internal/backend/workloadproxy/reconciler.go
@@ -134,7 +134,10 @@ func (registry *Reconciler) ensureLB(lbSts *lbStatus, cluster resource.ID, alias
 		}
 	}
 
-	lbSts.upstreamAddresses = upstreamAddresses
+	if lbSts != nil {
+		lbSts.upstreamAddresses = upstreamAddresses
+	}
+
 	registry.aliasToCluster[alias] = cluster
 
 	aliasToLB := registry.clusterToAliasToLBStatus[cluster]


### PR DESCRIPTION
Add the missed `nil` reference check to the workload proxy TCP load balancer upstreams reconciler.