### PR TITLE
fix: collect and handle UKI boot information

### DIFF
--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -18,10 +18,12 @@ message MachineSpec {
   reserved 4;
 }
 
-// SecureBootStatus describes the status of the SecureBoot feature.
-message SecureBootStatus {
-  // Enabled is true if SecureBoot is detected to be available and enabled.
-  bool enabled = 1;
+// SecurityState describes the UKI and secure boot information of the machine.
+message SecurityState {
+  // SecureBoot is true if secure boot is detected to be available and enabled.
+  bool secure_boot = 1; // use existing logic
+  // BootedWithUki is true if the machine is booted with a UKI. Always true if secure boot is enabled.
+  bool booted_with_uki = 2;
 }
 
 message Overlay {
@@ -238,8 +240,7 @@ message MachineStatusSpec {
   string initial_talos_version = 16;
 
   reserved 17;
-
-  SecureBootStatus secure_boot_status = 18;
+  reserved 18;
 
   repeated Diagnostic diagnostics = 19;
 
@@ -251,6 +252,8 @@ message MachineStatusSpec {
   };
 
   PowerState power_state = 20;
+
+  SecurityState security_state = 21;
 }
 
 // TalosConfigSpec describes a Talos cluster config.
@@ -1054,10 +1057,11 @@ message MachineConfigGenOptionsSpec {
     bool schematic_initialized = 3;
     // SchematicInvalid is true if the schematic is invalid.
     bool schematic_invalid = 4;
-    // SecureBootStatus is the status of the SecureBoot feature.
-    SecureBootStatus secure_boot_status = 5;
+    reserved 5;
     // Platform is the machine platform to use for the install image.
     string platform = 6;
+    // SecurityState is used to decide the secure boot enablement in the install image.
+    SecurityState security_state = 7;
   }
 
   string install_disk = 1;

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -45,12 +45,13 @@ func (m *MachineSpec) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
-func (m *SecureBootStatus) CloneVT() *SecureBootStatus {
+func (m *SecurityState) CloneVT() *SecurityState {
 	if m == nil {
-		return (*SecureBootStatus)(nil)
+		return (*SecurityState)(nil)
 	}
-	r := new(SecureBootStatus)
-	r.Enabled = m.Enabled
+	r := new(SecurityState)
+	r.SecureBoot = m.SecureBoot
+	r.BootedWithUki = m.BootedWithUki
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -58,7 +59,7 @@ func (m *SecureBootStatus) CloneVT() *SecureBootStatus {
 	return r
 }
 
-func (m *SecureBootStatus) CloneMessageVT() proto.Message {
+func (m *SecurityState) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -361,8 +362,8 @@ func (m *MachineStatusSpec) CloneVT() *MachineStatusSpec {
 	r.PlatformMetadata = m.PlatformMetadata.CloneVT()
 	r.Schematic = m.Schematic.CloneVT()
 	r.InitialTalosVersion = m.InitialTalosVersion
-	r.SecureBootStatus = m.SecureBootStatus.CloneVT()
 	r.PowerState = m.PowerState
+	r.SecurityState = m.SecurityState.CloneVT()
 	if rhs := m.ImageLabels; rhs != nil {
 		tmpContainer := make(map[string]string, len(rhs))
 		for k, v := range rhs {
@@ -1779,8 +1780,8 @@ func (m *MachineConfigGenOptionsSpec_InstallImage) CloneVT() *MachineConfigGenOp
 	r.SchematicId = m.SchematicId
 	r.SchematicInitialized = m.SchematicInitialized
 	r.SchematicInvalid = m.SchematicInvalid
-	r.SecureBootStatus = m.SecureBootStatus.CloneVT()
 	r.Platform = m.Platform
+	r.SecurityState = m.SecurityState.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -2530,20 +2531,23 @@ func (this *MachineSpec) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
-func (this *SecureBootStatus) EqualVT(that *SecureBootStatus) bool {
+func (this *SecurityState) EqualVT(that *SecurityState) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
 		return false
 	}
-	if this.Enabled != that.Enabled {
+	if this.SecureBoot != that.SecureBoot {
+		return false
+	}
+	if this.BootedWithUki != that.BootedWithUki {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
-func (this *SecureBootStatus) EqualMessageVT(thatMsg proto.Message) bool {
-	that, ok := thatMsg.(*SecureBootStatus)
+func (this *SecurityState) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*SecurityState)
 	if !ok {
 		return false
 	}
@@ -3047,9 +3051,6 @@ func (this *MachineStatusSpec) EqualVT(that *MachineStatusSpec) bool {
 	if this.InitialTalosVersion != that.InitialTalosVersion {
 		return false
 	}
-	if !this.SecureBootStatus.EqualVT(that.SecureBootStatus) {
-		return false
-	}
 	if len(this.Diagnostics) != len(that.Diagnostics) {
 		return false
 	}
@@ -3068,6 +3069,9 @@ func (this *MachineStatusSpec) EqualVT(that *MachineStatusSpec) bool {
 		}
 	}
 	if this.PowerState != that.PowerState {
+		return false
+	}
+	if !this.SecurityState.EqualVT(that.SecurityState) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -4949,10 +4953,10 @@ func (this *MachineConfigGenOptionsSpec_InstallImage) EqualVT(that *MachineConfi
 	if this.SchematicInvalid != that.SchematicInvalid {
 		return false
 	}
-	if !this.SecureBootStatus.EqualVT(that.SecureBootStatus) {
+	if this.Platform != that.Platform {
 		return false
 	}
-	if this.Platform != that.Platform {
+	if !this.SecurityState.EqualVT(that.SecurityState) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -5948,7 +5952,7 @@ func (m *MachineSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *SecureBootStatus) MarshalVT() (dAtA []byte, err error) {
+func (m *SecurityState) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -5961,12 +5965,12 @@ func (m *SecureBootStatus) MarshalVT() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *SecureBootStatus) MarshalToVT(dAtA []byte) (int, error) {
+func (m *SecurityState) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *SecureBootStatus) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *SecurityState) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -5978,9 +5982,19 @@ func (m *SecureBootStatus) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if m.Enabled {
+	if m.BootedWithUki {
 		i--
-		if m.Enabled {
+		if m.BootedWithUki {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.SecureBoot {
+		i--
+		if m.SecureBoot {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
@@ -6815,6 +6829,18 @@ func (m *MachineStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.SecurityState != nil {
+		size, err := m.SecurityState.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xaa
+	}
 	if m.PowerState != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.PowerState))
 		i--
@@ -6835,18 +6861,6 @@ func (m *MachineStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			i--
 			dAtA[i] = 0x9a
 		}
-	}
-	if m.SecureBootStatus != nil {
-		size, err := m.SecureBootStatus.MarshalToSizedBufferVT(dAtA[:i])
-		if err != nil {
-			return 0, err
-		}
-		i -= size
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
-		i--
-		dAtA[i] = 0x1
-		i--
-		dAtA[i] = 0x92
 	}
 	if len(m.InitialTalosVersion) > 0 {
 		i -= len(m.InitialTalosVersion)
@@ -10735,22 +10749,22 @@ func (m *MachineConfigGenOptionsSpec_InstallImage) MarshalToSizedBufferVT(dAtA [
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.Platform) > 0 {
-		i -= len(m.Platform)
-		copy(dAtA[i:], m.Platform)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Platform)))
-		i--
-		dAtA[i] = 0x32
-	}
-	if m.SecureBootStatus != nil {
-		size, err := m.SecureBootStatus.MarshalToSizedBufferVT(dAtA[:i])
+	if m.SecurityState != nil {
+		size, err := m.SecurityState.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
 			return 0, err
 		}
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
-		dAtA[i] = 0x2a
+		dAtA[i] = 0x3a
+	}
+	if len(m.Platform) > 0 {
+		i -= len(m.Platform)
+		copy(dAtA[i:], m.Platform)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Platform)))
+		i--
+		dAtA[i] = 0x32
 	}
 	if m.SchematicInvalid {
 		i--
@@ -12569,13 +12583,16 @@ func (m *MachineSpec) SizeVT() (n int) {
 	return n
 }
 
-func (m *SecureBootStatus) SizeVT() (n int) {
+func (m *SecurityState) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
-	if m.Enabled {
+	if m.SecureBoot {
+		n += 2
+	}
+	if m.BootedWithUki {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -12983,10 +13000,6 @@ func (m *MachineStatusSpec) SizeVT() (n int) {
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
-	if m.SecureBootStatus != nil {
-		l = m.SecureBootStatus.SizeVT()
-		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
 	if len(m.Diagnostics) > 0 {
 		for _, e := range m.Diagnostics {
 			l = e.SizeVT()
@@ -12995,6 +13008,10 @@ func (m *MachineStatusSpec) SizeVT() (n int) {
 	}
 	if m.PowerState != 0 {
 		n += 2 + protohelpers.SizeOfVarint(uint64(m.PowerState))
+	}
+	if m.SecurityState != nil {
+		l = m.SecurityState.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -14473,12 +14490,12 @@ func (m *MachineConfigGenOptionsSpec_InstallImage) SizeVT() (n int) {
 	if m.SchematicInvalid {
 		n += 2
 	}
-	if m.SecureBootStatus != nil {
-		l = m.SecureBootStatus.SizeVT()
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
 	l = len(m.Platform)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.SecurityState != nil {
+		l = m.SecurityState.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -15267,7 +15284,7 @@ func (m *MachineSpec) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *SecureBootStatus) UnmarshalVT(dAtA []byte) error {
+func (m *SecurityState) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -15290,15 +15307,15 @@ func (m *SecureBootStatus) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SecureBootStatus: wiretype end group for non-group")
+			return fmt.Errorf("proto: SecurityState: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: SecureBootStatus: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: SecurityState: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Enabled", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field SecureBoot", wireType)
 			}
 			var v int
 			for shift := uint(0); ; shift += 7 {
@@ -15315,7 +15332,27 @@ func (m *SecureBootStatus) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
-			m.Enabled = bool(v != 0)
+			m.SecureBoot = bool(v != 0)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BootedWithUki", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.BootedWithUki = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -18073,42 +18110,6 @@ func (m *MachineStatusSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.InitialTalosVersion = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 18:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field SecureBootStatus", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.SecureBootStatus == nil {
-				m.SecureBootStatus = &SecureBootStatus{}
-			}
-			if err := m.SecureBootStatus.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		case 19:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Diagnostics", wireType)
@@ -18162,6 +18163,42 @@ func (m *MachineStatusSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 21:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SecurityState", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SecurityState == nil {
+				m.SecurityState = &SecurityState{}
+			}
+			if err := m.SecurityState.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -27459,42 +27496,6 @@ func (m *MachineConfigGenOptionsSpec_InstallImage) UnmarshalVT(dAtA []byte) erro
 				}
 			}
 			m.SchematicInvalid = bool(v != 0)
-		case 5:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field SecureBootStatus", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.SecureBootStatus == nil {
-				m.SecureBootStatus = &SecureBootStatus{}
-			}
-			if err := m.SecureBootStatus.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Platform", wireType)
@@ -27526,6 +27527,42 @@ func (m *MachineConfigGenOptionsSpec_InstallImage) UnmarshalVT(dAtA []byte) erro
 				return io.ErrUnexpectedEOF
 			}
 			m.Platform = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SecurityState", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SecurityState == nil {
+				m.SecurityState = &SecurityState{}
+			}
+			if err := m.SecurityState.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -177,8 +177,9 @@ export type MachineSpec = {
   connected?: boolean
 }
 
-export type SecureBootStatus = {
-  enabled?: boolean
+export type SecurityState = {
+  secure_boot?: boolean
+  booted_with_uki?: boolean
 }
 
 export type Overlay = {
@@ -284,9 +285,9 @@ export type MachineStatusSpec = {
   image_labels?: {[key: string]: string}
   schematic?: MachineStatusSpecSchematic
   initial_talos_version?: string
-  secure_boot_status?: SecureBootStatus
   diagnostics?: MachineStatusSpecDiagnostic[]
   power_state?: MachineStatusSpecPowerState
+  security_state?: SecurityState
 }
 
 export type TalosConfigSpec = {
@@ -689,8 +690,8 @@ export type MachineConfigGenOptionsSpecInstallImage = {
   schematic_id?: string
   schematic_initialized?: boolean
   schematic_invalid?: boolean
-  secure_boot_status?: SecureBootStatus
   platform?: string
+  security_state?: SecurityState
 }
 
 export type MachineConfigGenOptionsSpec = {

--- a/frontend/src/views/cluster/Nodes/NodeOverview.vue
+++ b/frontend/src/views/cluster/Nodes/NodeOverview.vue
@@ -461,12 +461,12 @@ const getMemInfo = () => {
 }
 
 const getSecureBootStatus = () => {
-  const secureBootStatus = machineStatus?.value?.spec.message_status?.secure_boot_status;
-  if (!secureBootStatus) {
+  const securityState = machineStatus?.value?.spec.message_status?.security_state;
+  if (!securityState) {
     return TCommonStatuses.UNKNOWN;
   }
 
-  if (secureBootStatus.enabled) {
+  if (securityState.secure_boot) {
     return TCommonStatuses.ENABLED;
   }
 

--- a/frontend/src/views/omni/Machines/MachineItem.vue
+++ b/frontend/src/views/omni/Machines/MachineItem.vue
@@ -251,12 +251,12 @@ const timeGetter = (fn :() => string|undefined) => {
 const machineLastAlive = timeGetter(() => machine.value?.spec?.siderolink_counter?.last_alive);
 const machineCreatedAt = timeGetter(() => machine.value?.spec?.machine_created_at);
 const secureBoot = computed(() => {
-  let secureBootStatus = machine.value.spec.message_status?.secure_boot_status;
-  if (!secureBootStatus) {
+  const securityState = machine.value.spec.message_status?.security_state;
+  if (!securityState) {
     return "Unknown";
   }
 
-  return secureBootStatus.enabled ? "Enabled" : "Disabled";
+  return securityState.secure_boot ? "Enabled" : "Disabled";
 });
 
 const copyMachineID = () => {

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
@@ -230,7 +230,7 @@ func reconcileClusterMachineConfig(
 		return xerrors.NewTagged[qtransform.SkipReconcileTag](errors.New("machine schematic is not set detected"))
 	}
 
-	if installImage.SecureBootStatus == nil {
+	if installImage.SecurityState == nil {
 		logger.Error("secure boot status is not detected, skip reconcile")
 
 		return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("secure boot status for machine %q is not yet set", machineConfigGenOptions.Metadata().ID())
@@ -468,13 +468,13 @@ func buildInstallImage(imageFactoryHost string, resID resource.ID, installImage 
 
 	schematicID := installImage.SchematicId
 
-	secureBootStatus := installImage.SecureBootStatus
-	if secureBootStatus == nil { // should never happen - must have been handled before entering this function
+	securityState := installImage.SecurityState
+	if securityState == nil { // should never happen - must have been handled before entering this function
 		return "", fmt.Errorf("machine %q has no secure boot status set", resID)
 	}
 
 	installerName := "installer"
-	if secureBootStatus.Enabled {
+	if securityState.SecureBoot {
 		installerName = "installer-secureboot"
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status_test.go
@@ -214,9 +214,7 @@ func (suite *ClusterMachineConfigStatusSuite) prepareMachines(machines []*omni.C
 			func(res *omni.MachineStatus) error {
 				res.TypedSpec().Value.Connected = true
 				res.TypedSpec().Value.Maintenance = false
-				res.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-					Enabled: false,
-				}
+				res.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 				res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 					Platform: talosconstants.PlatformMetal,
 				}
@@ -285,9 +283,7 @@ func (suite *ClusterMachineConfigStatusSuite) TestResetUngraceful() {
 				res.TypedSpec().Value.Connected = true
 				res.TypedSpec().Value.Maintenance = false
 				res.TypedSpec().Value.ManagementAddress = unixSocket + machineService.address
-				res.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-					Enabled: false,
-				}
+				res.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 				res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 					Platform: talosconstants.PlatformMetal,
 				}
@@ -449,9 +445,7 @@ func (suite *ClusterMachineConfigStatusSuite) TestForceDestroy() {
 				res.TypedSpec().Value.Connected = true
 				res.TypedSpec().Value.Maintenance = false
 				res.TypedSpec().Value.ManagementAddress = unixSocket + machineSvc.address
-				res.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-					Enabled: false,
-				}
+				res.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 				res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 					Platform: talosconstants.PlatformMetal,
 				}
@@ -512,9 +506,7 @@ func (suite *ClusterMachineConfigStatusSuite) TestUpgrades() {
 			func(res *omni.MachineStatus) error {
 				res.TypedSpec().Value.Connected = true
 				res.TypedSpec().Value.Maintenance = false
-				res.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-					Enabled: false,
-				}
+				res.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 				res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 					Platform: talosconstants.PlatformMetal,
 				}
@@ -648,9 +640,7 @@ func (suite *ClusterMachineConfigStatusSuite) TestStagedUpgrade() {
 		res.TypedSpec().Value.Connected = true
 		res.TypedSpec().Value.Maintenance = false
 		res.TypedSpec().Value.ManagementAddress = unixSocket + machineSvc.address
-		res.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-			Enabled: false,
-		}
+		res.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 		res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 			Platform: talosconstants.PlatformMetal,
 		}
@@ -731,9 +721,7 @@ func (suite *ClusterMachineConfigStatusSuite) TestSchematicChanges() {
 			func(res *omni.MachineStatus) error {
 				res.TypedSpec().Value.Connected = true
 				res.TypedSpec().Value.Maintenance = false
-				res.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-					Enabled: false,
-				}
+				res.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 				res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 					Platform: talosconstants.PlatformMetal,
 				}
@@ -870,8 +858,9 @@ func (suite *ClusterMachineConfigStatusSuite) TestSecureBootInstallImage() {
 			func(res *omni.MachineStatus) error {
 				res.TypedSpec().Value.Connected = true
 				res.TypedSpec().Value.Maintenance = false
-				res.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-					Enabled: true,
+				res.TypedSpec().Value.SecurityState = &specs.SecurityState{
+					SecureBoot:    true,
+					BootedWithUki: true,
 				}
 				res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 					Platform: talosconstants.PlatformMetal,

--- a/internal/backend/runtime/omni/controllers/omni/infra_machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine.go
@@ -203,7 +203,7 @@ func (ctrl *InfraMachineController) reconcileRunning(ctx context.Context, r cont
 		return nil // the link is not created by a static infra provider
 	}
 
-	machineInfoCollected := machineStatus != nil && machineStatus.TypedSpec().Value.SecureBootStatus != nil
+	machineInfoCollected := machineStatus != nil && machineStatus.TypedSpec().Value.SecurityState != nil
 
 	helper := &infraMachineControllerHelper{
 		config:               config,

--- a/internal/backend/runtime/omni/controllers/omni/infra_machine_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine_test.go
@@ -60,7 +60,7 @@ func (suite *InfraMachineControllerSuite) TestReconcile() {
 	})
 
 	machineStatus := omni.NewMachineStatus(resources.DefaultNamespace, "machine-1")
-	machineStatus.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{}
+	machineStatus.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, machineStatus))
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/machine.go
@@ -67,7 +67,7 @@ type Info struct { //nolint:govet
 	NoAccess        bool
 
 	DefaultKernelArgs []string
-	SecureBootStatus  *specs.SecureBootStatus
+	SecurityState     *specs.SecurityState
 
 	Diagnostics []*specs.MachineStatusSpec_Diagnostic
 }

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
@@ -76,7 +76,7 @@ func GenInstallConfig(machineStatus *omni.MachineStatus, clusterMachineTalosVers
 			genOptions.TypedSpec().Value.InstallImage.SchematicInvalid = machineStatus.TypedSpec().Value.GetSchematic().GetInvalid()
 		}
 
-		genOptions.TypedSpec().Value.InstallImage.SecureBootStatus = machineStatus.TypedSpec().Value.SecureBootStatus
+		genOptions.TypedSpec().Value.InstallImage.SecurityState = machineStatus.TypedSpec().Value.SecurityState
 		genOptions.TypedSpec().Value.InstallImage.Platform = machineStatus.TypedSpec().Value.GetPlatformMetadata().GetPlatform()
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -486,8 +486,8 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 			m.Metadata().Labels().Delete(omni.MachineStatusLabelInvalidState)
 		}
 
-		if event.SecureBootStatus != nil {
-			spec.SecureBootStatus = event.SecureBootStatus
+		if event.SecurityState != nil {
+			spec.SecurityState = event.SecurityState
 		}
 
 		if event.Schematic != nil {

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -569,9 +569,7 @@ func (suite *OmniSuite) createClusterWithTalosVersion(clusterName string, contro
 			Id: defaultSchematic,
 		}
 		machineStatus.TypedSpec().Value.InitialTalosVersion = cluster.TypedSpec().Value.TalosVersion
-		machineStatus.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-			Enabled: false,
-		}
+		machineStatus.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 		machineStatus.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 			Platform: talosconstants.PlatformMetal,
 		}

--- a/internal/backend/runtime/omni/controllers/omni/schematic_configuration_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic_configuration_test.go
@@ -65,9 +65,7 @@ func (suite *SchematicConfigurationSuite) TestReconcile() {
 		InitialSchematic: initialSchematic,
 	}
 	machineStatus.TypedSpec().Value.InitialTalosVersion = "1.7.0"
-	machineStatus.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-		Enabled: false,
-	}
+	machineStatus.TypedSpec().Value.SecurityState = &specs.SecurityState{}
 	machineStatus.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
 		Platform: talosconstants.PlatformMetal,
 	}

--- a/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status.go
@@ -548,9 +548,9 @@ func populateEmptySchematics(ctx context.Context, r controller.ReaderWriter, clu
 			return nil
 		}
 
-		secureBootStatus := machineStatus.TypedSpec().Value.SecureBootStatus
-		if secureBootStatus == nil {
-			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("secure boot status for machine %q is not yet set", clusterMachineTalosVersion.Metadata().ID())
+		securityState := machineStatus.TypedSpec().Value.SecurityState
+		if securityState == nil {
+			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("boot type for machine %q is not yet set", clusterMachineTalosVersion.Metadata().ID())
 		}
 
 		return safe.WriterModify(ctx, r, clusterMachineTalosVersion, func(res *omni.ClusterMachineTalosVersion) error {

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -1404,8 +1404,9 @@ func (suite *MigrationSuite) TestMigrateInstallImageConfigIntoGenOptions() {
 
 	machineStatus := omni.NewMachineStatus(resources.DefaultNamespace, "test")
 
-	machineStatus.TypedSpec().Value.SecureBootStatus = &specs.SecureBootStatus{
-		Enabled: true,
+	machineStatus.TypedSpec().Value.SecurityState = &specs.SecurityState{
+		SecureBoot:    true,
+		BootedWithUki: true,
 	}
 
 	machineStatus.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
@@ -1461,7 +1462,7 @@ func (suite *MigrationSuite) TestMigrateInstallImageConfigIntoGenOptions() {
 	suite.Equal("test-schematic-id", installImage.SchematicId)
 	suite.True(installImage.SchematicInitialized)
 	suite.True(installImage.SchematicInvalid)
-	suite.True(installImage.GetSecureBootStatus().GetEnabled())
+	suite.True(installImage.SecurityState.SecureBoot)
 
 	// assert that the input version is updated on the ClusterMachineConfig
 


### PR DESCRIPTION
With Talos v1.10, even non-secure boot machines can be booted with a UKI. Replace the secure boot status collection and handling logic to take UKI boot into consideration instead.

This affects which schematic ID we use to compare the desired vs actual schematics.

Closes https://github.com/siderolabs/omni/issues/1070.