### PR TITLE
feat: Add support for Zitadel IdP

### DIFF
--- a/internal/backend/saml/session.go
+++ b/internal/backend/saml/session.go
@@ -372,6 +372,9 @@ func LocateUserInfo(assertion *saml.Assertion) (UserInfo, error) {
 		"email":     &user.Identity,
 		"givenName": &givenName,
 		"surname":   &surname,
+		// Zitadel SAML
+		"UserName": &user.Identity,
+		"FullName": &user.Fullname,
 	}
 
 	// Google SAML keeps that info in Subject.


### PR DESCRIPTION
Add mappings for SAML attributes provided by default in [Zitadel](https://zitadel.com/docs/). This allows signing in with self-hosted Zitadel IdP. Without this PR Omni fails to identify the user name in the SAML response and the user gets an error message after signing in and the web console is inaccessible.

More info: https://zitadel.com/docs/guides/integrate/login/saml#saml-requests-and-responses

As a workaround, it is possible to get Zitadel to provide extra attributes that match the names of the fields that Omni expects by using a custom Zitadel Action on the Complement SAMLResponse/Pre SAMLResponse creation trigger, although it takes a little bit of manual extra effort from the Zitadel admin to add this.

For reference, this is the workaround script I have used on my self-hosted Zitadel instance:

Action `samlOmniUsername`:
```js
function samlOmniUsername(ctx, api) {
    api.v1.attributes.setCustomAttribute('urn:oasis:names:tc:SAML:attribute:subject-id','', ctx.v1.getUser().preferredLoginName);
}
```