### PR TITLE
fix: fix crash in the workload proxy controller

### DIFF
--- a/internal/backend/workloadproxy/reconcile_utils.go
+++ b/internal/backend/workloadproxy/reconcile_utils.go
@@ -55,7 +55,7 @@ func (a *aliasToCluster) ReplaceCluster(clusterID resource.ID, rd *ReconcileData
 	got, ok := a.clusters[clusterID]
 	if !ok {
 		for als := range rd.AliasesData() {
-			if res := a.aliases[alias(als)]; res.clusterData != nil {
+			if res, ok := a.aliases[alias(als)]; ok && res.clusterData.clusterID != clusterID {
 				return fmt.Errorf("alias %q already exists and used by cluster %q", als, res.clusterData.clusterID)
 			}
 		}


### PR DESCRIPTION
If alias with the same cluster ID is found in the aliases map, reuse it.