### PR TITLE
fix: use YAML representation in `omnictl get`

### DIFF
--- a/client/pkg/omnictl/get.go
+++ b/client/pkg/omnictl/get.go
@@ -117,6 +117,7 @@ func getResources(cmd *cobra.Command, args []string) func(ctx context.Context, c
 			items, err := st.List(ctx, md,
 				state.WithLabelQuery(labelQuery...),
 				state.WithIDQuery(idQuery...),
+				state.WithListUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
 			)
 			if err != nil {
 				return err
@@ -134,6 +135,7 @@ func getResources(cmd *cobra.Command, args []string) func(ctx context.Context, c
 				state.WithBootstrapContents(true),
 				state.WatchWithLabelQuery(labelQuery...),
 				state.WatchWithIDQuery(idQuery...),
+				state.WithWatchKindUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
 			)
 			if err != nil {
 				return err
@@ -177,7 +179,9 @@ func getResources(cmd *cobra.Command, args []string) func(ctx context.Context, c
 				}
 			}
 		case resourceID != "" && !getCmdFlags.watch:
-			res, err := st.Get(ctx, md)
+			res, err := st.Get(ctx, md,
+				state.WithGetUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+			)
 			if err != nil {
 				return err
 			}
@@ -188,7 +192,9 @@ func getResources(cmd *cobra.Command, args []string) func(ctx context.Context, c
 		case resourceID != "" && getCmdFlags.watch:
 			watchCh := make(chan state.Event)
 
-			err := st.Watch(ctx, md, watchCh)
+			err := st.Watch(ctx, md, watchCh,
+				state.WithWatchUnmarshalOptions(state.WithSkipProtobufUnmarshal()),
+			)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The benefit is that if `omnictl` is out of sync with the server, it will still show correct server-side representation.

(If protobuf representation is out of sync with the server, it might skip unknown fields).

This doesn't affect other commands, like `apply` or `cluster template` family of functions, they still use protobuf representation.