### PR TITLE
fix: exclude `metal-agent` extension from available extensions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/jxskiss/base62 v1.1.0
+	github.com/klauspost/compress v1.18.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.62.0
@@ -181,7 +182,6 @@ require (
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/jsimonetti/rtnetlink/v2 v2.0.3-0.20241216183107-2d6e9f8ad3f2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/internal/backend/extensions/extensions.go
+++ b/internal/backend/extensions/extensions.go
@@ -15,6 +15,12 @@ import (
 // OfficialPrefix is the prefix for the official extensions.
 const OfficialPrefix = "siderolabs/"
 
+// MetalAgentExtensionName is the name of the metal agent extension.
+const MetalAgentExtensionName = "metal-agent"
+
+// MetalAgentExtensionFullName is the full name of the metal agent extension including the prefix.
+const MetalAgentExtensionFullName = OfficialPrefix + MetalAgentExtensionName
+
 var (
 	talosV170 = semver.MustParse("1.7.0")
 	talosV180 = semver.MustParse("1.8.0")

--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
@@ -57,7 +57,7 @@ func GetSchematicInfo(ctx context.Context, c *client.Client, defaultKernelArgs [
 
 	err = items.ForEachErr(func(status *runtime.ExtensionStatus) error {
 		name := status.TypedSpec().Metadata.Name
-		if name == "metal-agent" {
+		if name == extensions.MetalAgentExtensionName {
 			inAgentMode = true
 
 			return nil

--- a/internal/backend/runtime/omni/controllers/omni/talos_extensions.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_extensions.go
@@ -20,6 +20,7 @@ import (
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/extensions"
 	"github.com/siderolabs/omni/internal/backend/imagefactory"
 )
 
@@ -63,6 +64,10 @@ func NewTalosExtensionsController(imageFactoryClient *imagefactory.Client) *Talo
 				extensionsResource.TypedSpec().Value.Items = make([]*specs.TalosExtensionsSpec_Info, 0, len(extensionsVersions))
 
 				for _, ev := range extensionsVersions {
+					if ev.Name == extensions.MetalAgentExtensionFullName { // exclude the metal-agent extension
+						continue
+					}
+
 					info := &specs.TalosExtensionsSpec_Info{
 						Name:        ev.Name,
 						Digest:      ev.Digest,

--- a/internal/backend/runtime/omni/controllers/omni/talos_extensions_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_extensions_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/extensions"
 	"github.com/siderolabs/omni/internal/backend/imagefactory"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 )
@@ -200,6 +201,10 @@ func (suite *TalosExtensionsSuite) TestReconcile() {
 					Digest:      "aaaa",
 					Author:      "Sidero Labs",
 					Description: "This system extension provides an example Talos extension service.",
+				},
+				{
+					Name: extensions.MetalAgentExtensionFullName, // should be excluded
+					Ref:  "github.com/siderolabs/metal-agent:v0.1.2",
 				},
 			},
 			"200.0.0": {


### PR DESCRIPTION
It is a special extension and users should not be confused by it.