### PR TITLE
fix: fix node resolution cache for nodes in maintenance mode

### DIFF
--- a/internal/backend/dns/service.go
+++ b/internal/backend/dns/service.go
@@ -281,6 +281,7 @@ func (d *Service) updateEntryByMachineStatus(res *omni.MachineStatus) {
 
 	info := d.machineIDToInfo[res.Metadata().ID()]
 
+	info.ID = res.Metadata().ID()
 	info.TalosVersion = version
 	info.managementEndpoint = res.TypedSpec().Value.ManagementAddress
 
@@ -316,6 +317,8 @@ func (d *Service) deleteIdentityMappings(id resource.ID) {
 		d.nodenameToID.remove(info.Name, id)
 	}
 
+	info.Cluster = ""
+	info.Name = ""
 	info.address = ""
 
 	d.machineIDToInfo[id] = info


### PR DESCRIPTION
There was a problem with the node resolution (a.k.a. DNS) cache of the nodes. When a machine is in maintenance mode, there is a corresponding `MachineStatus` resource for it, but there isn't any `ClusterMachineIdentity`. Both of these types trigger updates in the node resolution cache. When a machine was never part of a cluster, the only source is `MachineStatus`, and the cache updates on it did not populate the machine ID in the cache. This caused the GRPC router to pick the wrong destination.

Furthermore, we did not remove the cluster and node name information from the cache when a machine was removed from a cluster. This caused the cache to contain obsolete cluster information, causing Talos GRPC proxy to not proxy the requests correctly after a machine was removed from a cluster.

Closes https://github.com/siderolabs/omni/issues/888.