### PR TITLE
fix: properly set up provider for autoprovision tests

### DIFF
--- a/cmd/integration-test/pkg/root.go
+++ b/cmd/integration-test/pkg/root.go
@@ -57,8 +57,7 @@ var rootCmd = &cobra.Command{
 				ScalingTimeout:           rootCmdFlags.scalingTimeout,
 			}
 
-			switch {
-			case rootCmdFlags.provisionConfigFile != "":
+			if rootCmdFlags.provisionConfigFile != "" {
 				f, err := os.Open(rootCmdFlags.provisionConfigFile)
 				if err != nil {
 					return fmt.Errorf("failed to open provision config file %q: %w", rootCmdFlags.provisionConfigFile, err)
@@ -79,7 +78,7 @@ var rootCmd = &cobra.Command{
 
 					testOptions.ProvisionConfigs = append(testOptions.ProvisionConfigs, cfg)
 				}
-			case rootCmdFlags.provisionMachinesCount != 0:
+			} else {
 				testOptions.ProvisionConfigs = append(testOptions.ProvisionConfigs,
 					tests.MachineProvisionConfig{
 						MachineCount: rootCmdFlags.provisionMachinesCount,

--- a/cmd/integration-test/pkg/tests/tests.go
+++ b/cmd/integration-test/pkg/tests/tests.go
@@ -88,6 +88,16 @@ func (o Options) defaultProviderData() string {
 	return o.ProvisionConfigs[0].Provider.Data
 }
 
+func (o Options) provisionMachines() bool {
+	var totalMachineCount int
+
+	for _, cfg := range o.ProvisionConfigs {
+		totalMachineCount += cfg.MachineCount
+	}
+
+	return totalMachineCount > 0
+}
+
 // MachineProvisionConfig tells the test to provision machines from the infra provider.
 type MachineProvisionConfig struct {
 	Provider     MachineProviderConfig `yaml:"provider"`
@@ -1362,7 +1372,7 @@ Test flow of cluster creation and scaling using cluster templates.`,
 
 	preRunTests := []testing.InternalTest{}
 
-	if len(options.ProvisionConfigs) != 0 {
+	if options.provisionMachines() {
 		for i, cfg := range options.ProvisionConfigs {
 			preRunTests = append(preRunTests, testing.InternalTest{
 				Name: "AssertMachinesShouldBeProvisioned",
@@ -1385,7 +1395,7 @@ Test flow of cluster creation and scaling using cluster templates.`,
 
 	postRunTests := []testing.InternalTest{}
 
-	if len(options.ProvisionConfigs) != 0 {
+	if options.provisionMachines() {
 		for i := range options.ProvisionConfigs {
 			postRunTests = append(postRunTests, testing.InternalTest{
 				Name: "AssertMachinesShouldBeDeprovisioned",


### PR DESCRIPTION
The change which introduced multiple infra provider configs support in the tests has broken the case when there's auto provisioning without pre-allocated machines.