### PR TITLE
test: disable secure boot in e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-10-21T13:53:43Z by kres 34e72ac.
+# Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
 name: default
 concurrency:
@@ -311,6 +311,84 @@ jobs:
             !~/.talos/clusters/**/swtpm.log
           retention-days: "5"
         continue-on-error: true
+  e2e-forced-removal:
+    runs-on:
+      - self-hosted
+      - omni
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/e2e') || contains(fromJSON(needs.default.outputs.labels), 'integration/e2e-forced-removal')
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.3.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Mask secrets
+        run: |
+          echo "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
+      - name: Set secrets for job
+        run: |
+          sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts
+          path: _out
+      - name: Fix artifact permissions
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: run-integration-test
+        env:
+          INTEGRATION_RUN_E2E_TEST: "false"
+          INTEGRATION_TEST_ARGS: --test.run CleanState/|ForcedMachineRemoval/|ReplaceControlPlanes/|ConfigPatching/|KubernetesNodeAudit/
+          RUN_TALEMU_TESTS: "false"
+          TALEMU_TEST_ARGS: --test.run ImmediateClusterDestruction/|EncryptedCluster/|SinglenodeCluster/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|TalosUpgrades/|KubernetesUpgrades/|MaintenanceDowngrade/|ClusterTemplate/|ScaleUpAndDownAutoProvisionMachineSets/
+          WITH_DEBUG: "true"
+        run: |
+          sudo -E make run-integration-test
+      - name: save-talos-logs-artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-e2e-forced-removal
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
+        continue-on-error: true
   e2e-scaling:
     runs-on:
       - self-hosted
@@ -373,7 +451,7 @@ jobs:
       - name: run-integration-test
         env:
           INTEGRATION_RUN_E2E_TEST: "false"
-          INTEGRATION_TEST_ARGS: --test.run CleanState/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|RollingUpdateParallelism/|ForcedMachineRemoval/|ReplaceControlPlanes/|ConfigPatching/|KubernetesNodeAudit/
+          INTEGRATION_TEST_ARGS: --test.run CleanState/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|RollingUpdateParallelism
           RUN_TALEMU_TESTS: "false"
           TALEMU_TEST_ARGS: --test.run ImmediateClusterDestruction/|EncryptedCluster/|SinglenodeCluster/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|TalosUpgrades/|KubernetesUpgrades/|MaintenanceDowngrade/|ClusterTemplate/|ScaleUpAndDownAutoProvisionMachineSets/
           WITH_DEBUG: "true"
@@ -462,6 +540,85 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: talos-logs-e2e-short
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+          retention-days: "5"
+        continue-on-error: true
+  e2e-short-secureboot:
+    runs-on:
+      - self-hosted
+      - omni
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/e2e-short-secureboot')
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.3.0
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Mask secrets
+        run: |
+          echo "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
+      - name: Set secrets for job
+        run: |
+          sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts
+          path: _out
+      - name: Fix artifact permissions
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: run-integration-test
+        env:
+          ENABLE_SECUREBOOT: "true"
+          INTEGRATION_RUN_E2E_TEST: "false"
+          INTEGRATION_TEST_ARGS: --test.run CleanState/|TalosImageGeneration/|ImmediateClusterDestruction/|DefaultCluster/|EncryptedCluster/|SinglenodeCluster/|Auth/
+          RUN_TALEMU_TESTS: "false"
+          TALEMU_TEST_ARGS: --test.run ImmediateClusterDestruction/|EncryptedCluster/|SinglenodeCluster/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|TalosUpgrades/|KubernetesUpgrades/|MaintenanceDowngrade/|ClusterTemplate/|ScaleUpAndDownAutoProvisionMachineSets/
+          WITH_DEBUG: "true"
+        run: |
+          sudo -E make run-integration-test
+      - name: save-talos-logs-artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-logs-e2e-short-secureboot
           path: |-
             ~/.talos/clusters/**/*.log
             !~/.talos/clusters/**/swtpm.log

--- a/.github/workflows/e2e-backups-cron.yaml
+++ b/.github/workflows/e2e-backups-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-30T14:56:12Z by kres 8be5fa7.
+# Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
 name: e2e-backups-cron
 concurrency:

--- a/.github/workflows/e2e-forced-removal-cron.yaml
+++ b/.github/workflows/e2e-forced-removal-cron.yaml
@@ -2,7 +2,7 @@
 #
 # Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
-name: e2e-templates-cron
+name: e2e-forced-removal-cron
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -61,7 +61,7 @@ jobs:
       - name: run-integration-test
         env:
           INTEGRATION_RUN_E2E_TEST: "false"
-          INTEGRATION_TEST_ARGS: --test.run CleanState/|ClusterTemplate/
+          INTEGRATION_TEST_ARGS: --test.run CleanState/|ForcedMachineRemoval/|ReplaceControlPlanes/|ConfigPatching/|KubernetesNodeAudit/
           RUN_TALEMU_TESTS: "false"
           TALEMU_TEST_ARGS: --test.run ImmediateClusterDestruction/|EncryptedCluster/|SinglenodeCluster/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|TalosUpgrades/|KubernetesUpgrades/|MaintenanceDowngrade/|ClusterTemplate/|ScaleUpAndDownAutoProvisionMachineSets/
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-scaling-cron.yaml
+++ b/.github/workflows/e2e-scaling-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-30T14:56:12Z by kres 8be5fa7.
+# Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
 name: e2e-scaling-cron
 concurrency:
@@ -61,7 +61,7 @@ jobs:
       - name: run-integration-test
         env:
           INTEGRATION_RUN_E2E_TEST: "false"
-          INTEGRATION_TEST_ARGS: --test.run CleanState/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|RollingUpdateParallelism/|ForcedMachineRemoval/|ReplaceControlPlanes/|ConfigPatching/|KubernetesNodeAudit/
+          INTEGRATION_TEST_ARGS: --test.run CleanState/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|RollingUpdateParallelism
           RUN_TALEMU_TESTS: "false"
           TALEMU_TEST_ARGS: --test.run ImmediateClusterDestruction/|EncryptedCluster/|SinglenodeCluster/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|TalosUpgrades/|KubernetesUpgrades/|MaintenanceDowngrade/|ClusterTemplate/|ScaleUpAndDownAutoProvisionMachineSets/
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-short-cron.yaml
+++ b/.github/workflows/e2e-short-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-30T14:56:12Z by kres 8be5fa7.
+# Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
 name: e2e-short-cron
 concurrency:

--- a/.github/workflows/e2e-short-secureboot-cron.yaml
+++ b/.github/workflows/e2e-short-secureboot-cron.yaml
@@ -2,7 +2,7 @@
 #
 # Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
-name: e2e-templates-cron
+name: e2e-short-secureboot-cron
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -60,8 +60,9 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-test
         env:
+          ENABLE_SECUREBOOT: "true"
           INTEGRATION_RUN_E2E_TEST: "false"
-          INTEGRATION_TEST_ARGS: --test.run CleanState/|ClusterTemplate/
+          INTEGRATION_TEST_ARGS: --test.run CleanState/|TalosImageGeneration/|ImmediateClusterDestruction/|DefaultCluster/|EncryptedCluster/|SinglenodeCluster/|Auth/
           RUN_TALEMU_TESTS: "false"
           TALEMU_TEST_ARGS: --test.run ImmediateClusterDestruction/|EncryptedCluster/|SinglenodeCluster/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|TalosUpgrades/|KubernetesUpgrades/|MaintenanceDowngrade/|ClusterTemplate/|ScaleUpAndDownAutoProvisionMachineSets/
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-upgrades-cron.yaml
+++ b/.github/workflows/e2e-upgrades-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-30T14:56:12Z by kres 8be5fa7.
+# Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
 name: e2e-upgrades-cron
 concurrency:

--- a/.github/workflows/e2e-workload-proxy-cron.yaml
+++ b/.github/workflows/e2e-workload-proxy-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-09-30T14:56:12Z by kres 8be5fa7.
+# Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
 name: e2e-workload-proxy-cron
 concurrency:

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,14 +1,16 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-15T23:44:03Z by kres 7be2a05.
+# Generated on 2024-10-30T17:18:04Z by kres 6d3cad4.
 
 name: slack-notify
 "on":
   workflow_run:
     workflows:
       - default
+      - e2e-short-secureboot-cron
       - e2e-short-cron
       - e2e-scaling-cron
+      - e2e-forced-removal-cron
       - e2e-upgrades-cron
       - e2e-templates-cron
       - e2e-backups-cron

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,14 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-06-19T21:17:41Z by kres 4c9f215.
+# Generated on 2024-10-30T12:55:25Z by kres 6d3cad4.
 
 # options for analysis running
 run:
   timeout: 10m
   issues-exit-code: 1
   tests: true
-  modules-download-mode: readonly
   build-tags: [ ]
+  modules-download-mode: readonly
 
 # output configuration options
 output:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -178,6 +178,18 @@ spec:
       TALEMU_TEST_ARGS: "--test.run ImmediateClusterDestruction/|EncryptedCluster/|SinglenodeCluster/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|TalosUpgrades/|KubernetesUpgrades/|MaintenanceDowngrade/|ClusterTemplate/|ScaleUpAndDownAutoProvisionMachineSets/"
       RUN_TALEMU_TESTS: true
     jobs:
+      - name: e2e-short-secureboot
+        crons:
+          - '30 1 * * *'
+        runnerLabels:
+          - omni
+        triggerLabels:
+          - integration/e2e-short-secureboot
+        environmentOverride:
+          INTEGRATION_RUN_E2E_TEST: "false"
+          INTEGRATION_TEST_ARGS: "--test.run CleanState/|TalosImageGeneration/|ImmediateClusterDestruction/|DefaultCluster/|EncryptedCluster/|SinglenodeCluster/|Auth/"
+          RUN_TALEMU_TESTS: false
+          ENABLE_SECUREBOOT: true
       - name: e2e-short
         crons:
           - '30 1 * * *'
@@ -200,7 +212,19 @@ spec:
           - integration/e2e-scaling
         environmentOverride:
           INTEGRATION_RUN_E2E_TEST: "false"
-          INTEGRATION_TEST_ARGS: "--test.run CleanState/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|RollingUpdateParallelism/|ForcedMachineRemoval/|ReplaceControlPlanes/|ConfigPatching/|KubernetesNodeAudit/"
+          INTEGRATION_TEST_ARGS: "--test.run CleanState/|ScaleUpAndDown/|ScaleUpAndDownMachineClassBasedMachineSets/|RollingUpdateParallelism"
+          RUN_TALEMU_TESTS: false
+      - name: e2e-forced-removal
+        crons:
+          - '30 1 * * *'
+        runnerLabels:
+          - omni
+        triggerLabels:
+          - integration/e2e
+          - integration/e2e-forced-removal
+        environmentOverride:
+          INTEGRATION_RUN_E2E_TEST: "false"
+          INTEGRATION_TEST_ARGS: "--test.run CleanState/|ForcedMachineRemoval/|ReplaceControlPlanes/|ConfigPatching/|KubernetesNodeAudit/"
           RUN_TALEMU_TESTS: false
       - name: e2e-upgrades
         crons:
@@ -581,3 +605,4 @@ spec:
     - e2e-templates
     - e2e-upgrades
     - e2e-backups
+    - e2e-forced-removal

--- a/cmd/integration-test/pkg/tests/talos.go
+++ b/cmd/integration-test/pkg/tests/talos.go
@@ -445,7 +445,7 @@ func AssertTalosVersion(testCtx context.Context, client *client.Client, clusterN
 
 			resp, err := c.Version(talosclient.WithNodes(ctx, machineIPs...))
 			if err != nil {
-				return err
+				return retry.ExpectedError(err)
 			}
 
 			for _, m := range resp.Messages {

--- a/hack/test/provisionconfig.yaml
+++ b/hack/test/provisionconfig.yaml
@@ -1,0 +1,10 @@
+---
+count: 15
+provider:
+  id: talemu
+---
+count: 15
+provider:
+  id: talemu
+  data: |
+    secure_boot: true

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/machineset.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/machineset.go
@@ -69,7 +69,7 @@ func ReconcileMachines(ctx context.Context, r controller.ReaderWriter, logger *z
 		var err error
 
 		operations, err = ReconcileControlPlanes(ctx, rc, func(ctx context.Context) (*check.EtcdStatusResult, error) {
-			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+			ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 
 			defer cancel()
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_status.go
@@ -170,6 +170,7 @@ func NewMachineSetStatusController() *MachineSetStatusController {
 				Kind: controller.OutputExclusive,
 			},
 		),
+		qtransform.WithConcurrency(8),
 	)
 }
 

--- a/internal/backend/runtime/omni/pkg/check/etcd.go
+++ b/internal/backend/runtime/omni/pkg/check/etcd.go
@@ -120,18 +120,18 @@ func GetEtcdMembers(ctx context.Context, r controller.Reader, clusterName string
 
 	var unixSocketOpts []client.OptionFunc
 
-	for _, r := range clusterMachineStatuses {
-		if r.TypedSpec().Value.ManagementAddress == "" {
+	for _, status := range clusterMachineStatuses {
+		if status.TypedSpec().Value.ManagementAddress == "" || status.TypedSpec().Value.IsRemoved {
 			continue
 		}
 
-		if o := talos.GetSocketOptions(r.TypedSpec().Value.ManagementAddress); o != nil {
+		if o := talos.GetSocketOptions(status.TypedSpec().Value.ManagementAddress); o != nil {
 			unixSocketOpts = o
 
 			break
 		}
 
-		endpoints = append(endpoints, r.TypedSpec().Value.ManagementAddress)
+		endpoints = append(endpoints, status.TypedSpec().Value.ManagementAddress)
 	}
 
 	if len(unixSocketOpts) == 0 && len(endpoints) == 0 {
@@ -322,7 +322,7 @@ func getMemberState(ctx context.Context, talosConfig *omni.TalosConfig, clusterM
 
 	opts = append(opts, client.WithConfig(config))
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
 
 	defer cancel()
 


### PR DESCRIPTION
Talos running in secure boot is very unstable in QEMU, it's the main source of test flakiness.
So secureboot tests will run on cron and in Talemu only.

Split e2e-scaling tests: extract forced removal flows from it. Changed the tests flags to support more complicated machine provision flows: now it can read the config from the yaml file.