### PR TITLE
fix: properly skip the contract config patch removal migration

### DIFF
--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -1825,7 +1825,7 @@ func (suite *MigrationSuite) TestDropObsoleteConfigPatches() {
 	suite.Require().NoError(suite.state.Create(ctx, normalConfigPatch))
 
 	version := system.NewDBVersion(resources.DefaultNamespace, system.DBVersionID)
-	version.TypedSpec().Value.Version = 39
+	version.TypedSpec().Value.Version = 40
 
 	suite.Require().NoError(suite.state.Create(ctx, version))
 
@@ -1856,10 +1856,7 @@ func (suite *MigrationSuite) TestDropObsoleteConfigPatchesSkipped() {
 
 	suite.Require().NoError(suite.state.Create(ctx, obsoleteConfigPatch))
 
-	version := system.NewDBVersion(resources.DefaultNamespace, system.DBVersionID)
-	version.TypedSpec().Value.Version = 38
-
-	suite.Require().NoError(suite.state.Create(ctx, version))
+	suite.Require().NoError(suite.manager.Run(ctx, migration.WithMaxVersion(39)))
 
 	suite.Require().NoError(suite.manager.Run(ctx, migration.WithFilter(filterWith("dropObsoleteConfigPatches"))))
 

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1553,8 +1553,8 @@ func dropObsoleteConfigPatches(ctx context.Context, st state.State, logger *zap.
 		return fmt.Errorf("failed to find the old version contract fix migration")
 	}
 
-	if migrationContext.initialDBVersion < uint64(patchMigrationIndex) {
-		logger.Info("nothing to do because of the db version", zap.Uint64("initial_db_version", migrationContext.initialDBVersion), zap.Int("expects_greater_or_equal", patchMigrationIndex))
+	if migrationContext.initialDBVersion <= uint64(patchMigrationIndex) {
+		logger.Info("nothing to do because of the db version", zap.Uint64("initial_db_version", migrationContext.initialDBVersion), zap.Int("expect_greater", patchMigrationIndex))
 
 		return nil
 	}
@@ -1727,7 +1727,7 @@ func markVersionContract(ctx context.Context, st state.State, logger *zap.Logger
 		}
 	}
 
-	logger.Info("created version contract revert config patches",
+	logger.Info("added annotations on the cluster machine to fix the version contract mismatch",
 		zap.Int("num_total_processed", clusterMachineConfigList.Len()),
 		zap.Int("num_config_was_not_applied", numConfigWasNotApplied),
 		zap.Int("num_disk_quota_support_enabled", numDiskQuotaSupportEnabled),


### PR DESCRIPTION
The db version is at len(migrations) after migrations are completed. So if we ran migration 39, it would be at 40.

Change the condition to properly handle that.