### PR TITLE
fix: do not compress resources with phase != running (backport)

### DIFF
--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1370,6 +1370,10 @@ func compressUncompressed[
 		}
 
 		for val := range items.All() {
+			if val.Metadata().Phase() != resource.PhaseRunning {
+				continue
+			}
+
 			spec := val.TypedSpec()
 
 			if ok, uerr := update(spec); uerr != nil {


### PR DESCRIPTION
Prevent migration errors. Also update tests.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>