### PR TITLE
fix: fix crash in the SAML ACS handler

### DIFF
--- a/internal/backend/saml/saml.go
+++ b/internal/backend/saml/saml.go
@@ -57,7 +57,8 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 			requestTracker,
 			logger.With(logging.Component("saml_session")),
 		),
-		RequestTracker: requestTracker,
+		RequestTracker:   requestTracker,
+		AssertionHandler: samlsp.DefaultAssertionHandler(samlsp.Options{}),
 	}
 
 	return m, nil


### PR DESCRIPTION
It looks like the library update requires a new argument which we didn't pass.
Fixes: https://github.com/siderolabs/omni/issues/1188


(cherry picked from commit aa24c7c707506d8bc2919482b140ebf43776631e)