### PR TITLE
fix: fixing helm deployment resources

### DIFF
--- a/deploy/helm/omni/templates/deployment.yaml
+++ b/deploy/helm/omni/templates/deployment.yaml
@@ -52,11 +52,6 @@ spec:
           - name: wireguard
             containerPort: 50180
             protocol: UDP
-        resources:
-          limits:
-            # Required for /dev/net/tun
-            # https://www.talos.dev/v1.8/kubernetes-guides/configuration/device-plugins/
-            squat.ai/tun: 1
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -35,6 +35,9 @@ resources:
   limits:
     cpu: 200m
     memory: 256Mi
+    # Required for /dev/net/tun
+    # https://www.talos.dev/v1.8/kubernetes-guides/configuration/device-plugins/
+    squat.ai/tun: 1
 extraArgs:
   # - --debug
   # - --image-factory-address=factory.talos.dev


### PR DESCRIPTION
This PR removes the duplicated resources from the deployment template in the helm chart.