### PR TITLE
fix: skip applying maintenance config to unsupported machines

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_status_test.go
@@ -67,6 +67,7 @@ func (suite *MachineStatusSnapshotControllerSuite) TestMaintenanceConfigStatus()
 	machineStatus.TypedSpec().Value.Maintenance = true
 
 	machineStatus.TypedSpec().Value.ManagementAddress = "test-address"
+	machineStatus.TypedSpec().Value.TalosVersion = "1.5.0"
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, machineStatus))
 


### PR DESCRIPTION
If a machine does not support multidoc (<1.5.0) or running un agent mode, do not fail the maintenance apply controller - skip applying without failure instead.

Closes https://github.com/siderolabs/omni/issues/973.