### PR TITLE
chore: rekres to get BUSL license change date updated on releases

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -509,7 +509,7 @@ spec:
         Licensor: Sidero Labs, Inc.
         LicensedWork: Omni
         Copyright: (c) 2024 Sidero Labs, Inc.
-        ChangeDate: "2028-02-22"
+        ChangeDate: "2028-08-22"
         ChangeLicense: Mozilla Public License, version 2.0
         EnterpriseLink: https://www.siderolabs.com/contact/
       header: |

--- a/LICENSE
+++ b/LICENSE
@@ -7,7 +7,7 @@ Licensed Work:        Omni
                       The Licensed Work is (c) 2024 Sidero Labs, Inc.
 Additional Use Grant: None
 
-Change Date:          2028-08-16
+Change Date:          2028-08-22
 
 Change License:       Mozilla Public License, version 2.0
 


### PR DESCRIPTION
Bring in https://github.com/siderolabs/kres/pull/436 from kres.

Closes siderolabs/omni#557.