### PR TITLE
fix: add siderolink connection params to the infra provider interface

### DIFF
--- a/client/pkg/infra/infra_test.go
+++ b/client/pkg/infra/infra_test.go
@@ -28,8 +28,10 @@ import (
 	cloudspecs "github.com/siderolabs/omni/client/api/omni/specs/cloud"
 	"github.com/siderolabs/omni/client/pkg/infra"
 	"github.com/siderolabs/omni/client/pkg/infra/provision"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/cloud"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 )
 
 type ms struct {
@@ -44,7 +46,7 @@ type provisioner struct {
 }
 
 // Provision implements provision.Provisioner interface.
-func (p *provisioner) Provision(ctx context.Context, _ *zap.Logger, state *TestResource, request *cloud.MachineRequest) (provision.Result, error) {
+func (p *provisioner) Provision(ctx context.Context, _ *zap.Logger, state *TestResource, request *cloud.MachineRequest, _ *siderolink.ConnectionParams) (provision.Result, error) {
 	p.machinesMu.Lock()
 	defer p.machinesMu.Unlock()
 
@@ -129,6 +131,10 @@ func TestInfra(t *testing.T) {
 	machineRequest.Metadata().Labels().Set(customLabel, customValue)
 
 	require.NoError(t, state.Create(ctx, machineRequest))
+
+	connectionParams := siderolink.NewConnectionParams(resources.DefaultNamespace, siderolink.ConfigID)
+
+	require.NoError(t, state.Create(ctx, connectionParams))
 
 	rtestutils.AssertResources(ctx, t, state, []string{machineRequest.Metadata().ID()}, func(machineRequestStatus *cloud.MachineRequestStatus, assert *assert.Assertions) {
 		val, ok := machineRequestStatus.Metadata().Labels().Get(omni.LabelCloudProviderID)

--- a/client/pkg/infra/provision/provision.go
+++ b/client/pkg/infra/provision/provision.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/cloud"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 )
 
 // Result is returned from the provision function.
@@ -24,6 +25,6 @@ type Result struct {
 
 // Provisioner is the interface that should be implemented by an infra provider.
 type Provisioner[T resource.Resource] interface {
-	Provision(context.Context, *zap.Logger, T, *cloud.MachineRequest) (Result, error)
+	Provision(context.Context, *zap.Logger, T, *cloud.MachineRequest, *siderolink.ConnectionParams) (Result, error)
 	Deprovision(context.Context, *zap.Logger, T, *cloud.MachineRequest) error
 }


### PR DESCRIPTION
The provider should know the config to use for the machine provisioning.