### PR TITLE
chore: remove deprecated linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -144,7 +144,6 @@ linters:
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     - goimports # same as gci
     - musttag # seems to be broken - goes into imported libraries and reports issues there
-    - exportloopref # WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
 
 issues:
   exclude: [ ]


### PR DESCRIPTION
The linter "[exportloopref](https://github.com/kyoh86/exportloopref?tab=readme-ov-file)" is deprecated and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle

As of Go 1.22 the exportloopref problem no longer occurs and fixed by Go team, see [here](https://go.dev/blog/loopvar-preview)