### PR TITLE
fix: call deprovision only after the machine request status is deleted

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -536,6 +536,8 @@ func (ctrl *MachineStatusController) setClusterRelation(in inputs, machineStatus
 		machineStatus.Metadata().Labels().Set(omni.MachineStatusLabelAvailable, "")
 
 		machineStatus.Metadata().Labels().Delete(omni.LabelCluster)
+		machineStatus.Metadata().Labels().Delete(omni.LabelControlPlaneRole)
+		machineStatus.Metadata().Labels().Delete(omni.LabelWorkerRole)
 
 		return nil
 	}


### PR DESCRIPTION
Otherwise the infra provider stops the machine before Omni can run the reset and everything gets stuck when the machine is allocated into a cluster.

Also fix labels not being reset on the machine status.