### PR TITLE
fix: loosen s3 integrity check for etcd backups

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/s3store.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/s3store.go
@@ -201,6 +201,7 @@ func S3ClientFromResource(ctx context.Context, s3Conf *omni.EtcdBackupS3Conf) (*
 	client := s3.NewFromConfig(loadedCfg, func(o *s3.Options) {
 		o.UsePathStyle = true
 		o.BaseEndpoint = aws.String(baseEndpoint)
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 	})
 
 	_, err = client.ListObjects(ctx, &s3.ListObjectsInput{Bucket: pointer.To(bucket)})


### PR DESCRIPTION
S3 Go SDK introduced a breaking change which broke uploads to S3-compatible APIs like Backblaze. Revert it by setting request checksum calculation to "when required".

For more info, see the discussion and the comment here: https://github.com/aws/aws-sdk-go-v2/discussions/2960#discussioncomment-12077210

Fixes https://github.com/siderolabs/omni/issues/1086.