### PR TITLE
fix: get proper IP from peer metadata

### DIFF
--- a/client/api/omni/specs/siderolink.pb.go
+++ b/client/api/omni/specs/siderolink.pb.go
@@ -130,7 +130,7 @@ type SiderolinkSpec struct {
 	Connected       bool   `protobuf:"varint,4,opt,name=connected,proto3" json:"connected,omitempty"`
 	VirtualAddrport string `protobuf:"bytes,7,opt,name=virtual_addrport,json=virtualAddrport,proto3" json:"virtual_addrport,omitempty"`
 	// RemoteAddr is the machine address how it's visible from Omni
-	// it is determined by reading X-Real-IP header coming from the gRPC API.
+	// it is determined by reading X-Forwarded-For header coming from the gRPC API.
 	RemoteAddr string `protobuf:"bytes,8,opt,name=remote_addr,json=remoteAddr,proto3" json:"remote_addr,omitempty"`
 }
 

--- a/client/api/omni/specs/siderolink.proto
+++ b/client/api/omni/specs/siderolink.proto
@@ -26,7 +26,7 @@ message SiderolinkSpec {
   reserved 6;
   string virtual_addrport = 7;
   // RemoteAddr is the machine address how it's visible from Omni
-  // it is determined by reading X-Real-IP header coming from the gRPC API.
+  // it is determined by reading X-Forwarded-For header coming from the gRPC API.
   string remote_addr = 8;
 }
 

--- a/internal/backend/logging/handler.go
+++ b/internal/backend/logging/handler.go
@@ -28,7 +28,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	remoteAddr := r.RemoteAddr
 	remoteAddr, _, _ = net.SplitHostPort(remoteAddr) //nolint:errcheck
 
-	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+	if realIP := r.Header.Get("X-Forwarded-For"); realIP != "" {
 		remoteAddr = realIP
 	}
 

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -902,10 +902,10 @@ func runK8sProxyServer(
 	return (&server{server: k8sProxyServer, certData: data}).Run(ctx, logger)
 }
 
-// setRealIPRequest extracts ip from the request and sets it to the X-Real-IP header if there is neither X-Real-IP nore
-// X-Forwarded-For.
+// setRealIPRequest extracts ip from the request and sets it to the X-Forwarded-For header if there is no
+// existing X-Forwarded-For.
 func setRealIPRequest(req *http.Request) *http.Request {
-	if req.Header.Get("X-Real-IP") != "" || req.Header.Get("X-Forwarded-For") != "" {
+	if req.Header.Get("X-Forwarded-For") != "" {
 		return req
 	}
 
@@ -916,7 +916,7 @@ func setRealIPRequest(req *http.Request) *http.Request {
 
 	newReq := req.Clone(req.Context())
 
-	newReq.Header.Set("X-Real-IP", actualIP)
+	newReq.Header.Set("X-Forwarded-For", actualIP)
 
 	return newReq
 }

--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -716,10 +716,6 @@ func (manager *Manager) getLink(ctx context.Context, req *pb.ProvisionRequest, i
 
 func getRemoteAddr(ctx context.Context) string {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if vals := md.Get("X-Real-IP"); vals != nil {
-			return vals[0]
-		}
-
 		if vals := md.Get("X-Forwarded-For"); vals != nil {
 			return vals[0]
 		}


### PR DESCRIPTION
Currently, if gateway meets existing X-Forwarded-For header, it will append peer address that it sees to the existing value using comma. Our IP extraction function didn't account for that, and so it failed to parse IP and it used the original `peer.address` which set deep below in the gRPC middleware.

This commit ensures that we try to split the string value using `,`.

Closes #668