### PR TITLE
fix: do not read Talos versions from the image registry ever

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/versions.go
+++ b/internal/backend/runtime/omni/controllers/omni/versions.go
@@ -126,10 +126,6 @@ func (ctrl *VersionsController) fetchVersionsFromRegistry(ctx context.Context, s
 }
 
 func (ctrl *VersionsController) fetchTalosVersions(ctx context.Context, factoryURL string) ([]string, error) {
-	if config.Config.EnableTalosPreReleaseVersions {
-		return ctrl.fetchVersionsFromRegistry(ctx, config.Config.TalosRegistry)
-	}
-
 	client, err := client.New(factoryURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It was reading from the image registry if the pre-release versions are enabled, but that doesn't work as factory won't generate the images for versions which are not in the list.