### PR TITLE
chore: allow multiple IP's for `siderolink-wireguard-advertised-addr` flag

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -23,3 +23,11 @@ There are two ways to get audit log, and for both you need Admin role:
 1. By using the UI: Simply click "Download audit log" in the main menu.
 2. Using `omnictl audit-log` command. This command will stream the audit log from the Omni to the local machine stdout.
 """
+
+  [notes.allow-multiple-ip]
+    title = "Allow multiple IP's in `siderolink-wireguard-advertised-addr` flag"
+    description = """\
+The `siderolink-wireguard-advertised-addr` flag now accepts multiple IP addresses separated by commas. This is useful
+when you have multiple IPs (IPv4 and IPv6) on the host machine and want to allow Talos nodes to connect to the Omni
+using any of them.
+"""

--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -15,6 +15,7 @@ import (
 	"net/netip"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -780,8 +781,10 @@ func (manager *Manager) Provision(ctx context.Context, req *pb.ProvisionRequest)
 		endpoint = spec.VirtualAddrport
 	}
 
+	endpoints := strings.Split(endpoint, ",")
+
 	return &pb.ProvisionResponse{
-		ServerEndpoint:    pb.MakeEndpoints(endpoint),
+		ServerEndpoint:    pb.MakeEndpoints(endpoints...),
 		ServerPublicKey:   manager.wgConfig().PublicKey,
 		NodeAddressPrefix: spec.NodeSubnet,
 		ServerAddress:     manager.wgConfig().ServerAddress,


### PR DESCRIPTION
The code is already there: Talos will simply fail to connect and will try again by rotating the IP. We simply add support for specifing multiple IP's in the `siderolink-wireguard-advertised-addr` flag separated by a comma.

Fixes #495