### PR TITLE
tests: improve e2e upgrades and e2e templates tests stability

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
-	github.com/cosi-project/runtime v0.9.3
+	github.com/cosi-project/runtime v0.9.4
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/gertd/go-pluralize v0.2.1

--- a/client/go.sum
+++ b/client/go.sum
@@ -26,8 +26,8 @@ github.com/containerd/go-cni v1.1.12 h1:wm/5VD/i255hjM4uIZjBRiEQ7y98W9ACy/mHeLi4
 github.com/containerd/go-cni v1.1.12/go.mod h1:+jaqRBdtW5faJxj2Qwg1Of7GsV66xcvnCx4mSJtUlxU=
 github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8FuJbEslXM=
 github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
-github.com/cosi-project/runtime v0.9.3 h1:Bncip4n85/W4zvwTztTAS5tICK0DzBJJQU3fh9jJXBc=
-github.com/cosi-project/runtime v0.9.3/go.mod h1:uhFAU0UI27d4iIC0ZEKxnoT5UWSr6uPgVuNWB3RBi8s=
+github.com/cosi-project/runtime v0.9.4 h1:jGuXLGPeS4fyYl2UH79cLMnHYBEEYjU2Y++PijxYF68=
+github.com/cosi-project/runtime v0.9.4/go.mod h1:uhFAU0UI27d4iIC0ZEKxnoT5UWSr6uPgVuNWB3RBi8s=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/cmd/integration-test/pkg/tests/template.go
+++ b/cmd/integration-test/pkg/tests/template.go
@@ -109,7 +109,7 @@ func AssertClusterTemplateFlow(testCtx context.Context, st state.State) TestFunc
 		}))
 
 		// re-check with short timeout to make sure the cluster is ready
-		checkCtx, checkCancel := context.WithTimeout(ctx, 10*time.Second)
+		checkCtx, checkCancel := context.WithTimeout(ctx, 30*time.Second)
 		defer checkCancel()
 
 		rtestutils.AssertResources(checkCtx, t, st, []string{clusterName}, func(status *omni.ClusterStatus, assert *assert.Assertions) {

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/containers/image/v5 v5.33.0
-	github.com/cosi-project/runtime v0.9.3
+	github.com/cosi-project/runtime v0.9.4
 	github.com/cosi-project/state-etcd v0.5.1
 	github.com/crewjam/saml v0.4.14
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cosi-project/runtime v0.9.3 h1:Bncip4n85/W4zvwTztTAS5tICK0DzBJJQU3fh9jJXBc=
-github.com/cosi-project/runtime v0.9.3/go.mod h1:uhFAU0UI27d4iIC0ZEKxnoT5UWSr6uPgVuNWB3RBi8s=
+github.com/cosi-project/runtime v0.9.4 h1:jGuXLGPeS4fyYl2UH79cLMnHYBEEYjU2Y++PijxYF68=
+github.com/cosi-project/runtime v0.9.4/go.mod h1:uhFAU0UI27d4iIC0ZEKxnoT5UWSr6uPgVuNWB3RBi8s=
 github.com/cosi-project/state-etcd v0.5.1 h1:RB/mifXuM/PJMxvJyS17HeDRQq5nG3fzgaNtX0bVeIA=
 github.com/cosi-project/state-etcd v0.5.1/go.mod h1:ipZli6U/vUl3Je6DStoV9+h6cntDtpFu7elpXr+/Ig0=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=


### PR DESCRIPTION
Use dedicated request timeout in the function to clear connection refused. Otherwise the request might hang forever and will fail the whole retry block.

Increase templates cluster health check timeout. Kubernetes components sometimes flap to unhealthy for a short moment after the cluster is healty.