### PR TITLE
fix: fix panic in `ConfigPatchRequestController`

### DIFF
--- a/client/pkg/infra/provision/context.go
+++ b/client/pkg/infra/provision/context.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
@@ -143,7 +142,7 @@ func (context *Context[T]) UnmarshalProviderData(dest any) error {
 
 // CreateConfigPatch for the provisioned machine.
 func (context *Context[T]) CreateConfigPatch(ctx context.Context, name string, data []byte) error {
-	r := infra.NewConfigPatchRequest(resources.InfraProviderNamespace, name)
+	r := infra.NewConfigPatchRequest(name)
 
 	providerID, ok := context.machineRequest.Metadata().Labels().Get(omni.LabelInfraProviderID)
 	if !ok {

--- a/client/pkg/omni/resources/infra/config_patch_request.go
+++ b/client/pkg/omni/resources/infra/config_patch_request.go
@@ -15,9 +15,9 @@ import (
 )
 
 // NewConfigPatchRequest creates new ConfigPatchRequest resource.
-func NewConfigPatchRequest(ns string, id resource.ID) *ConfigPatchRequest {
+func NewConfigPatchRequest(id resource.ID) *ConfigPatchRequest {
 	return typed.NewResource[ConfigPatchRequestSpec, ConfigPatchRequestExtension](
-		resource.NewMetadata(ns, ConfigPatchRequestType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.InfraProviderNamespace, ConfigPatchRequestType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.ConfigPatchSpec{}),
 	)
 }

--- a/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch.go
@@ -35,7 +35,7 @@ func NewInfraProviderConfigPatchController() *InfraProviderConfigPatchController
 				return omni.NewConfigPatch(resources.DefaultNamespace, request.Metadata().ID())
 			},
 			UnmapMetadataFunc: func(configPatch *omni.ConfigPatch) *infra.ConfigPatchRequest {
-				return infra.NewConfigPatchRequest(resources.DefaultNamespace, configPatch.Metadata().ID())
+				return infra.NewConfigPatchRequest(configPatch.Metadata().ID())
 			},
 			TransformFunc: func(ctx context.Context, r controller.Reader, _ *zap.Logger, request *infra.ConfigPatchRequest, patch *omni.ConfigPatch) error {
 				machineRequestID, ok := request.Metadata().Labels().Get(omni.LabelMachineRequest)

--- a/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
@@ -38,7 +37,7 @@ func (suite *InfraProviderConfigPatchControllerSuite) TestReconcile() {
 	id := "patch"
 	requestID := "request-1"
 
-	request := infra.NewConfigPatchRequest(resources.InfraProviderNamespace, id)
+	request := infra.NewConfigPatchRequest(id)
 	request.Metadata().Labels().Set(omni.LabelMachineRequest, requestID)
 	request.Metadata().Labels().Set(omni.LabelInfraProviderID, provider)
 

--- a/internal/backend/runtime/omni/infraprovider/state_test.go
+++ b/internal/backend/runtime/omni/infraprovider/state_test.go
@@ -114,7 +114,7 @@ func TestInfraProviderAccess(t *testing.T) {
 
 	// ConfigPatchRequest
 
-	cpr := infra.NewConfigPatchRequest(resources.InfraProviderNamespace, "test-cpr")
+	cpr := infra.NewConfigPatchRequest("test-cpr")
 
 	// create
 	assert.NoError(t, st.Create(ctx, cpr))


### PR DESCRIPTION
`ConfigPatchRequest` was created with the wrong namespace in the unmap method there.
Dropped the namespace from the resource constructor method, to avoid such mistakes in the future.