### PR TITLE
chore: bump COSI runtime to `v0.7.5`

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ProtonMail/gopenpgp/v2 v2.8.1
 	github.com/adrg/xdg v0.5.3
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/cosi-project/runtime v0.7.4
+	github.com/cosi-project/runtime v0.7.5
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/gertd/go-pluralize v0.2.1

--- a/client/go.sum
+++ b/client/go.sum
@@ -26,8 +26,8 @@ github.com/containerd/go-cni v1.1.10 h1:c2U73nld7spSWfiJwSh/8W9DK+/qQwYM2rngIhCy
 github.com/containerd/go-cni v1.1.10/go.mod h1:/Y/sL8yqYQn1ZG1om1OncJB1W4zN3YmjfP/ShCzG/OY=
 github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8FuJbEslXM=
 github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
-github.com/cosi-project/runtime v0.7.4 h1:DQAXhYQ9dkDHIGHsrCAuJOrTNaIp13gvrOUtJ4kkeys=
-github.com/cosi-project/runtime v0.7.4/go.mod h1:9hGWkvz7PORXNzC/gJokapXvR+Fb/Mpl6Ic+05WDRMk=
+github.com/cosi-project/runtime v0.7.5 h1:PDUtvyU2LarHRcwFPmnUu+F4m6qa3zN3PQWxrJzsh6Y=
+github.com/cosi-project/runtime v0.7.5/go.mod h1:9hGWkvz7PORXNzC/gJokapXvR+Fb/Mpl6Ic+05WDRMk=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containers/image/v5 v5.33.0
-	github.com/cosi-project/runtime v0.7.4
+	github.com/cosi-project/runtime v0.7.5
 	github.com/cosi-project/state-etcd v0.4.1
 	github.com/crewjam/saml v0.4.14
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cosi-project/runtime v0.7.4 h1:DQAXhYQ9dkDHIGHsrCAuJOrTNaIp13gvrOUtJ4kkeys=
-github.com/cosi-project/runtime v0.7.4/go.mod h1:9hGWkvz7PORXNzC/gJokapXvR+Fb/Mpl6Ic+05WDRMk=
+github.com/cosi-project/runtime v0.7.5 h1:PDUtvyU2LarHRcwFPmnUu+F4m6qa3zN3PQWxrJzsh6Y=
+github.com/cosi-project/runtime v0.7.5/go.mod h1:9hGWkvz7PORXNzC/gJokapXvR+Fb/Mpl6Ic+05WDRMk=
 github.com/cosi-project/state-etcd v0.4.1 h1:WNSl8CFR+dv4DP3W6GwRyszjvofMEPNk89aB4r6sEbY=
 github.com/cosi-project/state-etcd v0.4.1/go.mod h1:RVakFrVCR3bwt/3C2UxZC7EP25d+Zq1lIT4Uyrsfk9I=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=


### PR DESCRIPTION
Include the fix in https://github.com/cosi-project/runtime/pull/528.