### PR TITLE
fix: keep ClusterUUID resource alive until the cluster is destroyed

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster.go
@@ -24,6 +24,8 @@ import (
 // ClusterController plays the role of machine discovery.
 type ClusterController = cleanup.Controller[*omni.Cluster]
 
+const clusterControllerName = "ClusterController"
+
 type handler struct {
 	handler   cleanup.Handler[*omni.Cluster]
 	finalizer string
@@ -59,13 +61,11 @@ func (c handler) Outputs() []controller.Output {
 
 // NewClusterController creates new ClusterController.
 func NewClusterController() *ClusterController {
-	name := "ClusterController"
-
 	return cleanup.NewController(
 		cleanup.Settings[*omni.Cluster]{
-			Name: name,
+			Name: clusterControllerName,
 			Handler: handler{
-				finalizer: name,
+				finalizer: clusterControllerName,
 				handler: cleanup.Combine(
 					cleanup.RemoveOutputs[*omni.MachineSet](func(cluster *omni.Cluster) state.ListOption {
 						return state.WithLabelQuery(

--- a/internal/backend/runtime/omni/controllers/omni/cluster_uuid.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_uuid.go
@@ -42,12 +42,12 @@ func NewClusterUUIDController() *ClusterUUIDController {
 					return nil
 				}
 
-				generatedUUUID, err := uuid.NewRandom()
+				generatedUUID, err := uuid.NewRandom()
 				if err != nil {
 					return fmt.Errorf("error generating cluster UUID for cluster '%s': %w", cluster.Metadata().ID(), err)
 				}
 
-				uuidStr := generatedUUUID.String()
+				uuidStr := generatedUUID.String()
 				clusterUUID.TypedSpec().Value.Uuid = uuidStr
 
 				clusterUUID.Metadata().Labels().Set(omni.LabelClusterUUID, uuidStr)
@@ -55,5 +55,6 @@ func NewClusterUUIDController() *ClusterUUIDController {
 				return nil
 			},
 		},
+		qtransform.WithIgnoreTeardownWhile(clusterControllerName),
 	)
 }


### PR DESCRIPTION
Keeping `ClusterUUID` also keeps `EtcdBackupEncryptionController` alive. Which can help in case of accental cluster teardown call, if the cluster is stuck in destroying phase.