### PR TITLE
feat: add Turing RK1 SoM to SBCs dropdown

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/installation_media.go
+++ b/internal/backend/runtime/omni/controllers/omni/installation_media.go
@@ -343,6 +343,14 @@ var installationMedia = []installationMediaSpec{
 		SBC:          true,
 		ContentType:  "application/x-xz",
 	},
+	{
+		Name:         "Turing RK1",
+		Architecture: arm64Arch,
+		Profile:      "turingrk1",
+		Type:         rawType,
+		SBC:          true,
+		ContentType:  "application/x-xz",
+	},
 }
 
 // InstallationMediaController manages omni.InstallationMedia.

--- a/internal/backend/runtime/omni/controllers/omni/internal/boards/boards.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/boards/boards.go
@@ -59,6 +59,11 @@ func GetOverlay(board string) *schematic.Overlay {
 			Name:  "rpi_generic",
 			Image: "siderolabs/sbc-raspberrypi",
 		}
+	case "turingrk1":
+		return &schematic.Overlay{
+			Name:  "turingrk1",
+			Image: "siderolabs/sbc-rockchip",
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This has hardcoded "turingrk1" strings as discussed in https://github.com/siderolabs/talos/pull/9869