### PR TITLE
fix: increase log level of the SideroLink GRPC tunnel handler

### DIFF
--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -249,7 +249,8 @@ func createListener(ctx context.Context, host, port string) (net.Listener, error
 // Register implements controller.Manager interface.
 func (manager *Manager) Register(server *grpc.Server) {
 	pb.RegisterProvisionServiceServer(server, manager.provisionServer)
-	pb.RegisterWireGuardOverGRPCServiceServer(server, wggrpc.NewService(manager.peerTraffic, manager.allowedPeers, manager.logger))
+	pb.RegisterWireGuardOverGRPCServiceServer(server,
+		wggrpc.NewService(manager.peerTraffic, manager.allowedPeers, manager.logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel))))
 }
 
 // Run implements controller.Manager interface.


### PR DESCRIPTION
It seems SideroLink logs are too verbose in debug mode when the GRPC tunnel is used. Reduce their level to info.

Closes https://github.com/siderolabs/omni/issues/958.