### PR TITLE
fix: use proper selectors in the MachineClass create UI

### DIFF
--- a/frontend/src/views/omni/MachineClasses/MachineClass.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClass.vue
@@ -355,7 +355,7 @@ const watchOpts = computed(() => {
       namespace: DefaultNamespace,
       type: MachineStatusType,
     },
-    selectors: nonEmptyConditions.value.concat([`!${LabelNoManualAllocation}`]),
+    selectors: nonEmptyConditions.value.map(c => c + `,!${LabelNoManualAllocation}`),
     selectUsingOR: true,
     runtime: Runtime.Omni,
   };


### PR DESCRIPTION
We added `no-manual-allocation` filter there, but it was added using `OR`. It should be concatenated with each condition in `OR` to work as `AND`.