### PR TITLE
fix: add gRPC read buffer pool for etcd client

### DIFF
--- a/internal/backend/runtime/omni/state_etcd.go
+++ b/internal/backend/runtime/omni/state_etcd.go
@@ -29,6 +29,7 @@ import (
 	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/experimental"
 
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/panichandler"
@@ -210,9 +211,9 @@ func getEmbeddedEtcdClient(ctx context.Context, params *config.EtcdParams, logge
 		Endpoints:   xslices.Map(embeddedServer.Clients, func(l net.Listener) string { return l.Addr().String() }),
 		DialTimeout: 5 * time.Second,
 		DialOptions: []grpc.DialOption{
-			grpc.WithBlock(), //nolint:staticcheck
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize)),
 			grpc.WithSharedWriteBuffer(true),
+			experimental.WithRecvBufferPool(grpc.NewSharedBufferPool()),
 		},
 		Logger: logger.WithOptions(
 			// never enable debug logs for etcd client, they are too chatty
@@ -279,6 +280,7 @@ func getExternalEtcdClient(ctx context.Context, params *config.EtcdParams, logge
 		DialOptions: []grpc.DialOption{
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize)),
 			grpc.WithSharedWriteBuffer(true),
+			experimental.WithRecvBufferPool(grpc.NewSharedBufferPool()),
 		},
 		TLS: tlsConfig,
 		Logger: logger.WithOptions(


### PR DESCRIPTION
As Omni does lots of gRPC operations with etcd, it should help.

![image](https://github.com/user-attachments/assets/7d713727-d2ae-4440-898c-d22065b569bf)
