### PR TITLE
perf: move etcd backup status resources into secondary storage

### DIFF
--- a/client/pkg/omni/resources/omni/etcd_backup_overall_status.go
+++ b/client/pkg/omni/resources/omni/etcd_backup_overall_status.go
@@ -17,7 +17,7 @@ import (
 // NewEtcdBackupOverallStatus creates new etcd backup status info.
 func NewEtcdBackupOverallStatus() *EtcdBackupOverallStatus {
 	return typed.NewResource[EtcdBackupOverallStatusSpec, EtcdBackupOverallStatusExtension](
-		resource.NewMetadata(resources.DefaultNamespace, EtcdBackupOverallStatusType, EtcdBackupOverallStatusID, resource.VersionUndefined),
+		resource.NewMetadata(resources.MetricsNamespace, EtcdBackupOverallStatusType, EtcdBackupOverallStatusID, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.EtcdBackupOverallStatusSpec{}),
 	)
 }
@@ -46,7 +46,7 @@ func (EtcdBackupOverallStatusExtension) ResourceDefinition() meta.ResourceDefini
 	return meta.ResourceDefinitionSpec{
 		Type:             EtcdBackupOverallStatusType,
 		Aliases:          []resource.Type{},
-		DefaultNamespace: resources.DefaultNamespace,
+		DefaultNamespace: resources.MetricsNamespace,
 		PrintColumns: []meta.PrintColumn{
 			{
 				Name:     "Configuration Name",

--- a/client/pkg/omni/resources/omni/etcd_backup_status.go
+++ b/client/pkg/omni/resources/omni/etcd_backup_status.go
@@ -17,7 +17,7 @@ import (
 // NewEtcdBackupStatus creates new etcd backup status info.
 func NewEtcdBackupStatus(id resource.ID) *EtcdBackupStatus {
 	return typed.NewResource[EtcdBackupStatusSpec, EtcdBackupStatusExtension](
-		resource.NewMetadata(resources.DefaultNamespace, EtcdBackupStatusType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.MetricsNamespace, EtcdBackupStatusType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.EtcdBackupStatusSpec{}),
 	)
 }
@@ -42,7 +42,7 @@ func (EtcdBackupStatusExtension) ResourceDefinition() meta.ResourceDefinitionSpe
 	return meta.ResourceDefinitionSpec{
 		Type:             EtcdBackupStatusType,
 		Aliases:          []resource.Type{},
-		DefaultNamespace: resources.DefaultNamespace,
+		DefaultNamespace: resources.MetricsNamespace,
 		PrintColumns: []meta.PrintColumn{
 			{
 				Name:     "Status",

--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -7,7 +7,7 @@ import { ManagementService } from "@/api/omni/management/management.pb";
 import { NodesViewFilterOptions, TCommonStatuses } from "@/constants";
 import { showError } from "@/notification";
 import { computed, ComputedRef, Ref, ref } from "vue";
-import { DefaultNamespace, EtcdBackupOverallStatusID, EtcdBackupOverallStatusType } from "@/api/resources";
+import { EtcdBackupOverallStatusID, EtcdBackupOverallStatusType, MetricsNamespace } from "@/api/resources";
 import { withContext } from "@/api/options";
 import { b64Decode, fetchOption } from "@/api/fetch.pb";
 import { V1Node } from "@kubernetes/client-node";
@@ -177,7 +177,7 @@ export const setupBackupStatus = (): { status: ComputedRef<BackupsStatus>, watch
   watch.setup({
     resource: {
       id: EtcdBackupOverallStatusID,
-      namespace: DefaultNamespace,
+      namespace: MetricsNamespace,
       type: EtcdBackupOverallStatusType,
     },
     runtime: Runtime.Omni,

--- a/frontend/src/views/cluster/Backups/BackupsList.vue
+++ b/frontend/src/views/cluster/Backups/BackupsList.vue
@@ -88,7 +88,7 @@ import {
   EtcdBackupType,
   LabelCluster,
   EtcdBackupStatusType,
-  DefaultNamespace,
+  MetricsNamespace,
   EtcdBackupOverallStatusID,
   EtcdBackupOverallStatusType,
 } from "@/api/resources";
@@ -119,7 +119,7 @@ const sortOptions = [
 const watchStatusOpts = computed((): WatchOptions => {
   return {
     resource: {
-      namespace: DefaultNamespace,
+      namespace: MetricsNamespace,
       type: EtcdBackupStatusType,
       id: route.params.cluster as string,
     },
@@ -130,7 +130,7 @@ const watchStatusOpts = computed((): WatchOptions => {
 const watchOverallStatusOpts = computed((): WatchOptions => {
   return {
     resource: {
-      namespace: DefaultNamespace,
+      namespace: MetricsNamespace,
       type: EtcdBackupOverallStatusType,
       id: EtcdBackupOverallStatusID,
     },

--- a/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue
@@ -223,7 +223,7 @@ import {
   KubernetesStatusType,
   DefaultNamespace,
   EtcdBackupStatusType,
-  ClusterDiagnosticsType,
+  ClusterDiagnosticsType, MetricsNamespace,
 } from "@/api/resources";
 import { BackupsStatus, downloadKubeconfig, downloadTalosconfig } from "@/methods";
 import { controlPlaneMachineSetId } from "@/methods/machineset";
@@ -313,7 +313,7 @@ kubernetesStatusWatch.setup({
 backupStatusWatch.setup({
   runtime: Runtime.Omni,
   resource: {
-    namespace: DefaultNamespace,
+    namespace: MetricsNamespace,
     type: EtcdBackupStatusType,
     id: route.params.cluster as string,
   }

--- a/frontend/src/views/omni/Settings/BackupStorage.vue
+++ b/frontend/src/views/omni/Settings/BackupStorage.vue
@@ -44,7 +44,7 @@ import { canManageBackupStore } from "@/methods/auth";
 import { Resource, ResourceService } from "@/api/grpc";
 import { EtcdBackupOverallStatusSpec, EtcdBackupS3ConfSpec } from "@/api/omni/specs/omni.pb";
 import { Runtime } from "@/api/common/omni.pb";
-import { DefaultNamespace, EtcdBackupOverallStatusID, EtcdBackupOverallStatusType, EtcdBackupS3ConfID, EtcdBackupS3ConfType } from "@/api/resources";
+import { DefaultNamespace, EtcdBackupOverallStatusID, EtcdBackupOverallStatusType, EtcdBackupS3ConfID, EtcdBackupS3ConfType, MetricsNamespace } from "@/api/resources";
 import { withRuntime } from "@/api/options";
 import { Code } from '@/api/google/rpc/code.pb';
 
@@ -70,7 +70,7 @@ onMounted(async () => {
   const status: Resource<EtcdBackupOverallStatusSpec> = await ResourceService.Get({
     id: EtcdBackupOverallStatusID,
     type: EtcdBackupOverallStatusType,
-    namespace: DefaultNamespace,
+    namespace: MetricsNamespace,
   }, withRuntime(Runtime.Omni));
 
   store.value = status.spec.configuration_name!;

--- a/internal/backend/runtime/omni/external/state_test.go
+++ b/internal/backend/runtime/omni/external/state_test.go
@@ -90,7 +90,7 @@ func TestStateList(t *testing.T) {
 			opts: []state.ListOption{
 				state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, "cluster1")),
 			},
-			errCheck: check.EqualError(`unsupported resource type: unsupported resource kind for list "EtcdBackupStatuses.omni.sidero.dev(default/@undefined)"`),
+			errCheck: check.EqualError(`unsupported resource type: unsupported resource kind for list "EtcdBackupStatuses.omni.sidero.dev(metrics/@undefined)"`),
 		},
 		"empty cluster id": {
 			kind: etcdBackupPtr,
@@ -195,7 +195,7 @@ func TestStateGet(t *testing.T) {
 		},
 		"incorrect type": {
 			pointer:  omni.NewEtcdBackupStatus("").Metadata(),
-			errCheck: check.EqualError(`unsupported resource type: unsupported resource type for get "EtcdBackupStatuses.omni.sidero.dev(default/@undefined)"`),
+			errCheck: check.EqualError(`unsupported resource type: unsupported resource type for get "EtcdBackupStatuses.omni.sidero.dev(metrics/@undefined)"`),
 		},
 		"not found": {
 			pointer: omni.NewEtcdBackup("cluster1", happyResult[0].F2).Metadata(),

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -195,6 +195,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: compressConfigPatches,
 				name:     "compressConfigPatches",
 			},
+			{
+				callback: moveEtcdBackupStatuses,
+				name:     "moveEtcdBackupStatuses",
+			},
 		},
 	}
 }


### PR DESCRIPTION
The resources `EtcdBackupStatus` and `EtcdBackupOverallStatus` get updated very frequently, as both succeeded and failed attempts of backups trigger an update. Some users have a lot of clusters with many of them are inaccessible/dead, causing excessive resource updates.

Move these two resource types into the `metrics` namespace - the namespace for the frequently updated resources.

Noticed while investigating frequently updated resources while working on https://github.com/siderolabs/omni/issues/789.