### PR TITLE
fix: properly reset `MachineStatus` hostname for deallocated machines

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
@@ -99,6 +99,9 @@ func pollVersion(ctx context.Context, c *client.Client, info *Info) error {
 }
 
 func pollHostname(ctx context.Context, c *client.Client, info *Info) error {
+	info.Hostname = pointer.To("")
+	info.Domainname = pointer.To("")
+
 	return forEachResource(
 		ctx,
 		c,


### PR DESCRIPTION
Need to treat `nil` hostname as no hostname and wipe the current value in the `MachineStatus`.