### PR TITLE
fix: ignore `Unimplemented` errors in `MetaDelete` calls

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status.go
@@ -814,6 +814,12 @@ func (h *clusterMachineConfigStatusControllerHandler) deleteUpgradeMetaKey(ctx c
 			return nil
 		}
 
+		if status.Code(err) == codes.Unimplemented {
+			h.logger.Debug("upgrade meta key is not removed, unimplemented in the Talos version", zap.String("machine", machineConfig.Metadata().ID()))
+
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Otherwise it breaks config update for the Talos version which do not support `MetaDelete` API.