### PR TITLE
feat: improve logging/debugging of exposed services

### DIFF
--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -310,6 +310,10 @@ func (s *managementServer) collectClusterResources(ctx context.Context, cluster 
 			rt:          omni.ExtensionsConfigurationType,
 			listOptions: clusterQuery,
 		},
+		{
+			rt:          omni.ExposedServiceType,
+			listOptions: clusterQuery,
+		},
 	}
 
 	machineIDs := map[string]struct{}{}

--- a/internal/backend/workloadproxy/handler.go
+++ b/internal/backend/workloadproxy/handler.go
@@ -240,6 +240,10 @@ func (h *HTTPHandler) redirectToLogin(writer http.ResponseWriter, request *http.
 
 	loginURL.RawQuery = q.Encode()
 
+	h.logger.Info("redirect workload proxy request to login",
+		zap.Stringer("request_url", request.URL),
+		zap.Stringer("login_url", loginURL))
+
 	http.Redirect(writer, request, loginURL.String(), http.StatusSeeOther)
 }
 


### PR DESCRIPTION
- Include exposed services in the support bundles.
- Produce a log when an exposed service request is redirected to the login (do not log other requests to avoid excessive logging).

Closes #1068.