### PR TITLE
fix: do not clip the tooltip in the cluster machine status

### DIFF
--- a/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
+++ b/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
@@ -15,7 +15,7 @@ included in the LICENSE file.
         </router-link>
       </div>
       <div class="flex justify-between gap-2 col-span-2 pr-2">
-        <div class="flex gap-2 truncate">
+        <div class="flex gap-2">
           <cluster-machine-phase :machine="machine"/>
           <div v-if="lockedUpdate" class="flex gap-1 items-center text-light-blue-400 truncate">
             <t-icon icon="time" class="h-4 w-4 min-w-max"/>

--- a/frontend/src/views/cluster/ClusterMachines/ClusterMachinePhase.vue
+++ b/frontend/src/views/cluster/ClusterMachines/ClusterMachinePhase.vue
@@ -7,20 +7,16 @@ included in the LICENSE file.
 <template>
   <div
     :style="'color: ' + stageColor(machine)"
-    :class="'cluster-stage-box' + (connected(machine) ? '' : ' brightness-50')"
   >
-    <popper v-if="!connected(machine)" hover placement="right" offsetDistance="4">
-      <template #content>
-        <div class="px-2 py-1 rounded bg-naturals-N4 drop-shadow text-naturals-N12">
-          The machine is unreachable. The last known state is shown.
+    <tooltip placement="bottom" :description="connected(machine) ? undefined : 'The machine is unreachable. The last known state is shown'">
+      <div class="flex gap-1"
+        :class="'cluster-stage-box' + (connected(machine) ? '' : ' brightness-50')">
+        <t-icon :icon="stageIcon(machine)" class="h-4" />
+        <div class="truncate flex-1" id="cluster-machine-stage-name">
+          {{ stageName(machine) || "" }}
         </div>
-      </template>
-      <t-icon class="w-4 h-4" icon="unknown"/>
-    </popper>
-    <t-icon v-else :icon="stageIcon(machine)" class="h-4" />
-    <div class="cluster-stage-name">
-      {{ stageName(machine) || "" }}
-    </div>
+      </div>
+    </tooltip>
   </div>
 </template>
 
@@ -30,7 +26,7 @@ import { MachineStatusLabelConnected } from "@/api/resources";
 import { Resource } from "@/api/grpc";
 
 import TIcon, { IconType } from "@/components/common/Icon/TIcon.vue";
-import Popper from "vue3-popper";
+import Tooltip from "@/components/common/Tooltip/Tooltip.vue";
 
 const connected = (machine: Resource<ClusterMachineStatusSpec>): boolean => {
   if (machine.spec.stage === ClusterMachineStatusSpecStage.POWERING_ON) {
@@ -72,6 +68,10 @@ const stageName = (machine: Resource<ClusterMachineStatusSpec>): string => {
 };
 
 const stageIcon = (machine: Resource<ClusterMachineStatusSpec>): IconType => {
+  if (!connected(machine)) {
+    return "unknown";
+  }
+
   switch (machine?.spec.stage) {
     case ClusterMachineStatusSpecStage.BOOTING:
     case ClusterMachineStatusSpecStage.INSTALLING:

--- a/frontend/src/views/cluster/ClusterMachines/MachineSetPhase.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineSetPhase.vue
@@ -11,7 +11,7 @@ included in the LICENSE file.
       class="cluster-phase-box"
       >
         <t-icon :icon="phaseIcon(item)" class="h-4"/>
-        <div class="cluster-phase-name">{{ phaseName(item) || "" }}</div>
+        <div id="machine-set-phase-name">{{ phaseName(item) || "" }}</div>
       </div>
       <div v-if="item.spec.locked_updates"
         class="flex gap-1 items-center text-light-blue-400">

--- a/internal/e2e-tests/main_test.go
+++ b/internal/e2e-tests/main_test.go
@@ -431,7 +431,7 @@ func (s *E2ESuite) assertClusterCreation() {
 				return retry.ExpectedErrorf("the cluster is not created yet")
 			}
 
-			runningMachineSet := page.Locator(`div[class="cluster-phase-name"]:has-text("Running")`)
+			runningMachineSet := page.Locator(`div[id="machine-set-phase-name"]:has-text("Running")`)
 			runningMachineSetCount, err := runningMachineSet.Count()
 			if err != nil {
 				openPage()
@@ -439,7 +439,7 @@ func (s *E2ESuite) assertClusterCreation() {
 				return retry.ExpectedErrorf("failed to get running machine sets count %s", err)
 			}
 
-			runningMachines := page.Locator(`div[class="cluster-stage-name"]:has-text("Running")`)
+			runningMachines := page.Locator(`div[id="cluster-machine-stage-name"]:has-text("Running")`)
 			runningMachinesCount, err := runningMachines.Count()
 			if err != nil {
 				openPage()


### PR DESCRIPTION
The way it was implemented there was incorrect.
Drop direct `popper` usage there and use the Tooltip instead.

Fixes: https://github.com/siderolabs/omni/issues/1004

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>