### PR TITLE
fix: delete upgrade meta key from nodes after upgrades

### DIFF
--- a/client/pkg/meta/meta.go
+++ b/client/pkg/meta/meta.go
@@ -5,6 +5,9 @@
 // Package meta keeps Talos meta partition utils.
 package meta
 
+// Upgrade is github.com/siderolabs/talos/internal/pkg/meta.Upgrade.
+const Upgrade = 6
+
 // StateEncryptionConfig is github.com/siderolabs/talos/internal/pkg/meta.StateEncryptionConfig.
 const StateEncryptionConfig = 9
 


### PR DESCRIPTION
Remove the meta key to prevent auto-rollbacks, as Omni manages upgrades & downgrades.

Closes siderolabs/omni#509.

Depends on https://github.com/siderolabs/talemu/pull/17