### PR TITLE
fix: update to fix "make mkcert-install" 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ REMOVE_VOLUMES ?= false
 # help menu
 
 export define HELP_MENU_HEADER
+
+define BUILD_SETUP_GUIDE
 # Getting Started
 
 To build this project, you must have the following installed:


### PR DESCRIPTION
When I run on mac `make mkcert-install`  
the issue is,  `Makefile:94: *** missing separator.  Stop.`
https://github.com/siderolabs/omni/blob/main/Makefile#L94

@smira What do you think about this update does this works on Linux for you maybe (just asking I don't know on what OS are you)

or maybe it's better just to make HELP_MENU_HEADER unexported ? 
as it's not closing this, https://github.com/siderolabs/omni/blob/main/Makefile#L135

cheers ! 