### PR TITLE
test: fix the error message in infra test

### DIFF
--- a/cmd/integration-test/pkg/tests/infra.go
+++ b/cmd/integration-test/pkg/tests/infra.go
@@ -86,7 +86,7 @@ func AssertMachinesShouldBeProvisioned(testCtx context.Context, client *client.C
 			}
 
 			if machines.Len() < machineCount {
-				return retry.ExpectedErrorf("links count is %d, expected at least %d", resources.Len(), machineCount)
+				return retry.ExpectedErrorf("links count is %d, expected at least %d", machines.Len(), machineCount)
 			}
 
 			for r := range resources.All() {


### PR DESCRIPTION
The error message is misleading due to printing the wrong length.