### PR TITLE
fix: enable IDP initiated SAML logins

### DIFF
--- a/internal/backend/saml/saml.go
+++ b/internal/backend/saml/saml.go
@@ -38,9 +38,10 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 	}
 
 	opts := samlsp.Options{
-		URL:            *rootURL,
-		IDPMetadata:    idpMetadata,
-		LogoutBindings: []string{saml.HTTPPostBinding},
+		URL:               *rootURL,
+		IDPMetadata:       idpMetadata,
+		LogoutBindings:    []string{saml.HTTPPostBinding},
+		AllowIDPInitiated: true,
 	}
 
 	serviceProvider := samlsp.DefaultServiceProvider(opts)


### PR DESCRIPTION
Should probably help with logging into the system initiated from the SAML apps Google drawer.