### PR TITLE
fix: do not show some menu elements for Reader users in the UI

### DIFF
--- a/frontend/src/views/cluster/Nodes/NodeExtensions.vue
+++ b/frontend/src/views/cluster/Nodes/NodeExtensions.vue
@@ -59,6 +59,7 @@ included in the LICENSE file.
     <div class="sticky -bottom-6 -my-6 -mx-6 bg-naturals-N1 border-t border-naturals-N5 h-16 flex items-center justify-end gap-2 px-12 py-6 text-xs">
       <t-button type="highlighted"
         @click="openExtensionsUpdate"
+        :disabled="!canUpdateTalos"
         >
         Update Extensions
       </t-button>
@@ -82,6 +83,7 @@ import TIcon from "@/components/common/Icon/TIcon.vue";
 import TSpinner from "@/components/common/Spinner/TSpinner.vue";
 import TAlert from "@/components/TAlert.vue";
 import WordHighlighter from "vue-word-highlighter";
+import { setupClusterPermissions } from "@/methods/auth";
 
 const machineExtensionsStatus = ref<Resource<MachineExtensionsStatusSpec>>();
 const machineExtensionsStatusWatch = new Watch(machineExtensionsStatus);
@@ -94,6 +96,8 @@ const machineExtensionsStatusWatchLoading = machineExtensionsStatusWatch.loading
 const ready = computed(() => {
   return !machineExtensionsStatusWatchLoading.value;
 });
+
+const { canUpdateTalos } = setupClusterPermissions(computed(() => route.params.cluster as string));
 
 machineExtensionsStatusWatch.setup(computed((): WatchOptions | undefined => {
   return {

--- a/frontend/src/views/common/NodeContextMenu.vue
+++ b/frontend/src/views/common/NodeContextMenu.vue
@@ -16,20 +16,22 @@ included in the LICENSE file.
     <t-actions-box-item
       icon="power"
       @click="shutdownNode"
+      v-if="canRebootMachines"
     >Shutdown</t-actions-box-item>
     <t-actions-box-item
       icon="reboot"
       @click="rebootNode"
+      v-if="canRebootMachines"
     >Reboot</t-actions-box-item>
     <t-actions-box-item
-      v-if="clusterMachineStatus.spec.stage === ClusterMachineStatusSpecStage.BEFORE_DESTROY"
+      v-if="clusterMachineStatus.spec.stage === ClusterMachineStatusSpecStage.BEFORE_DESTROY && canAddClusterMachines"
       icon="rollback"
       @click="restoreNode"
     >
       Cancel Destroy
     </t-actions-box-item>
     <t-actions-box-item
-      v-else-if="!deleteDisabled"
+      v-else-if="!deleteDisabled && canRemoveMachines"
       icon="delete"
       danger
       @click="deleteNode"
@@ -44,6 +46,7 @@ import { useRouter } from 'vue-router';
 import { Resource } from "@/api/grpc";
 import { ClusterMachineStatusSpec, ClusterMachineStatusSpecStage } from "@/api/omni/specs/omni.pb";
 import { copyText } from "vue3-clipboard";
+import { setupClusterPermissions } from '@/methods/auth';
 
 import TActionsBox from "@/components/common/ActionsBox/TActionsBox.vue";
 import TActionsBoxItem from "@/components/common/ActionsBox/TActionsBoxItem.vue";
@@ -54,6 +57,8 @@ const props = defineProps<{
   deleteDisabled?: boolean,
   clusterMachineStatus: Resource<ClusterMachineStatusSpec>
 }>();
+
+const { canRebootMachines, canAddClusterMachines, canRemoveMachines } = setupClusterPermissions({ value: props.clusterName });
 
 const deleteNode = () => {
   router.push({

--- a/internal/backend/runtime/omni/virtual/state.go
+++ b/internal/backend/runtime/omni/virtual/state.go
@@ -243,13 +243,13 @@ func (v *State) clusterPermissions(ctx context.Context, ptr resource.Pointer) (*
 	clusterPermissions := virtual.NewClusterPermissions(ptr.ID())
 
 	if userRole.Check(role.Reader) == nil {
-		clusterPermissions.TypedSpec().Value.CanRebootMachines = true
 		clusterPermissions.TypedSpec().Value.CanDownloadKubeconfig = true
 		clusterPermissions.TypedSpec().Value.CanDownloadTalosconfig = true
 		clusterPermissions.TypedSpec().Value.CanReadConfigPatches = true
 	}
 
 	if userRole.Check(role.Operator) == nil {
+		clusterPermissions.TypedSpec().Value.CanRebootMachines = true
 		clusterPermissions.TypedSpec().Value.CanAddMachines = true
 		clusterPermissions.TypedSpec().Value.CanRemoveMachines = true
 		clusterPermissions.TypedSpec().Value.CanUpdateKubernetes = true


### PR DESCRIPTION
Also introduce the cluster permissions cache in the memory of the browser session.
Otherwise fetching cluster permissions will be done for each cluster machine item.
From this point, to see the updated cluster permissions, the user will just have to reload the page.

Fixes: https://github.com/siderolabs/omni/issues/1200