### PR TITLE
fix: fix config compression migration

### DIFF
--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1388,7 +1388,7 @@ func compressUncompressed[
 				res.TypedSpec().Value = spec.Value
 
 				return nil
-			}); err != nil {
+			}, state.WithUpdateOwner(val.Metadata().Owner())); err != nil {
 				return fmt.Errorf("failed to update %s: %w", val.Metadata(), err)
 			}
 		}


### PR DESCRIPTION
Update the resources ignoring ownership checks.

Also fix the unit tests, they had 2 issues:

1. It was disabled and had the wrong migration name in the filter.
2. Migration wasn't creating the resources with owners.