### PR TITLE
fix: pass the logger to machine logs circular buffer

### DIFF
--- a/internal/pkg/siderolink/machines.go
+++ b/internal/pkg/siderolink/machines.go
@@ -195,6 +195,7 @@ func (m *MachineCache) init() {
 				circular.WithMaxCapacity(m.logStorageConfig.BufferMaxCapacity),
 				circular.WithSafetyGap(m.logStorageConfig.BufferSafetyGap),
 				circular.WithNumCompressedChunks(m.logStorageConfig.NumCompressedChunks, m.compressor),
+				circular.WithLogger(m.logger),
 			}
 
 			if m.logStorageConfig.StorageEnabled {


### PR DESCRIPTION
We were not passing a logger to this, so its logs were going nowhere.