### PR TITLE
chore: migrate uncompressed resources data

### DIFF
--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -181,6 +181,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: removeMaintenanceConfigPatchFinalizers,
 				name:     "removeMaintenanceConfigPatchFinalizers",
 			},
+			{
+				callback: compressMachineConfigsAndPatches,
+				name:     "compressMachineConfigsAndPatches",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Abusing generics to compress uncompressed data in `*omni.ConfigPatch`, `*omni.ClusterMachineConfig`, `*omni.RedactedClusterMachineConfig` and `*omni.ClusterMachineConfigPatches`.

Fixes #853