### PR TITLE
chore: fix capitalization of wireguard

### DIFF
--- a/cmd/omni/main.go
+++ b/cmd/omni/main.go
@@ -324,14 +324,14 @@ func init() {
 	rootCmd.Flags().StringVar(&config.Config.Name, "name", config.Config.Name, "instance user-facing name.")
 	rootCmd.Flags().StringVar(&config.Config.APIURL, "advertised-api-url", config.Config.APIURL, "advertised API frontend URL.")
 	rootCmd.Flags().StringVar(&config.Config.KubernetesProxyURL, "advertised-kubernetes-proxy-url", config.Config.KubernetesProxyURL, "advertised Kubernetes proxy URL.")
-	rootCmd.Flags().BoolVar(&config.Config.SiderolinkDisableLastEndpoint, "siderolink-disable-last-endpoint", false, "do not populate last known peer endpoint for the wireguard peers")
+	rootCmd.Flags().BoolVar(&config.Config.SiderolinkDisableLastEndpoint, "siderolink-disable-last-endpoint", false, "do not populate last known peer endpoint for the WireGuard peers")
 	rootCmd.Flags().StringVar(
 		&config.Config.SiderolinkWireguardAdvertisedAddress,
 		"siderolink-wireguard-advertised-addr",
 		config.Config.SiderolinkWireguardAdvertisedAddress,
 		"advertised wireguard address which is passed down to the nodes.")
-	rootCmd.Flags().StringVar(&config.Config.SiderolinkWireguardBindAddress, "siderolink-wireguard-bind-addr", config.Config.SiderolinkWireguardBindAddress, "Siderolink wireguard bind address.")
-	rootCmd.Flags().BoolVar(&config.Config.SiderolinkUseGRPCTunnel, "siderolink-use-grpc-tunnel", false, "use gRPC tunnel to wrap wireguard traffic instead of UDP")
+	rootCmd.Flags().StringVar(&config.Config.SiderolinkWireguardBindAddress, "siderolink-wireguard-bind-addr", config.Config.SiderolinkWireguardBindAddress, "SideroLink WireGuard bind address.")
+	rootCmd.Flags().BoolVar(&config.Config.SiderolinkUseGRPCTunnel, "siderolink-use-grpc-tunnel", false, "use gRPC tunnel to wrap WireGuard traffic instead of UDP")
 
 	rootCmd.Flags().StringVar(&config.Config.MachineAPIBindAddress, "siderolink-api-bind-addr", config.Config.MachineAPIBindAddress, "SideroLink provision bind address.")
 	rootCmd.Flags().StringVar(&config.Config.MachineAPICertFile, "siderolink-api-cert", config.Config.MachineAPICertFile, "SideroLink TLS cert file path.")
@@ -521,7 +521,7 @@ func init() {
 		&config.Config.EmbeddedDiscoveryService.Enabled,
 		"embedded-discovery-service-enabled",
 		config.Config.EmbeddedDiscoveryService.Enabled,
-		"enable embedded discovery service, binds only to the siderolink wireguard address",
+		"enable embedded discovery service, binds only to the SideroLink WireGuard address",
 	)
 	rootCmd.Flags().IntVar(
 		&config.Config.EmbeddedDiscoveryService.Port,

--- a/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanelCondition.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanelCondition.vue
@@ -35,6 +35,10 @@ const getConditionName = (t?: ConditionType) => {
     return "Unknown condition";
   }
 
+  if (t === ConditionType.WireguardConnection) {
+    return "WireGuard Connection";
+  }
+
   return mapping[t];
 }
 

--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -76,7 +76,7 @@ included in the LICENSE file.
       <tooltip>
         <template #description>
           <div class="flex flex-col gap-1 p-2">
-            <p>Configure Talos to use a GRPC tunnel for Siderolink (wireguard) connection to Omni.</p>
+            <p>Configure Talos to use a GRPC tunnel for Siderolink (WireGuard) connection to Omni.</p>
             <p>The default value configured for this Omni instance is <code>{{ useGrpcTunnelDefault.toString() }}</code>.</p>
           </div>
         </template>

--- a/frontend/src/views/omni/Overview/Overview.vue
+++ b/frontend/src/views/omni/Overview/Overview.vue
@@ -52,7 +52,7 @@ included in the LICENSE file.
                     <t-icon icon="copy" class="overview-copy-icon"
                       @click="() => copyValue(items[0]?.spec?.api_endpoint)" />
                   </div>
-                  <div>Wireguard Endpoint</div>
+                  <div>WireGuard Endpoint</div>
                   <div>
                     {{ items[0]?.spec?.wireguard_endpoint }}
                     <t-icon icon="copy" class="overview-copy-icon"

--- a/hack/zstd-dict/data/machineconfig.tmpl.yaml
+++ b/hack/zstd-dict/data/machineconfig.tmpl.yaml
@@ -130,9 +130,9 @@ machine:
         #       # dhcpOptions:
         #       #     routeMetric: 1024 # The priority of all routes received via DHCP.
 
-        #       # # Wireguard specific configuration.
+        #       # # WireGuard specific configuration.
 
-        #       # # wireguard server example
+        #       # # wireguard: server example
         #       # wireguard:
         #       #     privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
         #       #     listenPort: 51111 # Specifies a device's listening port.
@@ -143,7 +143,7 @@ machine:
         #       #           # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
         #       #           allowedIPs:
         #       #             - 192.168.1.0/24
-        #       # # wireguard peer example
+        #       # # wireguard: peer example
         #       # wireguard:
         #       #     privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
         #       #     # Specifies a list of peer configurations to apply to a device.


### PR DESCRIPTION
I'm a sucker for proper capitalization and noticed this in the hands-on lab under TalosCon.  This only changes the Omni web UI.  I've not touched the source itself as I did in https://github.com/siderolabs/talos/pull/8623.  I'm happy to do that too if you want.

I've added the `:` to show that it's a key example.  Just not to interfere with only having proper caps and the other not.  I can of course change this back. :smile:

![IMG_3464](https://github.com/user-attachments/assets/14894ce0-4337-494d-a478-6bd11ff51c7e)
