### PR TITLE
fix: use the correct res order for the cluster operations in the UI

### DIFF
--- a/frontend/src/components/common/Form/JsonForm.vue
+++ b/frontend/src/components/common/Form/JsonForm.vue
@@ -165,7 +165,6 @@ watch(jsonSchema, renderSchema);
 
 renderSchema();
 
-console.log(modelValue.value)
 updateErrors(modelValue.value);
 
 const uiSchema = computed(() => {

--- a/frontend/src/states/cluster-management/index.ts
+++ b/frontend/src/states/cluster-management/index.ts
@@ -45,6 +45,13 @@ import yaml from "js-yaml";
 import { withRuntime, withSelectors } from "@/api/options";
 import { Runtime } from "@/api/common/omni.pb";
 
+export const typesOrder = {
+  [ClusterType]: 4,
+  [ConfigPatchType]: 3,
+  [MachineSetType]: 2,
+  [MachineSetNodeType]: 1
+};
+
 const dec2hex = (dec: number) => {
   return dec.toString(16).padStart(2, "0");
 }
@@ -333,7 +340,7 @@ export class State {
       cluster.spec.backup_configuration = undefined;
     }
 
-    const resources: Resource[] = [
+    let resources: Resource[] = [
       cluster,
     ];
 
@@ -460,6 +467,16 @@ export class State {
         [LabelMachineSet]: ms.metadata.id!,
       }, ms.metadata.id));
     }
+
+    resources = resources.sort((a: Resource, b: Resource) => {
+      if (typesOrder[a.metadata.type!] > typesOrder[b.metadata.type!]) {
+        return -1;
+      } else if (typesOrder[a.metadata.type!] < typesOrder[b.metadata.type!]) {
+        return 1;
+      }
+
+      return 0;
+    });
 
     if (!this.baseResources) {
       return resources;

--- a/frontend/test/unit/clusterManageState.spec.ts
+++ b/frontend/test/unit/clusterManageState.spec.ts
@@ -6,7 +6,7 @@
 import { Resource } from "../../src/api/grpc";
 import { ClusterSpec, ConfigPatchSpec, MachineSetNodeSpec, MachineSetSpec, MachineSetSpecMachineAllocationType, MachineSetSpecUpdateStrategy } from "../../src/api/omni/specs/omni.pb";
 import { ClusterType, ConfigPatchType, DefaultNamespace, LabelCluster, LabelClusterMachine, LabelControlPlaneRole, LabelMachineSet, LabelWorkerRole, MachineSetNodeType, MachineSetType } from "../../src/api/resources";
-import { Cluster, initState, MachineSet, PatchID, state } from "../../src/states/cluster-management";
+import { Cluster, initState, MachineSet, PatchID, state, typesOrder } from "../../src/states/cluster-management";
 
 import { describe, expect, test } from "bun:test";
 
@@ -358,7 +358,7 @@ describe("cluster-management-state", () => {
         state.value.cluster = tt.cluster;
 
         if (tt.machineSets) {
-          for (let i = 0; i < tt.machineSets.length ?? 0; i++) {
+          for (let i = 0; i < tt.machineSets.length; i++) {
             const machineSet = tt.machineSets[i];
 
             if (state.value.machineSets.length <= i) {
@@ -386,12 +386,16 @@ describe("cluster-management-state", () => {
           empty[key] = {};
         }
 
+        for (let i = 1; i < resources.length; i++) {
+          expect(typesOrder[resources[i-1].metadata.type],
+            `${resources[i].metadata.type} is not expected after ${resources[i-1].metadata.type}`,
+          ).toBeGreaterThanOrEqual(typesOrder[resources[i].metadata.type]);
+        }
+
         for (const res of resources) {
           const expected = tt.expectedResources?.[res.metadata.type!]?.[res.metadata.id!];
 
-          console.log(`should have resource ${res.metadata.type}/${res.metadata.id}`);
-
-          expect(expected).toBeDefined();
+          expect(expected, `should have resource ${res.metadata.type}/${res.metadata.id}`).toBeDefined();
 
           delete tt.expectedResources?.[res.metadata.type!]?.[res.metadata.id!];
 

--- a/frontend/test/unit/watch.spec.ts
+++ b/frontend/test/unit/watch.spec.ts
@@ -20,8 +20,6 @@ class fakeStream extends EventTarget {
   private reject?: (value: Error | PromiseLike<void>) => void;
 
   public run(...args: any[]): Promise<void> {
-    console.log("starting fake stream", ...args);
-
     this.dispatchEvent(new Event("run"));
 
     return new Promise<void>(


### PR DESCRIPTION
The way resources were ordered was making config patch being created before machine set node resources.
That kind of order makes Omni code racy and it might install Talos to the wrong disk for example.