### PR TITLE
test: fix the flaky key storage test

### DIFF
--- a/internal/backend/oidc/internal/storage/keys/storage_test.go
+++ b/internal/backend/oidc/internal/storage/keys/storage_test.go
@@ -147,9 +147,14 @@ func TestStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	keyIDs := getKeyIDs(keySet)
+	require.GreaterOrEqual(t, len(keyIDs), 2, "at least two keys should be present")
 
-	assert.GreaterOrEqual(t, len(keyIDs), 2, "at least two keys should be present")
-	assert.Equal(t, sorted(expectedPublicKeyIDs), keyIDs)
+	slices.Sort(expectedPublicKeyIDs)
+
+	// get last N key IDs, where N is the number of expected public keys
+	mostRecentKeyIDs := keyIDs[len(keyIDs)-len(expectedPublicKeyIDs):]
+
+	assert.Equal(t, expectedPublicKeyIDs, mostRecentKeyIDs)
 }
 
 func getKeyIDs(keySet []op.Key) []string {


### PR DESCRIPTION
The test was flaky due to it being time-sensitive - at the end of the test, it could have generated 2 or more keys, which we expected in the first assertion, but in the second one we compared it to a fixed set of keys of size 2.