### PR TITLE
feat: implement async delete from discovery service(s)

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -2705,9 +2705,14 @@ type ClusterMachineIdentitySpec struct {
 	// Nodename is the Kubernetes node name.
 	Nodename string `protobuf:"bytes,3,opt,name=nodename,proto3" json:"nodename,omitempty"`
 	// NodeIps are the IPs of the Kubernetes node.
-	NodeIps       []string `protobuf:"bytes,8,rep,name=node_ips,json=nodeIps,proto3" json:"node_ips,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	NodeIps []string `protobuf:"bytes,8,rep,name=node_ips,json=nodeIps,proto3" json:"node_ips,omitempty"`
+	// DiscoveryServiceEndpoint is the endpoint of the discovery service used by the node.
+	// It contains the protocol prefix (http://|https://) and the port.
+	//
+	// It is empty if discovery service is not enabled.
+	DiscoveryServiceEndpoint string `protobuf:"bytes,9,opt,name=discovery_service_endpoint,json=discoveryServiceEndpoint,proto3" json:"discovery_service_endpoint,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *ClusterMachineIdentitySpec) Reset() {
@@ -2766,6 +2771,13 @@ func (x *ClusterMachineIdentitySpec) GetNodeIps() []string {
 		return x.NodeIps
 	}
 	return nil
+}
+
+func (x *ClusterMachineIdentitySpec) GetDiscoveryServiceEndpoint() string {
+	if x != nil {
+		return x.DiscoveryServiceEndpoint
+	}
+	return ""
 }
 
 // ClusterMachineTemplateSpec
@@ -6492,6 +6504,58 @@ func (*NodeForceDestroyRequestSpec) Descriptor() ([]byte, []int) {
 	return file_omni_specs_omni_proto_rawDescGZIP(), []int{83}
 }
 
+type DiscoveryAffiliateDeleteTaskSpec struct {
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	ClusterId                string                 `protobuf:"bytes,1,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	DiscoveryServiceEndpoint string                 `protobuf:"bytes,2,opt,name=discovery_service_endpoint,json=discoveryServiceEndpoint,proto3" json:"discovery_service_endpoint,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *DiscoveryAffiliateDeleteTaskSpec) Reset() {
+	*x = DiscoveryAffiliateDeleteTaskSpec{}
+	mi := &file_omni_specs_omni_proto_msgTypes[84]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoveryAffiliateDeleteTaskSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoveryAffiliateDeleteTaskSpec) ProtoMessage() {}
+
+func (x *DiscoveryAffiliateDeleteTaskSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_specs_omni_proto_msgTypes[84]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoveryAffiliateDeleteTaskSpec.ProtoReflect.Descriptor instead.
+func (*DiscoveryAffiliateDeleteTaskSpec) Descriptor() ([]byte, []int) {
+	return file_omni_specs_omni_proto_rawDescGZIP(), []int{84}
+}
+
+func (x *DiscoveryAffiliateDeleteTaskSpec) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
+}
+
+func (x *DiscoveryAffiliateDeleteTaskSpec) GetDiscoveryServiceEndpoint() string {
+	if x != nil {
+		return x.DiscoveryServiceEndpoint
+	}
+	return ""
+}
+
 // HardwareStatus describes machine hardware status.
 type MachineStatusSpec_HardwareStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -6509,7 +6573,7 @@ type MachineStatusSpec_HardwareStatus struct {
 
 func (x *MachineStatusSpec_HardwareStatus) Reset() {
 	*x = MachineStatusSpec_HardwareStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[84]
+	mi := &file_omni_specs_omni_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6521,7 +6585,7 @@ func (x *MachineStatusSpec_HardwareStatus) String() string {
 func (*MachineStatusSpec_HardwareStatus) ProtoMessage() {}
 
 func (x *MachineStatusSpec_HardwareStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[84]
+	mi := &file_omni_specs_omni_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6584,7 +6648,7 @@ type MachineStatusSpec_NetworkStatus struct {
 
 func (x *MachineStatusSpec_NetworkStatus) Reset() {
 	*x = MachineStatusSpec_NetworkStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[85]
+	mi := &file_omni_specs_omni_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6596,7 +6660,7 @@ func (x *MachineStatusSpec_NetworkStatus) String() string {
 func (*MachineStatusSpec_NetworkStatus) ProtoMessage() {}
 
 func (x *MachineStatusSpec_NetworkStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[85]
+	mi := &file_omni_specs_omni_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6672,7 +6736,7 @@ type MachineStatusSpec_PlatformMetadata struct {
 
 func (x *MachineStatusSpec_PlatformMetadata) Reset() {
 	*x = MachineStatusSpec_PlatformMetadata{}
-	mi := &file_omni_specs_omni_proto_msgTypes[86]
+	mi := &file_omni_specs_omni_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6684,7 +6748,7 @@ func (x *MachineStatusSpec_PlatformMetadata) String() string {
 func (*MachineStatusSpec_PlatformMetadata) ProtoMessage() {}
 
 func (x *MachineStatusSpec_PlatformMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[86]
+	mi := &file_omni_specs_omni_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6788,7 +6852,7 @@ type MachineStatusSpec_Schematic struct {
 
 func (x *MachineStatusSpec_Schematic) Reset() {
 	*x = MachineStatusSpec_Schematic{}
-	mi := &file_omni_specs_omni_proto_msgTypes[87]
+	mi := &file_omni_specs_omni_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6800,7 +6864,7 @@ func (x *MachineStatusSpec_Schematic) String() string {
 func (*MachineStatusSpec_Schematic) ProtoMessage() {}
 
 func (x *MachineStatusSpec_Schematic) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[87]
+	mi := &file_omni_specs_omni_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6883,7 +6947,7 @@ type MachineStatusSpec_Diagnostic struct {
 
 func (x *MachineStatusSpec_Diagnostic) Reset() {
 	*x = MachineStatusSpec_Diagnostic{}
-	mi := &file_omni_specs_omni_proto_msgTypes[88]
+	mi := &file_omni_specs_omni_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6895,7 +6959,7 @@ func (x *MachineStatusSpec_Diagnostic) String() string {
 func (*MachineStatusSpec_Diagnostic) ProtoMessage() {}
 
 func (x *MachineStatusSpec_Diagnostic) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[88]
+	mi := &file_omni_specs_omni_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6951,7 +7015,7 @@ type MachineStatusSpec_HardwareStatus_Processor struct {
 
 func (x *MachineStatusSpec_HardwareStatus_Processor) Reset() {
 	*x = MachineStatusSpec_HardwareStatus_Processor{}
-	mi := &file_omni_specs_omni_proto_msgTypes[90]
+	mi := &file_omni_specs_omni_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6963,7 +7027,7 @@ func (x *MachineStatusSpec_HardwareStatus_Processor) String() string {
 func (*MachineStatusSpec_HardwareStatus_Processor) ProtoMessage() {}
 
 func (x *MachineStatusSpec_HardwareStatus_Processor) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[90]
+	mi := &file_omni_specs_omni_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7027,7 +7091,7 @@ type MachineStatusSpec_HardwareStatus_MemoryModule struct {
 
 func (x *MachineStatusSpec_HardwareStatus_MemoryModule) Reset() {
 	*x = MachineStatusSpec_HardwareStatus_MemoryModule{}
-	mi := &file_omni_specs_omni_proto_msgTypes[91]
+	mi := &file_omni_specs_omni_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7039,7 +7103,7 @@ func (x *MachineStatusSpec_HardwareStatus_MemoryModule) String() string {
 func (*MachineStatusSpec_HardwareStatus_MemoryModule) ProtoMessage() {}
 
 func (x *MachineStatusSpec_HardwareStatus_MemoryModule) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[91]
+	mi := &file_omni_specs_omni_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7102,7 +7166,7 @@ type MachineStatusSpec_HardwareStatus_BlockDevice struct {
 
 func (x *MachineStatusSpec_HardwareStatus_BlockDevice) Reset() {
 	*x = MachineStatusSpec_HardwareStatus_BlockDevice{}
-	mi := &file_omni_specs_omni_proto_msgTypes[92]
+	mi := &file_omni_specs_omni_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7114,7 +7178,7 @@ func (x *MachineStatusSpec_HardwareStatus_BlockDevice) String() string {
 func (*MachineStatusSpec_HardwareStatus_BlockDevice) ProtoMessage() {}
 
 func (x *MachineStatusSpec_HardwareStatus_BlockDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[92]
+	mi := &file_omni_specs_omni_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7233,7 +7297,7 @@ type MachineStatusSpec_NetworkStatus_NetworkLinkStatus struct {
 
 func (x *MachineStatusSpec_NetworkStatus_NetworkLinkStatus) Reset() {
 	*x = MachineStatusSpec_NetworkStatus_NetworkLinkStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[93]
+	mi := &file_omni_specs_omni_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7245,7 +7309,7 @@ func (x *MachineStatusSpec_NetworkStatus_NetworkLinkStatus) String() string {
 func (*MachineStatusSpec_NetworkStatus_NetworkLinkStatus) ProtoMessage() {}
 
 func (x *MachineStatusSpec_NetworkStatus_NetworkLinkStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[93]
+	mi := &file_omni_specs_omni_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7310,7 +7374,7 @@ type ClusterSpec_Features struct {
 
 func (x *ClusterSpec_Features) Reset() {
 	*x = ClusterSpec_Features{}
-	mi := &file_omni_specs_omni_proto_msgTypes[94]
+	mi := &file_omni_specs_omni_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7322,7 +7386,7 @@ func (x *ClusterSpec_Features) String() string {
 func (*ClusterSpec_Features) ProtoMessage() {}
 
 func (x *ClusterSpec_Features) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[94]
+	mi := &file_omni_specs_omni_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7369,7 +7433,7 @@ type ClusterMachineStatusSpec_ProvisionStatus struct {
 
 func (x *ClusterMachineStatusSpec_ProvisionStatus) Reset() {
 	*x = ClusterMachineStatusSpec_ProvisionStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[95]
+	mi := &file_omni_specs_omni_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7381,7 +7445,7 @@ func (x *ClusterMachineStatusSpec_ProvisionStatus) String() string {
 func (*ClusterMachineStatusSpec_ProvisionStatus) ProtoMessage() {}
 
 func (x *ClusterMachineStatusSpec_ProvisionStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[95]
+	mi := &file_omni_specs_omni_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7426,7 +7490,7 @@ type MachineSetSpec_MachineClass struct {
 
 func (x *MachineSetSpec_MachineClass) Reset() {
 	*x = MachineSetSpec_MachineClass{}
-	mi := &file_omni_specs_omni_proto_msgTypes[96]
+	mi := &file_omni_specs_omni_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7438,7 +7502,7 @@ func (x *MachineSetSpec_MachineClass) String() string {
 func (*MachineSetSpec_MachineClass) ProtoMessage() {}
 
 func (x *MachineSetSpec_MachineClass) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[96]
+	mi := &file_omni_specs_omni_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7493,7 +7557,7 @@ type MachineSetSpec_MachineAllocation struct {
 
 func (x *MachineSetSpec_MachineAllocation) Reset() {
 	*x = MachineSetSpec_MachineAllocation{}
-	mi := &file_omni_specs_omni_proto_msgTypes[97]
+	mi := &file_omni_specs_omni_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7505,7 +7569,7 @@ func (x *MachineSetSpec_MachineAllocation) String() string {
 func (*MachineSetSpec_MachineAllocation) ProtoMessage() {}
 
 func (x *MachineSetSpec_MachineAllocation) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[97]
+	mi := &file_omni_specs_omni_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7563,7 +7627,7 @@ type MachineSetSpec_BootstrapSpec struct {
 
 func (x *MachineSetSpec_BootstrapSpec) Reset() {
 	*x = MachineSetSpec_BootstrapSpec{}
-	mi := &file_omni_specs_omni_proto_msgTypes[98]
+	mi := &file_omni_specs_omni_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7575,7 +7639,7 @@ func (x *MachineSetSpec_BootstrapSpec) String() string {
 func (*MachineSetSpec_BootstrapSpec) ProtoMessage() {}
 
 func (x *MachineSetSpec_BootstrapSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[98]
+	mi := &file_omni_specs_omni_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7617,7 +7681,7 @@ type MachineSetSpec_RollingUpdateStrategyConfig struct {
 
 func (x *MachineSetSpec_RollingUpdateStrategyConfig) Reset() {
 	*x = MachineSetSpec_RollingUpdateStrategyConfig{}
-	mi := &file_omni_specs_omni_proto_msgTypes[99]
+	mi := &file_omni_specs_omni_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7629,7 +7693,7 @@ func (x *MachineSetSpec_RollingUpdateStrategyConfig) String() string {
 func (*MachineSetSpec_RollingUpdateStrategyConfig) ProtoMessage() {}
 
 func (x *MachineSetSpec_RollingUpdateStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[99]
+	mi := &file_omni_specs_omni_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7664,7 +7728,7 @@ type MachineSetSpec_UpdateStrategyConfig struct {
 
 func (x *MachineSetSpec_UpdateStrategyConfig) Reset() {
 	*x = MachineSetSpec_UpdateStrategyConfig{}
-	mi := &file_omni_specs_omni_proto_msgTypes[100]
+	mi := &file_omni_specs_omni_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7676,7 +7740,7 @@ func (x *MachineSetSpec_UpdateStrategyConfig) String() string {
 func (*MachineSetSpec_UpdateStrategyConfig) ProtoMessage() {}
 
 func (x *MachineSetSpec_UpdateStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[100]
+	mi := &file_omni_specs_omni_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7711,7 +7775,7 @@ type ControlPlaneStatusSpec_Condition struct {
 
 func (x *ControlPlaneStatusSpec_Condition) Reset() {
 	*x = ControlPlaneStatusSpec_Condition{}
-	mi := &file_omni_specs_omni_proto_msgTypes[101]
+	mi := &file_omni_specs_omni_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7723,7 +7787,7 @@ func (x *ControlPlaneStatusSpec_Condition) String() string {
 func (*ControlPlaneStatusSpec_Condition) ProtoMessage() {}
 
 func (x *ControlPlaneStatusSpec_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[101]
+	mi := &file_omni_specs_omni_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7778,7 +7842,7 @@ type KubernetesStatusSpec_NodeStatus struct {
 
 func (x *KubernetesStatusSpec_NodeStatus) Reset() {
 	*x = KubernetesStatusSpec_NodeStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[102]
+	mi := &file_omni_specs_omni_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7790,7 +7854,7 @@ func (x *KubernetesStatusSpec_NodeStatus) String() string {
 func (*KubernetesStatusSpec_NodeStatus) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_NodeStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[102]
+	mi := &file_omni_specs_omni_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7838,7 +7902,7 @@ type KubernetesStatusSpec_StaticPodStatus struct {
 
 func (x *KubernetesStatusSpec_StaticPodStatus) Reset() {
 	*x = KubernetesStatusSpec_StaticPodStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[103]
+	mi := &file_omni_specs_omni_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7850,7 +7914,7 @@ func (x *KubernetesStatusSpec_StaticPodStatus) String() string {
 func (*KubernetesStatusSpec_StaticPodStatus) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_StaticPodStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[103]
+	mi := &file_omni_specs_omni_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7897,7 +7961,7 @@ type KubernetesStatusSpec_NodeStaticPods struct {
 
 func (x *KubernetesStatusSpec_NodeStaticPods) Reset() {
 	*x = KubernetesStatusSpec_NodeStaticPods{}
-	mi := &file_omni_specs_omni_proto_msgTypes[104]
+	mi := &file_omni_specs_omni_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7909,7 +7973,7 @@ func (x *KubernetesStatusSpec_NodeStaticPods) String() string {
 func (*KubernetesStatusSpec_NodeStaticPods) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_NodeStaticPods) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[104]
+	mi := &file_omni_specs_omni_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7953,7 +8017,7 @@ type MachineClassSpec_Provision struct {
 
 func (x *MachineClassSpec_Provision) Reset() {
 	*x = MachineClassSpec_Provision{}
-	mi := &file_omni_specs_omni_proto_msgTypes[105]
+	mi := &file_omni_specs_omni_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7965,7 +8029,7 @@ func (x *MachineClassSpec_Provision) String() string {
 func (*MachineClassSpec_Provision) ProtoMessage() {}
 
 func (x *MachineClassSpec_Provision) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[105]
+	mi := &file_omni_specs_omni_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8036,7 +8100,7 @@ type MachineConfigGenOptionsSpec_InstallImage struct {
 
 func (x *MachineConfigGenOptionsSpec_InstallImage) Reset() {
 	*x = MachineConfigGenOptionsSpec_InstallImage{}
-	mi := &file_omni_specs_omni_proto_msgTypes[106]
+	mi := &file_omni_specs_omni_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8048,7 +8112,7 @@ func (x *MachineConfigGenOptionsSpec_InstallImage) String() string {
 func (*MachineConfigGenOptionsSpec_InstallImage) ProtoMessage() {}
 
 func (x *MachineConfigGenOptionsSpec_InstallImage) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[106]
+	mi := &file_omni_specs_omni_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8117,7 +8181,7 @@ type KubernetesUsageSpec_Quantity struct {
 
 func (x *KubernetesUsageSpec_Quantity) Reset() {
 	*x = KubernetesUsageSpec_Quantity{}
-	mi := &file_omni_specs_omni_proto_msgTypes[107]
+	mi := &file_omni_specs_omni_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8129,7 +8193,7 @@ func (x *KubernetesUsageSpec_Quantity) String() string {
 func (*KubernetesUsageSpec_Quantity) ProtoMessage() {}
 
 func (x *KubernetesUsageSpec_Quantity) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[107]
+	mi := &file_omni_specs_omni_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8176,7 +8240,7 @@ type KubernetesUsageSpec_Pod struct {
 
 func (x *KubernetesUsageSpec_Pod) Reset() {
 	*x = KubernetesUsageSpec_Pod{}
-	mi := &file_omni_specs_omni_proto_msgTypes[108]
+	mi := &file_omni_specs_omni_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8188,7 +8252,7 @@ func (x *KubernetesUsageSpec_Pod) String() string {
 func (*KubernetesUsageSpec_Pod) ProtoMessage() {}
 
 func (x *KubernetesUsageSpec_Pod) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[108]
+	mi := &file_omni_specs_omni_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8228,7 +8292,7 @@ type ImagePullRequestSpec_NodeImageList struct {
 
 func (x *ImagePullRequestSpec_NodeImageList) Reset() {
 	*x = ImagePullRequestSpec_NodeImageList{}
-	mi := &file_omni_specs_omni_proto_msgTypes[109]
+	mi := &file_omni_specs_omni_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8240,7 +8304,7 @@ func (x *ImagePullRequestSpec_NodeImageList) String() string {
 func (*ImagePullRequestSpec_NodeImageList) ProtoMessage() {}
 
 func (x *ImagePullRequestSpec_NodeImageList) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[109]
+	mi := &file_omni_specs_omni_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8285,7 +8349,7 @@ type TalosExtensionsSpec_Info struct {
 
 func (x *TalosExtensionsSpec_Info) Reset() {
 	*x = TalosExtensionsSpec_Info{}
-	mi := &file_omni_specs_omni_proto_msgTypes[110]
+	mi := &file_omni_specs_omni_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8297,7 +8361,7 @@ func (x *TalosExtensionsSpec_Info) String() string {
 func (*TalosExtensionsSpec_Info) ProtoMessage() {}
 
 func (x *TalosExtensionsSpec_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[110]
+	mi := &file_omni_specs_omni_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8366,7 +8430,7 @@ type MachineExtensionsStatusSpec_Item struct {
 
 func (x *MachineExtensionsStatusSpec_Item) Reset() {
 	*x = MachineExtensionsStatusSpec_Item{}
-	mi := &file_omni_specs_omni_proto_msgTypes[111]
+	mi := &file_omni_specs_omni_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8378,7 +8442,7 @@ func (x *MachineExtensionsStatusSpec_Item) String() string {
 func (*MachineExtensionsStatusSpec_Item) ProtoMessage() {}
 
 func (x *MachineExtensionsStatusSpec_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[111]
+	mi := &file_omni_specs_omni_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8425,7 +8489,7 @@ type ClusterDiagnosticsSpec_Node struct {
 
 func (x *ClusterDiagnosticsSpec_Node) Reset() {
 	*x = ClusterDiagnosticsSpec_Node{}
-	mi := &file_omni_specs_omni_proto_msgTypes[113]
+	mi := &file_omni_specs_omni_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8437,7 +8501,7 @@ func (x *ClusterDiagnosticsSpec_Node) String() string {
 func (*ClusterDiagnosticsSpec_Node) ProtoMessage() {}
 
 func (x *ClusterDiagnosticsSpec_Node) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[113]
+	mi := &file_omni_specs_omni_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8479,7 +8543,7 @@ type InfraMachineBMCConfigSpec_IPMI struct {
 
 func (x *InfraMachineBMCConfigSpec_IPMI) Reset() {
 	*x = InfraMachineBMCConfigSpec_IPMI{}
-	mi := &file_omni_specs_omni_proto_msgTypes[114]
+	mi := &file_omni_specs_omni_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8491,7 +8555,7 @@ func (x *InfraMachineBMCConfigSpec_IPMI) String() string {
 func (*InfraMachineBMCConfigSpec_IPMI) ProtoMessage() {}
 
 func (x *InfraMachineBMCConfigSpec_IPMI) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[114]
+	mi := &file_omni_specs_omni_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8544,7 +8608,7 @@ type InfraMachineBMCConfigSpec_API struct {
 
 func (x *InfraMachineBMCConfigSpec_API) Reset() {
 	*x = InfraMachineBMCConfigSpec_API{}
-	mi := &file_omni_specs_omni_proto_msgTypes[115]
+	mi := &file_omni_specs_omni_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8556,7 +8620,7 @@ func (x *InfraMachineBMCConfigSpec_API) String() string {
 func (*InfraMachineBMCConfigSpec_API) ProtoMessage() {}
 
 func (x *InfraMachineBMCConfigSpec_API) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[115]
+	mi := &file_omni_specs_omni_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8781,12 +8845,13 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x0fcompressed_data\x18\x04 \x01(\fR\x0ecompressedData\"_\n" +
 	" RedactedClusterMachineConfigSpec\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\tR\x04data\x12'\n" +
-	"\x0fcompressed_data\x18\x02 \x01(\fR\x0ecompressedData\"\x9e\x01\n" +
+	"\x0fcompressed_data\x18\x02 \x01(\fR\x0ecompressedData\"\xdc\x01\n" +
 	"\x1aClusterMachineIdentitySpec\x12#\n" +
 	"\rnode_identity\x18\x01 \x01(\tR\fnodeIdentity\x12$\n" +
 	"\x0eetcd_member_id\x18\x02 \x01(\x04R\fetcdMemberId\x12\x1a\n" +
 	"\bnodename\x18\x03 \x01(\tR\bnodename\x12\x19\n" +
-	"\bnode_ips\x18\b \x03(\tR\anodeIps\"\xa9\x01\n" +
+	"\bnode_ips\x18\b \x03(\tR\anodeIps\x12<\n" +
+	"\x1adiscovery_service_endpoint\x18\t \x01(\tR\x18discoveryServiceEndpoint\"\xa9\x01\n" +
 	"\x1aClusterMachineTemplateSpec\x12#\n" +
 	"\rinstall_image\x18\x01 \x01(\tR\finstallImage\x12-\n" +
 	"\x12kubernetes_version\x18\x02 \x01(\tR\x11kubernetesVersion\x12!\n" +
@@ -9225,7 +9290,11 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\"U\n" +
 	"\x1bMaintenanceConfigStatusSpec\x126\n" +
 	"\x18public_key_at_last_apply\x18\x01 \x01(\tR\x14publicKeyAtLastApply\"\x1d\n" +
-	"\x1bNodeForceDestroyRequestSpec*F\n" +
+	"\x1bNodeForceDestroyRequestSpec\"\x7f\n" +
+	" DiscoveryAffiliateDeleteTaskSpec\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\x01 \x01(\tR\tclusterId\x12<\n" +
+	"\x1adiscovery_service_endpoint\x18\x02 \x01(\tR\x18discoveryServiceEndpoint*F\n" +
 	"\x11ConfigApplyStatus\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aPENDING\x10\x01\x12\v\n" +
@@ -9264,7 +9333,7 @@ func file_omni_specs_omni_proto_rawDescGZIP() []byte {
 }
 
 var file_omni_specs_omni_proto_enumTypes = make([]protoimpl.EnumInfo, 23)
-var file_omni_specs_omni_proto_msgTypes = make([]protoimpl.MessageInfo, 116)
+var file_omni_specs_omni_proto_msgTypes = make([]protoimpl.MessageInfo, 117)
 var file_omni_specs_omni_proto_goTypes = []any{
 	(ConfigApplyStatus)(0),                                    // 0: specs.ConfigApplyStatus
 	(MachineSetPhase)(0),                                      // 1: specs.MachineSetPhase
@@ -9373,124 +9442,125 @@ var file_omni_specs_omni_proto_goTypes = []any{
 	(*InfraMachineBMCConfigSpec)(nil),                         // 104: specs.InfraMachineBMCConfigSpec
 	(*MaintenanceConfigStatusSpec)(nil),                       // 105: specs.MaintenanceConfigStatusSpec
 	(*NodeForceDestroyRequestSpec)(nil),                       // 106: specs.NodeForceDestroyRequestSpec
-	(*MachineStatusSpec_HardwareStatus)(nil),                  // 107: specs.MachineStatusSpec.HardwareStatus
-	(*MachineStatusSpec_NetworkStatus)(nil),                   // 108: specs.MachineStatusSpec.NetworkStatus
-	(*MachineStatusSpec_PlatformMetadata)(nil),                // 109: specs.MachineStatusSpec.PlatformMetadata
-	(*MachineStatusSpec_Schematic)(nil),                       // 110: specs.MachineStatusSpec.Schematic
-	(*MachineStatusSpec_Diagnostic)(nil),                      // 111: specs.MachineStatusSpec.Diagnostic
-	nil,                                                       // 112: specs.MachineStatusSpec.ImageLabelsEntry
-	(*MachineStatusSpec_HardwareStatus_Processor)(nil),        // 113: specs.MachineStatusSpec.HardwareStatus.Processor
-	(*MachineStatusSpec_HardwareStatus_MemoryModule)(nil),     // 114: specs.MachineStatusSpec.HardwareStatus.MemoryModule
-	(*MachineStatusSpec_HardwareStatus_BlockDevice)(nil),      // 115: specs.MachineStatusSpec.HardwareStatus.BlockDevice
-	(*MachineStatusSpec_NetworkStatus_NetworkLinkStatus)(nil), // 116: specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
-	(*ClusterSpec_Features)(nil),                              // 117: specs.ClusterSpec.Features
-	(*ClusterMachineStatusSpec_ProvisionStatus)(nil),          // 118: specs.ClusterMachineStatusSpec.ProvisionStatus
-	(*MachineSetSpec_MachineClass)(nil),                       // 119: specs.MachineSetSpec.MachineClass
-	(*MachineSetSpec_MachineAllocation)(nil),                  // 120: specs.MachineSetSpec.MachineAllocation
-	(*MachineSetSpec_BootstrapSpec)(nil),                      // 121: specs.MachineSetSpec.BootstrapSpec
-	(*MachineSetSpec_RollingUpdateStrategyConfig)(nil),        // 122: specs.MachineSetSpec.RollingUpdateStrategyConfig
-	(*MachineSetSpec_UpdateStrategyConfig)(nil),               // 123: specs.MachineSetSpec.UpdateStrategyConfig
-	(*ControlPlaneStatusSpec_Condition)(nil),                  // 124: specs.ControlPlaneStatusSpec.Condition
-	(*KubernetesStatusSpec_NodeStatus)(nil),                   // 125: specs.KubernetesStatusSpec.NodeStatus
-	(*KubernetesStatusSpec_StaticPodStatus)(nil),              // 126: specs.KubernetesStatusSpec.StaticPodStatus
-	(*KubernetesStatusSpec_NodeStaticPods)(nil),               // 127: specs.KubernetesStatusSpec.NodeStaticPods
-	(*MachineClassSpec_Provision)(nil),                        // 128: specs.MachineClassSpec.Provision
-	(*MachineConfigGenOptionsSpec_InstallImage)(nil),          // 129: specs.MachineConfigGenOptionsSpec.InstallImage
-	(*KubernetesUsageSpec_Quantity)(nil),                      // 130: specs.KubernetesUsageSpec.Quantity
-	(*KubernetesUsageSpec_Pod)(nil),                           // 131: specs.KubernetesUsageSpec.Pod
-	(*ImagePullRequestSpec_NodeImageList)(nil),                // 132: specs.ImagePullRequestSpec.NodeImageList
-	(*TalosExtensionsSpec_Info)(nil),                          // 133: specs.TalosExtensionsSpec.Info
-	(*MachineExtensionsStatusSpec_Item)(nil),                  // 134: specs.MachineExtensionsStatusSpec.Item
-	nil,                                                       // 135: specs.ClusterStatusMetricsSpec.PhasesEntry
-	(*ClusterDiagnosticsSpec_Node)(nil),                       // 136: specs.ClusterDiagnosticsSpec.Node
-	(*InfraMachineBMCConfigSpec_IPMI)(nil),                    // 137: specs.InfraMachineBMCConfigSpec.IPMI
-	(*InfraMachineBMCConfigSpec_API)(nil),                     // 138: specs.InfraMachineBMCConfigSpec.API
-	(*durationpb.Duration)(nil),                               // 139: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                             // 140: google.protobuf.Timestamp
-	(*machine.MachineStatusEvent)(nil),                        // 141: machine.MachineStatusEvent
+	(*DiscoveryAffiliateDeleteTaskSpec)(nil),                  // 107: specs.DiscoveryAffiliateDeleteTaskSpec
+	(*MachineStatusSpec_HardwareStatus)(nil),                  // 108: specs.MachineStatusSpec.HardwareStatus
+	(*MachineStatusSpec_NetworkStatus)(nil),                   // 109: specs.MachineStatusSpec.NetworkStatus
+	(*MachineStatusSpec_PlatformMetadata)(nil),                // 110: specs.MachineStatusSpec.PlatformMetadata
+	(*MachineStatusSpec_Schematic)(nil),                       // 111: specs.MachineStatusSpec.Schematic
+	(*MachineStatusSpec_Diagnostic)(nil),                      // 112: specs.MachineStatusSpec.Diagnostic
+	nil,                                                       // 113: specs.MachineStatusSpec.ImageLabelsEntry
+	(*MachineStatusSpec_HardwareStatus_Processor)(nil),        // 114: specs.MachineStatusSpec.HardwareStatus.Processor
+	(*MachineStatusSpec_HardwareStatus_MemoryModule)(nil),     // 115: specs.MachineStatusSpec.HardwareStatus.MemoryModule
+	(*MachineStatusSpec_HardwareStatus_BlockDevice)(nil),      // 116: specs.MachineStatusSpec.HardwareStatus.BlockDevice
+	(*MachineStatusSpec_NetworkStatus_NetworkLinkStatus)(nil), // 117: specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
+	(*ClusterSpec_Features)(nil),                              // 118: specs.ClusterSpec.Features
+	(*ClusterMachineStatusSpec_ProvisionStatus)(nil),          // 119: specs.ClusterMachineStatusSpec.ProvisionStatus
+	(*MachineSetSpec_MachineClass)(nil),                       // 120: specs.MachineSetSpec.MachineClass
+	(*MachineSetSpec_MachineAllocation)(nil),                  // 121: specs.MachineSetSpec.MachineAllocation
+	(*MachineSetSpec_BootstrapSpec)(nil),                      // 122: specs.MachineSetSpec.BootstrapSpec
+	(*MachineSetSpec_RollingUpdateStrategyConfig)(nil),        // 123: specs.MachineSetSpec.RollingUpdateStrategyConfig
+	(*MachineSetSpec_UpdateStrategyConfig)(nil),               // 124: specs.MachineSetSpec.UpdateStrategyConfig
+	(*ControlPlaneStatusSpec_Condition)(nil),                  // 125: specs.ControlPlaneStatusSpec.Condition
+	(*KubernetesStatusSpec_NodeStatus)(nil),                   // 126: specs.KubernetesStatusSpec.NodeStatus
+	(*KubernetesStatusSpec_StaticPodStatus)(nil),              // 127: specs.KubernetesStatusSpec.StaticPodStatus
+	(*KubernetesStatusSpec_NodeStaticPods)(nil),               // 128: specs.KubernetesStatusSpec.NodeStaticPods
+	(*MachineClassSpec_Provision)(nil),                        // 129: specs.MachineClassSpec.Provision
+	(*MachineConfigGenOptionsSpec_InstallImage)(nil),          // 130: specs.MachineConfigGenOptionsSpec.InstallImage
+	(*KubernetesUsageSpec_Quantity)(nil),                      // 131: specs.KubernetesUsageSpec.Quantity
+	(*KubernetesUsageSpec_Pod)(nil),                           // 132: specs.KubernetesUsageSpec.Pod
+	(*ImagePullRequestSpec_NodeImageList)(nil),                // 133: specs.ImagePullRequestSpec.NodeImageList
+	(*TalosExtensionsSpec_Info)(nil),                          // 134: specs.TalosExtensionsSpec.Info
+	(*MachineExtensionsStatusSpec_Item)(nil),                  // 135: specs.MachineExtensionsStatusSpec.Item
+	nil,                                                       // 136: specs.ClusterStatusMetricsSpec.PhasesEntry
+	(*ClusterDiagnosticsSpec_Node)(nil),                       // 137: specs.ClusterDiagnosticsSpec.Node
+	(*InfraMachineBMCConfigSpec_IPMI)(nil),                    // 138: specs.InfraMachineBMCConfigSpec.IPMI
+	(*InfraMachineBMCConfigSpec_API)(nil),                     // 139: specs.InfraMachineBMCConfigSpec.API
+	(*durationpb.Duration)(nil),                               // 140: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                             // 141: google.protobuf.Timestamp
+	(*machine.MachineStatusEvent)(nil),                        // 142: machine.MachineStatusEvent
 }
 var file_omni_specs_omni_proto_depIdxs = []int32{
-	107, // 0: specs.MachineStatusSpec.hardware:type_name -> specs.MachineStatusSpec.HardwareStatus
-	108, // 1: specs.MachineStatusSpec.network:type_name -> specs.MachineStatusSpec.NetworkStatus
+	108, // 0: specs.MachineStatusSpec.hardware:type_name -> specs.MachineStatusSpec.HardwareStatus
+	109, // 1: specs.MachineStatusSpec.network:type_name -> specs.MachineStatusSpec.NetworkStatus
 	4,   // 2: specs.MachineStatusSpec.role:type_name -> specs.MachineStatusSpec.Role
-	109, // 3: specs.MachineStatusSpec.platform_metadata:type_name -> specs.MachineStatusSpec.PlatformMetadata
-	112, // 4: specs.MachineStatusSpec.image_labels:type_name -> specs.MachineStatusSpec.ImageLabelsEntry
-	110, // 5: specs.MachineStatusSpec.schematic:type_name -> specs.MachineStatusSpec.Schematic
+	110, // 3: specs.MachineStatusSpec.platform_metadata:type_name -> specs.MachineStatusSpec.PlatformMetadata
+	113, // 4: specs.MachineStatusSpec.image_labels:type_name -> specs.MachineStatusSpec.ImageLabelsEntry
+	111, // 5: specs.MachineStatusSpec.schematic:type_name -> specs.MachineStatusSpec.Schematic
 	24,  // 6: specs.MachineStatusSpec.secure_boot_status:type_name -> specs.SecureBootStatus
-	111, // 7: specs.MachineStatusSpec.diagnostics:type_name -> specs.MachineStatusSpec.Diagnostic
+	112, // 7: specs.MachineStatusSpec.diagnostics:type_name -> specs.MachineStatusSpec.Diagnostic
 	5,   // 8: specs.MachineStatusSpec.power_state:type_name -> specs.MachineStatusSpec.PowerState
-	117, // 9: specs.ClusterSpec.features:type_name -> specs.ClusterSpec.Features
+	118, // 9: specs.ClusterSpec.features:type_name -> specs.ClusterSpec.Features
 	31,  // 10: specs.ClusterSpec.backup_configuration:type_name -> specs.EtcdBackupConf
-	139, // 11: specs.EtcdBackupConf.interval:type_name -> google.protobuf.Duration
-	140, // 12: specs.EtcdBackupSpec.created_at:type_name -> google.protobuf.Timestamp
-	139, // 13: specs.BackupDataSpec.interval:type_name -> google.protobuf.Duration
+	140, // 11: specs.EtcdBackupConf.interval:type_name -> google.protobuf.Duration
+	141, // 12: specs.EtcdBackupSpec.created_at:type_name -> google.protobuf.Timestamp
+	140, // 13: specs.BackupDataSpec.interval:type_name -> google.protobuf.Duration
 	6,   // 14: specs.EtcdBackupStatusSpec.status:type_name -> specs.EtcdBackupStatusSpec.Status
-	140, // 15: specs.EtcdBackupStatusSpec.last_backup_time:type_name -> google.protobuf.Timestamp
-	140, // 16: specs.EtcdBackupStatusSpec.last_backup_attempt:type_name -> google.protobuf.Timestamp
-	140, // 17: specs.EtcdManualBackupSpec.backup_at:type_name -> google.protobuf.Timestamp
+	141, // 15: specs.EtcdBackupStatusSpec.last_backup_time:type_name -> google.protobuf.Timestamp
+	141, // 16: specs.EtcdBackupStatusSpec.last_backup_attempt:type_name -> google.protobuf.Timestamp
+	141, // 17: specs.EtcdManualBackupSpec.backup_at:type_name -> google.protobuf.Timestamp
 	37,  // 18: specs.EtcdBackupOverallStatusSpec.last_backup_status:type_name -> specs.EtcdBackupStatusSpec
 	7,   // 19: specs.ClusterMachineStatusSpec.stage:type_name -> specs.ClusterMachineStatusSpec.Stage
 	0,   // 20: specs.ClusterMachineStatusSpec.config_apply_status:type_name -> specs.ConfigApplyStatus
-	118, // 21: specs.ClusterMachineStatusSpec.provision_status:type_name -> specs.ClusterMachineStatusSpec.ProvisionStatus
+	119, // 21: specs.ClusterMachineStatusSpec.provision_status:type_name -> specs.ClusterMachineStatusSpec.ProvisionStatus
 	49,  // 22: specs.ClusterStatusSpec.machines:type_name -> specs.Machines
 	8,   // 23: specs.ClusterStatusSpec.phase:type_name -> specs.ClusterStatusSpec.Phase
 	9,   // 24: specs.MachineSetSpec.update_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	120, // 25: specs.MachineSetSpec.machine_class:type_name -> specs.MachineSetSpec.MachineAllocation
-	121, // 26: specs.MachineSetSpec.bootstrap_spec:type_name -> specs.MachineSetSpec.BootstrapSpec
+	121, // 25: specs.MachineSetSpec.machine_class:type_name -> specs.MachineSetSpec.MachineAllocation
+	122, // 26: specs.MachineSetSpec.bootstrap_spec:type_name -> specs.MachineSetSpec.BootstrapSpec
 	9,   // 27: specs.MachineSetSpec.delete_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	123, // 28: specs.MachineSetSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	123, // 29: specs.MachineSetSpec.delete_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	120, // 30: specs.MachineSetSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
+	124, // 28: specs.MachineSetSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	124, // 29: specs.MachineSetSpec.delete_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	121, // 30: specs.MachineSetSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
 	13,  // 31: specs.TalosUpgradeStatusSpec.phase:type_name -> specs.TalosUpgradeStatusSpec.Phase
 	1,   // 32: specs.MachineSetStatusSpec.phase:type_name -> specs.MachineSetPhase
 	49,  // 33: specs.MachineSetStatusSpec.machines:type_name -> specs.Machines
-	120, // 34: specs.MachineSetStatusSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
-	141, // 35: specs.MachineStatusSnapshotSpec.machine_status:type_name -> machine.MachineStatusEvent
+	121, // 34: specs.MachineSetStatusSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
+	142, // 35: specs.MachineStatusSnapshotSpec.machine_status:type_name -> machine.MachineStatusEvent
 	14,  // 36: specs.MachineStatusSnapshotSpec.power_stage:type_name -> specs.MachineStatusSnapshotSpec.PowerStage
-	124, // 37: specs.ControlPlaneStatusSpec.conditions:type_name -> specs.ControlPlaneStatusSpec.Condition
-	125, // 38: specs.KubernetesStatusSpec.nodes:type_name -> specs.KubernetesStatusSpec.NodeStatus
-	127, // 39: specs.KubernetesStatusSpec.static_pods:type_name -> specs.KubernetesStatusSpec.NodeStaticPods
+	125, // 37: specs.ControlPlaneStatusSpec.conditions:type_name -> specs.ControlPlaneStatusSpec.Condition
+	126, // 38: specs.KubernetesStatusSpec.nodes:type_name -> specs.KubernetesStatusSpec.NodeStatus
+	128, // 39: specs.KubernetesStatusSpec.static_pods:type_name -> specs.KubernetesStatusSpec.NodeStaticPods
 	17,  // 40: specs.KubernetesUpgradeStatusSpec.phase:type_name -> specs.KubernetesUpgradeStatusSpec.Phase
 	63,  // 41: specs.OngoingTaskSpec.talos_upgrade:type_name -> specs.TalosUpgradeStatusSpec
 	71,  // 42: specs.OngoingTaskSpec.kubernetes_upgrade:type_name -> specs.KubernetesUpgradeStatusSpec
 	73,  // 43: specs.OngoingTaskSpec.destroy:type_name -> specs.DestroyStatusSpec
 	79,  // 44: specs.FeaturesConfigSpec.etcd_backup_settings:type_name -> specs.EtcdBackupSettings
-	139, // 45: specs.EtcdBackupSettings.tick_interval:type_name -> google.protobuf.Duration
-	139, // 46: specs.EtcdBackupSettings.min_interval:type_name -> google.protobuf.Duration
-	139, // 47: specs.EtcdBackupSettings.max_interval:type_name -> google.protobuf.Duration
-	128, // 48: specs.MachineClassSpec.auto_provision:type_name -> specs.MachineClassSpec.Provision
-	129, // 49: specs.MachineConfigGenOptionsSpec.install_image:type_name -> specs.MachineConfigGenOptionsSpec.InstallImage
-	130, // 50: specs.KubernetesUsageSpec.cpu:type_name -> specs.KubernetesUsageSpec.Quantity
-	130, // 51: specs.KubernetesUsageSpec.mem:type_name -> specs.KubernetesUsageSpec.Quantity
-	130, // 52: specs.KubernetesUsageSpec.storage:type_name -> specs.KubernetesUsageSpec.Quantity
-	131, // 53: specs.KubernetesUsageSpec.pods:type_name -> specs.KubernetesUsageSpec.Pod
-	132, // 54: specs.ImagePullRequestSpec.node_image_list:type_name -> specs.ImagePullRequestSpec.NodeImageList
-	133, // 55: specs.TalosExtensionsSpec.items:type_name -> specs.TalosExtensionsSpec.Info
+	140, // 45: specs.EtcdBackupSettings.tick_interval:type_name -> google.protobuf.Duration
+	140, // 46: specs.EtcdBackupSettings.min_interval:type_name -> google.protobuf.Duration
+	140, // 47: specs.EtcdBackupSettings.max_interval:type_name -> google.protobuf.Duration
+	129, // 48: specs.MachineClassSpec.auto_provision:type_name -> specs.MachineClassSpec.Provision
+	130, // 49: specs.MachineConfigGenOptionsSpec.install_image:type_name -> specs.MachineConfigGenOptionsSpec.InstallImage
+	131, // 50: specs.KubernetesUsageSpec.cpu:type_name -> specs.KubernetesUsageSpec.Quantity
+	131, // 51: specs.KubernetesUsageSpec.mem:type_name -> specs.KubernetesUsageSpec.Quantity
+	131, // 52: specs.KubernetesUsageSpec.storage:type_name -> specs.KubernetesUsageSpec.Quantity
+	132, // 53: specs.KubernetesUsageSpec.pods:type_name -> specs.KubernetesUsageSpec.Pod
+	133, // 54: specs.ImagePullRequestSpec.node_image_list:type_name -> specs.ImagePullRequestSpec.NodeImageList
+	134, // 55: specs.TalosExtensionsSpec.items:type_name -> specs.TalosExtensionsSpec.Info
 	18,  // 56: specs.ExtensionsConfigurationStatusSpec.phase:type_name -> specs.ExtensionsConfigurationStatusSpec.Phase
-	134, // 57: specs.MachineExtensionsStatusSpec.extensions:type_name -> specs.MachineExtensionsStatusSpec.Item
-	135, // 58: specs.ClusterStatusMetricsSpec.phases:type_name -> specs.ClusterStatusMetricsSpec.PhasesEntry
+	135, // 57: specs.MachineExtensionsStatusSpec.extensions:type_name -> specs.MachineExtensionsStatusSpec.Item
+	136, // 58: specs.ClusterStatusMetricsSpec.phases:type_name -> specs.ClusterStatusMetricsSpec.PhasesEntry
 	26,  // 59: specs.MachineRequestSetSpec.meta_values:type_name -> specs.MetaValue
 	3,   // 60: specs.MachineRequestSetSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	136, // 61: specs.ClusterDiagnosticsSpec.nodes:type_name -> specs.ClusterDiagnosticsSpec.Node
+	137, // 61: specs.ClusterDiagnosticsSpec.nodes:type_name -> specs.ClusterDiagnosticsSpec.Node
 	20,  // 62: specs.ClusterMachineRequestStatusSpec.stage:type_name -> specs.ClusterMachineRequestStatusSpec.Stage
 	22,  // 63: specs.InfraMachineConfigSpec.power_state:type_name -> specs.InfraMachineConfigSpec.MachinePowerState
 	21,  // 64: specs.InfraMachineConfigSpec.acceptance_status:type_name -> specs.InfraMachineConfigSpec.AcceptanceStatus
-	137, // 65: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
-	138, // 66: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
-	113, // 67: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
-	114, // 68: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
-	115, // 69: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
-	116, // 70: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
+	138, // 65: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
+	139, // 66: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
+	114, // 67: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
+	115, // 68: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
+	116, // 69: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
+	117, // 70: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
 	25,  // 71: specs.MachineStatusSpec.Schematic.overlay:type_name -> specs.Overlay
 	26,  // 72: specs.MachineStatusSpec.Schematic.meta_values:type_name -> specs.MetaValue
 	10,  // 73: specs.MachineSetSpec.MachineClass.allocation_type:type_name -> specs.MachineSetSpec.MachineClass.Type
 	11,  // 74: specs.MachineSetSpec.MachineAllocation.allocation_type:type_name -> specs.MachineSetSpec.MachineAllocation.Type
 	12,  // 75: specs.MachineSetSpec.MachineAllocation.source:type_name -> specs.MachineSetSpec.MachineAllocation.Source
-	122, // 76: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
+	123, // 76: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
 	2,   // 77: specs.ControlPlaneStatusSpec.Condition.type:type_name -> specs.ConditionType
 	15,  // 78: specs.ControlPlaneStatusSpec.Condition.status:type_name -> specs.ControlPlaneStatusSpec.Condition.Status
 	16,  // 79: specs.ControlPlaneStatusSpec.Condition.severity:type_name -> specs.ControlPlaneStatusSpec.Condition.Severity
-	126, // 80: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
+	127, // 80: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
 	26,  // 81: specs.MachineClassSpec.Provision.meta_values:type_name -> specs.MetaValue
 	3,   // 82: specs.MachineClassSpec.Provision.grpc_tunnel:type_name -> specs.GrpcTunnelMode
 	24,  // 83: specs.MachineConfigGenOptionsSpec.InstallImage.secure_boot_status:type_name -> specs.SecureBootStatus
@@ -9518,7 +9588,7 @@ func file_omni_specs_omni_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_omni_specs_omni_proto_rawDesc), len(file_omni_specs_omni_proto_rawDesc)),
 			NumEnums:      23,
-			NumMessages:   116,
+			NumMessages:   117,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -458,6 +458,12 @@ message ClusterMachineIdentitySpec {
   string nodename = 3;
   // NodeIps are the IPs of the Kubernetes node.
   repeated string node_ips = 8;
+
+  // DiscoveryServiceEndpoint is the endpoint of the discovery service used by the node.
+  // It contains the protocol prefix (http://|https://) and the port.
+  //
+  // It is empty if discovery service is not enabled.
+  string discovery_service_endpoint = 9;
 }
 
 // ClusterMachineTemplateSpec
@@ -1330,3 +1336,8 @@ message MaintenanceConfigStatusSpec {
 
 // NodeForceDestroyRequestSpec is used to force delete a node.
 message NodeForceDestroyRequestSpec {}
+
+message DiscoveryAffiliateDeleteTaskSpec {
+  string cluster_id = 1;
+  string discovery_service_endpoint = 2;
+}

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -782,6 +782,7 @@ func (m *ClusterMachineIdentitySpec) CloneVT() *ClusterMachineIdentitySpec {
 	r.NodeIdentity = m.NodeIdentity
 	r.EtcdMemberId = m.EtcdMemberId
 	r.Nodename = m.Nodename
+	r.DiscoveryServiceEndpoint = m.DiscoveryServiceEndpoint
 	if rhs := m.NodeIps; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -2490,6 +2491,24 @@ func (m *NodeForceDestroyRequestSpec) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *DiscoveryAffiliateDeleteTaskSpec) CloneVT() *DiscoveryAffiliateDeleteTaskSpec {
+	if m == nil {
+		return (*DiscoveryAffiliateDeleteTaskSpec)(nil)
+	}
+	r := new(DiscoveryAffiliateDeleteTaskSpec)
+	r.ClusterId = m.ClusterId
+	r.DiscoveryServiceEndpoint = m.DiscoveryServiceEndpoint
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DiscoveryAffiliateDeleteTaskSpec) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *MachineSpec) EqualVT(that *MachineSpec) bool {
 	if this == that {
 		return true
@@ -3551,6 +3570,9 @@ func (this *ClusterMachineIdentitySpec) EqualVT(that *ClusterMachineIdentitySpec
 		if vx != vy {
 			return false
 		}
+	}
+	if this.DiscoveryServiceEndpoint != that.DiscoveryServiceEndpoint {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -5858,6 +5880,28 @@ func (this *NodeForceDestroyRequestSpec) EqualMessageVT(thatMsg proto.Message) b
 	}
 	return this.EqualVT(that)
 }
+func (this *DiscoveryAffiliateDeleteTaskSpec) EqualVT(that *DiscoveryAffiliateDeleteTaskSpec) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.ClusterId != that.ClusterId {
+		return false
+	}
+	if this.DiscoveryServiceEndpoint != that.DiscoveryServiceEndpoint {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *DiscoveryAffiliateDeleteTaskSpec) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DiscoveryAffiliateDeleteTaskSpec)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (m *MachineSpec) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -7975,6 +8019,13 @@ func (m *ClusterMachineIdentitySpec) MarshalToSizedBufferVT(dAtA []byte) (int, e
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.DiscoveryServiceEndpoint) > 0 {
+		i -= len(m.DiscoveryServiceEndpoint)
+		copy(dAtA[i:], m.DiscoveryServiceEndpoint)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DiscoveryServiceEndpoint)))
+		i--
+		dAtA[i] = 0x4a
 	}
 	if len(m.NodeIps) > 0 {
 		for iNdEx := len(m.NodeIps) - 1; iNdEx >= 0; iNdEx-- {
@@ -12463,6 +12514,53 @@ func (m *NodeForceDestroyRequestSpec) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	return len(dAtA) - i, nil
 }
 
+func (m *DiscoveryAffiliateDeleteTaskSpec) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DiscoveryAffiliateDeleteTaskSpec) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DiscoveryAffiliateDeleteTaskSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.DiscoveryServiceEndpoint) > 0 {
+		i -= len(m.DiscoveryServiceEndpoint)
+		copy(dAtA[i:], m.DiscoveryServiceEndpoint)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DiscoveryServiceEndpoint)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ClusterId) > 0 {
+		i -= len(m.ClusterId)
+		copy(dAtA[i:], m.ClusterId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ClusterId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *MachineSpec) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -13320,6 +13418,10 @@ func (m *ClusterMachineIdentitySpec) SizeVT() (n int) {
 			l = len(s)
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	l = len(m.DiscoveryServiceEndpoint)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -15052,6 +15154,24 @@ func (m *NodeForceDestroyRequestSpec) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DiscoveryAffiliateDeleteTaskSpec) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ClusterId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.DiscoveryServiceEndpoint)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -20747,6 +20867,38 @@ func (m *ClusterMachineIdentitySpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.NodeIps = append(m.NodeIps, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DiscoveryServiceEndpoint", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DiscoveryServiceEndpoint = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -31453,6 +31605,121 @@ func (m *NodeForceDestroyRequestSpec) UnmarshalVT(dAtA []byte) error {
 			return fmt.Errorf("proto: NodeForceDestroyRequestSpec: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DiscoveryAffiliateDeleteTaskSpec) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DiscoveryAffiliateDeleteTaskSpec: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DiscoveryAffiliateDeleteTaskSpec: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClusterId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DiscoveryServiceEndpoint", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DiscoveryServiceEndpoint = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/omni/resources/omni/cluster_machine_identity.go
+++ b/client/pkg/omni/resources/omni/cluster_machine_identity.go
@@ -43,6 +43,27 @@ func (ClusterMachineIdentityExtension) ResourceDefinition() meta.ResourceDefinit
 		Type:             ClusterMachineIdentityType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: resources.DefaultNamespace,
-		PrintColumns:     []meta.PrintColumn{},
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Node Identity",
+				JSONPath: "{.nodeidentity}",
+			},
+			{
+				Name:     "Etcd Member ID",
+				JSONPath: "{.etcdmemberid}",
+			},
+			{
+				Name:     "Node Name",
+				JSONPath: "{.nodename}",
+			},
+			{
+				Name:     "Node IPs",
+				JSONPath: "{.nodeips}",
+			},
+			{
+				Name:     "Discovery Service Endpoint",
+				JSONPath: "{.discoveryserviceendpoint}",
+			},
+		},
 	}
 }

--- a/client/pkg/omni/resources/omni/discovery_affiliate_delete_task.go
+++ b/client/pkg/omni/resources/omni/discovery_affiliate_delete_task.go
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package omni
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+)
+
+// NewDiscoveryAffiliateDeleteTask creates a new DiscoveryAffiliateDeleteTask resource.
+func NewDiscoveryAffiliateDeleteTask(id resource.ID) *DiscoveryAffiliateDeleteTask {
+	return typed.NewResource[DiscoveryAffiliateDeleteTaskSpec, DiscoveryAffiliateDeleteTaskExtension](
+		resource.NewMetadata(resources.DefaultNamespace, DiscoveryAffiliateDeleteTaskType, id, resource.VersionUndefined),
+		protobuf.NewResourceSpec(&specs.DiscoveryAffiliateDeleteTaskSpec{}),
+	)
+}
+
+const (
+	// DiscoveryAffiliateDeleteTaskType is the type of the DiscoveryAffiliateDeleteTask resource.
+	// tsgen:DiscoveryAffiliateDeleteTaskType
+	DiscoveryAffiliateDeleteTaskType = resource.Type("DiscoveryAffiliateDeleteTasks.omni.sidero.dev")
+)
+
+// DiscoveryAffiliateDeleteTask describes the spec of the resource.
+type DiscoveryAffiliateDeleteTask = typed.Resource[DiscoveryAffiliateDeleteTaskSpec, DiscoveryAffiliateDeleteTaskExtension]
+
+// DiscoveryAffiliateDeleteTaskSpec wraps specs.DiscoveryAffiliateDeleteTaskSpec.
+type DiscoveryAffiliateDeleteTaskSpec = protobuf.ResourceSpec[specs.DiscoveryAffiliateDeleteTaskSpec, *specs.DiscoveryAffiliateDeleteTaskSpec]
+
+// DiscoveryAffiliateDeleteTaskExtension provides auxiliary methods for DiscoveryAffiliateDeleteTask resource.
+type DiscoveryAffiliateDeleteTaskExtension struct{}
+
+// ResourceDefinition implements [typed.Extension] interface.
+func (DiscoveryAffiliateDeleteTaskExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             DiscoveryAffiliateDeleteTaskType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: resources.DefaultNamespace,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Cluster ID",
+				JSONPath: "{.clusterid}",
+			},
+			{
+				Name:     "Discovery Service Endpoint",
+				JSONPath: "{.discoveryserviceendpoint}",
+			},
+		},
+	}
+}

--- a/client/pkg/omni/resources/omni/omni.go
+++ b/client/pkg/omni/resources/omni/omni.go
@@ -31,6 +31,7 @@ func init() {
 	registry.MustRegisterResource(ClusterMachineTemplateType, &ClusterMachineTemplate{})
 	registry.MustRegisterResource(ClusterTaintType, &ClusterTaint{})
 	registry.MustRegisterResource(ConfigPatchType, &ConfigPatch{})
+	registry.MustRegisterResource(DiscoveryAffiliateDeleteTaskType, &DiscoveryAffiliateDeleteTask{})
 	registry.MustRegisterResource(EtcdAuditResultType, &EtcdAuditResult{})
 	registry.MustRegisterResource(EtcdBackupType, &EtcdBackup{})
 	registry.MustRegisterResource(EtcdBackupS3ConfType, &EtcdBackupS3Conf{})

--- a/cmd/integration-test/pkg/tests/auth.go
+++ b/cmd/integration-test/pkg/tests/auth.go
@@ -994,6 +994,10 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				resource:       omni.NewMaintenanceConfigStatus(uuid.NewString()),
 				allowedVerbSet: readOnlyVerbSet,
 			},
+			{
+				resource:       omni.NewDiscoveryAffiliateDeleteTask(uuid.NewString()),
+				allowedVerbSet: readOnlyVerbSet,
+			},
 		}...)
 
 		// no access resources

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -406,6 +406,7 @@ export type ClusterMachineIdentitySpec = {
   etcd_member_id?: string
   nodename?: string
   node_ips?: string[]
+  discovery_service_endpoint?: string
 }
 
 export type ClusterMachineTemplateSpec = {
@@ -876,4 +877,9 @@ export type MaintenanceConfigStatusSpec = {
 }
 
 export type NodeForceDestroyRequestSpec = {
+}
+
+export type DiscoveryAffiliateDeleteTaskSpec = {
+  cluster_id?: string
+  discovery_service_endpoint?: string
 }

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -96,6 +96,7 @@ export const ClusterUUIDType = "ClusterUUIDs.omni.sidero.dev";
 export const ClusterWorkloadProxyStatusType = "ClusterWorkloadProxyStatuses.omni.sidero.dev";
 export const ConfigPatchType = "ConfigPatches.omni.sidero.dev";
 export const ControlPlaneStatusType = "ControlPlaneStatuses.omni.sidero.dev";
+export const DiscoveryAffiliateDeleteTaskType = "DiscoveryAffiliateDeleteTasks.omni.sidero.dev";
 export const EtcdBackupType = "EtcdBackups.omni.sidero.dev";
 export const EtcdBackupStoreStatusID = "etcdbackup-store-status";
 export const EtcdBackupStoreStatusType = "EtcdBackupStoreStatuses.omni.sidero.dev";

--- a/internal/backend/discovery/clientcache.go
+++ b/internal/backend/discovery/clientcache.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/siderolabs/omni/internal/backend/discovery/internal/discovery"
+)
+
+// ClientCache is a discovery client cache.
+type ClientCache struct {
+	cache *expirable.LRU[string, *discovery.Client]
+	sf    singleflight.Group
+
+	metricCacheSize, metricActiveClients prometheus.Gauge
+	metricCacheHits, metricCacheMisses   prometheus.Counter
+	logger                               *zap.Logger
+}
+
+// NewClientCache creates a new client cache.
+func NewClientCache(logger *zap.Logger) *ClientCache {
+	metricActiveClients := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "omni_discovery_clientcache_active_clients",
+		Help: "Number of active Discovery clients created by Discovery client cache.",
+	})
+
+	return &ClientCache{
+		logger: logger,
+		cache: expirable.NewLRU[string, *discovery.Client](16, func(endpoint string, client *discovery.Client) {
+			if err := client.Close(); err != nil {
+				logger.Error("failed to close discovery client", zap.String("endpoint", endpoint), zap.Error(err))
+			}
+
+			metricActiveClients.Dec()
+			logger.Debug("evicted cached discovery client", zap.String("endpoint", endpoint))
+		}, 1*time.Hour),
+		metricCacheSize: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "omni_discovery_clientcache_cache_size",
+			Help: "Number of Discovery clients in the cache of Discovery client cache.",
+		}),
+		metricActiveClients: metricActiveClients,
+		metricCacheHits: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "omni_discovery_clientcache_cache_hits_total",
+			Help: "Number of Discovery client cache hits.",
+		}),
+		metricCacheMisses: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "omni_discovery_clientcache_cache_misses_total",
+			Help: "Number of Discovery client cache misses.",
+		}),
+	}
+}
+
+// get constructs a discovery service client for the given endpoint.
+func (cache *ClientCache) get(ctx context.Context, endpoint string) (*discovery.Client, error) {
+	if cli, ok := cache.cache.Get(endpoint); ok {
+		cache.logger.Debug("cache hit, returning cached Discovery client", zap.String("endpoint", endpoint))
+
+		cache.metricCacheHits.Inc()
+
+		return cli, nil
+	}
+
+	ch := cache.sf.DoChan(endpoint, func() (any, error) {
+		cache.logger.Debug("cache miss, creating new Discovery client", zap.String("endpoint", endpoint))
+
+		cache.metricCacheMisses.Inc()
+
+		cli, err := discovery.NewClient(endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		cache.metricActiveClients.Inc()
+		cache.cache.Add(endpoint, cli)
+
+		return cli, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+
+		cli := res.Val.(*discovery.Client) //nolint:forcetypeassert,errcheck
+
+		return cli, nil
+	}
+}
+
+// Close purges the discovery client cache, closing and releasing all cached clients.
+func (cache *ClientCache) Close() {
+	cache.cache.Purge()
+	cache.metricCacheSize.Set(0)
+	cache.metricActiveClients.Set(0)
+}
+
+// AffiliateDelete deletes the given affiliate from the given cluster from the discovery service running on the given endpoint.
+func (cache *ClientCache) AffiliateDelete(ctx context.Context, endpoint, cluster, affiliate string) error {
+	cli, err := cache.get(ctx, endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to get discovery client for endpoint %q: %w", endpoint, err)
+	}
+
+	if err = cli.AffiliateDelete(ctx, cluster, affiliate); err != nil {
+		return fmt.Errorf("failed to delete affiliate %q for cluster %q from %q: %w", affiliate, cluster, endpoint, err)
+	}
+
+	return nil
+}
+
+// Describe implements prom.Collector interface.
+func (cache *ClientCache) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(cache, ch)
+}
+
+// Collect implements prom.Collector interface.
+func (cache *ClientCache) Collect(ch chan<- prometheus.Metric) {
+	cache.metricActiveClients.Collect(ch)
+
+	cache.metricCacheSize.Set(float64(cache.cache.Len()))
+	cache.metricCacheSize.Collect(ch)
+
+	cache.metricCacheHits.Collect(ch)
+	cache.metricCacheMisses.Collect(ch)
+}
+
+var _ prometheus.Collector = &ClientCache{}

--- a/internal/backend/grpc/configs_test.go
+++ b/internal/backend/grpc/configs_test.go
@@ -59,7 +59,7 @@ func TestGenerateConfigs(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	rt, err := omniruntime.New(nil, nil, nil, nil,
-		nil, nil, nil, nil, st, nil, prometheus.NewRegistry(), nil, nil, logger)
+		nil, nil, nil, nil, st, nil, prometheus.NewRegistry(), nil, logger)
 	require.NoError(t, err)
 
 	runtime.Install(omniruntime.Name, rt)

--- a/internal/backend/grpc/grpc_test.go
+++ b/internal/backend/grpc/grpc_test.go
@@ -77,7 +77,7 @@ func (suite *GrpcSuite) SetupTest() {
 	logger := zaptest.NewLogger(suite.T())
 	clientFactory := talos.NewClientFactory(suite.state, logger)
 	dnsService := dns.NewService(suite.state, logger)
-	discoveryServiceClientMock := &discoveryClientMock{}
+	discoveryClientCache := &discoveryClientCacheMock{}
 
 	suite.imageFactory = &imageFactoryMock{}
 
@@ -94,7 +94,7 @@ func (suite *GrpcSuite) SetupTest() {
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zap.InfoLevel)
 
 	suite.runtime, err = omniruntime.New(clientFactory, dnsService, workloadProxyReconciler, nil,
-		imageFactoryClient, nil, nil, nil, suite.state, nil, prometheus.NewRegistry(), discoveryServiceClientMock, nil, logger)
+		imageFactoryClient, nil, nil, nil, suite.state, nil, prometheus.NewRegistry(), discoveryClientCache, logger)
 	suite.Require().NoError(err)
 	runtime.Install(omniruntime.Name, suite.runtime)
 
@@ -335,10 +335,10 @@ func (suite *GrpcSuite) newServer(imageFactoryClient *imagefactory.Client, logge
 	return nil
 }
 
-type discoveryClientMock struct{}
+type discoveryClientCacheMock struct{}
 
 // AffiliateDelete implements the omni.DiscoveryClient interface.
-func (d *discoveryClientMock) AffiliateDelete(context.Context, string, string) error {
+func (d *discoveryClientCacheMock) AffiliateDelete(context.Context, string, string, string) error {
 	return nil
 }
 

--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -314,6 +314,10 @@ func (s *managementServer) collectClusterResources(ctx context.Context, cluster 
 			rt:          omni.ExposedServiceType,
 			listOptions: clusterQuery,
 		},
+		{
+			rt:          omni.DiscoveryAffiliateDeleteTaskType,
+			listOptions: clusterQuery,
+		},
 	}
 
 	machineIDs := map[string]struct{}{}

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_identity.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_identity.go
@@ -90,8 +90,8 @@ func (ctrl *ClusterMachineIdentityController) Run(ctx context.Context, r control
 				})
 
 				_, isCp := clusterMachineIdentity.Metadata().Labels().Get(omni.LabelControlPlaneRole)
-
 				spec := clusterMachineIdentity.TypedSpec().Value
+				res.TypedSpec().Value.DiscoveryServiceEndpoint = spec.DiscoveryServiceEndpoint
 
 				switch {
 				case !isCp:

--- a/internal/backend/runtime/omni/controllers/omni/discovery_affiliate_delete_task.go
+++ b/internal/backend/runtime/omni/controllers/omni/discovery_affiliate_delete_task.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/jonboulle/clockwork"
+	"github.com/siderolabs/gen/optional"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+// DiscoveryClientCache is an interface for interacting with discovery services.
+type DiscoveryClientCache interface {
+	AffiliateDelete(ctx context.Context, endpoint, cluster, affiliate string) error
+}
+
+// DiscoveryAffiliateDeleteTaskController manages DiscoveryAffiliateDeleteTask resource lifecycle.
+//
+// DiscoveryAffiliateDeleteTaskController generates cluster UUID for every cluster.
+type DiscoveryAffiliateDeleteTaskController struct {
+	discoveryClientCache DiscoveryClientCache
+	clock                clockwork.Clock
+	affiliateTTL         time.Duration
+}
+
+// NewDiscoveryAffiliateDeleteTaskController creates a new DiscoveryAffiliateDeleteTaskController.
+func NewDiscoveryAffiliateDeleteTaskController(clock clockwork.Clock, discoveryClientCache DiscoveryClientCache) *DiscoveryAffiliateDeleteTaskController {
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
+
+	return &DiscoveryAffiliateDeleteTaskController{
+		clock:                clock,
+		discoveryClientCache: discoveryClientCache,
+		affiliateTTL:         30 * time.Minute,
+	}
+}
+
+// Name implements controller.QController interface.
+func (ctrl *DiscoveryAffiliateDeleteTaskController) Name() string {
+	return "DiscoveryAffiliateDeleteTaskController"
+}
+
+// Settings implements controller.QController interface.
+func (ctrl *DiscoveryAffiliateDeleteTaskController) Settings() controller.QSettings {
+	return controller.QSettings{
+		Inputs: []controller.Input{
+			{
+				Namespace: resources.DefaultNamespace,
+				Type:      omni.DiscoveryAffiliateDeleteTaskType,
+				Kind:      controller.InputQPrimary,
+			},
+		},
+		Outputs: []controller.Output{
+			{
+				Kind: controller.OutputShared,
+				Type: omni.DiscoveryAffiliateDeleteTaskType,
+			},
+		},
+		Concurrency: optional.Some[uint](4),
+	}
+}
+
+// Reconcile implements controller.QController interface.
+func (ctrl *DiscoveryAffiliateDeleteTaskController) Reconcile(ctx context.Context, logger *zap.Logger, r controller.QRuntime, ptr resource.Pointer) error {
+	res, err := safe.ReaderGetByID[*omni.DiscoveryAffiliateDeleteTask](ctx, r, ptr.ID())
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	expiredOnDiscoveryService := res.Metadata().Created().Add(ctrl.affiliateTTL).Before(ctrl.clock.Now())
+	if expiredOnDiscoveryService {
+		logger.Info("skipping affiliate delete, already expired on discovery service",
+			zap.String("cluster_id", res.TypedSpec().Value.ClusterId),
+			zap.String("affiliate_id", res.Metadata().ID()),
+			zap.String("endpoint", res.TypedSpec().Value.DiscoveryServiceEndpoint),
+		)
+	}
+
+	isTearingDown := res.Metadata().Phase() == resource.PhaseTearingDown
+	affiliateAlreadyDeleted := expiredOnDiscoveryService || isTearingDown
+
+	if !affiliateAlreadyDeleted {
+		endpoint := res.TypedSpec().Value.DiscoveryServiceEndpoint
+		clusterID := res.TypedSpec().Value.ClusterId
+		affiliateID := res.Metadata().ID()
+
+		if err = ctrl.discoveryClientCache.AffiliateDelete(ctx, endpoint, clusterID, affiliateID); err != nil {
+			return fmt.Errorf("error deleting affiliate %q/%q from %q: %w", clusterID, affiliateID, endpoint, err)
+		}
+
+		logger.Info("deleted the affiliate from the discovery service",
+			zap.String("cluster_id", clusterID),
+			zap.String("affiliate_id", affiliateID),
+			zap.String("endpoint", endpoint),
+		)
+	}
+
+	destroyReady, err := r.Teardown(ctx, ptr, controller.WithOwner(ClusterMachineTeardownControllerName))
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if !destroyReady {
+		return nil
+	}
+
+	if err = r.Destroy(ctx, ptr, controller.WithOwner(ClusterMachineTeardownControllerName)); err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	logger.Info("destroyed DiscoveryAffiliateDeleteTask")
+
+	return err
+}
+
+// MapInput implements controller.QController interface.
+func (ctrl *DiscoveryAffiliateDeleteTaskController) MapInput(_ context.Context, _ *zap.Logger, _ controller.QRuntime, ptr resource.Pointer) ([]resource.Pointer, error) {
+	if ptr.Type() == omni.DiscoveryAffiliateDeleteTaskType {
+		return []resource.Pointer{ptr}, nil
+	}
+
+	return nil, fmt.Errorf("unexpected resource type %q", ptr.Type())
+}

--- a/internal/backend/runtime/omni/controllers/omni/discovery_affiliate_delete_task_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/discovery_affiliate_delete_task_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+)
+
+type DiscoveryAffiliateDeleteTaskSuite struct {
+	OmniSuite
+}
+
+func (suite *DiscoveryAffiliateDeleteTaskSuite) TestReconcile() {
+	suite.startRuntime()
+
+	deleteCh := make(chan affiliateDelete)
+	clock := clockwork.NewFakeClock()
+	discoveryClientCache := &discoveryClientCacheMock{
+		deleteCh: deleteCh,
+	}
+	controller := omnictrl.NewDiscoveryAffiliateDeleteTaskController(clock, discoveryClientCache)
+
+	suite.Require().NoError(suite.runtime.RegisterQController(controller))
+
+	task := omni.NewDiscoveryAffiliateDeleteTask("affiliate1")
+	task.TypedSpec().Value.ClusterId = "cluster1"
+	task.TypedSpec().Value.DiscoveryServiceEndpoint = "endpoint1"
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, task, state.WithCreateOwner(omnictrl.ClusterMachineTeardownControllerName)))
+
+	// capture the single deletion attempt and assert the values
+	select {
+	case <-suite.ctx.Done():
+		suite.Require().Fail("reconciliation timed out")
+	case affDelete := <-deleteCh:
+		suite.Equal("endpoint1", affDelete.endpoint)
+		suite.Equal("cluster1", affDelete.cluster)
+		suite.Equal("affiliate1", affDelete.affiliate)
+	}
+
+	// assert that the delete task is cleaned up
+	rtestutils.AssertNoResource[*omni.DiscoveryAffiliateDeleteTask](suite.ctx, suite.T(), suite.state, task.Metadata().ID())
+}
+
+func (suite *DiscoveryAffiliateDeleteTaskSuite) TestExpiration() {
+	suite.startRuntime()
+
+	deleteCh := make(chan affiliateDelete, 128) // use a large enough buffer to not block retries of the controller
+	clock := clockwork.NewFakeClock()
+	discoveryClientCache := &discoveryClientCacheMock{
+		deleteCh:     deleteCh,
+		failDeletion: true, // block deletion - simulate discovery service being not accessible
+	}
+	controller := omnictrl.NewDiscoveryAffiliateDeleteTaskController(clock, discoveryClientCache)
+
+	suite.Require().NoError(suite.runtime.RegisterQController(controller))
+
+	task := omni.NewDiscoveryAffiliateDeleteTask("affiliate1")
+	task.TypedSpec().Value.ClusterId = "cluster1"
+	task.TypedSpec().Value.DiscoveryServiceEndpoint = "endpoint1"
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, task, state.WithCreateOwner(omnictrl.ClusterMachineTeardownControllerName)))
+
+	// advance time, but not enough for the affiliate to be assumed to be pruned by the discovery service itself
+	clock.Advance(10 * time.Minute)
+
+	// capture a deletion attempt and assert the values
+	select {
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timed out")
+	case affDelete := <-deleteCh:
+		suite.Equal("endpoint1", affDelete.endpoint)
+		suite.Equal("cluster1", affDelete.cluster)
+		suite.Equal("affiliate1", affDelete.affiliate)
+	}
+
+	// capture another deletion attempt, since the first one has failed, and re-assert the values
+	select {
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timed out")
+	case affDelete := <-deleteCh:
+		suite.Equal("endpoint1", affDelete.endpoint)
+		suite.Equal("cluster1", affDelete.cluster)
+		suite.Equal("affiliate1", affDelete.affiliate)
+	}
+
+	// assert that the task is still there, as the deletion failed
+	rtestutils.AssertResource[*omni.DiscoveryAffiliateDeleteTask](suite.ctx, suite.T(), suite.state, task.Metadata().ID(),
+		func(r *omni.DiscoveryAffiliateDeleteTask, assertion *assert.Assertions) {
+			assertion.Equal(resource.PhaseRunning, r.Metadata().Phase())
+		},
+	)
+
+	// advance the time further so that the affiliate is assumed to be pruned by the discovery service itself and a delete call will not be attempted
+	clock.Advance(21 * time.Minute)
+
+	// assert that the delete task is cleaned up
+	rtestutils.AssertNoResource[*omni.DiscoveryAffiliateDeleteTask](suite.ctx, suite.T(), suite.state, task.Metadata().ID())
+}
+
+func TestDiscoveryAffiliateDeleteTaskSuite(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, new(DiscoveryAffiliateDeleteTaskSuite))
+}
+
+type affiliateDelete struct {
+	endpoint  string
+	cluster   string
+	affiliate string
+}
+
+type discoveryClientCacheMock struct {
+	deleteCh     chan affiliateDelete
+	failDeletion bool
+}
+
+func (d *discoveryClientCacheMock) AffiliateDelete(ctx context.Context, endpoint, cluster, affiliate string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case d.deleteCh <- affiliateDelete{endpoint, cluster, affiliate}:
+	}
+
+	if d.failDeletion {
+		return fmt.Errorf("deletion blocked - discovery service is not accessible")
+	}
+
+	return nil
+}

--- a/internal/backend/runtime/omni/omni_test.go
+++ b/internal/backend/runtime/omni/omni_test.go
@@ -81,11 +81,11 @@ func (suite *OmniRuntimeSuite) SetupTest() {
 	logger := zaptest.NewLogger(suite.T())
 	clientFactory := talos.NewClientFactory(resourceState, logger)
 	dnsService := dns.NewService(resourceState, logger)
-	discoveryServiceClient := &discoveryClientMock{}
+	discoveryClientCache := &discoveryClientCacheMock{}
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel)
 
 	suite.runtime, err = omniruntime.New(clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
-		resourceState, nil, prometheus.NewRegistry(), discoveryServiceClient, nil, logger)
+		resourceState, nil, prometheus.NewRegistry(), discoveryClientCache, logger)
 
 	suite.Require().NoError(err)
 
@@ -192,9 +192,9 @@ func TestOmniRuntimeSuite(t *testing.T) {
 	suite.Run(t, new(OmniRuntimeSuite))
 }
 
-type discoveryClientMock struct{}
+type discoveryClientCacheMock struct{}
 
-// AffiliateDelete implements the omni.DiscoveryClient interface.
-func (d *discoveryClientMock) AffiliateDelete(context.Context, string, string) error {
+// AffiliateDelete deletes an affiliate.
+func (d *discoveryClientCacheMock) AffiliateDelete(context.Context, string, string, string) error {
 	return nil
 }

--- a/internal/backend/runtime/omni/state_access.go
+++ b/internal/backend/runtime/omni/state_access.go
@@ -76,6 +76,7 @@ var (
 		omni.MachineExtensionsType,
 		omni.ExtensionsConfigurationStatusType,
 		omni.NodeForceDestroyRequestType, // cluster label is not strictly required to be present on this resource, except when the cluster access is granted via ACLs
+		omni.DiscoveryAffiliateDeleteTaskType,
 	})
 
 	// userManagedResourceTypeSet is the set of resource types that are managed by the user.
@@ -382,6 +383,7 @@ func filterAccess(ctx context.Context, access state.Access) error {
 		omni.ClusterTaintType,
 		omni.ConfigPatchType,
 		omni.ControlPlaneStatusType,
+		omni.DiscoveryAffiliateDeleteTaskType,
 		omni.KubernetesNodeAuditResultType,
 		omni.ExposedServiceType,
 		omni.EtcdBackupType,
@@ -533,6 +535,7 @@ func filterAccessByType(access state.Access) error {
 		omni.ClusterUUIDType,
 		omni.ClusterWorkloadProxyStatusType,
 		omni.ControlPlaneStatusType,
+		omni.DiscoveryAffiliateDeleteTaskType,
 		omni.KubernetesNodeAuditResultType,
 		omni.ExposedServiceType,
 		omni.EtcdBackupType,

--- a/internal/backend/runtime/omni/talosconfig_test.go
+++ b/internal/backend/runtime/omni/talosconfig_test.go
@@ -38,11 +38,11 @@ func TestOperatorTalosconfig(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	clientFactory := talos.NewClientFactory(st, logger)
 	dnsService := dns.NewService(st, logger)
-	discoveryServiceClient := &discoveryClientMock{}
+	discoveryClientCache := &discoveryClientCacheMock{}
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel)
 
 	r, err := omniruntime.New(clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
-		st, nil, prometheus.NewRegistry(), discoveryServiceClient, nil, logger)
+		st, nil, prometheus.NewRegistry(), discoveryClientCache, logger)
 
 	require.NoError(t, err)
 


### PR DESCRIPTION
Rework the discovery service affiliate deletion by doing the following changes:

1. Add support for arbitrary discovery services (e.g., self-hosted or third party):
   - Read the discovery service used by a machine from the machine itself
   - Implement a cache for discovery service clients
   - Use this discovery service client to remove the affiliate on node removal.

2. Make the discovery affiliate deletion asynchronous:
   - Introduce `DiscoveryAffiliateDeleteTask` resource
   - When a node is removed from a cluster, a resource for this node ID is created
   - A controller continuously tries to remove the affiliate until it succeeds or until it gets expired in the discovery service itself (after 30 minutes)
   - The controller removes the `DiscoveryAffiliateDeleteTask` resource

Closes #1084, closes #1085.