### PR TITLE
fix: remove `MaintenanceConfigPatchController` finalizers

### DIFF
--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -177,6 +177,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: deleteAllResources(resource.NewMetadata(resources.DefaultNamespace, MachineClassStatusType, "", resource.VersionUndefined)),
 				name:     "deleteMachineClassStatuses",
 			},
+			{
+				callback: removeMaintenanceConfigPatchFinalizers,
+				name:     "removeMaintenanceConfigPatchFinalizers",
+			},
 		},
 	}
 }

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1319,3 +1319,17 @@ func deleteAllResources(md resource.Metadata) func(context.Context, state.State,
 		return nil
 	}
 }
+
+func removeMaintenanceConfigPatchFinalizers(ctx context.Context, st state.State, _ *zap.Logger) error {
+	items, err := safe.ReaderListAll[*omni.MachineStatus](
+		ctx,
+		st,
+	)
+	if err != nil {
+		return err
+	}
+
+	return items.ForEachErr(func(item *omni.MachineStatus) error {
+		return st.RemoveFinalizer(ctx, item.Metadata(), "MaintenanceConfigPatchController")
+	})
+}


### PR DESCRIPTION
It looks like they weren't removed for Talos < 1.5.0, due to absence of the maintenance config patches for these machines.