### PR TITLE
feat: support creating config patches in the infrastructure providers

### DIFF
--- a/client/pkg/omni/resources/infra/config_patch_request.go
+++ b/client/pkg/omni/resources/infra/config_patch_request.go
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package infra
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+)
+
+// NewConfigPatchRequest creates new ConfigPatchRequest resource.
+func NewConfigPatchRequest(ns string, id resource.ID) *ConfigPatchRequest {
+	return typed.NewResource[ConfigPatchRequestSpec, ConfigPatchRequestExtension](
+		resource.NewMetadata(ns, ConfigPatchRequestType, id, resource.VersionUndefined),
+		protobuf.NewResourceSpec(&specs.ConfigPatchSpec{}),
+	)
+}
+
+const (
+	// ConfigPatchRequestType is the type of the ConfigPatch resource.
+	// tsgen:ConfigPatchRequestType
+	ConfigPatchRequestType = resource.Type("ConfigPatchRequests.omni.sidero.dev")
+)
+
+// ConfigPatchRequest requests a config patch to be created for the machine.
+// The controller should copy this resource contents to the target config patch, if the patch is valid.
+type ConfigPatchRequest = typed.Resource[ConfigPatchRequestSpec, ConfigPatchRequestExtension]
+
+// ConfigPatchRequestSpec wraps specs.ConfigPatchRequestSpec.
+type ConfigPatchRequestSpec = protobuf.ResourceSpec[specs.ConfigPatchSpec, *specs.ConfigPatchSpec]
+
+// ConfigPatchRequestExtension provides auxiliary methods for ConfigPatch resource.
+type ConfigPatchRequestExtension struct{}
+
+// ResourceDefinition implements [typed.Extension] interface.
+func (ConfigPatchRequestExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             ConfigPatchRequestType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: resources.InfraProviderNamespace,
+		PrintColumns:     []meta.PrintColumn{},
+		Sensitivity:      meta.Sensitive,
+	}
+}

--- a/client/pkg/omni/resources/infra/infra.go
+++ b/client/pkg/omni/resources/infra/infra.go
@@ -11,4 +11,5 @@ func init() {
 	registry.MustRegisterResource(MachineRequestType, &MachineRequest{})
 	registry.MustRegisterResource(MachineRequestStatusType, &MachineRequestStatus{})
 	registry.MustRegisterResource(InfraProviderStatusType, &ProviderStatus{})
+	registry.MustRegisterResource(ConfigPatchRequestType, &ConfigPatchRequest{})
 }

--- a/cmd/integration-test/pkg/tests/auth.go
+++ b/cmd/integration-test/pkg/tests/auth.go
@@ -1042,6 +1042,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 		delete(untestedResourceTypes, infra.MachineRequestType)
 		delete(untestedResourceTypes, infra.MachineRequestStatusType)
 		delete(untestedResourceTypes, infra.InfraProviderStatusType)
+		delete(untestedResourceTypes, infra.ConfigPatchRequestType)
 
 		for _, tc := range testCases {
 			for _, testVerb := range allVerbs {

--- a/cmd/integration-test/pkg/tests/stats.go
+++ b/cmd/integration-test/pkg/tests/stats.go
@@ -35,7 +35,7 @@ func AssertStatsLimits(testCtx context.Context) TestFunc {
 			{
 				name:  "resource CRUD",
 				query: `sum(omni_resource_operations_total{operation=~"create|update", type!="MachineStatusLinks.omni.sidero.dev"})`,
-				check: func(assert *assert.Assertions, value float64) { assert.Less(value, float64(10000)) },
+				check: func(assert *assert.Assertions, value float64) { assert.Less(value, float64(11000)) },
 			},
 			{
 				name:  "queue length",
@@ -45,7 +45,7 @@ func AssertStatsLimits(testCtx context.Context) TestFunc {
 			{
 				name:  "controller wakeups",
 				query: `sum(omni_runtime_controller_wakeups{controller!="MachineStatusLinkController"})`,
-				check: func(assert *assert.Assertions, value float64) { assert.Less(value, float64(10000)) },
+				check: func(assert *assert.Assertions, value float64) { assert.Less(value, float64(11000)) },
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {

--- a/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/gen/xerrors"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
+)
+
+// InfraProviderConfigPatchController manages endpoints for each Cluster.
+type InfraProviderConfigPatchController = qtransform.QController[*infra.ConfigPatchRequest, *omni.ConfigPatch]
+
+// NewInfraProviderConfigPatchController initializes ConfigPatchRequestController.
+func NewInfraProviderConfigPatchController() *InfraProviderConfigPatchController {
+	return qtransform.NewQController(
+		qtransform.Settings[*infra.ConfigPatchRequest, *omni.ConfigPatch]{
+			Name: "ConfigPatchRequestController",
+			MapMetadataFunc: func(request *infra.ConfigPatchRequest) *omni.ConfigPatch {
+				return omni.NewConfigPatch(resources.DefaultNamespace, request.Metadata().ID())
+			},
+			UnmapMetadataFunc: func(configPatch *omni.ConfigPatch) *infra.ConfigPatchRequest {
+				return infra.NewConfigPatchRequest(resources.DefaultNamespace, configPatch.Metadata().ID())
+			},
+			TransformFunc: func(ctx context.Context, r controller.Reader, _ *zap.Logger, request *infra.ConfigPatchRequest, patch *omni.ConfigPatch) error {
+				machineRequestID, ok := request.Metadata().Labels().Get(omni.LabelMachineRequest)
+				if !ok {
+					return xerrors.NewTaggedf[qtransform.DestroyOutputTag]("missing machine request label on the patch request")
+				}
+
+				machineRequestStatus, err := safe.ReaderGetByID[*infra.MachineRequestStatus](ctx, r, machineRequestID)
+				if err != nil {
+					if state.IsNotFoundError(err) {
+						return xerrors.NewTaggedf[qtransform.DestroyOutputTag]("machine request status with id %q doesn't exist", machineRequestID)
+					}
+
+					return err
+				}
+
+				if machineRequestStatus.TypedSpec().Value.Id == "" {
+					return errors.New("failed to create config patch from the request: machine request status doesn't have machine UUID")
+				}
+
+				patch.TypedSpec().Value = request.TypedSpec().Value
+
+				helpers.CopyAllLabels(request, patch)
+
+				patch.Metadata().Labels().Set(omni.LabelSystemPatch, "")
+				patch.Metadata().Labels().Set(omni.LabelMachine, machineRequestStatus.TypedSpec().Value.Id)
+
+				return nil
+			},
+		},
+		qtransform.WithExtraMappedInput(
+			func(ctx context.Context, _ *zap.Logger, r controller.QRuntime, machineRequestStatus *infra.MachineRequestStatus) ([]resource.Pointer, error) {
+				patchRequests, err := safe.ReaderListAll[*infra.ConfigPatchRequest](ctx, r, state.WithLabelQuery(
+					resource.LabelEqual(omni.LabelMachineRequest, machineRequestStatus.Metadata().ID())),
+				)
+				if err != nil {
+					return nil, err
+				}
+
+				return safe.ToSlice(patchRequests, func(r *infra.ConfigPatchRequest) resource.Pointer { return r.Metadata() }), nil
+			},
+		),
+		qtransform.WithOutputKind(controller.OutputShared),
+	)
+}

--- a/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2024 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+)
+
+type InfraProviderConfigPatchControllerSuite struct {
+	OmniSuite
+}
+
+func (suite *InfraProviderConfigPatchControllerSuite) TestReconcile() {
+	require := suite.Require()
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
+	defer cancel()
+
+	suite.startRuntime()
+
+	require.NoError(suite.runtime.RegisterQController(omnictrl.NewInfraProviderConfigPatchController()))
+
+	provider := "provider"
+	id := "patch"
+	requestID := "request-1"
+
+	request := infra.NewConfigPatchRequest(resources.InfraProviderNamespace, id)
+	request.Metadata().Labels().Set(omni.LabelMachineRequest, requestID)
+	request.Metadata().Labels().Set(omni.LabelInfraProviderID, provider)
+
+	status := infra.NewMachineRequestStatus(requestID)
+
+	suite.Require().NoError(request.TypedSpec().Value.SetUncompressedData([]byte("machine: {}")))
+
+	status.TypedSpec().Value.Id = "1234"
+
+	suite.Require().NoError(suite.state.Create(ctx, request))
+	suite.Require().NoError(suite.state.Create(ctx, status))
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{id}, func(configPatch *omni.ConfigPatch, assert *assert.Assertions) {
+		assert.Equal(configPatch.TypedSpec().Value.CompressedData, request.TypedSpec().Value.CompressedData) //nolint:staticcheck
+
+		value, ok := configPatch.Metadata().Labels().Get(omni.LabelMachine)
+		assert.True(ok)
+		assert.Equal(status.TypedSpec().Value.Id, value)
+
+		value, ok = configPatch.Metadata().Labels().Get(omni.LabelMachineRequest)
+		assert.True(ok)
+		assert.Equal(requestID, value)
+
+		value, ok = configPatch.Metadata().Labels().Get(omni.LabelInfraProviderID)
+		assert.True(ok)
+		assert.Equal(provider, value)
+	})
+
+	rtestutils.DestroyAll[*infra.ConfigPatchRequest](suite.ctx, suite.T(), suite.state)
+
+	rtestutils.AssertNoResource[*omni.ConfigPatch](ctx, suite.T(), suite.state, id)
+}
+
+func TestInfraProviderConfigPatchControllerSuite(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, new(InfraProviderConfigPatchControllerSuite))
+}

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -30,6 +30,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/cosi/labels"
 	omniresources "github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	siderolinkresources "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
@@ -148,6 +149,7 @@ func New(talosClientFactory *talos.ClientFactory, dnsService *dns.Service, workl
 			safe.WithResourceCache[*siderolinkresources.ConnectionParams](),
 			safe.WithResourceCache[*siderolinkresources.Link](),
 			safe.WithResourceCache[*system.ResourceLabels[*omni.MachineStatus]](),
+			safe.WithResourceCache[*infra.ConfigPatchRequest](),
 			options.WithWarnOnUncachedReads(false), // turn this to true to debug resource cache misses
 		)
 	}
@@ -255,6 +257,7 @@ func New(talosClientFactory *talos.ClientFactory, dnsService *dns.Service, workl
 		omnictrl.NewMachineRequestSetStatusController(),
 		omnictrl.NewClusterMachineRequestStatusController(),
 		omnictrl.NewMachineTeardownController(),
+		omnictrl.NewInfraProviderConfigPatchController(),
 	}
 
 	if config.Config.Auth.SAML.Enabled {


### PR DESCRIPTION
Patches can be created for a single machine in the machine provision flow: the provider can call `CreateConfigPatch` method at any point. This will create a `ConfigPatchRequest` resource which will be turned into a `ConfigPatch` after the `MachineRequestStatus` UUID gets populated.

Fixes: https://github.com/siderolabs/omni/issues/728