### PR TITLE
chore: change upload and download limits flags to mbps

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -516,18 +516,18 @@ var initOnce = sync.OnceValue(func() *cobra.Command {
 		"maximal interval between etcd backups",
 	)
 
-	rootCmd.Flags().Int64Var(
-		&config.Config.EtcdBackup.UploadLimit,
-		"etcd-backup-upload-limit",
-		config.Config.EtcdBackup.UploadLimit,
-		"throughput limit for etcd backup uploads",
+	rootCmd.Flags().Uint64Var(
+		&config.Config.EtcdBackup.UploadLimitMbps,
+		"etcd-backup-upload-limit-mbps",
+		config.Config.EtcdBackup.UploadLimitMbps,
+		"throughput limit in Mbps for etcd backup uploads, zero means unlimited",
 	)
 
-	rootCmd.Flags().Int64Var(
-		&config.Config.EtcdBackup.DownloadLimit,
-		"etcd-backup-download-limit",
-		config.Config.EtcdBackup.DownloadLimit,
-		"throughput limit for etcd backup downloads",
+	rootCmd.Flags().Uint64Var(
+		&config.Config.EtcdBackup.DownloadLimitMbps,
+		"etcd-backup-download-limit-mbps",
+		config.Config.EtcdBackup.DownloadLimitMbps,
+		"throughput limit in Mbps for etcd backup downloads, zero means unlimited",
 	)
 
 	rootCmd.Flags().StringSliceVar(&config.Config.LogResourceUpdatesTypes,

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -33,5 +33,5 @@ User-managed config patches not associated with an existing target (e.g., cluste
 [notes.custom-etcd-backup-throughput]
 title = "Custom Etcd Backup Throughput"
 description = """\
-The throughput for etcd backup uploads/downloads can now be limited using the `--etcd-backup-upload-limit` and `--etcd-backup-download-limit` flags.
+The throughput for etcd backup uploads/downloads can now be limited using the `--etcd-backup-upload-limit-mbps` and `--etcd-backup-download-limit-mbps` flags.
 """

--- a/internal/backend/runtime/omni/controllers/omni/cluster_bootstrap_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_bootstrap_status_test.go
@@ -35,7 +35,7 @@ type mockStoreFactory struct {
 	etcdBackupDataMock etcdbackup.BackupData
 }
 
-func (m *mockStoreFactory) SetThroughputs(int64, int64) {}
+func (m *mockStoreFactory) SetThroughputs(uint64, uint64) {}
 
 func (m *mockStoreFactory) GetStore() (etcdbackup.Store, error) {
 	return &mockEtcdBackupStore{m.etcdBackupDataMock}, nil

--- a/internal/backend/runtime/omni/controllers/omni/etcd_backup_mock_2_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcd_backup_mock_2_test.go
@@ -128,7 +128,7 @@ func (c *MockFactoryGetStoreCall) DoAndReturn(f func() (etcdbackup.Store, error)
 }
 
 // SetThroughputs mocks base method.
-func (m *MockFactory) SetThroughputs(up, down int64) {
+func (m *MockFactory) SetThroughputs(up, down uint64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetThroughputs", up, down)
 }

--- a/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/disabledstore.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/disabledstore.go
@@ -36,4 +36,4 @@ func (d *disabledStoreFactory) Start(ctx context.Context, state state.State, _ *
 
 func (d *disabledStoreFactory) Description() string { return "disabled store" }
 
-func (d *disabledStoreFactory) SetThroughputs(int64, int64) {}
+func (d *disabledStoreFactory) SetThroughputs(uint64, uint64) {}

--- a/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/filestore.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/filestore.go
@@ -45,4 +45,4 @@ func (f *fileStoreFactory) Start(ctx context.Context, state state.State, _ *zap.
 
 func (f *fileStoreFactory) Description() string { return fmt.Sprintf("local store: %s", f.path) }
 
-func (f *fileStoreFactory) SetThroughputs(int64, int64) {}
+func (f *fileStoreFactory) SetThroughputs(uint64, uint64) {}

--- a/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/metrics.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/metrics.go
@@ -84,7 +84,7 @@ func (s *factoryWithMetrics) Description() string {
 	return s.factory.Description()
 }
 
-func (s *factoryWithMetrics) SetThroughputs(up, down int64) { s.factory.SetThroughputs(up, down) }
+func (s *factoryWithMetrics) SetThroughputs(up, down uint64) { s.factory.SetThroughputs(up, down) }
 
 type storeWithMetrics struct {
 	store   etcdbackup.Store

--- a/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/s3store.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/s3store.go
@@ -37,8 +37,8 @@ type S3StoreFactory struct { //nolint:govet
 	store          etcdbackup.Store
 	err            error
 	bucket         string
-	upThroughput   int64
-	downThroughput int64
+	upThroughput   uint64
+	downThroughput uint64
 }
 
 // NewS3StoreFactory returns a new S3 store factory.
@@ -220,7 +220,7 @@ func (sf *S3StoreFactory) Description() string {
 }
 
 // SetThroughputs sets the download and upload throughput for the store.
-func (sf *S3StoreFactory) SetThroughputs(up, down int64) {
+func (sf *S3StoreFactory) SetThroughputs(up, down uint64) {
 	sf.mx.Lock()
 	defer sf.mx.Unlock()
 

--- a/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/store.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/store.go
@@ -25,7 +25,7 @@ type Factory interface {
 	GetStore() (etcdbackup.Store, error)
 	Start(context.Context, state.State, *zap.Logger) error
 	Description() string
-	SetThroughputs(up, down int64)
+	SetThroughputs(up, down uint64)
 }
 
 // NewStoreFactory returns a new store factory.

--- a/internal/backend/runtime/omni/controllers/omni/internal/etcdbackup/s3store/s3store.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/etcdbackup/s3store/s3store.go
@@ -32,7 +32,7 @@ type Store struct {
 }
 
 // NewStore initializes [Store].
-func NewStore(client *s3.Client, bucket string, upRate, downRate int64) *Store {
+func NewStore(client *s3.Client, bucket string, upRate, downRate uint64) *Store {
 	upLimit := rate.Inf
 	if upRate > 0 {
 		upLimit = rate.Limit(upRate)
@@ -154,12 +154,12 @@ func (r *readerLimiter) Read(p []byte) (int, error) {
 
 	readInto := p[:min(burst, len(p))]
 
-	err := r.l.WaitN(context.Background(), len(readInto))
+	n, err := r.rdr.Read(readInto)
 	if err != nil {
-		return 0, err
+		return n, err
 	}
 
-	n, err := r.rdr.Read(readInto)
+	err = r.l.WaitN(context.Background(), n)
 	if err != nil {
 		return n, err
 	}

--- a/internal/backend/runtime/omni/controllers/omni/internal/etcdbackup/s3store/s3store_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/etcdbackup/s3store/s3store_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestReaderLimiter(t *testing.T) {
-	const str = "Hello Siderolabs!"
+	const str = "Hello Siderolabs!!"
 
 	rdr := strings.NewReader(str)
 	r := rate.NewLimiter(rate.Limit(6), 6)
@@ -41,7 +41,7 @@ func TestReaderLimiter(t *testing.T) {
 		t.Fatalf("expected %q, got %q", str, builder.String())
 	}
 
-	if time.Since(now) < time.Second*3 {
-		t.Fatalf("expected at least 3 seconds to pass")
+	if e := time.Since(now); e < time.Second*2 {
+		t.Fatalf("expected at least 2 seconds to pass, got %v", e)
 	}
 }

--- a/internal/backend/runtime/omni/controllers/omni/secrets_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets_test.go
@@ -95,7 +95,7 @@ func (m *mockBackupStore) Download(context.Context, []byte, string, string) (etc
 
 type mockBackupStoreFactory struct{}
 
-func (m *mockBackupStoreFactory) SetThroughputs(int64, int64) {}
+func (m *mockBackupStoreFactory) SetThroughputs(uint64, uint64) {}
 
 func (m *mockBackupStoreFactory) GetStore() (etcdbackup.Store, error) { return &mockBackupStore{}, nil }
 

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -182,11 +182,10 @@ func New(
 		return nil, err
 	}
 
-	storeFactory.SetThroughputs(
-		config.Config.EtcdBackup.UploadLimit,
-		config.Config.EtcdBackup.DownloadLimit,
-	)
+	uploadLimitPerSecondBytes := config.Config.EtcdBackup.UploadLimitMbps * 125000     // Mbit in bytes
+	downloadLimitPerSecondBytes := config.Config.EtcdBackup.DownloadLimitMbps * 125000 // Mbit in bytes
 
+	storeFactory.SetThroughputs(uploadLimitPerSecondBytes, downloadLimitPerSecondBytes)
 	metricsRegistry.MustRegister(storeFactory)
 
 	backupController, err := omnictrl.NewEtcdBackupController(omnictrl.EtcdBackupControllerSettings{

--- a/internal/backend/runtime/omni/state_validation_test.go
+++ b/internal/backend/runtime/omni/state_validation_test.go
@@ -1239,7 +1239,7 @@ type mockEtcdBackupStoreFactory struct {
 	store etcdbackup.Store
 }
 
-func (m *mockEtcdBackupStoreFactory) SetThroughputs(int64, int64) {}
+func (m *mockEtcdBackupStoreFactory) SetThroughputs(uint64, uint64) {}
 
 func (m *mockEtcdBackupStoreFactory) GetStore() (etcdbackup.Store, error) {
 	return m.store, nil

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -168,14 +168,14 @@ type EmbeddedDiscoveryServiceParams struct {
 
 // EtcdBackupParams defines etcd backup configs.
 type EtcdBackupParams struct {
-	LocalPath     string        `yaml:"localPath"`
-	S3Enabled     bool          `yaml:"s3Enabled"`
-	TickInterval  time.Duration `yaml:"tickInterval"`
-	MinInterval   time.Duration `yaml:"minInterval"`
-	MaxInterval   time.Duration `yaml:"maxInterval"`
-	UploadLimit   int64         `yaml:"uploadLimit"`
-	DownloadLimit int64         `yaml:"downloadLimit"`
-	Jitter        time.Duration `yaml:"jitter"`
+	LocalPath         string        `yaml:"localPath"`
+	S3Enabled         bool          `yaml:"s3Enabled"`
+	TickInterval      time.Duration `yaml:"tickInterval"`
+	MinInterval       time.Duration `yaml:"minInterval"`
+	MaxInterval       time.Duration `yaml:"maxInterval"`
+	UploadLimitMbps   uint64        `yaml:"uploadLimitMbps"`
+	DownloadLimitMbps uint64        `yaml:"downloadLimitMbps"`
+	Jitter            time.Duration `yaml:"jitter"`
 }
 
 // GetStorageType returns the storage type.


### PR DESCRIPTION
This is easier to process for the cli operator, since we now force it being at least 1 Mbps.

It also fixes the problem of limiter incorrectly assuming that the reader will use the entirety of a passed buffer,
resulting in incorrect limiting.