### PR TITLE
chore: deprecate Talos 1.4

### DIFF
--- a/internal/pkg/constants/versions.go
+++ b/internal/pkg/constants/versions.go
@@ -12,7 +12,7 @@ const AnotherTalosVersion = "1.7.0"
 const MinDiscoveredTalosVersion = "1.3.0"
 
 // MinTalosVersion allowed to be used when creating the cluster.
-const MinTalosVersion = "1.4.0"
+const MinTalosVersion = "1.5.0"
 
 // DefaultKubernetesVersion is pre-selected in the UI and used in the integration tests.
 //


### PR DESCRIPTION
Now the minimum supported version of Talos is 1.5 (as per our support policy).
Running existing clusters on 1.4 will be still possible.