### PR TITLE
feat: automatically resolve cluster in `talosctl` calls

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,8 @@ run:
   timeout: 10m
   issues-exit-code: 1
   tests: true
-  build-tags: [ ]
   modules-download-mode: readonly
+  build-tags: [ ]
 
 # output configuration options
 output:

--- a/cmd/integration-test/pkg/tests/talos.go
+++ b/cmd/integration-test/pkg/tests/talos.go
@@ -210,6 +210,29 @@ func AssertTalosAPIAccessViaOmni(testCtx context.Context, omniClient *client.Cli
 			assertTalosAPI(ctx, t, c)
 		})
 
+		t.Run("InstanceWideTalosconfigWithoutCluster", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(testCtx, backoff.DefaultConfig.MaxDelay+10*time.Second)
+			t.Cleanup(cancel)
+
+			data, err := omniClient.Management().Talosconfig(ctx)
+			require.NoError(t, err)
+			assert.NotEmpty(t, data)
+
+			config, err := clientconfig.FromBytes(data)
+			require.NoError(t, err)
+
+			require.NoError(t, talosAPIKeyPrepare(ctx, "default"))
+
+			c, err := talosclient.New(ctx, talosclient.WithConfig(config))
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				require.NoError(t, c.Close())
+			})
+
+			assertTalosAPI(ctx, t, c)
+		})
+
 		t.Run("ClusterWideTalosconfig", func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(testCtx, backoff.DefaultConfig.MaxDelay+10*time.Second)
 			t.Cleanup(cancel)

--- a/internal/backend/dns/service.go
+++ b/internal/backend/dns/service.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -34,6 +35,8 @@ type Info struct {
 
 	address            string
 	managementEndpoint string
+
+	Ambiguous bool
 }
 
 // NewInfo exports unexported.
@@ -55,6 +58,34 @@ func (i Info) GetAddress() string {
 	return i.managementEndpoint
 }
 
+type resolverMap map[string][]resource.ID
+
+func (m resolverMap) get(key string) []resource.ID {
+	return m[key]
+}
+
+func (m resolverMap) add(key string, id resource.ID) {
+	if slices.Index(m[key], id) != -1 {
+		return
+	}
+
+	m[key] = append(m[key], id)
+}
+
+func (m resolverMap) remove(key string, id resource.ID) {
+	ids, ok := m[key]
+	if !ok {
+		return
+	}
+
+	ids = slices.DeleteFunc(ids, func(item string) bool { return item == id })
+	if len(ids) == 0 {
+		delete(m, key)
+	} else {
+		m[key] = ids
+	}
+}
+
 // Service is the DNS service.
 type Service struct {
 	omniState state.State
@@ -62,6 +93,8 @@ type Service struct {
 
 	recordToMachineID map[record]resource.ID
 	machineIDToInfo   map[resource.ID]Info
+	addressToID       resolverMap
+	nodenameToID      resolverMap
 
 	lock sync.Mutex
 }
@@ -73,6 +106,8 @@ func NewService(omniState state.State, logger *zap.Logger) *Service {
 		logger:            logger,
 		recordToMachineID: make(map[record]string),
 		machineIDToInfo:   make(map[string]Info),
+		addressToID:       make(resolverMap),
+		nodenameToID:      make(resolverMap),
 	}
 }
 
@@ -165,9 +200,11 @@ func (d *Service) updateEntryByIdentity(res *omni.ClusterMachineIdentity) {
 
 	info.Cluster = clusterName
 	info.ID = res.Metadata().ID()
-	info.Name = nodeName
 
 	previousAddress := info.address
+	previousNodename := info.Name
+
+	info.Name = nodeName
 
 	nodeIPs := res.TypedSpec().Value.NodeIps
 	if len(nodeIPs) == 0 {
@@ -190,12 +227,16 @@ func (d *Service) updateEntryByIdentity(res *omni.ClusterMachineIdentity) {
 		name:    res.Metadata().ID(),
 	}] = res.Metadata().ID()
 
+	d.nodenameToID.add(nodeName, res.Metadata().ID())
+
 	// create entry by address
 	if info.address != "" {
 		d.recordToMachineID[record{
 			cluster: clusterName,
 			name:    info.address,
 		}] = res.Metadata().ID()
+
+		d.addressToID.add(info.address, res.Metadata().ID())
 	}
 
 	// cleanup old entry by address
@@ -204,6 +245,18 @@ func (d *Service) updateEntryByIdentity(res *omni.ClusterMachineIdentity) {
 			cluster: clusterName,
 			name:    previousAddress,
 		})
+
+		d.addressToID.remove(previousAddress, res.Metadata().ID())
+	}
+
+	// cleanup old entry by nodename
+	if previousNodename != "" && previousNodename != info.Name {
+		delete(d.recordToMachineID, record{
+			cluster: clusterName,
+			name:    previousNodename,
+		})
+
+		d.nodenameToID.remove(previousNodename, res.Metadata().ID())
 	}
 
 	d.logger.Debug(
@@ -258,6 +311,9 @@ func (d *Service) deleteIdentityMappings(id resource.ID) {
 			cluster: info.Cluster,
 			name:    info.address,
 		})
+
+		d.addressToID.remove(info.address, id)
+		d.nodenameToID.remove(info.Name, id)
 	}
 
 	info.address = ""
@@ -293,6 +349,27 @@ func (d *Service) deleteMachineMappings(id resource.ID) {
 	)
 }
 
+func (d *Service) resolveByAddressOrNodename(name string) (Info, bool) {
+	for _, resolver := range []resolverMap{
+		d.addressToID,
+		d.nodenameToID,
+	} {
+		ids := resolver.get(name)
+		if len(ids) > 1 {
+			return Info{
+				Name:      name,
+				Ambiguous: true,
+			}, true
+		}
+
+		if len(ids) > 0 {
+			return d.machineIDToInfo[ids[0]], true
+		}
+	}
+
+	return Info{}, false
+}
+
 // Resolve returns the dns.Info for the given node name, address or machine UUID.
 func (d *Service) Resolve(clusterName, name string) Info {
 	d.lock.Lock()
@@ -302,6 +379,12 @@ func (d *Service) Resolve(clusterName, name string) Info {
 		cluster: clusterName,
 		name:    name,
 	}]
+
+	if !ok {
+		if info, found := d.resolveByAddressOrNodename(name); found {
+			return info
+		}
+	}
 
 	if !ok {
 		return d.machineIDToInfo[name]

--- a/internal/backend/dns/service_test.go
+++ b/internal/backend/dns/service_test.go
@@ -134,7 +134,7 @@ func (suite *ServiceSuite) assertResolveAddress(cluster, node, expected string) 
 		resolved := suite.dnsService.Resolve(cluster, node)
 
 		if resolved.GetAddress() != expected {
-			return retry.ExpectedErrorf("expected %s, got %s", expected, resolved)
+			return retry.ExpectedErrorf("expected %s, got %s", expected, resolved.GetAddress())
 		}
 
 		return nil


### PR DESCRIPTION
`talosctl --cluster` flag is now optional, Omni will automatically resolve the cluster if the machine is a part of one.

Fixes: https://github.com/siderolabs/omni/issues/620