### PR TITLE
fix: remove deprecated controller finalizers from the machine classes

### DIFF
--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -216,6 +216,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: markVersionContract,
 				name:     "markVersionContract",
 			},
+			{
+				callback: dropMachineClassStatusFinalizers,
+				name:     "dropMachineClassStatusFinalizers",
+			},
 		},
 	}
 }


### PR DESCRIPTION
There was `MachineClassStatusController` that wasn't used for long. It was introduced and dropped within one minor Omni version. But if that particular Omni version was used, the controller would add it's finalizer on the `MachineClass` resources.
Then as the controller is dropped, nothing removes the finalizer.

Introduce migration to drop that finalizer forcefully.

Fixes: https://github.com/siderolabs/omni/issues/1197