### PR TITLE
feat: add disk wipe warning when accepting a pending machine

### DIFF
--- a/frontend/src/views/omni/Modals/MachineAccept.vue
+++ b/frontend/src/views/omni/Modals/MachineAccept.vue
@@ -15,6 +15,12 @@ included in the LICENSE file.
 
     <p class="text-xs py-2">Please confirm the action.</p>
 
+    <div class="text-xs">
+      <p class="text-primary-P3 py-2 font-bold">
+        Accepting the machine will wipe ALL of its disks.
+      </p>
+    </div>
+
     <div class="flex justify-end gap-4 mt-8">
       <t-button @click="reject" class="w-32 h-9" icon="check" iconPosition="left">
         Accept


### PR DESCRIPTION
Warn the user that its disks are going to be wiped.

Per @steverfrancis's feedback.

<img width="862" alt="Screenshot 2025-01-16 at 12 02 21" src="https://github.com/user-attachments/assets/2f73da07-a482-4cae-a1c9-eae66b7518af" />
