### PR TITLE
test: bump Talemu tests timeout

### DIFF
--- a/cmd/integration-test/pkg/tests/talos.go
+++ b/cmd/integration-test/pkg/tests/talos.go
@@ -33,6 +33,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
@@ -81,6 +83,14 @@ func clearConnectionRefused(ctx context.Context, t *testing.T, c *talosclient.Cl
 			}
 
 			if strings.Contains(err.Error(), "connection reset by peer") {
+				return retry.ExpectedError(err)
+			}
+
+			// nolint:exhaustive
+			switch status.Code(err) {
+			case codes.DeadlineExceeded,
+				codes.Unavailable,
+				codes.Canceled:
 				return retry.ExpectedError(err)
 			}
 

--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -159,7 +159,7 @@ if [[ "${RUN_TALEMU_TESTS:-false}" == "true" ]]; then
     --expected-machines=30 \
     --provision-config-file=hack/test/provisionconfig.yaml \
     --run-stats-check \
-    -t 4m \
+    -t 10m \
     -p 10 \
     ${TALEMU_TEST_ARGS:-}
 


### PR DESCRIPTION
The internal timeout for the provision test is 6 minutes. With 4 minutes timeout for the whole test run we miss the actual error report.