### PR TITLE
fix: extentions list hidden on small screens

### DIFF
--- a/frontend/src/views/omni/Extensions/ExtensionsPicker.vue
+++ b/frontend/src/views/omni/Extensions/ExtensionsPicker.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <template>
-  <div class="flex flex-col gap-2 overflow-hidden">
+  <div class="flex flex-col gap-2 overflow-hidden min-h-36">
     <t-input icon="search" v-model="filterExtensions"/>
 
     <div class="grid grid-cols-4 bg-naturals-N4 uppercase text-xs text-naturals-N13 pl-2 py-2">


### PR DESCRIPTION
I got the omni fe dev env working and decided to submit a small bug fix as a reward to myself :)

Fix extensions scroll list being hidden on horizontally tight screens by adding a small minimal height that allows to see about two rows.

fixes https://github.com/siderolabs/omni/issues/889


https://github.com/user-attachments/assets/b939437e-d06c-4fd7-a014-85430971f136

