### PR TITLE
fix: return proper errors for the SideroLink provision API

### DIFF
--- a/internal/pkg/siderolink/provision.go
+++ b/internal/pkg/siderolink/provision.go
@@ -375,6 +375,10 @@ func establishLink[T res](ctx context.Context, logger *zap.Logger, st state.Stat
 
 		link, err = updateResourceWithMatchingToken[T](ctx, logger, st, provisionContext, link, annotationsToAdd, annotationsToRemove)
 		if err != nil {
+			if state.IsPhaseConflictError(err) {
+				return nil, status.Errorf(codes.AlreadyExists, "the machine with the same UUID is already registered in Omni and is in the tearing down phase")
+			}
+
 			return nil, err
 		}
 	}


### PR DESCRIPTION
If the `Link` already exists and is being torn down, we were returing pretty cryptic error back.

Replace the error message with the one which better describes what the user should do to fix the issue with the node not being able to join.