### PR TITLE
fix: fix bug with Omni adding machine to a cluster before upgrading

### DIFF
--- a/frontend/src/views/omni/Machines/Machines.vue
+++ b/frontend/src/views/omni/Machines/Machines.vue
@@ -33,7 +33,7 @@ included in the LICENSE file.
         >
           <div class="flex gap-1">
             Download and boot the
-            <t-button type="subtle" @click="() => $router.push({name: 'Overview', query: {modal: 'downloadInstallationMedia'}})">installation media</t-button> on
+            <t-button type="subtle" @click="() => $router.push({name: 'Overview', query: {modal: 'downloadInstallationMedia'}})">installation media</t-button>
             to connect machines to your Omni instance.
           </div>
         </t-alert>

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status.go
@@ -163,7 +163,7 @@ func NewClusterMachineConfigStatusController(imageFactoryHost string) *ClusterMa
 					machineStatus.TypedSpec().Value.Schematic.Id != expectedSchematic
 
 				// don't run the upgrade check if the running version and expected versions match
-				if versionMismatch && installImage.TalosVersion != "" {
+				if versionMismatch {
 					inSync, syncErr := handler.syncInstallImageAndSchematic(ctx, configStatus, machineStatus, machineConfig, statusSnapshot, installImage)
 					if syncErr != nil {
 						return syncErr


### PR DESCRIPTION
The old logic could ignore version check if the install image Talos version isn't populated.
There's another check inside the version sync function that skips reconciliation if the install image isn't populated: it should catch it.

Also fix the typo in the UI.