### PR TITLE
feat: support insecure localhost infra provider access mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-11T13:55:52Z by kres 34e72ac.
+# Generated on 2024-10-16T15:16:19Z by kres 34e72ac.
 
 name: default
 concurrency:
@@ -108,12 +108,36 @@ jobs:
       - name: integration-test
         run: |
           make integration-test
-      - name: omni
-        run: |
-          make omni
       - name: lint
         run: |
           make lint
+      - name: Login to registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+      - name: image-integration-test
+        run: |
+          make image-integration-test
+      - name: push-omni-integration-test
+        if: github.event_name != 'pull_request'
+        env:
+          PLATFORM: linux/amd64,linux/arm64
+          PUSH: "true"
+        run: |
+          make image-integration-test
+      - name: push-omni-integration-test-latest
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          PLATFORM: linux/amd64,linux/arm64
+          PUSH: "true"
+        run: |
+          make image-integration-test IMAGE_TAG=latest
+      - name: omni
+        run: |
+          make omni
       - name: Login to registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -4,11 +4,6 @@ name: omnictl
 spec:
   disableImage: true
 ---
-kind: auto.CommandConfig
-name: integration-test
-spec:
-  disableImage: true
----
 kind: common.GHWorkflow
 spec:
   customRunners:
@@ -486,6 +481,13 @@ spec:
   artifacts:
     - omnictl-*
     - omni-*
+---
+kind: common.Image
+name: image-integration-test
+spec:
+  extraEnvironment:
+    PLATFORM: linux/amd64,linux/arm64
+  imageName: "omni-integration-test"
 ---
 kind: common.Image
 name: image-omni

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-07T18:59:07Z by kres 34e72ac.
+# Generated on 2024-10-15T13:33:30Z by kres 34e72ac.
 
 ARG JS_TOOLCHAIN
 ARG TOOLCHAIN
@@ -493,6 +493,15 @@ COPY --from=omnictl-darwin-arm64 / /
 COPY --from=omnictl-linux-amd64 / /
 COPY --from=omnictl-linux-arm64 / /
 COPY --from=omnictl-windows-amd64.exe / /
+
+FROM scratch AS image-integration-test
+ARG TARGETARCH
+COPY --from=integration-test integration-test-linux-${TARGETARCH} /integration-test
+COPY --from=integration-test integration-test-linux-${TARGETARCH} /integration-test
+COPY --from=image-fhs / /
+COPY --from=image-ca-certificates / /
+LABEL org.opencontainers.image.source=https://github.com/siderolabs/omni
+ENTRYPOINT ["/integration-test"]
 
 FROM scratch AS image-omni
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-07T18:59:07Z by kres 34e72ac.
+# Generated on 2024-10-16T15:16:19Z by kres 34e72ac.
 
 # common variables
 
@@ -141,7 +141,7 @@ else
 GO_LDFLAGS += -s
 endif
 
-all: unit-tests-frontend lint-eslint frontend unit-tests-client unit-tests integration-test omni image-omni omnictl dev-server docker-compose-up docker-compose-down mkcert-install mkcert-generate mkcert-uninstall run-integration-test lint
+all: unit-tests-frontend lint-eslint frontend unit-tests-client unit-tests integration-test image-integration-test omni image-omni omnictl dev-server docker-compose-up docker-compose-down mkcert-install mkcert-generate mkcert-uninstall run-integration-test lint
 
 $(ARTIFACTS):  ## Creates artifacts directory.
 	@mkdir -p $(ARTIFACTS)
@@ -236,6 +236,17 @@ integration-test-linux-amd64: $(ARTIFACTS)/integration-test-linux-amd64  ## Buil
 .PHONY: integration-test
 integration-test: integration-test-linux-amd64  ## Builds executables for integration-test.
 
+.PHONY: lint-markdown
+lint-markdown:  ## Runs markdownlint.
+	@$(MAKE) target-$@
+
+.PHONY: lint
+lint: lint-eslint lint-golangci-lint-client lint-gofumpt-client lint-govulncheck-client lint-golangci-lint lint-gofumpt lint-govulncheck lint-markdown  ## Run all linters for the project.
+
+.PHONY: image-integration-test
+image-integration-test:  ## Builds image for omni-integration-test.
+	@$(MAKE) target-$@ TARGET_ARGS="--tag=$(REGISTRY)/$(USERNAME)/omni-integration-test:$(IMAGE_TAG)"
+
 .PHONY: $(ARTIFACTS)/omni-darwin-amd64
 $(ARTIFACTS)/omni-darwin-amd64:
 	@$(MAKE) local-omni-darwin-amd64 DEST=$(ARTIFACTS)
@@ -266,13 +277,6 @@ omni-linux-arm64: $(ARTIFACTS)/omni-linux-arm64  ## Builds executable for omni-l
 
 .PHONY: omni
 omni: omni-darwin-amd64 omni-darwin-arm64 omni-linux-amd64 omni-linux-arm64  ## Builds executables for omni.
-
-.PHONY: lint-markdown
-lint-markdown:  ## Runs markdownlint.
-	@$(MAKE) target-$@
-
-.PHONY: lint
-lint: lint-eslint lint-golangci-lint-client lint-gofumpt-client lint-govulncheck-client lint-golangci-lint lint-gofumpt lint-govulncheck lint-markdown  ## Run all linters for the project.
 
 .PHONY: image-omni
 image-omni:  ## Builds image for omni.

--- a/client/pkg/access/serviceaccount.go
+++ b/client/pkg/access/serviceaccount.go
@@ -4,7 +4,9 @@
 
 package access
 
-import "strings"
+import (
+	"strings"
+)
 
 const (
 	serviceAccountDomain              = "serviceaccount.omni.sidero.dev"

--- a/client/pkg/access/validate.go
+++ b/client/pkg/access/validate.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package access
+
+import (
+	"errors"
+	"time"
+
+	pgpcrypto "github.com/ProtonMail/gopenpgp/v2/crypto"
+	authpb "github.com/siderolabs/go-api-signature/api/auth"
+	"github.com/siderolabs/go-api-signature/pkg/pgp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// PublicKey is returned by the result of validation.
+type PublicKey struct {
+	Expiration time.Time
+	ID         string
+	Username   string
+	Data       []byte
+}
+
+// ValidatePublicKey validates the public key in the request and returns a publicKey.
+func ValidatePublicKey(keypb *authpb.PublicKey, opts ...pgp.ValidationOption) (PublicKey, error) {
+	if keypb.GetPgpData() == nil && keypb.GetWebauthnData() == nil {
+		return PublicKey{}, errors.New("no public key data provided")
+	}
+
+	if keypb.GetWebauthnData() != nil {
+		return PublicKey{}, status.Error(codes.Unimplemented, "unimplemented") // todo: implement webauthn
+	}
+
+	return ValidatePGPPublicKey(keypb.GetPgpData(), opts...)
+}
+
+// ValidatePGPPublicKey validates the public key in the request and returns a publicKey.
+func ValidatePGPPublicKey(armored []byte, opts ...pgp.ValidationOption) (PublicKey, error) {
+	pgpKey, err := pgpcrypto.NewKeyFromArmored(string(armored))
+	if err != nil {
+		return PublicKey{}, err
+	}
+
+	key, err := pgp.NewKey(pgpKey)
+	if err != nil {
+		return PublicKey{}, err
+	}
+
+	err = key.Validate(opts...)
+	if err != nil {
+		return PublicKey{}, err
+	}
+
+	if key.IsPrivate() {
+		return PublicKey{}, errors.New("PGP key contains private key")
+	}
+
+	lifetimeSecs := pgpKey.GetEntity().PrimaryIdentity().SelfSignature.KeyLifetimeSecs
+	if lifetimeSecs == nil {
+		return PublicKey{}, errors.New("PGP key has no expiration")
+	}
+
+	expiration := pgpKey.GetEntity().PrimaryKey.CreationTime.Add(time.Duration(*lifetimeSecs) * time.Second)
+
+	return PublicKey{
+		Data:       armored,
+		ID:         pgpKey.GetFingerprint(),
+		Username:   pgpKey.GetEntity().PrimaryIdentity().UserId.Name,
+		Expiration: expiration,
+	}, nil
+}

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -29,7 +29,8 @@ import (
 
 // Client is Omni API client.
 type Client struct {
-	conn *grpc.ClientConn
+	conn    *grpc.ClientConn
+	options *Options
 
 	endpoint string
 }
@@ -93,6 +94,7 @@ func New(endpoint string, opts ...Option) (*Client, error) {
 
 	c := &Client{
 		endpoint: u.String(),
+		options:  &options,
 	}
 
 	c.conn, err = grpc.NewClient(u.Host, grpcDialOptions...)
@@ -110,7 +112,7 @@ func (c *Client) Close() error {
 
 // Omni provides access to Omni resource API.
 func (c *Client) Omni() *omni.Client {
-	return omni.NewClient(c.conn)
+	return omni.NewClient(c.conn, c.options.OmniClientOptions...)
 }
 
 // Management provides access to the management API.

--- a/client/pkg/client/omni/omni.go
+++ b/client/pkg/client/omni/omni.go
@@ -6,11 +6,15 @@
 package omni
 
 import (
+	"context"
+
 	"github.com/cosi-project/runtime/api/v1alpha1"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/protobuf/client"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
+	"github.com/siderolabs/omni/client/pkg/constants"
 	_ "github.com/siderolabs/omni/client/pkg/omni/resources/auth" // import resources to register protobufs
 	_ "github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	_ "github.com/siderolabs/omni/client/pkg/omni/resources/k8s"
@@ -21,19 +25,63 @@ import (
 	_ "github.com/siderolabs/omni/client/pkg/omni/resources/virtual"
 )
 
+// Options defines additional Omni client options.
+type Options struct {
+	infraProviderID string
+}
+
+// Option define an additional Omni client option.
+type Option func(*Options)
+
+// WithProviderID sets provider ID to the metadata of each request.
+func WithProviderID(id string) Option {
+	return func(o *Options) {
+		o.infraProviderID = id
+	}
+}
+
 // Client for Omni resource API (COSI).
 type Client struct {
-	state state.State
+	conn    *grpc.ClientConn
+	state   state.State
+	options Options
 }
 
 // NewClient builds a client out of gRPC connection.
-func NewClient(conn *grpc.ClientConn) *Client {
-	return &Client{
-		state: state.WrapCore(client.NewAdapter(v1alpha1.NewStateClient(conn))),
+func NewClient(conn *grpc.ClientConn, options ...Option) *Client {
+	c := &Client{
+		conn: conn,
 	}
+
+	for _, o := range options {
+		o(&c.options)
+	}
+
+	c.state = state.WrapCore(client.NewAdapter(v1alpha1.NewStateClient(c)))
+
+	return c
 }
 
 // State provides access to the COSI resource state.
 func (client *Client) State() state.State { //nolint:ireturn
 	return client.state
+}
+
+// Invoke performs a unary RPC and returns after the response is received
+// into reply.
+func (client *Client) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
+	return client.conn.Invoke(client.appendMetadata(ctx), method, args, reply, opts...)
+}
+
+// NewStream begins a streaming RPC.
+func (client *Client) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return client.conn.NewStream(client.appendMetadata(ctx), desc, method, opts...)
+}
+
+func (client *Client) appendMetadata(ctx context.Context) context.Context {
+	if client.options.infraProviderID != "" {
+		return metadata.AppendToOutgoingContext(ctx, constants.InfraProviderMetadataKey, client.options.infraProviderID)
+	}
+
+	return ctx
 }

--- a/client/pkg/client/options.go
+++ b/client/pkg/client/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/siderolabs/go-api-signature/pkg/pgp/client"
 	"google.golang.org/grpc"
 
+	"github.com/siderolabs/omni/client/pkg/client/omni"
 	"github.com/siderolabs/omni/client/pkg/version"
 )
 
@@ -18,6 +19,7 @@ type Options struct {
 	AuthInterceptor *interceptor.Interceptor
 
 	AdditionalGRPCDialOptions []grpc.DialOption
+	OmniClientOptions         []omni.Option
 
 	InsecureSkipTLSVerify bool
 }
@@ -60,5 +62,12 @@ func signatureAuthInterceptor(contextName, identity, serviceAccountBase64 string
 func WithGrpcOpts(opts ...grpc.DialOption) Option {
 	return func(options *Options) {
 		options.AdditionalGRPCDialOptions = append(options.AdditionalGRPCDialOptions, opts...)
+	}
+}
+
+// WithOmniClientOptions adds Omni client options.
+func WithOmniClientOptions(opts ...omni.Option) Option {
+	return func(options *Options) {
+		options.OmniClientOptions = opts
 	}
 }

--- a/client/pkg/constants/constants.go
+++ b/client/pkg/constants/constants.go
@@ -73,3 +73,7 @@ const CertificateValidityTime = time.Hour * 24 * 365 // 1 year
 
 // KubernetesAdminCertCommonName is the common name of the Kubernetes admin certificate.
 const KubernetesAdminCertCommonName = "omni:admin"
+
+// InfraProviderMetadataKey is the id of the key which is set by the infrastructure provider when it establishes client connection
+// to the Omni instance.
+const InfraProviderMetadataKey = "providerID"

--- a/client/pkg/infra/controllers/provision.go
+++ b/client/pkg/infra/controllers/provision.go
@@ -7,6 +7,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic"
@@ -203,6 +204,8 @@ func (ctrl *ProvisionController[T]) reconcileRunning(ctx context.Context, r cont
 		var requeueError error
 
 		machineRequestStatus.TypedSpec().Value.Status = fmt.Sprintf("Running Step: %q (%d/%d)", step.Name(), i+1, len(steps))
+		machineRequestStatus.TypedSpec().Value.Error = ""
+		machineRequestStatus.TypedSpec().Value.Stage = specs.MachineRequestStatusSpec_PROVISIONING
 
 		if err = safe.WriterModify(ctx, r, res.(T), func(st T) error { //nolint:forcetypeassert
 			err = step.Run(ctx, logger, provision.NewContext(
@@ -230,7 +233,7 @@ func (ctrl *ProvisionController[T]) reconcileRunning(ctx context.Context, r cont
 			machineRequestStatus.TypedSpec().Value.Error = err.Error()
 			machineRequestStatus.TypedSpec().Value.Stage = specs.MachineRequestStatusSpec_FAILED
 
-			return nil //nolint:nilerr
+			return controller.NewRequeueError(err, time.Minute)
 		}
 
 		if err = safe.WriterModify(ctx, r, machineRequestStatus, func(res *infra.MachineRequestStatus) error {

--- a/client/pkg/infra/infra.go
+++ b/client/pkg/infra/infra.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/siderolabs/omni/client/pkg/client"
+	"github.com/siderolabs/omni/client/pkg/client/omni"
 	"github.com/siderolabs/omni/client/pkg/infra/controllers"
 	"github.com/siderolabs/omni/client/pkg/infra/imagefactory"
 	"github.com/siderolabs/omni/client/pkg/infra/internal/resources"
@@ -101,6 +102,10 @@ func (provider *Provider[T]) Run(ctx context.Context, logger *zap.Logger, opts .
 			return err
 		}
 	}
+
+	options.clientOptions = append(options.clientOptions, client.WithOmniClientOptions(
+		omni.WithProviderID(provider.id),
+	))
 
 	switch {
 	case options.state != nil:

--- a/cmd/integration-test/pkg/root.go
+++ b/cmd/integration-test/pkg/root.go
@@ -55,6 +55,7 @@ var rootCmd = &cobra.Command{
 				OmnictlPath:              rootCmdFlags.omnictlPath,
 				InfraProvider:            rootCmdFlags.infraProvider,
 				ProviderData:             rootCmdFlags.providerData,
+				ScalingTimeout:           rootCmdFlags.scalingTimeout,
 			}
 
 			if rootCmdFlags.restartAMachineScript != "" {
@@ -130,7 +131,8 @@ var rootCmdFlags struct {
 	cleanupLinks           bool
 	runStatsCheck          bool
 
-	testsTimeout time.Duration
+	testsTimeout   time.Duration
+	scalingTimeout time.Duration
 
 	restartAMachineScript    string
 	wipeAMachineScript       string
@@ -172,6 +174,7 @@ var onceInit = sync.OnceValue(func() *cobra.Command {
 	rootCmd.Flags().IntVar(&rootCmdFlags.provisionMachinesCount, "provision-machines", 0, "provisions machines through the infrastructure provider")
 	rootCmd.Flags().StringVar(&rootCmdFlags.infraProvider, "infra-provider", "talemu", "use infra provider with the specified ID when provisioning the machines")
 	rootCmd.Flags().StringVar(&rootCmdFlags.providerData, "provider-data", "{}", "the infra provider machine template data to use")
+	rootCmd.Flags().DurationVar(&rootCmdFlags.scalingTimeout, "scale-timeout", time.Second*150, "scale up test timeout")
 
 	return rootCmd
 })

--- a/cmd/integration-test/pkg/tests/auth.go
+++ b/cmd/integration-test/pkg/tests/auth.go
@@ -505,7 +505,7 @@ func AssertAPIAuthz(rootCtx context.Context, rootCli *client.Client, clientConfi
 		for _, tc := range testCases {
 			// test each test case without signature
 			t.Run(fmt.Sprintf("%s-no-signature", tc.namePrefix), func(t *testing.T) {
-				scopedClient, testErr := clientConfig.GetClient()
+				scopedClient, testErr := clientConfig.GetClient(rootCtx)
 				require.NoError(t, testErr)
 
 				// skip signing the request
@@ -537,6 +537,7 @@ func AssertAPIAuthz(rootCtx context.Context, rootCli *client.Client, clientConfi
 			// test with the role which should succeed
 			t.Run(fmt.Sprintf("%s-success", tc.namePrefix), func(t *testing.T) {
 				scopedClient, testErr := clientConfig.GetClient(
+					rootCtx,
 					authcli.WithRole(string(tc.requiredRole)),
 					authcli.WithSkipUserRole(true),
 				)
@@ -563,6 +564,7 @@ func AssertAPIAuthz(rootCtx context.Context, rootCli *client.Client, clientConfi
 
 			t.Run(fmt.Sprintf("%s-failure", tc.namePrefix), func(t *testing.T) {
 				scopedClient, testErr := clientConfig.GetClient(
+					rootCtx,
 					authcli.WithRole(string(failureRole)),
 					authcli.WithSkipUserRole(true))
 				require.NoError(t, testErr)
@@ -1051,6 +1053,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 
 					t.Run(name, func(t *testing.T) {
 						scopedCli, testErr := clientConfig.GetClient(
+							rootCtx,
 							authcli.WithRole(string(testRole)),
 							authcli.WithSkipUserRole(true),
 						)
@@ -1195,7 +1198,7 @@ func AssertResourceAuthzWithACL(ctx context.Context, rootCli *client.Client, cli
 
 		t.Cleanup(func() { destroy(ctx, t, rootCli, accessPolicy.Metadata()) })
 
-		userCli, err := clientConfig.GetClientForEmail(identity.Metadata().ID())
+		userCli, err := clientConfig.GetClientForEmail(ctx, identity.Metadata().ID())
 		require.NoError(t, err)
 
 		t.Cleanup(func() { userCli.Close() }) //nolint:errcheck

--- a/cmd/integration-test/pkg/tests/blocks.go
+++ b/cmd/integration-test/pkg/tests/blocks.go
@@ -125,6 +125,7 @@ func TestBlockRestoreEtcdFromLatestBackup(ctx context.Context, rootClient *clien
 				Name:           clusterName,
 				ControlPlanes:  controlPlaneNodeCount,
 				MachineOptions: options.MachineOptions,
+				ScalingTimeout: options.ScalingTimeout,
 			}),
 		},
 	}.Append(
@@ -178,6 +179,7 @@ func TestBlockCreateClusterFromEtcdBackup(ctx context.Context, rootClient *clien
 				RestoreFromEtcdBackupClusterID: sourceClusterName,
 
 				MachineOptions: options.MachineOptions,
+				ScalingTimeout: options.ScalingTimeout,
 			}),
 		},
 	}.Append(

--- a/cmd/integration-test/pkg/tests/cluster.go
+++ b/cmd/integration-test/pkg/tests/cluster.go
@@ -55,6 +55,8 @@ type ClusterOptions struct {
 
 	InfraProvider string
 	ProviderData  string
+
+	ScalingTimeout time.Duration
 }
 
 // MachineOptions are the options for machine creation.
@@ -66,7 +68,11 @@ type MachineOptions struct {
 // CreateCluster verifies cluster creation.
 func CreateCluster(testCtx context.Context, cli *client.Client, options ClusterOptions) TestFunc {
 	return func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(testCtx, 150*time.Second)
+		if options.ScalingTimeout == 0 {
+			options.ScalingTimeout = time.Second * 150
+		}
+
+		ctx, cancel := context.WithTimeout(testCtx, options.ScalingTimeout)
 		defer cancel()
 
 		st := cli.Omni().State()
@@ -123,7 +129,11 @@ func CreateCluster(testCtx context.Context, cli *client.Client, options ClusterO
 // CreateClusterWithMachineClass verifies cluster creation.
 func CreateClusterWithMachineClass(testCtx context.Context, st state.State, options ClusterOptions) TestFunc {
 	return func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(testCtx, 150*time.Second)
+		if options.ScalingTimeout == 0 {
+			options.ScalingTimeout = time.Second * 150
+		}
+
+		ctx, cancel := context.WithTimeout(testCtx, options.ScalingTimeout)
 		defer cancel()
 
 		require := require.New(t)
@@ -175,7 +185,11 @@ func CreateClusterWithMachineClass(testCtx context.Context, st state.State, opti
 // ScaleClusterMachineSets scales the cluster with machine sets which are using machine classes.
 func ScaleClusterMachineSets(testCtx context.Context, st state.State, options ClusterOptions) TestFunc {
 	return func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(testCtx, time.Minute*2)
+		if options.ScalingTimeout == 0 {
+			options.ScalingTimeout = time.Second * 30
+		}
+
+		ctx, cancel := context.WithTimeout(testCtx, options.ScalingTimeout)
 		defer cancel()
 
 		updateMachineClassMachineSets(ctx, t, st, options, nil)
@@ -185,7 +199,11 @@ func ScaleClusterMachineSets(testCtx context.Context, st state.State, options Cl
 // ScaleClusterUp scales up the cluster.
 func ScaleClusterUp(testCtx context.Context, st state.State, options ClusterOptions) TestFunc {
 	return func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(testCtx, 30*time.Second)
+		if options.ScalingTimeout == 0 {
+			options.ScalingTimeout = time.Second * 30
+		}
+
+		ctx, cancel := context.WithTimeout(testCtx, options.ScalingTimeout)
 		defer cancel()
 
 		pickUnallocatedMachines(ctx, t, st, options.ControlPlanes+options.Workers, func(machineIDs []resource.ID) {

--- a/cmd/integration-test/pkg/tests/tests.go
+++ b/cmd/integration-test/pkg/tests/tests.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/cmd/integration-test/pkg/clientconfig"
@@ -70,19 +71,27 @@ type Options struct {
 	OmnictlPath              string
 	InfraProvider            string
 	ProviderData             string
+	ScalingTimeout           time.Duration
 }
 
 // Run the integration tests.
 //
-//nolint:maintidx
+//nolint:maintidx,gocyclo,cyclop
 func Run(ctx context.Context, clientConfig *clientconfig.ClientConfig, options Options) error {
-	rootClient, err := clientConfig.GetClient()
+	rootClient, err := clientConfig.GetClient(ctx)
 	if err != nil {
 		return err
 	}
 
 	talosAPIKeyPrepare := func(ctx context.Context, contextName string) error {
 		return clientconfig.TalosAPIKeyPrepare(ctx, rootClient, contextName)
+	}
+
+	if !constants.IsDebugBuild {
+		// noop for non-debug builds
+		talosAPIKeyPrepare = func(context.Context, string) error {
+			return nil
+		}
 	}
 
 	testList := []testGroup{
@@ -164,6 +173,7 @@ Generate various Talos images with Omni and try to download them.`,
 						Workers:       1,
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -216,6 +226,7 @@ In the tests, we wipe and reboot the VMs to bring them back as available for the
 						Workers:       1,
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -259,6 +270,7 @@ Regression test: create a cluster and destroy it without waiting for the cluster
 						Workers:       2,
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 				subTest{
@@ -339,6 +351,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						Workers:       0,
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -357,6 +370,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						ControlPlanes:  0,
 						Workers:        1,
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -375,6 +389,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						ControlPlanes:  2,
 						Workers:        0,
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -393,6 +408,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						ControlPlanes:  0,
 						Workers:        -1,
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -411,6 +427,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						ControlPlanes:  -2,
 						Workers:        0,
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -452,6 +469,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						Workers:       0,
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -470,6 +488,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						ControlPlanes:  0,
 						Workers:        1,
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -488,6 +507,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						ControlPlanes:  2,
 						Workers:        0,
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -506,6 +526,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						ControlPlanes:  0,
 						Workers:        -1,
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -524,6 +545,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						ControlPlanes:  -2,
 						Workers:        0,
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -566,6 +588,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 
 						MachineOptions: options.MachineOptions,
 						ProviderData:   options.ProviderData,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -586,6 +609,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						InfraProvider:  options.InfraProvider,
 						MachineOptions: options.MachineOptions,
 						ProviderData:   options.ProviderData,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -605,6 +629,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						Workers:        0,
 						MachineOptions: options.MachineOptions,
 						ProviderData:   options.ProviderData,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -625,6 +650,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						InfraProvider:  options.InfraProvider,
 						MachineOptions: options.MachineOptions,
 						ProviderData:   options.ProviderData,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -730,6 +756,7 @@ In between the scaling operations, assert that the cluster is ready and accessib
 						Workers:       0,
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -780,6 +807,7 @@ Tests applying various config patching, including "broken" config patches which 
 						Workers:       1,
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -872,6 +900,7 @@ Tests upgrading Talos version, including reverting a failed upgrade.`,
 							TalosVersion:      options.AnotherTalosVersion,
 							KubernetesVersion: options.AnotherKubernetesVersion, // use older Kubernetes compatible with AnotherTalosVersion
 						},
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -969,6 +998,7 @@ Tests upgrading Kubernetes version, including reverting a failed upgrade.`,
 							TalosVersion:      options.MachineOptions.TalosVersion,
 							KubernetesVersion: options.AnotherKubernetesVersion,
 						},
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -1041,6 +1071,7 @@ Finally, a completely new cluster is created using the same backup to test the "
 							Enabled:  true,
 						},
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -1183,6 +1214,7 @@ Test authorization on accessing Omni API, some tests run without a cluster, some
 						},
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					}),
 				},
 			).Append(
@@ -1238,6 +1270,7 @@ Test flow of cluster creation and scaling using cluster templates.`,
 						},
 
 						MachineOptions: options.MachineOptions,
+						ScalingTimeout: options.ScalingTimeout,
 					},
 					),
 				},

--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -565,5 +565,33 @@ var initOnce = sync.OnceValue(func() *cobra.Command {
 		"Directory for audit log storage",
 	)
 
+	rootCmd.Flags().BoolVar(
+		&config.Config.InitialServiceAccount.Enabled,
+		"create-initial-service-account",
+		config.Config.InitialServiceAccount.Enabled,
+		"create and dump a service account credentials on the first start of Omni",
+	)
+
+	rootCmd.Flags().StringVar(
+		&config.Config.InitialServiceAccount.KeyPath,
+		"initial-service-account-key-path",
+		config.Config.InitialServiceAccount.KeyPath,
+		"dump the initial service account key into the path",
+	)
+
+	rootCmd.Flags().StringVar(
+		&config.Config.InitialServiceAccount.Role,
+		"initial-service-account-role",
+		config.Config.InitialServiceAccount.Role,
+		"the initial service account access role",
+	)
+
+	rootCmd.Flags().DurationVar(
+		&config.Config.InitialServiceAccount.Lifetime,
+		"initial-service-account-lifetime",
+		config.Config.InitialServiceAccount.Lifetime,
+		"the lifetime duration of the initial service account key",
+	)
+
 	return rootCmd
 })

--- a/internal/pkg/auth/actor/actor.go
+++ b/internal/pkg/auth/actor/actor.go
@@ -9,15 +9,34 @@ package actor
 import (
 	"context"
 
+	"github.com/siderolabs/omni/internal/pkg/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 
 // internalActorContextKey is the key for internal actor context.
 type internalActorContextKey struct{}
 
+// tnfraProviderContextKey forces infra provider role and sets infrastructure provider name in the context.
+type infraProviderContextKey struct {
+	ProviderID string
+}
+
 // MarkContextAsInternalActor returns a new derived context from the given context, marked as an internal actor.
 func MarkContextAsInternalActor(ctx context.Context) context.Context {
 	return ctxstore.WithValue(ctx, internalActorContextKey{})
+}
+
+// MarkContextAsInfraProvider marks context as infra provider.
+func MarkContextAsInfraProvider(ctx context.Context, name string) context.Context {
+	fullID := name + "@infra-provider.serviceaccount.omni.sidero.dev"
+
+	ctx = ctxstore.WithValue(ctx, auth.EnabledAuthContextKey{Enabled: true})
+	ctx = ctxstore.WithValue(ctx, auth.IdentityContextKey{Identity: fullID})
+	ctx = ctxstore.WithValue(ctx, auth.VerifiedEmailContextKey{Email: fullID})
+	ctx = ctxstore.WithValue(ctx, auth.RoleContextKey{Role: role.InfraProvider})
+
+	return ctx
 }
 
 // ContextIsInternalActor returns true if the given context is marked as an internal actor.
@@ -25,4 +44,15 @@ func ContextIsInternalActor(ctx context.Context) bool {
 	_, ok := ctxstore.Value[internalActorContextKey](ctx)
 
 	return ok
+}
+
+// ContextInfraProvider returns id of the infra provider if it's set in the context.
+func ContextInfraProvider(ctx context.Context) string {
+	value, ok := ctxstore.Value[infraProviderContextKey](ctx)
+
+	if !ok {
+		return ""
+	}
+
+	return value.ProviderID
 }

--- a/internal/pkg/auth/serviceaccount/serviceaccount.go
+++ b/internal/pkg/auth/serviceaccount/serviceaccount.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2024 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package serviceaccount defines common code for creating a service account.
+package serviceaccount
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/google/uuid"
+	"github.com/siderolabs/go-api-signature/pkg/pgp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/actor"
+	"github.com/siderolabs/omni/internal/pkg/auth/role"
+)
+
+// Create a service account.
+func Create(ctx context.Context, st state.State, name, userRole string, useUserRole bool, armoredPGPPublicKey []byte) (string, error) {
+	sa := access.ParseServiceAccountFromName(name)
+	saRole := role.Admin
+
+	if useUserRole && sa.IsInfraProvider {
+		return "", fmt.Errorf("infra provider service accounts must have the role %q, but use-user-role was requested", role.InfraProvider)
+	}
+
+	if !useUserRole {
+		var err error
+
+		if saRole, err = role.Parse(userRole); err != nil {
+			return "", err
+		}
+
+		if sa.IsInfraProvider && saRole != role.InfraProvider {
+			return "", fmt.Errorf("infra-provider service accounts must have the role %q", role.InfraProvider)
+		}
+
+		if saRole == role.InfraProvider && !sa.IsInfraProvider {
+			return "", fmt.Errorf("service accounts with role %q must be prefixed with %q", role.InfraProvider, access.InfraProviderServiceAccountPrefix)
+		}
+	}
+
+	id := sa.FullID()
+
+	ctx = actor.MarkContextAsInternalActor(ctx)
+
+	_, err := st.Get(ctx, authres.NewIdentity(resources.DefaultNamespace, id).Metadata())
+	if err == nil {
+		return "", fmt.Errorf("service account %q already exists", id)
+	}
+
+	if !state.IsNotFoundError(err) { // the identity must not exist
+		return "", err
+	}
+
+	key, err := access.ValidatePGPPublicKey(
+		armoredPGPPublicKey,
+		pgp.WithMaxAllowedLifetime(auth.ServiceAccountMaxAllowedLifetime),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	newUserID := uuid.NewString()
+
+	publicKeyResource := authres.NewPublicKey(resources.DefaultNamespace, key.ID)
+	publicKeyResource.Metadata().Labels().Set(authres.LabelPublicKeyUserID, newUserID)
+
+	if sa.IsInfraProvider {
+		publicKeyResource.Metadata().Labels().Set(authres.LabelInfraProvider, "")
+	}
+
+	publicKeyResource.TypedSpec().Value.PublicKey = key.Data
+	publicKeyResource.TypedSpec().Value.Expiration = timestamppb.New(key.Expiration)
+	publicKeyResource.TypedSpec().Value.Role = string(saRole)
+
+	// register the public key of the service account as "confirmed" because we are already authenticated
+	publicKeyResource.TypedSpec().Value.Confirmed = true
+
+	publicKeyResource.TypedSpec().Value.Identity = &specs.Identity{
+		Email: id,
+	}
+
+	err = st.Create(ctx, publicKeyResource)
+	if err != nil {
+		return "", err
+	}
+
+	// create the user resource representing the service account with the same scopes as the public key
+	user := authres.NewUser(resources.DefaultNamespace, newUserID)
+	user.TypedSpec().Value.Role = publicKeyResource.TypedSpec().Value.GetRole()
+
+	if sa.IsInfraProvider {
+		user.Metadata().Labels().Set(authres.LabelInfraProvider, "")
+	}
+
+	err = st.Create(ctx, user)
+	if err != nil {
+		return "", err
+	}
+
+	// create the identity resource representing the service account
+	identity := authres.NewIdentity(resources.DefaultNamespace, id)
+	identity.TypedSpec().Value.UserId = user.Metadata().ID()
+	identity.Metadata().Labels().Set(authres.LabelIdentityUserID, newUserID)
+	identity.Metadata().Labels().Set(authres.LabelIdentityTypeServiceAccount, "")
+
+	if sa.IsInfraProvider {
+		identity.Metadata().Labels().Set(authres.LabelInfraProvider, "")
+	}
+
+	err = st.Create(ctx, identity)
+	if err != nil {
+		return "", err
+	}
+
+	return key.ID, nil
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -18,6 +18,7 @@ import (
 
 	consts "github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/common"
+	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 const (
@@ -96,6 +97,17 @@ type Params struct {
 	EnableBreakGlassConfigs bool `yaml:"enableBreakGlassConfigs"`
 
 	AuditLogDir string `yaml:"auditLogDir"`
+
+	InitialServiceAccount InitialServiceAccount `yaml:"initialServiceAccount"`
+}
+
+// InitialServiceAccount allows creating a service account for automated omnictl runs on the Omni service deployment.
+type InitialServiceAccount struct {
+	Role     string
+	KeyPath  string
+	Name     string
+	Lifetime time.Duration
+	Enabled  bool
 }
 
 // EmbeddedDiscoveryServiceParams defines embedded discovery service configs.
@@ -284,6 +296,14 @@ var (
 
 		ConfigDataCompression: ConfigDataCompressionParams{
 			Enabled: false,
+		},
+
+		InitialServiceAccount: InitialServiceAccount{
+			Enabled:  false,
+			Role:     string(role.Admin),
+			KeyPath:  "_out/initial-service-account-key",
+			Name:     "automation",
+			Lifetime: time.Hour,
 		},
 
 		LocalResourceServerPort: 8081,


### PR DESCRIPTION
Also:
- support generating the initial service account and dumping it's key somewhere.
- support running omni integration tests against the production build of Omni using a service account.
- enable `omni-integration-test` image.