### PR TITLE
feat: update Talos machinery to final 1.9.0-beta.1

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/ProtonMail/gopenpgp/v2 v2.8.1
 	github.com/adrg/xdg v0.5.3
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cosi-project/runtime v0.7.5
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
@@ -33,7 +34,7 @@ require (
 	github.com/siderolabs/go-pointer v1.0.0
 	github.com/siderolabs/image-factory v0.6.2
 	github.com/siderolabs/proto-codec v0.1.1
-	github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.0
+	github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
 	github.com/xlab/treeprint v1.2.0
@@ -51,7 +52,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.3 // indirect
 	github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cloudflare/circl v1.5.0 // indirect
 	github.com/containerd/go-cni v1.1.10 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -180,8 +180,8 @@ github.com/siderolabs/proto-codec v0.1.1 h1:4jiUwW/vaXTZ+YNgZDs37B4aj/1mzV/erIkz
 github.com/siderolabs/proto-codec v0.1.1/go.mod h1:rIvmhKJG8+JwSCGPX+cQljpOMDmuHhLKPkt6KaFwEaU=
 github.com/siderolabs/protoenc v0.2.1 h1:BqxEmeWQeMpNP3R6WrPqDatX8sM/r4t97OP8mFmg6GA=
 github.com/siderolabs/protoenc v0.2.1/go.mod h1:StTHxjet1g11GpNAWiATgc8K0HMKiFSEVVFOa/H0otc=
-github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.0 h1:ueS/a+PjzchYO3ZouHgpOZfoUTk/9dO+XHxH3uSM7IU=
-github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.0/go.mod h1:jFnOdqa3IfiUHO/ZG0jfON7SxbNIkowVsom8pO0OwBU=
+github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.1 h1:mhWMKHowS2ea1RTGeqYxicFAT92BE7plh2VgPVqwNpw=
+github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.1/go.mod h1:jFnOdqa3IfiUHO/ZG0jfON7SxbNIkowVsom8pO0OwBU=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/siderolabs/omni/client v0.42.1
 	github.com/siderolabs/proto-codec v0.1.1
 	github.com/siderolabs/siderolink v0.3.11
-	github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.0
+	github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.1
 	github.com/siderolabs/tcpproxy v0.1.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,8 @@ github.com/siderolabs/protoenc v0.2.1 h1:BqxEmeWQeMpNP3R6WrPqDatX8sM/r4t97OP8mFm
 github.com/siderolabs/protoenc v0.2.1/go.mod h1:StTHxjet1g11GpNAWiATgc8K0HMKiFSEVVFOa/H0otc=
 github.com/siderolabs/siderolink v0.3.11 h1:teJ/LMjSyLekhJVy2+nDIuOBPrVRAMwusJQzxdA95K0=
 github.com/siderolabs/siderolink v0.3.11/go.mod h1:QbGnXpHI5MDq6qMZkCFnxYOOw5eE+lkLx53L5ZgjLMQ=
-github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.0 h1:ueS/a+PjzchYO3ZouHgpOZfoUTk/9dO+XHxH3uSM7IU=
-github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.0/go.mod h1:jFnOdqa3IfiUHO/ZG0jfON7SxbNIkowVsom8pO0OwBU=
+github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.1 h1:mhWMKHowS2ea1RTGeqYxicFAT92BE7plh2VgPVqwNpw=
+github.com/siderolabs/talos/pkg/machinery v1.9.0-beta.1/go.mod h1:jFnOdqa3IfiUHO/ZG0jfON7SxbNIkowVsom8pO0OwBU=
 github.com/siderolabs/tcpproxy v0.1.0 h1:IbkS9vRhjMOscc1US3M5P1RnsGKFgB6U5IzUk+4WkKA=
 github.com/siderolabs/tcpproxy v0.1.0/go.mod h1:onn6CPPj/w1UNqQ0U97oRPF0CqbrgEApYCw4P9IiCW8=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
This means full compatibility with future 1.9.0.

The schemas were updated in bbbf6f2c770914a6c5c98ecec39113dfa832d122.