### PR TITLE
fix: use the correct sort order for the automatic install disk selection

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
@@ -6,6 +6,7 @@
 package omni
 
 import (
+	"cmp"
 	"context"
 	"slices"
 
@@ -102,11 +103,7 @@ func GenInstallConfig(machineStatus *omni.MachineStatus, clusterMachineTalosVers
 				return -1
 			}
 
-			if a.Size < b.Size {
-				return 1
-			}
-
-			return 0
+			return cmp.Compare(a.Size, b.Size)
 		}
 
 		slices.SortFunc(candidates, sortFunc)

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options_test.go
@@ -106,6 +106,40 @@ func TestGenInstallConfig(t *testing.T) {
 			expectedInstallDisk: "/dev/sdb",
 		},
 		{
+			name: "select by size",
+			machineStatusSpec: &specs.MachineStatusSpec{
+				Hardware: &specs.MachineStatusSpec_HardwareStatus{
+					Blockdevices: []*specs.MachineStatusSpec_HardwareStatus_BlockDevice{
+						{
+							Size:      25165824000,
+							LinuxName: "/dev/sda",
+							Transport: "sata",
+							Type:      "HDD",
+						},
+						{
+							Size:      6442450944,
+							LinuxName: "/dev/vdb",
+							Transport: "usb",
+							Type:      "HDD",
+						},
+						{
+							Size:      6442450944,
+							LinuxName: "/dev/vda",
+							Transport: "virtio",
+							Type:      "HDD",
+						},
+						{
+							Size:      6442450943,
+							LinuxName: "/dev/vdc",
+							Transport: "usb",
+							Type:      "HDD",
+						},
+					},
+				},
+			},
+			expectedInstallDisk: "/dev/vda",
+		},
+		{
 			name: "system disk",
 			machineStatusSpec: &specs.MachineStatusSpec{
 				Hardware: &specs.MachineStatusSpec_HardwareStatus{


### PR DESCRIPTION
It was inverted, so it was picking the biggest disk.