### PR TITLE
fix: sort Talos versions by semver on the cluster creation screen

### DIFF
--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -387,6 +387,8 @@ const talosVersions = computed(() => {
     res.push(version.spec.version!);
   }
 
+  res.sort(semver.compare)
+
   return res;
 });
 


### PR DESCRIPTION
The same fix we did for download installation media screen - alphabetic sorting does not order the versions as we expect anymore starting with Talos 1.10.