### PR TITLE
fix: close grpc connections after their usage is complete

### DIFF
--- a/client/pkg/omnictl/internal/access/client.go
+++ b/client/pkg/omnictl/internal/access/client.go
@@ -129,6 +129,8 @@ func WithClient(f func(ctx context.Context, client *client.Client) error, client
 			return err
 		}
 
+		defer client.Close() //nolint:errcheck
+
 		if !cliOpts.skipAuth {
 			// bootstrap the client, and perform auth/re-auth if needed via the unary call
 			// stream interceptor can't catch the auth error, as it comes async

--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -216,6 +216,10 @@ func runWithState(logger *zap.Logger) func(context.Context, state.State, *virtua
 			if closeErr := defaultDiscoveryClient.Close(); closeErr != nil {
 				logger.Error("failed to close discovery client", zap.Error(closeErr))
 			}
+
+			if embeddedDiscoveryClient != nil {
+				embeddedDiscoveryClient.Close() //nolint:errcheck
+			}
 		}()
 
 		omniRuntime, err := omni.New(talosClientFactory, dnsService, workloadProxyReconciler, resourceLogger,

--- a/internal/backend/grpc/grpc_test.go
+++ b/internal/backend/grpc/grpc_test.go
@@ -245,8 +245,7 @@ func (suite *GrpcSuite) TestCrud() {
 				} `json:"spec"`
 			}
 
-			e = json.Unmarshal([]byte(item), &data)
-			if e != nil {
+			if e = json.Unmarshal([]byte(item), &data); e != nil {
 				return e
 			}
 

--- a/internal/backend/runtime/omni/controllers/omni/cluster_bootstrap_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_bootstrap_status.go
@@ -93,6 +93,12 @@ func NewClusterBootstrapStatusController(etcdBackupStoreFactory store.Factory) *
 					return fmt.Errorf("error getting talos client for cluster '%s': %w", clusterStatus.Metadata().ID(), err)
 				}
 
+				defer func() {
+					if e := talosCli.Close(); e != nil {
+						logger.Error("failed to close talos client", zap.Error(e))
+					}
+				}()
+
 				bootstrapSpec := cpMachineSet.TypedSpec().Value.GetBootstrapSpec()
 				recoverEtcd := bootstrapSpec != nil
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/clustermachine/identity.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/clustermachine/identity.go
@@ -327,5 +327,5 @@ func (spec IdentityCollectorTaskSpec) getClient(ctx context.Context) (*client.Cl
 		return nil, err
 	}
 
-	return c, err
+	return c, nil
 }


### PR DESCRIPTION
- `NewClusterBootstrapStatusController.TransformExtraOutputFunc` gets `*client.Client` but forgets to close it.
This leads to `*grpc.ClientConn` leakage.
- `MachineTeardownController.resetMachine` gets `*client.Client` but forgets to close it.
This leads to `*grpc.ClientConn` leakage.
- `runWithState` gets `*discovery.Client` but forgets to close it. This leads to `*grpc.ClientConn` leakage.
- `WithClient` gets `*client.Client` but forgets to close it. This leads to `*grpc.ClientConn` leakage.

Shorten the code in some places, while we are at it.