### PR TITLE
fix: do not allow using static infra providers in the machine classes

### DIFF
--- a/client/pkg/omni/resources/omni/labels.go
+++ b/client/pkg/omni/resources/omni/labels.go
@@ -60,6 +60,7 @@ const (
 
 	// LabelIsStaticInfraProvider is set on the infra.ProviderStatus resources to mark them as static providers - they do not work with MachineRequests to
 	// allocate and de-allocate machines, but rather work with a static set of machines (e.g., bare-metal machines).
+	// tsgen:LabelIsStaticInfraProvider
 	LabelIsStaticInfraProvider = SystemLabelPrefix + "is-static-infra-provider"
 
 	// LabelMachineClassName is the name of the machine class.

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -126,6 +126,7 @@ export const LabelMachine = "omni.sidero.dev/machine";
 export const LabelSystemPatch = "omni.sidero.dev/system-patch";
 export const LabelExposedServiceAlias = "omni.sidero.dev/exposed-service-alias";
 export const LabelInfraProviderID = "omni.sidero.dev/infra-provider-id";
+export const LabelIsStaticInfraProvider = "omni.sidero.dev/is-static-infra-provider";
 export const LabelMachineRequest = "omni.sidero.dev/machine-request";
 export const LabelMachineRequestSet = "omni.sidero.dev/machine-request-set";
 export const LabelNoManualAllocation = "omni.sidero.dev/no-manual-allocation";

--- a/frontend/src/views/omni/MachineClasses/ProviderConfig.vue
+++ b/frontend/src/views/omni/MachineClasses/ProviderConfig.vue
@@ -6,7 +6,7 @@ included in the LICENSE file.
 -->
 <template>
   <div class="text-naturals-N13">Infrastructure Provider</div>
-  <t-list :opts="{resource: { type: InfraProviderStatusType, namespace: InfraProviderNamespace }, runtime: Runtime.Omni}" :key="infraProvider" :search="showAllProviders" class="mb-1">
+  <t-list :opts="infraProviderResources" :key="infraProvider" :search="showAllProviders" class="mb-1">
     <template #default="{ items, searchQuery }">
       <div class="flex md:flex-col gap-2 max-md:flex-wrap">
         <div v-for="item in filterProviders(items)"
@@ -43,13 +43,20 @@ included in the LICENSE file.
 import { Runtime } from '@/api/common/omni.pb';
 import { Resource } from '@/api/grpc';
 import { InfraProviderStatusSpec } from '@/api/omni/specs/infra.pb';
-import { InfraProviderNamespace, InfraProviderStatusType } from '@/api/resources';
+import { InfraProviderNamespace, InfraProviderStatusType, LabelIsStaticInfraProvider } from '@/api/resources';
 import { computed, ref, toRefs } from 'vue';
 
 import TIcon from '@/components/common/Icon/TIcon.vue';
 import WordHighlighter from "vue-word-highlighter";
 import IconButton from '@/components/common/Button/IconButton.vue';
 import TList from '@/components/common/List/TList.vue';
+import { WatchOptions } from '@/api/watch';
+
+const infraProviderResources: WatchOptions = {
+  resource: { type: InfraProviderStatusType, namespace: InfraProviderNamespace },
+  runtime: Runtime.Omni,
+  selectors: [`!${LabelIsStaticInfraProvider}`],
+};
 
 const props = defineProps<{
   infraProvider?: string

--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -1072,6 +1072,10 @@ func validateProviderData(ctx context.Context, st state.State, providerID, provi
 		return fmt.Errorf("failed to get provider: %w", err)
 	}
 
+	if _, static := providerStatus.Metadata().Labels().Get(omni.LabelIsStaticInfraProvider); static {
+		return fmt.Errorf("cannot use static provider in the auto-provisioned machine class")
+	}
+
 	return validateSchema(providerStatus)
 }
 


### PR DESCRIPTION
Auto-provision mode should be disabled for them.

This change has two parts:

1. Filter the static providers in the UI.
2. Block creating machine classes which reference infra provider with the `is-static-infra-provider` label set.