### PR TITLE
feat: bump kube-service-exposer to v0.2.0

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/data/kube-service-exposer-config-patch.tmpl.yaml
+++ b/internal/backend/runtime/omni/controllers/omni/data/kube-service-exposer-config-patch.tmpl.yaml
@@ -52,9 +52,10 @@ cluster:
                 - operator: Exists
               containers:
                 - name: omni-kube-service-exposer
-                  image: ghcr.io/siderolabs/kube-service-exposer:v0.1.4
+                  image: ghcr.io/siderolabs/kube-service-exposer:v0.2.0
                   args:
                     - --debug=false
                     - --annotation-key={{ .AnnotationKey }}
                     # siderolink CIDR
                     - --bind-cidrs="fdae:41e4:649b:9303::/64"
+                    - --disallowed-host-port-ranges=6443,10250,50000-50001


### PR DESCRIPTION
Contains the fix for the goroutine leak on port conflict, see: https://github.com/siderolabs/kube-service-exposer/releases/tag/v0.2.0

Also, use the new `--disallowed-host-port-ranges` flag to prevent a set of known ports used by Talos to not be used by the exposer.

Closes #502.