### PR TITLE
fix: detect infra provider internal resources correctly

### DIFF
--- a/internal/backend/runtime/omni/infraprovider/state.go
+++ b/internal/backend/runtime/omni/infraprovider/state.go
@@ -423,8 +423,8 @@ func (st *State) checkNamespaceAndType(ns resource.Namespace, infraProviderID st
 		return false, nil
 	}
 
-	return false, status.Errorf(codes.PermissionDenied, "namespace not allowed, must be one of %s or %s",
-		resources.InfraProviderNamespace, infraProviderSpecificNamespace)
+	return false, status.Errorf(codes.PermissionDenied, "namespace not allowed, must be one of: %s, %s, %s",
+		resources.InfraProviderNamespace, resources.InfraProviderEphemeralNamespace, infraProviderSpecificNamespace)
 }
 
 // resourceConfig defines the resource-specific configuration to be validated by the state.
@@ -444,7 +444,12 @@ func IsInfraProviderResource(ns resource.Namespace, resType resource.Type) bool 
 // getResourceConfig returns the configuration for the given resource type.
 func getResourceConfig(ns resource.Namespace, resType resource.Type) (config resourceConfig, isInfraProviderResource bool) {
 	if strings.HasPrefix(ns, resources.InfraProviderSpecificNamespacePrefix) {
-		return config, true
+		return resourceConfig{}, true
+	}
+
+	if ns != resources.InfraProviderNamespace &&
+		ns != resources.InfraProviderEphemeralNamespace {
+		return resourceConfig{}, false
 	}
 
 	switch resType {

--- a/internal/backend/runtime/omni/infraprovider/state_test.go
+++ b/internal/backend/runtime/omni/infraprovider/state_test.go
@@ -244,6 +244,7 @@ func TestInfraProviderSpecificNamespace(t *testing.T) {
 
 	res1 := newTestRes(infraProviderResNamespace, "test-res-1", testResSpec{str: "foo"})
 
+	require.True(t, infraprovider.IsInfraProviderResource(infraProviderResNamespace, res1.Metadata().Type()))
 	require.NoError(t, st.Create(ctx, res1))
 
 	_, err := safe.StateUpdateWithConflicts(ctx, st, res1.Metadata(), func(res *testRes) error {


### PR DESCRIPTION
Fix the regression where the resources in namespace `infra-provider:<provider-id>` were not correctly captured and managed by the infra provider state.