### PR TITLE
fix: disable `compressConfigsAndMachinePatches`

### DIFF
--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -188,7 +188,7 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				name:     "compressMachineConfigsAndPatches",
 			},
 			{
-				callback: compressConfigsAndMachinePatches,
+				callback: noopMigration,
 				name:     "compressConfigsAndMachinePatches",
 			},
 		},

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -1626,6 +1626,8 @@ func (suite *MigrationSuite) TestRemoveMaintenanceConfigPatchFinalizers() {
 }
 
 func (suite *MigrationSuite) TestCompressUncompressMigrations() {
+	suite.T().Skip("the migration for compressed resources is currently disabled")
+
 	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Second)
 	defer cancel()
 

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1338,6 +1338,8 @@ func removeMaintenanceConfigPatchFinalizers(ctx context.Context, st state.State,
 
 func noopMigration(context.Context, state.State, *zap.Logger) error { return nil }
 
+var _ = compressConfigsAndMachinePatches
+
 func compressConfigsAndMachinePatches(ctx context.Context, st state.State, l *zap.Logger) error {
 	doConfigPatch := updateSingle[string, specs.ConfigPatchSpec, *specs.ConfigPatchSpec]
 	doMachineConfig := updateSingle[[]byte, specs.ClusterMachineConfigSpec, *specs.ClusterMachineConfigSpec]


### PR DESCRIPTION
Migration takes a lot of time before booting Omni. The PR that only migrates `ConfigPatch` and no other resources will be the next one in chain.

For #966