### PR TITLE
fix: calculate requested and connected machines in the `ClusterStatus`

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_status.go
@@ -89,6 +89,8 @@ func NewClusterStatusController(embeddedDiscoveryServiceEnabled bool) *ClusterSt
 
 					machines.Total += machineSetStatus.GetMachines().GetTotal()
 					machines.Healthy += machineSetStatus.GetMachines().GetHealthy()
+					machines.Requested += machineSetStatus.GetMachines().GetRequested()
+					machines.Connected += machineSetStatus.GetMachines().GetConnected()
 
 					_, isControlPlane := mss.Metadata().Labels().Get(omni.LabelControlPlaneRole)
 					if isControlPlane {


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/omni/issues/609