### PR TITLE
Local dev enchancements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,13 @@ In this document, we are going to use the `172.20.0.0/24` CIDR, but you can use 
 With the CIDR `172.20.0.0/24`, the bridge IP is going to be `172.20.0.1`, so we are going to use the bridge IP
 as the Omni endpoint QEMU VMs can reach.
 
+## Mac considerations
+
+1. Make sure you have the latest version of `make` installed
+2. Configure your container engine to work with `network_mode: host`
+
+In case of Docker Desktop check `Enable host networking` under Settings > Resources > Network.
+
 ## Build Omni and omnictl
 
 ```shell

--- a/hack/generate-certs.example.yml
+++ b/hack/generate-certs.example.yml
@@ -14,6 +14,9 @@ pprof-bind-addr: 0.0.0.0:2135
 
 # auth0 client id and domain is used to enable authentication flow
 # you can create a free dev account in Auth0 and create an app there
+# make sure to add your hosts to the allowed callback URLs list
+# for example, for "localhost" add "https://localhost"
+# if you use a port other than 443, make sure to specify it as well
 # client-id: <client-id>
 # auth0-domain: <auth0-domain>
 


### PR DESCRIPTION
Hello, I went through the [DEVELOPMENT.md](./DEVELOPMENT.md) process and everything worked fine. I did run into a couple of issues which I address via this pr. It has only documentation changes.

1. In the auth0 app a callback url needs to be added in order for the authentication to work
2. On mac the host network mode has to be enabled for Docker Desktop in order for the networking to work
3. On mac `make` needs to be updated (v2 comes preinstalled) in order for the makefile to be parsed

---

Note about the docker host network option:
At first I thought that the `network_mode: host` feature is not available on Docker Desktop on mac and went through the process of removing it's usage, but on further research it seems that the feature IS available since version 4.29 if logged in, so a simple documentation addition suffices. I still think there might be benefits to switching away from the convenient host network to the more implicit and isolated docker bridge network. You can see my go at it in this commit https://github.com/Orzelius/omni/commit/cd275620d1086f75d8f3427cdc2ac2fbf3d1d160

Now that I have omnl locally running I'll be looking forward to making some real contributions :)
