### PR TITLE
fix: regenerate wipe id of infra machines only once per de-allocation

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/infra_machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine.go
@@ -119,9 +119,12 @@ func (h *infraMachineControllerHelper) transformExtraOutput(ctx context.Context,
 
 		// the machine is deallocated, clear the cluster information and mark it for wipe by assigning it a new wipe ID
 
+		if infraMachine.TypedSpec().Value.ClusterTalosVersion != "" {
+			infraMachine.TypedSpec().Value.WipeId = uuid.NewString()
+		}
+
 		infraMachine.TypedSpec().Value.ClusterTalosVersion = ""
 		infraMachine.TypedSpec().Value.Extensions = nil
-		infraMachine.TypedSpec().Value.WipeId = uuid.NewString()
 
 		if err = r.RemoveFinalizer(ctx, clusterMachine.Metadata(), InfraMachineControllerName); err != nil {
 			return err


### PR DESCRIPTION
We were generating a random wipe id multiple times in infra.MachineController, causing the infra provider to run many reconciles.

Fix it by doing it only once by checking the allocation information.