### PR TITLE
fix: do not switch Siderolink GRPC tunnel mode after provisioning

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -339,7 +339,8 @@ var initOnce = sync.OnceValue(func() *cobra.Command {
 		config.Config.SiderolinkWireguardAdvertisedAddress,
 		"advertised wireguard address which is passed down to the nodes.")
 	rootCmd.Flags().StringVar(&config.Config.SiderolinkWireguardBindAddress, "siderolink-wireguard-bind-addr", config.Config.SiderolinkWireguardBindAddress, "SideroLink WireGuard bind address.")
-	rootCmd.Flags().BoolVar(&config.Config.SiderolinkUseGRPCTunnel, "siderolink-use-grpc-tunnel", false, "use gRPC tunnel to wrap WireGuard traffic instead of UDP")
+	rootCmd.Flags().BoolVar(&config.Config.SiderolinkUseGRPCTunnel, "siderolink-use-grpc-tunnel", false, "use gRPC tunnel to wrap WireGuard traffic instead of UDP. When enabled, "+
+		"the SideroLink connections from Talos machines will be configured to use the tunnel mode, regardless of their individual configuration. ")
 
 	rootCmd.Flags().StringVar(&config.Config.MachineAPIBindAddress, "siderolink-api-bind-addr", config.Config.MachineAPIBindAddress, "SideroLink provision bind address.")
 	rootCmd.Flags().StringVar(&config.Config.MachineAPICertFile, "siderolink-api-cert", config.Config.MachineAPICertFile, "SideroLink TLS cert file path.")

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
@@ -492,14 +492,11 @@ func buildInstallImage(imageFactoryHost string, resID resource.ID, installImage 
 }
 
 func renderSiderolinkJoinConfig(connectionParams *siderolink.ConnectionParams, link *siderolink.Link, eventSinkPort int) ([]byte, error) {
-	var urlOpts []siderolink.APIURLOption
-
 	// If this machine is connected using the GRPC tunnel (grpc_tunnel=true), set it explicitly, so that option is preserved.
-	if link.TypedSpec().Value.GetVirtualAddrport() != "" {
-		urlOpts = append(urlOpts, siderolink.WithGRPCTunnel(true))
-	}
+	useSiderolinkGRPCTunnel := link.TypedSpec().Value.GetVirtualAddrport() != ""
 
-	url, err := siderolink.APIURL(connectionParams, urlOpts...)
+	// always pass the tunnel option explicitly here to avoid setting it to the instance default
+	url, err := siderolink.APIURL(connectionParams, siderolink.WithGRPCTunnel(useSiderolinkGRPCTunnel))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -110,6 +110,7 @@ func NewManager(
 			logger,
 			state,
 			config.Config.JoinTokensMode,
+			config.Config.SiderolinkUseGRPCTunnel,
 		),
 	}
 

--- a/internal/pkg/siderolink/provision_test.go
+++ b/internal/pkg/siderolink/provision_test.go
@@ -114,7 +114,7 @@ func TestProvision(t *testing.T) {
 			require.NoError(t, eg.Wait())
 		})
 
-		provisionHandler := siderolink.NewProvisionHandler(logger, state, mode)
+		provisionHandler := siderolink.NewProvisionHandler(logger, state, mode, false)
 
 		config := siderolinkres.NewConfig(resources.DefaultNamespace)
 		config.TypedSpec().Value.ServerAddress = "127.0.0.1"


### PR DESCRIPTION
Followup fix after https://github.com/siderolabs/omni/pull/976.

Change the way the global flag `--siderolink-use-grpc-tunnel` works: It now is used in the SideroLink provision API to decide whether to ignore what the machine requests in the prevision request and "force" the tunnel mode.

Additionally, now it is ignored in the generated `SideroLinkConfig` document which is pushed to the machines when they are allocated - instead, we simply check if the machine was already connected (provisioned) using a GRPC tunnel, and preserve that option. By doing that, we avoid switching the mode after the provisioning, avoiding the bug which is fixed in https://github.com/siderolabs/talos/pull/10517.