### PR TITLE
chore: add `compressConfigsAndMachinePatches` migration back

### DIFF
--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -185,6 +185,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: noopMigration,
 				name:     "compressMachineConfigsAndPatches",
 			},
+			{
+				callback: compressConfigsAndMachinePatches,
+				name:     "compressConfigsAndMachinePatches",
+			},
 		},
 	}
 }

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1338,9 +1338,7 @@ func removeMaintenanceConfigPatchFinalizers(ctx context.Context, st state.State,
 
 func noopMigration(context.Context, state.State, *zap.Logger) error { return nil }
 
-var _ = compressMachineConfigsAndPatches
-
-func compressMachineConfigsAndPatches(ctx context.Context, st state.State, l *zap.Logger) error {
+func compressConfigsAndMachinePatches(ctx context.Context, st state.State, l *zap.Logger) error {
 	doConfigPatch := updateSingle[string, specs.ConfigPatchSpec, *specs.ConfigPatchSpec]
 	doMachineConfig := updateSingle[[]byte, specs.ClusterMachineConfigSpec, *specs.ClusterMachineConfigSpec]
 	doRedactedMachineConfig := updateSingle[string, specs.RedactedClusterMachineConfigSpec, *specs.RedactedClusterMachineConfigSpec]


### PR DESCRIPTION
Rename it from `compressMachineConfigsAndPatches` `compressConfigsAndMachinePatches` just to make sure.