### PR TITLE
fix: display nodes sidebar

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -90,8 +90,8 @@ const withPrefix = (prefix: string, routes: RouteRecordRaw[], meta?: Record<stri
   routes.map((route) => {
     if (meta) {
       route.meta = {
-        ...route.meta,
         ...meta,
+        ...route.meta,
       }
     }
 


### PR DESCRIPTION
It was broken due to the incorrect object merge.