### PR TITLE
feat: add a flag to enable secure join token flow

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -607,13 +607,10 @@ var initOnce = sync.OnceValue(func() *cobra.Command {
 		"enable Stripe machine usage reporting",
 	)
 
-	rootCmd.Flags().BoolVar(
-		&config.Config.DisableLegacyJoinTokens,
-		"disable-legacy-join-tokens",
-		config.Config.DisableLegacyJoinTokens,
-		"disables joining the machines running Talos below 1.6 "+
-			"by forcing strict policy that uses join token only for the initial machine join, "+
-			"then uses randomly generated secret stored in the machine META partition",
+	rootCmd.Flags().Var(
+		&config.Config.JoinTokensMode,
+		"join-tokens-mode",
+		"configures Talos machine join flow to use secure node tokens",
 	)
 
 	return rootCmd

--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -108,7 +108,7 @@ func NewManager(
 		provisionServer: NewProvisionHandler(
 			logger,
 			state,
-			config.Config.DisableLegacyJoinTokens,
+			config.Config.JoinTokensMode,
 		),
 	}
 


### PR DESCRIPTION
With the feature flag it is now possible to use the old flow.

The new secure join flow is not stable yet, so the default mode is legacy, which doesn't enable node unique token generation for all machines, not only the ones using too old Talos versions.