### PR TITLE
fix: do not set empty initial labels in the UI

### DIFF
--- a/client/pkg/infra/controllers/provision.go
+++ b/client/pkg/infra/controllers/provision.go
@@ -254,6 +254,8 @@ func (ctrl *ProvisionController[T]) reconcileRunning(ctx context.Context, r cont
 
 	*machineRequestStatus.Metadata().Labels() = *machineRequest.Metadata().Labels()
 
+	logger.Info("machine provision finished")
+
 	return nil
 }
 

--- a/frontend/src/views/omni/MachineClasses/MachineClass.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClass.vue
@@ -455,11 +455,11 @@ const submit = async () => {
       grpc_tunnel: grpcTunnelMode.value,
     }
 
-    if (kernelArguments.value) {
+    if (kernelArguments.value.length > 0) {
       machineClass.spec.auto_provision.kernel_args = kernelArguments.value.split(" ");
     }
 
-    if (initialLabels.value) {
+    if (initialLabels.value.length > 0) {
       const l: Record<string, string> = {};
       for (const k in initialLabels.value) {
         l[k] = initialLabels.value[k].value;


### PR DESCRIPTION
The check was incorrect, so it was setting empty initial labels even if they are not set in the UI.