### PR TITLE
chore: add GOEXPERIMENT env to vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "css.lint.unknownAtRules": "ignore",
-    "vue3snippets.enable-compile-vue-file-on-did-save-code": false
+    "vue3snippets.enable-compile-vue-file-on-did-save-code": false,
+    "go.toolsEnvVars": {
+        "GOEXPERIMENT": "synctest"
+    }
 }


### PR DESCRIPTION
A small followup to [#998](https://github.com/siderolabs/omni/pull/998)

Without this option set the language server complains about synctest package not existing and in-editor compilation and test features stop working.