### PR TITLE
fix: properly read the `siderolink-disable-last-endpoint` flag

### DIFF
--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -537,7 +537,7 @@ func (manager *Manager) pollWireguardPeers(ctx context.Context) error {
 						spec.Connected = sinceLastHandshake < wireguard.PeerDownInterval
 					}
 
-					if !config.Config.SiderolinkDisableLastEndpoint {
+					if config.Config.SiderolinkDisableLastEndpoint {
 						spec.LastEndpoint = ""
 
 						return nil


### PR DESCRIPTION
The condition was inverted :facepalm: