### PR TITLE
fix: properly display error message when machine class removal failed

### DIFF
--- a/frontend/src/views/omni/Modals/MachineClassDestroy.vue
+++ b/frontend/src/views/omni/Modals/MachineClassDestroy.vue
@@ -58,6 +58,10 @@ const destroy = async () => {
     }, withRuntime(Runtime.Omni));
   } catch (e) {
     showError("Failed to remove the machine class", e.message)
+
+    close();
+
+    return;
   }
 
   close();


### PR DESCRIPTION
It was showing success even if it has failed.

Fixes: https://github.com/siderolabs/omni/issues/1022