### PR TITLE
feat: sync infra machine labels onto the machine status

### DIFF
--- a/client/pkg/omni/resources/omni/labels.go
+++ b/client/pkg/omni/resources/omni/labels.go
@@ -89,6 +89,9 @@ const (
 	// LabelMachinePendingAccept is added to the InfraMachine and is used to filter out the machines which are pending acceptance.
 	// tsgen:LabelMachinePendingAccept
 	LabelMachinePendingAccept = SystemLabelPrefix + "accept-pending"
+
+	// InfraProviderLabelPrefixFormat is the prefix of all labels which are managed by the infra providers.
+	InfraProviderLabelPrefixFormat = SystemLabelPrefix + "infra-provider[%s]/"
 )
 
 const (

--- a/cmd/integration-test/pkg/tests/infra.go
+++ b/cmd/integration-test/pkg/tests/infra.go
@@ -262,6 +262,18 @@ func AcceptInfraMachines(testCtx context.Context, omniState state.State, expecte
 			assertion.Equal(specs.InfraMachineStatusSpec_POWER_STATE_OFF, res.TypedSpec().Value.PowerState)
 			assertion.True(res.TypedSpec().Value.ReadyToUse)
 		})
+
+		// Assert the infra provider labels on MachineStatus resources
+		rtestutils.AssertResources(ctx, t, omniState, ids, func(res *omni.MachineStatus, assertion *assert.Assertions) {
+			aLabel := fmt.Sprintf(omni.InfraProviderLabelPrefixFormat, infraProviderID) + "a"
+			aVal, _ := res.Metadata().Labels().Get(aLabel)
+
+			assertion.Equal("b", aVal)
+
+			cLabel := fmt.Sprintf(omni.InfraProviderLabelPrefixFormat, infraProviderID) + "c"
+			_, cOk := res.Metadata().Labels().Get(cLabel)
+			assertion.True(cOk)
+		})
 	}
 }
 


### PR DESCRIPTION
Copy the labels set on infra.MachineStatus to omni.MachineStatus resources.

Introduce a special prefix for the labels set by infra providers, so that they can keep track and synchronize the labels as needed.

Related to/depends on https://github.com/siderolabs/omni-infra-provider-bare-metal/pull/16.