### PR TITLE
fix: parse machine labels and extensions as slices in `omnictl download`

### DIFF
--- a/client/pkg/omnictl/download.go
+++ b/client/pkg/omnictl/download.go
@@ -55,9 +55,9 @@ func init() {
 	downloadCmd.Flags().StringVar(&downloadCmdFlags.architecture, "arch", "amd64", "Image architecture to download (amd64, arm64)")
 	downloadCmd.Flags().StringVar(&downloadCmdFlags.output, "output", ".", "Output file or directory, defaults to current working directory")
 	downloadCmd.Flags().StringVar(&downloadCmdFlags.talosVersion, "talos-version", constants.DefaultTalosVersion, "Talos version to be used in the generated installation media")
-	downloadCmd.Flags().StringArrayVar(&downloadCmdFlags.labels, "initial-labels", nil, "Bake initial labels into the generated installation media")
+	downloadCmd.Flags().StringSliceVar(&downloadCmdFlags.labels, "initial-labels", nil, "Bake initial labels into the generated installation media")
 	downloadCmd.Flags().StringArrayVar(&downloadCmdFlags.extraKernelArgs, "extra-kernel-args", nil, "Add extra kernel args to the generated installation media")
-	downloadCmd.Flags().StringArrayVar(&downloadCmdFlags.extensions, "extensions", nil, "Generate installation media with extensions pre-installed")
+	downloadCmd.Flags().StringSliceVar(&downloadCmdFlags.extensions, "extensions", nil, "Generate installation media with extensions pre-installed")
 
 	RootCmd.AddCommand(downloadCmd)
 }


### PR DESCRIPTION
It allows using commas as separator when specifying multiple values. Commas are probably not expected/intended in labels, and will never appear in extension names.

Leave `extraKernelArgs` as-is, as it can actually contain commas.