### PR TITLE
fix: correctly handle conflict error in machine status handler

### DIFF
--- a/internal/pkg/machineevent/handler.go
+++ b/internal/pkg/machineevent/handler.go
@@ -148,13 +148,13 @@ func (handler *Handler) handleSequenceEvent(ctx context.Context, event *machinea
 
 	err = handler.state.Create(ctx, machineState)
 	if err != nil {
-		if state.IsConflictError(err) {
-			if _, err = safe.StateUpdateWithConflicts(ctx, handler.state, machineState.Metadata(), modify); err != nil {
-				return err
-			}
+		if !state.IsConflictError(err) {
+			return err
 		}
 
-		return err
+		if _, err = safe.StateUpdateWithConflicts(ctx, handler.state, machineState.Metadata(), modify); err != nil {
+			return err
+		}
 	}
 
 	logger.Info("marked infra machine as installed")


### PR DESCRIPTION
Fix the error handling in the "create or update" logic on the `MachineState` resources in the machine sequence event handler.