### PR TITLE
chore: use range-over-func iterators for resource iteration

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -13,7 +13,7 @@ replace (
 require (
 	github.com/adrg/xdg v0.5.0
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/cosi-project/runtime v0.5.5
+	github.com/cosi-project/runtime v0.6.0
 	github.com/fatih/color v1.17.0
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/google/uuid v1.6.0

--- a/client/go.sum
+++ b/client/go.sum
@@ -23,8 +23,8 @@ github.com/containerd/go-cni v1.1.10 h1:c2U73nld7spSWfiJwSh/8W9DK+/qQwYM2rngIhCy
 github.com/containerd/go-cni v1.1.10/go.mod h1:/Y/sL8yqYQn1ZG1om1OncJB1W4zN3YmjfP/ShCzG/OY=
 github.com/containernetworking/cni v1.2.2 h1:9IbP6KJQQxVKo4hhnm8r50YcVKrJbJu3Dqw+Rbt1vYk=
 github.com/containernetworking/cni v1.2.2/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
-github.com/cosi-project/runtime v0.5.5 h1:GFoHnngpg4QVZluAUDwUbCe/sYOYBXKULxL/6DD99pU=
-github.com/cosi-project/runtime v0.5.5/go.mod h1:m+bkfUzKYeUyoqYAQBxdce3bfgncG8BsqcbfKRbvJKs=
+github.com/cosi-project/runtime v0.6.0 h1:ufybTVO1TUVx3YbuazVGKjYd0XoBBlaTvT3W30t09oc=
+github.com/cosi-project/runtime v0.6.0/go.mod h1:14kfPrnGOG9pwc/AeRV1KquA5JYP7DUic/aGE8js9VE=
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/client/pkg/client/example_test.go
+++ b/client/pkg/client/example_test.go
@@ -64,9 +64,7 @@ func Example() {
 		machine *omni.MachineStatus
 	)
 
-	for iter := machines.Iterator(); iter.Next(); {
-		item := iter.Value()
-
+	for item := range machines.All() {
 		log.Printf("machine %s, connected: %t", item.Metadata(), item.TypedSpec().Value.GetConnected())
 
 		// Check cluster assignment for a machine.

--- a/client/pkg/omnictl/common.go
+++ b/client/pkg/omnictl/common.go
@@ -23,18 +23,18 @@ func resolveResourceType(ctx context.Context, st state.State, resourceType strin
 
 	var matched []*meta.ResourceDefinition
 
-	for it := rds.Iterator(); it.Next(); {
-		if strings.EqualFold(it.Value().Metadata().ID(), resourceType) {
-			matched = append(matched, it.Value())
+	for val := range rds.All() {
+		if strings.EqualFold(val.Metadata().ID(), resourceType) {
+			matched = append(matched, val)
 
 			continue
 		}
 
-		spec := it.Value().TypedSpec()
+		spec := val.TypedSpec()
 
 		for _, alias := range spec.AllAliases {
 			if strings.EqualFold(alias, resourceType) {
-				matched = append(matched, it.Value())
+				matched = append(matched, val)
 
 				break
 			}

--- a/client/pkg/omnictl/download.go
+++ b/client/pkg/omnictl/download.go
@@ -310,10 +310,10 @@ func filterMedia[T any](ctx context.Context, client *client.Client, check func(v
 		return nil, err
 	}
 
-	var result []T
+	result := make([]T, 0, media.Len())
 
-	for it := media.Iterator(); it.Next(); {
-		if val, ok := check(it.Value()); ok {
+	for item := range media.All() {
+		if val, ok := check(item); ok {
 			result = append(result, val)
 		}
 	}

--- a/client/pkg/template/operations/export_test.go
+++ b/client/pkg/template/operations/export_test.go
@@ -203,9 +203,7 @@ func buildState(ctx context.Context, t *testing.T) state.State {
 func listToMap[T resource.Resource](list safe.List[T]) map[resource.ID]T {
 	result := make(map[resource.ID]T, list.Len())
 
-	for iter := list.Iterator(); iter.Next(); {
-		value := iter.Value()
-
+	for value := range list.All() {
 		result[value.Metadata().ID()] = value
 	}
 

--- a/cmd/integration-test/pkg/tests/cli.go
+++ b/cmd/integration-test/pkg/tests/cli.go
@@ -45,8 +45,8 @@ func AssertDownloadUsingCLI(testCtx context.Context, client *client.Client, omni
 
 		var images []*omni.InstallationMedia
 
-		for it := media.Iterator(); it.Next(); {
-			spec := it.Value().TypedSpec().Value
+		for val := range media.All() {
+			spec := val.TypedSpec().Value
 
 			switch {
 			case spec.Profile == constants.BoardRPiGeneric:
@@ -54,7 +54,7 @@ func AssertDownloadUsingCLI(testCtx context.Context, client *client.Client, omni
 			case spec.Profile == "aws":
 				fallthrough
 			case spec.Profile == "iso":
-				images = append(images, it.Value())
+				images = append(images, val)
 			}
 		}
 

--- a/cmd/integration-test/pkg/tests/common.go
+++ b/cmd/integration-test/pkg/tests/common.go
@@ -82,9 +82,7 @@ func nodes(ctx context.Context, cli *client.Client, clusterName string, labels .
 
 	nodeList := make([]node, 0, clusterMachineList.Len())
 
-	for iter := clusterMachineList.Iterator(); iter.Next(); {
-		clusterMachine := iter.Value()
-
+	for clusterMachine := range clusterMachineList.All() {
 		machine, err := safe.StateGet[*omni.Machine](ctx, st, omni.NewMachine(resources.DefaultNamespace, clusterMachine.Metadata().ID()).Metadata())
 		if err != nil && !state.IsNotFoundError(err) {
 			return nil, err
@@ -169,9 +167,7 @@ func talosNodeIPs(ctx context.Context, talosState state.State) ([]string, error)
 
 	nodeIPs := make([]string, 0, list.Len())
 
-	for iter := list.Iterator(); iter.Next(); {
-		member := iter.Value()
-
+	for member := range list.All() {
 		if len(member.TypedSpec().Addresses) == 0 {
 			return nil, fmt.Errorf("no addresses for member %q", member.Metadata().ID())
 		}

--- a/cmd/integration-test/pkg/tests/extensions.go
+++ b/cmd/integration-test/pkg/tests/extensions.go
@@ -97,9 +97,7 @@ func checkExtension(ctx context.Context, cli *client.Client, machineID resource.
 		return err
 	}
 
-	for iter := extensionStatusList.Iterator(); iter.Next(); {
-		extensionStatus := iter.Value()
-
+	for extensionStatus := range extensionStatusList.All() {
 		if extensionStatus.TypedSpec().Metadata.Name == extension {
 			return nil
 		}

--- a/cmd/integration-test/pkg/tests/image.go
+++ b/cmd/integration-test/pkg/tests/image.go
@@ -35,8 +35,8 @@ func AssertSomeImagesAreDownloadable(testCtx context.Context, client *client.Cli
 
 		var images []*omni.InstallationMedia
 
-		for it := media.Iterator(); it.Next(); {
-			spec := it.Value().TypedSpec().Value
+		for val := range media.All() {
+			spec := val.TypedSpec().Value
 
 			switch {
 			case spec.Profile == constants.BoardRPiGeneric:
@@ -44,7 +44,7 @@ func AssertSomeImagesAreDownloadable(testCtx context.Context, client *client.Cli
 			case spec.Profile == "aws":
 				fallthrough
 			case spec.Profile == "iso":
-				images = append(images, it.Value())
+				images = append(images, val)
 			}
 		}
 

--- a/cmd/integration-test/pkg/tests/talos.go
+++ b/cmd/integration-test/pkg/tests/talos.go
@@ -764,8 +764,7 @@ func AssertTalosServiceIsRestarted(testCtx context.Context, cli *client.Client, 
 		clusterMachineList, err := safe.StateListAll[*omni.ClusterMachine](ctx, cli.Omni().State(), state.WithLabelQuery(labelQueryOpts...))
 		require.NoError(t, err)
 
-		for it := clusterMachineList.Iterator(); it.Next(); {
-			clusterMachine := it.Value()
+		for clusterMachine := range clusterMachineList.All() {
 			nodeID := clusterMachine.Metadata().ID()
 
 			t.Logf("Restarting service %q on node %q", service, nodeID)

--- a/cmd/integration-test/pkg/tests/utils.go
+++ b/cmd/integration-test/pkg/tests/utils.go
@@ -57,5 +57,5 @@ func (f matchStringOnly) ResetCoverage()    {}
 func (f matchStringOnly) SnapshotCoverage() {}
 
 func (f matchStringOnly) InitRuntimeCoverage() (mode string, tearDown func(coverprofile string, gocoverdir string) (string, error), snapcov func() float64) {
-	return "", nil, nil
+	return "", func(string, string) (string, error) { return "", nil }, func() float64 { return 0 }
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containers/image/v5 v5.32.1
-	github.com/cosi-project/runtime v0.5.5
+	github.com/cosi-project/runtime v0.6.0
 	github.com/cosi-project/state-etcd v0.3.0
 	github.com/crewjam/saml v0.4.14
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cosi-project/runtime v0.5.5 h1:GFoHnngpg4QVZluAUDwUbCe/sYOYBXKULxL/6DD99pU=
-github.com/cosi-project/runtime v0.5.5/go.mod h1:m+bkfUzKYeUyoqYAQBxdce3bfgncG8BsqcbfKRbvJKs=
+github.com/cosi-project/runtime v0.6.0 h1:ufybTVO1TUVx3YbuazVGKjYd0XoBBlaTvT3W30t09oc=
+github.com/cosi-project/runtime v0.6.0/go.mod h1:14kfPrnGOG9pwc/AeRV1KquA5JYP7DUic/aGE8js9VE=
 github.com/cosi-project/state-etcd v0.3.0 h1:mRqsowUb6Px6ZC9Qt61WOrATyMLJEahQ9T9rLriTDN4=
 github.com/cosi-project/state-etcd v0.3.0/go.mod h1:9PAv45buB5kWEGB+TuAk8FZxyRYxcB3198W/JndzcbA=
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -458,9 +458,9 @@ func (s *managementServer) KubernetesUpgradePreChecks(ctx context.Context, req *
 		return nil, err
 	}
 
-	for iter := cmis.Iterator(); iter.Next(); {
-		if len(iter.Value().TypedSpec().Value.NodeIps) > 0 {
-			controlplaneNodes = append(controlplaneNodes, iter.Value().TypedSpec().Value.NodeIps[0])
+	for cmi := range cmis.All() {
+		if len(cmi.TypedSpec().Value.NodeIps) > 0 {
+			controlplaneNodes = append(controlplaneNodes, cmi.TypedSpec().Value.NodeIps[0])
 		}
 	}
 

--- a/internal/backend/grpc/serviceaccount.go
+++ b/internal/backend/grpc/serviceaccount.go
@@ -213,9 +213,7 @@ func (s *managementServer) ListServiceAccounts(ctx context.Context, _ *emptypb.E
 
 	serviceAccounts := make([]*management.ListServiceAccountsResponse_ServiceAccount, 0, identityList.Len())
 
-	for iter := identityList.Iterator(); iter.Next(); {
-		identity := iter.Value()
-
+	for identity := range identityList.All() {
 		user, err := safe.StateGet[*authres.User](ctx, s.omniState, authres.NewUser(resources.DefaultNamespace, identity.TypedSpec().Value.UserId).Metadata())
 		if err != nil {
 			return nil, err
@@ -232,9 +230,7 @@ func (s *managementServer) ListServiceAccounts(ctx context.Context, _ *emptypb.E
 
 		publicKeys := make([]*management.ListServiceAccountsResponse_ServiceAccount_PgpPublicKey, 0, publicKeyList.Len())
 
-		for keyIter := publicKeyList.Iterator(); keyIter.Next(); {
-			key := keyIter.Value()
-
+		for key := range publicKeyList.All() {
 			publicKeys = append(publicKeys, &management.ListServiceAccountsResponse_ServiceAccount_PgpPublicKey{
 				Id:         key.Metadata().ID(),
 				Armored:    string(key.TypedSpec().Value.GetPublicKey()),

--- a/internal/backend/oidc/internal/storage/keys/storage.go
+++ b/internal/backend/oidc/internal/storage/keys/storage.go
@@ -222,9 +222,7 @@ func (s *Storage) cleanupOldKeys(ctx context.Context) error {
 
 	newKeySet := make([]op.Key, 0, keys.Len())
 
-	for iter := keys.Iterator(); iter.Next(); {
-		key := iter.Value()
-
+	for key := range keys.All() {
 		if s.clock.Now().After(key.TypedSpec().Value.Expiration.AsTime()) {
 			s.logger.Info("destroying expired OIDC key",
 				zap.String("key_id", key.Metadata().ID()),

--- a/internal/backend/resourcelogger/resourcelogger.go
+++ b/internal/backend/resourcelogger/resourcelogger.go
@@ -199,9 +199,7 @@ func resourceNamesToDefinitions(ctx context.Context, st state.State) (map[string
 		nameToRDs[name][rd.TypedSpec().Type] = rd
 	}
 
-	for it := rds.Iterator(); it.Next(); {
-		rd := it.Value()
-
+	for rd := range rds.All() {
 		add(rd.Metadata().ID(), rd)
 
 		for _, alias := range rd.TypedSpec().AllAliases {

--- a/internal/backend/runtime/omni/controllers/omni/cluster_destroy_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_destroy_status.go
@@ -83,9 +83,7 @@ func (ctrl *ClusterDestroyStatusController) Run(ctx context.Context, r controlle
 			return fmt.Errorf("error listing Cluster resources: %w", err)
 		}
 
-		for iter := clusters.Iterator(); iter.Next(); {
-			cluster := iter.Value()
-
+		for cluster := range clusters.All() {
 			if cluster.Metadata().Phase() != resource.PhaseTearingDown {
 				continue
 			}

--- a/internal/backend/runtime/omni/controllers/omni/cluster_endpoint.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_endpoint.go
@@ -48,14 +48,14 @@ func NewClusterEndpointController() *ClusterEndpointController {
 
 				clusterEndpoint.TypedSpec().Value.ManagementAddresses = nil
 
-				for iter := items.Iterator(); iter.Next(); {
-					if iter.Value().TypedSpec().Value.ManagementAddress == "" {
+				for val := range items.All() {
+					if val.TypedSpec().Value.ManagementAddress == "" {
 						continue
 					}
 
 					clusterEndpoint.TypedSpec().Value.ManagementAddresses = append(
 						clusterEndpoint.TypedSpec().Value.ManagementAddresses,
-						iter.Value().TypedSpec().Value.ManagementAddress,
+						val.TypedSpec().Value.ManagementAddress,
 					)
 				}
 

--- a/internal/backend/runtime/omni/controllers/omni/cluster_kubernetes_nodes.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_kubernetes_nodes.go
@@ -53,9 +53,7 @@ func NewClusterKubernetesNodesController() *ClusterKubernetesNodesController {
 
 				nodes := make([]string, 0, identityList.Len())
 
-				for iter := identityList.Iterator(); iter.Next(); {
-					identity := iter.Value()
-
+				for identity := range identityList.All() {
 					if identity.Metadata().Phase() == resource.PhaseTearingDown {
 						continue
 					}

--- a/internal/backend/runtime/omni/controllers/omni/cluster_loadbalancer.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_loadbalancer.go
@@ -108,15 +108,13 @@ func (ctrl *ClusterLoadBalancerController) Run(ctx context.Context, r controller
 		}
 
 		allocatedPorts := map[string]struct{}{}
-		for iter := configs.Iterator(); iter.Next(); {
-			allocatedPorts[iter.Value().TypedSpec().Value.BindPort] = struct{}{}
+		for val := range configs.All() {
+			allocatedPorts[val.TypedSpec().Value.BindPort] = struct{}{}
 		}
 
 		tracker := trackResource(r, resources.DefaultNamespace, omni.LoadBalancerConfigType)
 
-		for iter := list.Iterator(); iter.Next(); {
-			cluster := iter.Value()
-
+		for cluster := range list.All() {
 			tracker.keep(cluster)
 
 			var endpoints []string

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_identity.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_identity.go
@@ -137,9 +137,7 @@ func (ctrl *ClusterMachineIdentityController) reconcileCollectors(ctx context.Co
 
 	expectedCollectors := map[string]clustermachine.IdentityCollectorTaskSpec{}
 
-	for iter := list.Iterator(); iter.Next(); {
-		clusterMachine := iter.Value()
-
+	for clusterMachine := range list.All() {
 		tracker.keep(clusterMachine)
 
 		if clusterMachine.Metadata().Phase() == resource.PhaseTearingDown {

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_metrics.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_metrics.go
@@ -89,8 +89,8 @@ func (ctrl *ClusterMachineStatusMetricsController) Run(ctx context.Context, r co
 			specs.ClusterMachineStatusSpec_DESTROYING:    0,
 		}
 
-		for iter := clusterMachineStatusList.Iterator(); iter.Next(); {
-			clusterMachinesByStatus[iter.Value().TypedSpec().Value.Stage]++
+		for val := range clusterMachineStatusList.All() {
+			clusterMachinesByStatus[val.TypedSpec().Value.Stage]++
 		}
 
 		for status, num := range clusterMachinesByStatus {

--- a/internal/backend/runtime/omni/controllers/omni/cluster_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_status.go
@@ -84,19 +84,19 @@ func NewClusterStatusController(embeddedDiscoveryServiceEnabled bool) *ClusterSt
 
 				phases := map[specs.MachineSetPhase]int{}
 
-				for iter := list.Iterator(); iter.Next(); {
-					machineSetStatus := iter.Value().TypedSpec().Value
+				for mss := range list.All() {
+					machineSetStatus := mss.TypedSpec().Value
 
 					machines.Total += machineSetStatus.GetMachines().GetTotal()
 					machines.Healthy += machineSetStatus.GetMachines().GetHealthy()
 
-					_, isControlPlane := iter.Value().Metadata().Labels().Get(omni.LabelControlPlaneRole)
+					_, isControlPlane := mss.Metadata().Labels().Get(omni.LabelControlPlaneRole)
 					if isControlPlane {
 						var cpStatus *omni.ControlPlaneStatus
 
 						cpStatus, err = safe.ReaderGet[*omni.ControlPlaneStatus](
 							ctx, r,
-							resource.NewMetadata(resources.DefaultNamespace, omni.ControlPlaneStatusType, iter.Value().Metadata().ID(), resource.VersionUndefined),
+							resource.NewMetadata(resources.DefaultNamespace, omni.ControlPlaneStatusType, mss.Metadata().ID(), resource.VersionUndefined),
 						)
 						if err != nil && !state.IsNotFoundError(err) {
 							return err

--- a/internal/backend/runtime/omni/controllers/omni/cluster_status_metrics.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_status_metrics.go
@@ -94,13 +94,13 @@ func (ctrl *ClusterStatusMetricsController) Run(ctx context.Context, r controlle
 			specs.ClusterStatusSpec_DESTROYING:   0,
 		}
 
-		for iter := list.Iterator(); iter.Next(); {
-			phase := iter.Value().TypedSpec().Value.Phase
+		for val := range list.All() {
+			phase := val.TypedSpec().Value.Phase
 			clustersByStatus[phase]++
 
 			res.TypedSpec().Value.Phases[int32(phase)]++
 
-			if !iter.Value().TypedSpec().Value.Ready {
+			if !val.TypedSpec().Value.Ready {
 				res.TypedSpec().Value.NotReadyCount++
 			}
 		}

--- a/internal/backend/runtime/omni/controllers/omni/cluster_workload_proxy.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_workload_proxy.go
@@ -81,9 +81,7 @@ func (ctrl *ClusterWorkloadProxyController) Run(ctx context.Context, r controlle
 
 		var errs error
 
-		for iter := clusterList.Iterator(); iter.Next(); {
-			cluster := iter.Value()
-
+		for cluster := range clusterList.All() {
 			id := fmt.Sprintf("950-cluster-%s-workload-proxying", cluster.Metadata().ID())
 
 			configPatch := omni.NewConfigPatch(resources.DefaultNamespace, id)

--- a/internal/backend/runtime/omni/controllers/omni/cluster_workload_proxy_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_workload_proxy_status.go
@@ -90,9 +90,7 @@ func (helper *clusterWorkloadProxyStatusControllerHelper) transform(ctx context.
 
 	healthyTargetHosts := make([]string, 0, cmsList.Len())
 
-	for iter := cmsList.Iterator(); iter.Next(); {
-		cms := iter.Value()
-
+	for cms := range cmsList.All() {
 		if cms.Metadata().Phase() == resource.PhaseTearingDown {
 			if err = r.RemoveFinalizer(ctx, cms.Metadata(), ClusterWorkloadProxyStatusControllerName); err != nil {
 				return fmt.Errorf("failed to remove finalizer: %w", err)
@@ -125,9 +123,7 @@ func (helper *clusterWorkloadProxyStatusControllerHelper) transform(ctx context.
 
 	aliasToUpstreamAddresses := make(map[string][]string, svcList.Len())
 
-	for iter := svcList.Iterator(); iter.Next(); {
-		svc := iter.Value()
-
+	for svc := range svcList.All() {
 		if svc.Metadata().Phase() == resource.PhaseTearingDown {
 			if err = r.RemoveFinalizer(ctx, svc.Metadata(), ClusterWorkloadProxyStatusControllerName); err != nil {
 				return fmt.Errorf("failed to remove finalizer: %w", err)
@@ -167,9 +163,7 @@ func (helper *clusterWorkloadProxyStatusControllerHelper) teardown(ctx context.C
 		return fmt.Errorf("failed to list cluster machine statuses: %w", err)
 	}
 
-	for iter := cmsList.Iterator(); iter.Next(); {
-		cms := iter.Value()
-
+	for cms := range cmsList.All() {
 		if err = r.RemoveFinalizer(ctx, cms.Metadata(), ClusterWorkloadProxyStatusControllerName); err != nil {
 			return fmt.Errorf("failed to remove finalizer: %w", err)
 		}
@@ -180,9 +174,7 @@ func (helper *clusterWorkloadProxyStatusControllerHelper) teardown(ctx context.C
 		return fmt.Errorf("failed to list exposed services: %w", err)
 	}
 
-	for iter := svcList.Iterator(); iter.Next(); {
-		svc := iter.Value()
-
+	for svc := range svcList.All() {
 		if err = r.RemoveFinalizer(ctx, svc.Metadata(), ClusterWorkloadProxyStatusControllerName); err != nil {
 			return fmt.Errorf("failed to remove finalizer: %w", err)
 		}

--- a/internal/backend/runtime/omni/controllers/omni/etcd_backup.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcd_backup.go
@@ -241,8 +241,7 @@ func (ctrl *EtcdBackupController) findClustersToBackup(ctx context.Context, r co
 
 	result := make([]*omni.BackupData, 0, bdl.Len())
 
-	for it := bdl.Iterator(); it.Next(); {
-		backupData := it.Value()
+	for backupData := range bdl.All() {
 		clusterID := backupData.Metadata().ID()
 		value := backupData.TypedSpec().Value
 

--- a/internal/backend/runtime/omni/controllers/omni/image_pull_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/image_pull_status.go
@@ -130,9 +130,7 @@ func (ctrl *ImagePullStatusController) handleEvent(ctx context.Context, r contro
 
 	expectedPullTasks := map[string]imagetask.PullTaskSpec{}
 
-	for iter := requests.Iterator(); iter.Next(); {
-		request := iter.Value()
-
+	for request := range requests.All() {
 		tracker.keep(request)
 
 		if request.Metadata().Phase() == resource.PhaseTearingDown {
@@ -163,9 +161,7 @@ func (ctrl *ImagePullStatusController) getStatusIDToStatus(ctx context.Context, 
 
 	statusMap := make(map[resource.ID]*omni.ImagePullStatus, statuses.Len())
 
-	for iter := statuses.Iterator(); iter.Next(); {
-		status := iter.Value()
-
+	for status := range statuses.All() {
 		statusMap[status.Metadata().ID()] = status
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/machinemap.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/machinemap.go
@@ -41,11 +41,11 @@ func NewMachineMap(ctx context.Context, r controller.Reader, cluster *omni.Clust
 		return nil, err
 	}
 
-	for iter := clusterMachineIdentities.Iterator(); iter.Next(); {
-		if _, controlplane := iter.Value().Metadata().Labels().Get(omni.LabelControlPlaneRole); controlplane {
-			nodenameToMachineMap.ControlPlanes[iter.Value().TypedSpec().Value.Nodename] = iter.Value().Metadata().ID()
+	for cmi := range clusterMachineIdentities.All() {
+		if _, controlplane := cmi.Metadata().Labels().Get(omni.LabelControlPlaneRole); controlplane {
+			nodenameToMachineMap.ControlPlanes[cmi.TypedSpec().Value.Nodename] = cmi.Metadata().ID()
 		} else {
-			nodenameToMachineMap.Workers[iter.Value().TypedSpec().Value.Nodename] = iter.Value().Metadata().ID()
+			nodenameToMachineMap.Workers[cmi.TypedSpec().Value.Nodename] = cmi.Metadata().ID()
 		}
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/versions.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/versions.go
@@ -37,9 +37,9 @@ func CalculateUpgradeVersions(ctx context.Context, r controller.Reader, currentV
 
 	availableVersions := map[string]semver.Version{}
 
-	for iter := k8sVersions.Iterator(); iter.Next(); {
-		if iter.Value().TypedSpec().Value.Version != currentVersion {
-			availableVersions[iter.Value().TypedSpec().Value.Version], err = semver.ParseTolerant(iter.Value().TypedSpec().Value.Version)
+	for val := range k8sVersions.All() {
+		if val.TypedSpec().Value.Version != currentVersion {
+			availableVersions[val.TypedSpec().Value.Version], err = semver.ParseTolerant(val.TypedSpec().Value.Version)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/versions.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/versions.go
@@ -37,9 +37,9 @@ func CalculateUpgradeVersions(ctx context.Context, r controller.Reader, currentV
 
 	availableVersions := map[string]semver.Version{}
 
-	for iter := talosVersions.Iterator(); iter.Next(); {
-		if iter.Value().TypedSpec().Value.Version != currentVersion {
-			availableVersions[iter.Value().TypedSpec().Value.Version], err = semver.ParseTolerant(iter.Value().TypedSpec().Value.Version)
+	for val := range talosVersions.All() {
+		if val.TypedSpec().Value.Version != currentVersion {
+			availableVersions[val.TypedSpec().Value.Version], err = semver.ParseTolerant(val.TypedSpec().Value.Version)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/helpers.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/helpers.go
@@ -29,10 +29,8 @@ func forEachResource[T resource.Resource](
 		return err
 	}
 
-	iter := items.Iterator()
-
-	for iter.Next() {
-		if err = callback(iter.Value()); err != nil {
+	for val := range items.All() {
+		if err = callback(val); err != nil {
 			return err
 		}
 	}

--- a/internal/backend/runtime/omni/controllers/omni/key_pruner.go
+++ b/internal/backend/runtime/omni/controllers/omni/key_pruner.go
@@ -103,8 +103,7 @@ func (k *KeyPrunerController) run(ctx context.Context, runtime controller.Runtim
 		return err
 	}
 
-	for it := list.Iterator(); it.Next(); {
-		v := it.Value()
+	for v := range list.All() {
 		md := v.Metadata()
 		publicKeySpec := v.TypedSpec().Value
 

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
@@ -377,20 +377,20 @@ func (ctrl *KubernetesStatusController) reconcileRunners(ctx context.Context, r 
 
 	secretsPresent := map[string]struct{}{}
 
-	for iter := secrets.Iterator(); iter.Next(); {
-		secretsPresent[iter.Value().Metadata().ID()] = struct{}{}
+	for secret := range secrets.All() {
+		secretsPresent[secret.Metadata().ID()] = struct{}{}
 	}
 
 	lbHealthy := map[string]struct{}{}
 	lbStopped := map[string]struct{}{}
 
-	for iter := lbStatus.Iterator(); iter.Next(); {
-		if iter.Value().TypedSpec().Value.Healthy {
-			lbHealthy[iter.Value().Metadata().ID()] = struct{}{}
+	for lbs := range lbStatus.All() {
+		if lbs.TypedSpec().Value.Healthy {
+			lbHealthy[lbs.Metadata().ID()] = struct{}{}
 		}
 
-		if iter.Value().TypedSpec().Value.Stopped {
-			lbStopped[iter.Value().Metadata().ID()] = struct{}{}
+		if lbs.TypedSpec().Value.Stopped {
+			lbStopped[lbs.Metadata().ID()] = struct{}{}
 		}
 	}
 
@@ -442,8 +442,8 @@ func (ctrl *KubernetesStatusController) reconcileRunners(ctx context.Context, r 
 		return err
 	}
 
-	for iter := statuses.Iterator(); iter.Next(); {
-		cluster := iter.Value().Metadata().ID()
+	for status := range statuses.All() {
+		cluster := status.Metadata().ID()
 
 		if _, ok := secretsPresent[cluster]; ok {
 			continue
@@ -489,9 +489,7 @@ func (ctrl *KubernetesStatusController) cleanupExposedServices(ctx context.Conte
 
 	var multiErr error
 
-	for iter := exposedServices.Iterator(); iter.Next(); {
-		exposedService := iter.Value()
-
+	for exposedService := range exposedServices.All() {
 		if !shouldDestroy(exposedService) {
 			continue
 		}

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_upgrade_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_upgrade_status.go
@@ -214,9 +214,9 @@ func NewKubernetesUpgradeStatusController() *KubernetesUpgradeStatusController {
 					return err
 				}
 
-				for cpIter := configPatches.Iterator(); cpIter.Next(); {
-					if cpIter.Value().Metadata().Owner() == KubernetesUpgradeStatusControllerName {
-						if err = r.Destroy(ctx, cpIter.Value().Metadata()); err != nil {
+				for cp := range configPatches.All() {
+					if cp.Metadata().Owner() == KubernetesUpgradeStatusControllerName {
+						if err = r.Destroy(ctx, cp.Metadata()); err != nil {
 							return err
 						}
 					}
@@ -230,9 +230,9 @@ func NewKubernetesUpgradeStatusController() *KubernetesUpgradeStatusController {
 					return err
 				}
 
-				for iprIter := imagePullRequests.Iterator(); iprIter.Next(); {
-					if iprIter.Value().Metadata().Owner() == KubernetesUpgradeStatusControllerName {
-						if err = r.Destroy(ctx, iprIter.Value().Metadata()); err != nil {
+				for ipr := range imagePullRequests.All() {
+					if ipr.Metadata().Owner() == KubernetesUpgradeStatusControllerName {
+						if err = r.Destroy(ctx, ipr.Metadata()); err != nil {
 							return err
 						}
 					}

--- a/internal/backend/runtime/omni/controllers/omni/loadbalancer.go
+++ b/internal/backend/runtime/omni/controllers/omni/loadbalancer.go
@@ -111,9 +111,7 @@ func (ctrl *LoadBalancerController) reconcileLoadBalancers(ctx context.Context, 
 	endpoints := make(map[loadbalancer.ID][]string, list.Len())
 	stopped := map[loadbalancer.ID]struct{}{}
 
-	for iter := list.Iterator(); iter.Next(); {
-		item := iter.Value()
-
+	for item := range list.All() {
 		var clusterStatus *omni.ClusterStatus
 
 		clusterStatus, err = safe.ReaderGet[*omni.ClusterStatus](ctx, r, omni.NewClusterStatus(
@@ -166,8 +164,7 @@ func (ctrl *LoadBalancerController) reconcileLoadBalancers(ctx context.Context, 
 		return fmt.Errorf("error listing resources: %w", err)
 	}
 
-	for iter := statuses.Iterator(); iter.Next(); {
-		cfg := iter.Value()
+	for cfg := range statuses.All() {
 		id := cfg.Metadata().ID()
 
 		if _, ok := stopped[id]; ok {

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_destroy_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_destroy_status.go
@@ -76,9 +76,7 @@ func (ctrl *MachineSetDestroyStatusController) Run(ctx context.Context, r contro
 			return fmt.Errorf("error listing Machine Set resources: %w", err)
 		}
 
-		for iter := machineSets.Iterator(); iter.Next(); {
-			machineSet := iter.Value()
-
+		for machineSet := range machineSets.All() {
 			if machineSet.Metadata().Phase() != resource.PhaseTearingDown {
 				continue
 			}

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_etcd_audit.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_etcd_audit.go
@@ -298,8 +298,8 @@ func (auditor *etcdAuditor) auditEtcd(ctx context.Context, r controller.Reader, 
 	filteredMembers := maps.Clone(members)
 	machineIDToMemberID := make(map[string]string, list.Len())
 
-	for iter := list.Iterator(); iter.Next(); {
-		machineID := iter.Value().Metadata().ID()
+	for cm := range list.All() {
+		machineID := cm.Metadata().ID()
 
 		memberID, err := auditor.auditMember(ctx, r, machineID, cluster)
 		if err != nil {

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_metrics.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_metrics.go
@@ -103,18 +103,18 @@ func (ctrl *MachineStatusMetricsController) Run(ctx context.Context, r controlle
 		ctrl.versionsMu.Lock()
 		ctrl.versionsMap = map[string]int{}
 
-		for iter := list.Iterator(); iter.Next(); {
+		for ms := range list.All() {
 			machines++
 
-			if iter.Value().TypedSpec().Value.Connected {
+			if ms.TypedSpec().Value.Connected {
 				connectedMachines++
 			}
 
-			if iter.Value().TypedSpec().Value.TalosVersion != "" {
-				ctrl.versionsMap[iter.Value().TypedSpec().Value.TalosVersion]++
+			if ms.TypedSpec().Value.TalosVersion != "" {
+				ctrl.versionsMap[ms.TypedSpec().Value.TalosVersion]++
 			}
 
-			if iter.Value().TypedSpec().Value.Cluster != "" {
+			if ms.TypedSpec().Value.Cluster != "" {
 				allocatedMachines++
 			}
 		}

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -546,13 +546,13 @@ func (suite *OmniSuite) destroyClusterByID(clusterID string) {
 
 	suite.Require().NoError(err)
 
-	for iter := list.Iterator(); iter.Next(); {
-		rtestutils.Destroy[*omni.ClusterMachine](ctx, suite.T(), suite.state, []string{iter.Value().Metadata().ID()})
-		rtestutils.Destroy[*omni.MachineSetNode](ctx, suite.T(), suite.state, []string{iter.Value().Metadata().ID()})
-		rtestutils.Destroy[*omni.ClusterMachineStatus](ctx, suite.T(), suite.state, []string{iter.Value().Metadata().ID()})
-		rtestutils.Destroy[*omni.ClusterMachineConfigPatches](ctx, suite.T(), suite.state, []string{iter.Value().Metadata().ID()})
-		rtestutils.Destroy[*omni.MachineStatus](ctx, suite.T(), suite.state, []string{iter.Value().Metadata().ID()})
-		rtestutils.Destroy[*omni.Machine](ctx, suite.T(), suite.state, []string{iter.Value().Metadata().ID()})
+	for cs := range list.All() {
+		rtestutils.Destroy[*omni.ClusterMachine](ctx, suite.T(), suite.state, []string{cs.Metadata().ID()})
+		rtestutils.Destroy[*omni.MachineSetNode](ctx, suite.T(), suite.state, []string{cs.Metadata().ID()})
+		rtestutils.Destroy[*omni.ClusterMachineStatus](ctx, suite.T(), suite.state, []string{cs.Metadata().ID()})
+		rtestutils.Destroy[*omni.ClusterMachineConfigPatches](ctx, suite.T(), suite.state, []string{cs.Metadata().ID()})
+		rtestutils.Destroy[*omni.MachineStatus](ctx, suite.T(), suite.state, []string{cs.Metadata().ID()})
+		rtestutils.Destroy[*omni.Machine](ctx, suite.T(), suite.state, []string{cs.Metadata().ID()})
 	}
 
 	machineSets, err := safe.StateListAll[*omni.MachineSet](ctx, suite.state,
@@ -561,8 +561,8 @@ func (suite *OmniSuite) destroyClusterByID(clusterID string) {
 
 	suite.Require().NoError(err)
 
-	for iter := machineSets.Iterator(); iter.Next(); {
-		rtestutils.Destroy[*omni.MachineSet](ctx, suite.T(), suite.state, []string{iter.Value().Metadata().ID()})
+	for ms := range machineSets.All() {
+		rtestutils.Destroy[*omni.MachineSet](ctx, suite.T(), suite.state, []string{ms.Metadata().ID()})
 	}
 
 	rtestutils.Destroy[*omni.Cluster](ctx, suite.T(), suite.state, []string{clusterID})

--- a/internal/backend/runtime/omni/controllers/omni/saml_assertion.go
+++ b/internal/backend/runtime/omni/controllers/omni/saml_assertion.go
@@ -65,9 +65,7 @@ func (ctrl *SAMLAssertionController) Run(ctx context.Context, r controller.Runti
 			return fmt.Errorf("error listing Cluster resources: %w", err)
 		}
 
-		for iter := sessions.Iterator(); iter.Next(); {
-			assertion := iter.Value()
-
+		for assertion := range sessions.All() {
 			if time.Since(assertion.Metadata().Created()) > time.Hour*24 {
 				err = r.Destroy(ctx, assertion.Metadata(), controller.WithOwner(""))
 				if err != nil {

--- a/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status.go
@@ -268,9 +268,7 @@ func reconcileTalosUpdateStatus(ctx context.Context, r controller.ReaderWriter,
 		return err
 	}
 
-	for iter := clusterMachines.Iterator(); iter.Next(); {
-		machine := iter.Value()
-
+	for machine := range clusterMachines.All() {
 		if machine.Metadata().Phase() == resource.PhaseTearingDown {
 			continue
 		}

--- a/internal/backend/runtime/omni/migration/compat.go
+++ b/internal/backend/runtime/omni/migration/compat.go
@@ -8,6 +8,7 @@ package migration
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -58,9 +59,7 @@ func getConfigPatches(ctx context.Context, r controller.Reader, machine resource
 	machineSetPatches := make([]*omni.ConfigPatch, 0, clusterPatchList.Len())
 	clusterMachinePatches := make([]*omni.ConfigPatch, 0, clusterPatchList.Len())
 
-	for iter := clusterPatchList.Iterator(); iter.Next(); {
-		patch := iter.Value()
-
+	for patch := range clusterPatchList.All() {
 		machineSetName, machineSetOk := patch.Metadata().Labels().Get(prefix + "machine-set")
 		clusterMachineName, clusterMachineOk := patch.Metadata().Labels().Get(prefix + "cluster-machine")
 
@@ -83,11 +82,5 @@ func getConfigPatches(ctx context.Context, r controller.Reader, machine resource
 	patches = append(patches, machineSetPatches...)
 	patches = append(patches, clusterMachinePatches...)
 
-	for iter := machinePatchList.Iterator(); iter.Next(); {
-		patch := iter.Value()
-
-		patches = append(patches, patch)
-	}
-
-	return patches, nil
+	return slices.AppendSeq(patches, machinePatchList.All()), nil
 }

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -274,8 +274,8 @@ func (suite *MigrationSuite) TestMachineSets() {
 
 		suite.Require().NoError(err)
 
-		for iter := list.Iterator(); iter.Next(); {
-			machines = append(machines, iter.Value().Metadata().ID())
+		for val := range list.All() {
+			machines = append(machines, val.Metadata().ID())
 		}
 	}
 
@@ -306,8 +306,8 @@ func (suite *MigrationSuite) TestMachineSets() {
 
 		machines = make([]string, 0, list.Len())
 
-		for iter := list.Iterator(); iter.Next(); {
-			machines = append(machines, iter.Value().Metadata().ID())
+		for val := range list.All() {
+			machines = append(machines, val.Metadata().ID())
 		}
 	}
 

--- a/internal/backend/runtime/omni/pkg/check/connection.go
+++ b/internal/backend/runtime/omni/pkg/check/connection.go
@@ -31,8 +31,8 @@ func Connection(ctx context.Context, r controller.Reader, clusterName string) er
 		return newError(specs.ControlPlaneStatusSpec_Condition_Error, true, "Failed to get the list of machines %s", err.Error())
 	}
 
-	for iter := clusterMachineStatuses.Iterator(); iter.Next(); {
-		_, connected := iter.Value().Metadata().Labels().Get(omni.MachineStatusLabelConnected)
+	for val := range clusterMachineStatuses.All() {
+		_, connected := val.Metadata().Labels().Get(omni.MachineStatusLabelConnected)
 		if connected {
 			return nil
 		}

--- a/internal/backend/runtime/omni/pkg/check/etcd.go
+++ b/internal/backend/runtime/omni/pkg/check/etcd.go
@@ -66,11 +66,11 @@ func Etcd(ctx context.Context, r controller.Reader, clusterName string) error {
 
 	var members map[uint64]string
 
-	for iter := clusterMachineStatuses.Iterator(); iter.Next(); {
-		nodeMembers, err := GetEtcdMembers(ctx, r, clusterName, iter.Value())
+	for item := range clusterMachineStatuses.All() {
+		nodeMembers, err := GetEtcdMembers(ctx, r, clusterName, item)
 		if err != nil {
 			if talos.IsClientNotReadyError(err) {
-				return newError(specs.ControlPlaneStatusSpec_Condition_Error, false, "Talos client is not ready on node %s", iter.Value().Metadata().ID())
+				return newError(specs.ControlPlaneStatusSpec_Condition_Error, false, "Talos client is not ready on node %s", item.Metadata().ID())
 			}
 
 			return err
@@ -88,7 +88,7 @@ func Etcd(ctx context.Context, r controller.Reader, clusterName string) error {
 				false,
 				"Etcd members don't match on nodes %s and %s",
 				clusterMachineStatuses.Get(0).Metadata().ID(),
-				iter.Value().Metadata().ID(),
+				item.Metadata().ID(),
 			)
 		}
 	}

--- a/internal/backend/saml/session.go
+++ b/internal/backend/saml/session.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -307,13 +308,7 @@ func (sp *SessionProvider) getRoleInSAMLLabelRules(ctx context.Context, samlLabe
 		return "", err
 	}
 
-	labelRules := make([]*auth.SAMLLabelRule, 0)
-
-	for iter := labelRuleList.Iterator(); iter.Next(); {
-		labelRule := iter.Value()
-
-		labelRules = append(labelRules, labelRule)
-	}
+	labelRules := slices.AppendSeq(make([]*auth.SAMLLabelRule, 0, labelRuleList.Len()), labelRuleList.All())
 
 	return RoleInSAMLLabelRules(labelRules, samlLabels, sp.logger), nil
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1096,8 +1096,8 @@ func getReleaseData(ctx context.Context, state state.State) (releaseData, error)
 
 	versionNames := make([]string, 0, all.Len())
 
-	for it := all.Iterator(); it.Next(); {
-		version := it.Value().TypedSpec().Value.Version
+	for val := range all.All() {
+		version := val.TypedSpec().Value.Version
 		if !strings.HasPrefix(version, "v") {
 			version = "v" + version
 		}

--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -451,8 +451,8 @@ func (manager *Manager) pollWireguardPeers(ctx context.Context) error {
 		return err
 	}
 
-	for iter := links.Iterator(); iter.Next(); {
-		spec := iter.Value().TypedSpec().Value
+	for link := range links.All() {
+		spec := link.TypedSpec().Value
 
 		if err = manager.wgHandler.PeerEvent(ctx, spec, false); err != nil {
 			return err
@@ -506,8 +506,7 @@ func (manager *Manager) pollWireguardPeers(ctx context.Context) error {
 
 			counterDeltas := make(LinkCounterDeltas, links.Len())
 
-			for iter := links.Iterator(); iter.Next(); {
-				link := iter.Value()
+			for link := range links.All() {
 				spec := link.TypedSpec().Value
 
 				peer, ok := peersByKey[spec.NodePublicKey]

--- a/internal/pkg/siderolink/siderolink_test.go
+++ b/internal/pkg/siderolink/siderolink_test.go
@@ -295,14 +295,12 @@ func (suite *SiderolinkSuite) TestVirtualNodes() {
 				return retry.ExpectedErrorf("no links established yet")
 			}
 
-			for it := list.Iterator(); it.Next(); {
-				item := it.Value()
-
-				if item.Metadata().ID() == "" {
+			for link := range list.All() {
+				if link.Metadata().ID() == "" {
 					return errors.New("empty id in the resource list")
 				}
 
-				if item.TypedSpec().Value.VirtualAddrport == "" {
+				if link.TypedSpec().Value.VirtualAddrport == "" {
 					return errors.New("empty virtual address in the resource list")
 				}
 			}


### PR DESCRIPTION
Bump to Go 1.23 and use new iterator mechanism. Also fix new linter issues.