### PR TITLE
fix: detect more block devices

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
@@ -325,7 +325,7 @@ func pollDisks(ctx context.Context, c *client.Client, info *Info) error {
 				continue
 			}
 
-			if disk.Type == storage.Disk_UNKNOWN {
+			if disk.Type == storage.Disk_UNKNOWN && disk.Modalias == "" && disk.Subsystem != "/sys/class/block" {
 				continue
 			}
 


### PR DESCRIPTION
Do not ignore disks of the UNKNOWN type if their modalias is not empty and subsystem is `/sys/class/block`.
This is the workaround for Talos not detecting the correct disk types for some environments.