### PR TITLE
chore: migrate ConfigPatches above threshold of 2048

### DIFF
--- a/client/api/omni/specs/cluster_machine_config.go
+++ b/client/api/omni/specs/cluster_machine_config.go
@@ -70,11 +70,11 @@ func (x *ClusterMachineConfigSpec) GetUncompressedData(opts ...CompressionOption
 		return newNoOpBuffer(nil), nil
 	}
 
-	if x.CompressedData == nil {
-		return newNoOpBuffer(x.Data), nil
+	if len(x.GetCompressedData()) == 0 {
+		return newNoOpBuffer(x.GetData()), nil
 	}
 
-	return doDecompress(x.CompressedData, getCompressionConfig(opts))
+	return doDecompress(x.GetCompressedData(), getCompressionConfig(opts))
 }
 
 // SetUncompressedData sets the config data in the ClusterMachineConfigSpec, compressing it if requested.
@@ -86,7 +86,7 @@ func (x *ClusterMachineConfigSpec) SetUncompressedData(data []byte, opts ...Comp
 	config := getCompressionConfig(opts)
 	compress := config.Enabled
 
-	if !compress {
+	if !compress || len(data) < config.MinThreshold {
 		x.Data = data
 		x.CompressedData = nil
 

--- a/client/api/omni/specs/config_patch.go
+++ b/client/api/omni/specs/config_patch.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint:dupl,revive
+//nolint:revive
 package specs
 
 import (
@@ -67,13 +67,13 @@ func (x *ConfigPatchSpec) GetUncompressedData(opts ...CompressionOption) (Buffer
 		return newNoOpBuffer(nil), nil
 	}
 
-	if x.CompressedData == nil {
-		return newNoOpBuffer([]byte(x.Data)), nil
+	if len(x.GetCompressedData()) == 0 {
+		return newNoOpBuffer([]byte(x.GetData())), nil
 	}
 
 	config := getCompressionConfig(opts)
 
-	return doDecompress(x.CompressedData, config)
+	return doDecompress(x.GetCompressedData(), config)
 }
 
 // SetUncompressedData sets the patch data in the ConfigPatchSpec, compressing it if requested.
@@ -85,7 +85,7 @@ func (x *ConfigPatchSpec) SetUncompressedData(data []byte, opts ...CompressionOp
 	config := getCompressionConfig(opts)
 	compress := config.Enabled
 
-	if !compress {
+	if !compress || len(data) < config.MinThreshold {
 		x.Data = string(data)
 		x.CompressedData = nil
 

--- a/client/api/omni/specs/redacted_cluster_machine_config.go
+++ b/client/api/omni/specs/redacted_cluster_machine_config.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint:dupl,revive
+//nolint:revive
 package specs
 
 import (
@@ -67,13 +67,13 @@ func (x *RedactedClusterMachineConfigSpec) GetUncompressedData(opts ...Compressi
 		return newNoOpBuffer(nil), nil
 	}
 
-	if x.CompressedData == nil {
-		return newNoOpBuffer([]byte(x.Data)), nil
+	if x.GetCompressedData() == nil {
+		return newNoOpBuffer([]byte(x.GetData())), nil
 	}
 
 	config := getCompressionConfig(opts)
 
-	return doDecompress(x.CompressedData, config)
+	return doDecompress(x.GetCompressedData(), config)
 }
 
 // SetUncompressedData sets the config data in the RedactedClusterMachineConfigSpec, compressing it if requested.
@@ -85,7 +85,7 @@ func (x *RedactedClusterMachineConfigSpec) SetUncompressedData(data []byte, opts
 	config := getCompressionConfig(opts)
 	compress := config.Enabled
 
-	if !compress {
+	if !compress || len(data) < config.MinThreshold {
 		x.Data = string(data)
 		x.CompressedData = nil
 

--- a/client/pkg/compression/compression.go
+++ b/client/pkg/compression/compression.go
@@ -15,6 +15,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/constants"
 )
 
 var (
@@ -75,10 +76,11 @@ func BuildConfig(enabled, useDict, usePool bool) (specs.CompressionConfig, error
 	}
 
 	return specs.CompressionConfig{
-		Enabled:     enabled,
-		ZstdEncoder: encoder,
-		ZstdDecoder: decoder,
-		BufferPool:  pool,
+		ZstdEncoder:  encoder,
+		ZstdDecoder:  decoder,
+		BufferPool:   pool,
+		Enabled:      enabled,
+		MinThreshold: constants.CompressionThresholdBytes,
 	}, nil
 }
 

--- a/client/pkg/compression/compression_test.go
+++ b/client/pkg/compression/compression_test.go
@@ -7,12 +7,14 @@ package compression_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
@@ -21,7 +23,10 @@ func TestClusterMachineConfigPatchesYAML(t *testing.T) {
 
 	// set some patches
 
-	err := res.TypedSpec().Value.SetUncompressedPatches([]string{"aaaa", "bbbb"})
+	aString := strings.Repeat("a", constants.CompressionThresholdBytes)
+	bString := strings.Repeat("b", constants.CompressionThresholdBytes)
+
+	err := res.TypedSpec().Value.SetUncompressedPatches([]string{aString, bString})
 	require.NoError(t, err)
 
 	// assert that the patches are compressed
@@ -38,8 +43,8 @@ func TestClusterMachineConfigPatchesYAML(t *testing.T) {
 
 	// assert that the patches are in the YAML in uncompressed form, and do not contain the compressed form
 
-	require.Contains(t, string(specYAML), "aaaa")
-	require.Contains(t, string(specYAML), "bbbb")
+	require.Contains(t, string(specYAML), aString)
+	require.Contains(t, string(specYAML), bString)
 	require.NotContains(t, string(specYAML), "compressed")
 
 	t.Logf("yaml:\n%s", string(specYAML))
@@ -60,9 +65,12 @@ func TestClusterMachineConfigPatchesYAML(t *testing.T) {
 func TestClusterMachineConfigPatchesJSON(t *testing.T) {
 	res := omni.NewClusterMachineConfigPatches("test", "test")
 
+	aString := strings.Repeat("a", constants.CompressionThresholdBytes)
+	bString := strings.Repeat("b", constants.CompressionThresholdBytes)
+
 	// set some patches
 
-	err := res.TypedSpec().Value.SetUncompressedPatches([]string{"aaaa", "bbbb"})
+	err := res.TypedSpec().Value.SetUncompressedPatches([]string{aString, bString})
 	require.NoError(t, err)
 
 	// assert that the patches are compressed
@@ -79,8 +87,8 @@ func TestClusterMachineConfigPatchesJSON(t *testing.T) {
 
 	// assert that the patches are in the JSON in uncompressed form, and do not contain the compressed form
 
-	require.Contains(t, string(specJSON), "aaaa")
-	require.Contains(t, string(specJSON), "bbbb")
+	require.Contains(t, string(specJSON), aString)
+	require.Contains(t, string(specJSON), bString)
 	require.NotContains(t, string(specJSON), "compressed")
 
 	t.Logf("json:\n%s", string(specJSON))

--- a/client/pkg/constants/constants.go
+++ b/client/pkg/constants/constants.go
@@ -77,3 +77,6 @@ const KubernetesAdminCertCommonName = "omni:admin"
 // InfraProviderMetadataKey is the id of the key which is set by the infrastructure provider when it establishes client connection
 // to the Omni instance.
 const InfraProviderMetadataKey = "providerID"
+
+// CompressionThresholdBytes is the minimum marshaled size of the data to be considered for compression.
+const CompressionThresholdBytes = 2048

--- a/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_provider_config_patch_test.go
@@ -51,7 +51,7 @@ func (suite *InfraProviderConfigPatchControllerSuite) TestReconcile() {
 	suite.Require().NoError(suite.state.Create(ctx, status))
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{id}, func(configPatch *omni.ConfigPatch, assert *assert.Assertions) {
-		assert.Equal(configPatch.TypedSpec().Value.CompressedData, request.TypedSpec().Value.CompressedData) //nolint:staticcheck
+		assert.Equal(configPatch.TypedSpec().Value.GetCompressedData(), request.TypedSpec().Value.GetCompressedData())
 
 		value, ok := configPatch.Metadata().Labels().Get(omni.LabelMachine)
 		assert.True(ok)

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/operations.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/operations.go
@@ -6,14 +6,15 @@
 package machineset
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/gen/xiter"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
@@ -213,91 +214,11 @@ func setPatches(clusterMachineConfigPatches *omni.ClusterMachineConfigPatches, p
 	clusterMachineConfigPatches.TypedSpec().Value.Patches = nil
 	clusterMachineConfigPatches.TypedSpec().Value.CompressedPatches = nil
 
-	if specs.GetCompressionConfig().Enabled {
-		return setPatchesCompress(clusterMachineConfigPatches, patches)
-	}
-
-	return setPatchesNoCompress(clusterMachineConfigPatches, patches)
-}
-
-//nolint:staticcheck // we are ok with using the deprecated method here
-func setPatchesCompress(res *omni.ClusterMachineConfigPatches, patches []*omni.ConfigPatch) error {
-	for _, patch := range patches {
-		compressedSize := len(patch.TypedSpec().Value.CompressedData)
-
-		if compressedSize == 0 { // patch is not compressed, compress and then append it
-			if isEmptyPatch(patch) {
-				continue
-			}
-
-			buffer, err := patch.TypedSpec().Value.GetUncompressedData()
-			if err != nil {
-				return err
-			}
-
-			if err = patch.TypedSpec().Value.SetUncompressedData(buffer.Data()); err != nil {
-				return err
-			}
-
-			res.TypedSpec().Value.CompressedPatches = append(res.TypedSpec().Value.CompressedPatches, patch.TypedSpec().Value.CompressedData)
-
-			buffer.Free() // we can already free the buffer, as we already read and compressed it
-
-			continue
-		}
-
-		// patch is compressed, append it directly
-
-		if compressedSize < 1024 { // this is a small patch, decompress to check if it's all whitespace
-			if isEmptyPatch(patch) {
-				continue
-			}
-		}
-
-		// append the patch
-		res.TypedSpec().Value.CompressedPatches = append(res.TypedSpec().Value.CompressedPatches, patch.TypedSpec().Value.CompressedData)
-	}
-
-	return nil
-}
-
-//nolint:staticcheck // we are ok with using the deprecated method here
-func setPatchesNoCompress(res *omni.ClusterMachineConfigPatches, patches []*omni.ConfigPatch) error {
-	for _, patch := range patches {
-		compressedSize := len(patch.TypedSpec().Value.CompressedData)
-
-		if compressedSize == 0 { // not compressed, append the patch
-			if isEmptyPatch(patch) {
-				continue
-			}
-
-			res.TypedSpec().Value.Patches = append(res.TypedSpec().Value.Patches, patch.TypedSpec().Value.Data)
-
-			continue
-		}
-
-		// compressed, decompress and append the patch
-
-		buffer, err := patch.TypedSpec().Value.GetUncompressedData()
-		if err != nil {
-			return err
-		}
-
-		res.TypedSpec().Value.Patches = append(res.TypedSpec().Value.Patches, string(buffer.Data()))
-
-		buffer.Free() // we can already free the buffer, as we converted its bytes to a string
-	}
-
-	return nil
-}
-
-func isEmptyPatch(patch *omni.ConfigPatch) bool {
-	buffer, err := patch.TypedSpec().Value.GetUncompressedData()
-	if err != nil {
-		return false
-	}
-
-	defer buffer.Free()
-
-	return len(bytes.TrimSpace(buffer.Data())) == 0
+	return clusterMachineConfigPatches.TypedSpec().Value.FromConfigPatches(
+		xiter.Map(
+			func(in *omni.ConfigPatch) *specs.ConfigPatchSpec { return in.TypedSpec().Value },
+			slices.Values(patches),
+		),
+		specs.GetCompressionConfig().Enabled,
+	)
 }


### PR DESCRIPTION
Change `SetUncompressedData` methods to respect `compressionThresholdBytes` from
`internal/backend/runtime/omni/state_etcd.go` while we are at it.

Fix len(data) == 0 != nil bug.

Signed-off-by: Dmitriy Matrenichev <dmitry.matrenichev@siderolabs.com>
Co-authored-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>