### PR TITLE
docs: update omni template so docs are easier

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,4 +1,20 @@
 ## Omni On-Prem Compose File
 
-- Copy `env.template` and edit all fields necessary to match local paths to keys, domain names, etc.
+Follow the full documentation in the [Omni docs](https://omni.siderolabs.com/how-to-guides/self_hosted/index).
+
+The template requires the following environment variables to be set (change these for your environment):
+
+```bash
+OMNI_VERSION=v0.42.0
+OMNI_ACCOUNT_UUID=$(uuidgen)
+OMNI_DOMAIN_NAME=omni.siderolabs.com
+OMNI_WG_IP=10.10.1.100
+OMNI_ADMIN_EMAIL=omni@siderolabs.com
+AUTH0_CLIENT_ID=xxxyyyzzz
+AUTH0_DOMAIN=dev-aaabbbccc.us.auth0.com
+```
+
+You may also want to update certificate paths, etcd storage, and other settings.
+
+- Copy `env.template` and edit all fields necessary
 - Run docker compose, supplying the environment file edited above: `docker compose --env-file <path-to-env> up -d`

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,5 +1,4 @@
 name: omni-on-prem
-version: '3'
 services:
   omni:
     container_name: omni

--- a/deploy/env.template
+++ b/deploy/env.template
@@ -1,14 +1,14 @@
 # Omni
-OMNI_IMG_TAG=<latest-stable-omni-release>
-OMNI_ACCOUNT_UUID=<generated-uuid>
+OMNI_IMG_TAG=${OMNI_VERSION}
+OMNI_ACCOUNT_UUID=${OMNI_ACCOUNT_UUID}
 NAME=omni
 EVENT_SINK_PORT=8091
 
 ## Keys and Certs
-TLS_CERT=<full-path-to-fullchain-cert>
-TLS_KEY=<full-path-to-private-key>
-ETCD_VOLUME_PATH=<full-path-to-etcd-directory>
-ETCD_ENCRYPTION_KEY=<full-path-to-etcd-encryption-key>
+TLS_CERT=/etc/letsencrypt/live/${OMNI_DOMAIN_NAME}/fullchain.pem
+TLS_KEY=/etc/letsencrypt/live/${OMNI_DOMAIN_NAME}/privkey.pem
+ETCD_VOLUME_PATH=/etc/etcd/
+ETCD_ENCRYPTION_KEY=${PWD}/omni.asc
 
 ## Binding
 BIND_ADDR=0.0.0.0:443
@@ -16,20 +16,20 @@ MACHINE_API_BIND_ADDR=0.0.0.0:8090
 K8S_PROXY_BIND_ADDR=0.0.0.0:8100
 
 ## Domains and Advertisements
-OMNI_DOMAIN_NAME="<omni-host-domain-name>"
+OMNI_DOMAIN_NAME="${OMNI_DOMAIN_NAME}"
 ADVERTISED_API_URL="https://${OMNI_DOMAIN_NAME}"
 SIDEROLINK_ADVERTISED_API_URL="https://${OMNI_DOMAIN_NAME}:8090/"
 ADVERTISED_K8S_PROXY_URL="https://${OMNI_DOMAIN_NAME}:8100/"
-SIDEROLINK_WIREGUARD_ADVERTRISED_ADDR="<omni-host-ip>:50180"
+SIDEROLINK_WIREGUARD_ADVERTISED_ADDR="${OMNI_WG_IP}:50180"
 
 ## Users
-INITIAL_USER_EMAILS='<initial-emails>'
+INITIAL_USER_EMAILS="${OMNI_ADMIN_EMAIL}"
 
 ## Authentication
 #Auth0
 AUTH='--auth-auth0-enabled=true \
-      --auth-auth0-domain=<auth0-domain> \
-      --auth-auth0-client-id=<auth0-client-id>'
+      --auth-auth0-domain=${AUTH0_DOMAIN} \
+      --auth-auth0-client-id=${AUTH0_CLIENT_ID}
 # Or, when using SAML:
 # AUTH='--auth-saml-enabled=true \
 #       --auth-saml-url=<saml-url>'


### PR DESCRIPTION
Uses shell veriables so the template can be fed through envsubst to help people get started faster.

Will update docs at https://omni.siderolabs.com/how-to-guides/self_hosted/index once this template is available.