### PR TITLE
fix: allow accepting rejected infra machines

### DIFF
--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -1082,8 +1082,14 @@ func infraMachineConfigValidationOptions(st state.State) []validated.StateOption
 				return nil
 			}
 
-			if oldRes.TypedSpec().Value.AcceptanceStatus != newRes.TypedSpec().Value.AcceptanceStatus {
-				return errors.New("acceptance status cannot be changed after it is accepted or rejected")
+			if oldRes.TypedSpec().Value.AcceptanceStatus != specs.InfraMachineConfigSpec_PENDING &&
+				newRes.TypedSpec().Value.AcceptanceStatus == specs.InfraMachineConfigSpec_PENDING {
+				return errors.New("an accepted or rejected machine cannot be set to back to pending acceptance")
+			}
+
+			if oldRes.TypedSpec().Value.AcceptanceStatus == specs.InfraMachineConfigSpec_ACCEPTED &&
+				newRes.TypedSpec().Value.AcceptanceStatus == specs.InfraMachineConfigSpec_REJECTED {
+				return errors.New("an accepted machine cannot be rejected")
 			}
 
 			return nil

--- a/internal/backend/runtime/omni/state_validation_test.go
+++ b/internal/backend/runtime/omni/state_validation_test.go
@@ -1202,7 +1202,7 @@ func TestInfraMachineConfigValidation(t *testing.T) {
 		return nil
 	})
 	require.True(t, validated.IsValidationError(err), "expected validation error")
-	assert.ErrorContains(t, err, "acceptance status cannot be changed")
+	assert.ErrorContains(t, err, "an accepted machine cannot be rejected")
 
 	// try to destroy it
 


### PR DESCRIPTION
Accepting a previously rejected machine is ok, unlike rejecting a previously accepted machine.

Also prevent going back to the pending status from the accepted or rejected statuses.