### PR TITLE
fix: fallback to machine ID correctly if its hostname is missing

### DIFF
--- a/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
+++ b/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
@@ -79,7 +79,10 @@ const lockable = computed(() => {
 
 const router = useRouter();
 
-const hostname = computed(() => ((props.machine?.metadata?.labels || {})[LabelHostname] ?? props.machine?.metadata.id))
+const hostname = computed(() => {
+  const labelHostname = props.machine?.metadata?.labels?.[LabelHostname];
+  return labelHostname && labelHostname !== "" ? labelHostname : props.machine?.metadata.id;
+})
 const nodeName = computed(() => (props.machine?.metadata?.labels || {})[ClusterMachineStatusLabelNodeName] || hostname.value);
 const clusterName = computed(() => (props.machine?.metadata?.labels || {})[LabelCluster]);
 


### PR DESCRIPTION
If the hostname label is missing from the ClusterMachineStatus, we fall back to the machine ID as the displayed name in the UI. Fix the check in this fallback logic.