### PR TITLE
fix: create config patches to prevent reboot on version contract revert

### DIFF
--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -199,6 +199,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: moveEtcdBackupStatuses,
 				name:     "moveEtcdBackupStatuses",
 			},
+			{
+				callback: createVersionContractRevertConfigPatch,
+				name:     "createVersionContractRevertConfigPatch",
+			},
 		},
 	}
 }


### PR DESCRIPTION
For the needed machines, create a config patch with a low priority to preserve the config changes which require the machines to be rebooted.

Prevents the reboot due to the fix in https://github.com/siderolabs/omni/issues/1097.
Part of the fix for https://github.com/siderolabs/omni/issues/1095.