### PR TITLE
fix: properly remove `MachineSetNode` finalizer in the controller

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status.go
@@ -46,6 +46,11 @@ func NewClusterMachineStatusController() *ClusterMachineStatusController {
 					return err
 				}
 
+				machineSetNode, err := helpers.HandleInput[*omni.MachineSetNode](ctx, r, clusterMachineStatusControllerName, clusterMachine)
+				if err != nil {
+					return err
+				}
+
 				helpers.CopyLabels(clusterMachine, clusterMachineStatus,
 					omni.LabelCluster,
 					omni.LabelControlPlaneRole,
@@ -87,11 +92,6 @@ func NewClusterMachineStatusController() *ClusterMachineStatusController {
 				}
 
 				cmsVal.IsRemoved = machineStatus.Metadata().Phase() == resource.PhaseTearingDown
-
-				machineSetNode, err := helpers.HandleInput[*omni.MachineSetNode](ctx, r, clusterMachineStatusControllerName, clusterMachine)
-				if err != nil {
-					return err
-				}
 
 				var locked bool
 				if machineSetNode != nil {
@@ -201,6 +201,14 @@ func NewClusterMachineStatusController() *ClusterMachineStatusController {
 
 				if clusterMachineIdentity != nil {
 					clusterMachineStatus.Metadata().Labels().Set(omni.ClusterMachineStatusLabelNodeName, clusterMachineIdentity.TypedSpec().Value.Nodename)
+				}
+
+				return nil
+			},
+			FinalizerRemovalExtraOutputFunc: func(ctx context.Context, rw controller.ReaderWriter, _ *zap.Logger, clusterMachine *omni.ClusterMachine) error {
+				_, err := helpers.HandleInput[*omni.MachineSetNode](ctx, rw, clusterMachineStatusControllerName, clusterMachine)
+				if err != nil {
+					return err
 				}
 
 				return nil

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/go-retry/retry"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -30,6 +31,15 @@ func (suite *ClusterMachineStatusSuite) setup() {
 	suite.startRuntime()
 
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewClusterMachineStatusController()))
+}
+
+func (suite *ClusterMachineStatusSuite) TearDownTest() {
+	rtestutils.DestroyAll[*omni.ClusterMachine](suite.ctx, suite.T(), suite.state)
+	rtestutils.DestroyAll[*omni.Machine](suite.ctx, suite.T(), suite.state)
+	rtestutils.DestroyAll[*omni.MachineStatus](suite.ctx, suite.T(), suite.state)
+	rtestutils.DestroyAll[*omni.MachineSetNode](suite.ctx, suite.T(), suite.state)
+	rtestutils.DestroyAll[*omni.ClusterMachineConfigStatus](suite.ctx, suite.T(), suite.state)
+	rtestutils.DestroyAll[*omni.MachineStatusSnapshot](suite.ctx, suite.T(), suite.state)
 }
 
 func (suite *ClusterMachineStatusSuite) TestNoMachineStatusSnapShotClusterStatusZeroValue() {


### PR DESCRIPTION
`ClusterMachineStatus` controller should call `HandleInput` in the `FinalizerRemovalExtraOutputFunc` too.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
(cherry picked from commit ee7308376aa05411f11e739148989ac2b1403463)