### PR TITLE
fix: wait for infra machine info to be collected before powering off

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_cleanup.go
@@ -21,8 +21,11 @@ type MachineCleanupController = cleanup.Controller[*omni.Machine]
 func NewMachineCleanupController() *MachineCleanupController {
 	return cleanup.NewController(
 		cleanup.Settings[*omni.Machine]{
-			Name:    "MachineCleanupController",
-			Handler: &helpers.SameIDHandler[*omni.Machine, *omni.MachineSetNode]{},
+			Name: "MachineCleanupController",
+			Handler: cleanup.Combine(
+				&helpers.SameIDHandler[*omni.Machine, *omni.MachineSetNode]{},
+				&helpers.SameIDHandler[*omni.Machine, *omni.InfraMachineConfig]{},
+			),
 		},
 	)
 }


### PR DESCRIPTION
There were cases when an infra machine was accepted, it was powered off by the infra provider too quickly, before its specs were populated by the `MachineStatus` poller. This caused additional issues as some other resources like `SchematicConfiguration` were also never created, blocking cluster creation.

Address this by setting the preferred power state of the infra machine to ON until its status is populated (we check this by checking the secure boot status field).

Additionally, clean up `InfraMachineConfig` resources (user-managed) when a machine is deleted.

Closes #798.