### PR TITLE
fix: make cluster validations consistent between templates and UI

### DIFF
--- a/client/pkg/omni/resources/omni/cluster.go
+++ b/client/pkg/omni/resources/omni/cluster.go
@@ -5,10 +5,17 @@
 package omni
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/resource/protobuf"
 	"github.com/cosi-project/runtime/pkg/resource/typed"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
@@ -50,4 +57,137 @@ func (ClusterExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 // GetEncryptionEnabled returns cluster disk encryption feature flag state.
 func GetEncryptionEnabled(cluster *Cluster) bool {
 	return cluster.TypedSpec().Value.Features != nil && cluster.TypedSpec().Value.Features.DiskEncryption
+}
+
+// ClusterValidator runs validations which do not require the information from the server (e.g., client-side validations) for the provided cluster properties.
+type ClusterValidator struct {
+	ID                string
+	KubernetesVersion string
+	TalosVersion      string
+	EncryptionEnabled bool
+
+	// SkipClusterIDCheck indicates if the cluster ID check should be skipped. For example, this is used on server-side update validations.
+	SkipClusterIDCheck bool
+
+	// SkipTalosVersionCheck indicates if the Talos version check should be skipped. For example, this is used on server-side update validations.
+	SkipTalosVersionCheck bool
+
+	// SkipKubernetesVersionCheck indicates if the Kubernetes version check should be skipped. For example, this is used on server-side update validations.
+	SkipKubernetesVersionCheck bool
+
+	// RequireVPrefixOnTalosVersionCheck indicates if the Talos version should start with 'v'. For example, this is the format required by the cluster templates.
+	RequireVPrefixOnTalosVersionCheck bool
+}
+
+// Validate runs validations on the cluster properties.
+func (validator ClusterValidator) Validate() error {
+	var multiErr error
+
+	if err := validator.validateID(); err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	}
+
+	if !validator.SkipKubernetesVersionCheck {
+		if err := validator.validateKubernetesVersion(); err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+	}
+
+	if !validator.SkipTalosVersionCheck {
+		if err := validator.validateTalosVersion(); err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+	}
+
+	if err := validator.validateEncryption(); err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	}
+
+	return multiErr
+}
+
+func (validator ClusterValidator) validateID() error {
+	if validator.SkipClusterIDCheck {
+		return nil
+	}
+
+	var multiErr error
+
+	id := validator.ID
+
+	if id == "" {
+		multiErr = multierror.Append(multiErr, fmt.Errorf("name is required"))
+	}
+
+	for _, c := range id {
+		if !unicode.IsDigit(c) && !unicode.IsLetter(c) && c != '-' && c != '_' {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("name should only contain letters, digits, dashes and underscores"))
+
+			break
+		}
+	}
+
+	return multiErr
+}
+
+func (validator ClusterValidator) validateKubernetesVersion() error {
+	var multiErr error
+
+	if validator.KubernetesVersion == "" {
+		multiErr = multierror.Append(multiErr, fmt.Errorf("version is required"))
+	} else if _, err := semver.ParseTolerant(validator.KubernetesVersion); err != nil {
+		multiErr = multierror.Append(multiErr, fmt.Errorf("version should be in semver format: %w", err))
+	}
+
+	if multiErr != nil {
+		return fmt.Errorf("error validating Kubernetes version: %w", multiErr)
+	}
+
+	return nil
+}
+
+func (validator ClusterValidator) validateTalosVersion() error {
+	var multiErr error
+
+	if validator.TalosVersion == "" {
+		multiErr = multierror.Append(multiErr, fmt.Errorf("version is required"))
+	} else {
+		if _, err := semver.ParseTolerant(validator.TalosVersion); err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("version should be in semver format: %w", err))
+		}
+
+		if validator.RequireVPrefixOnTalosVersionCheck {
+			if !strings.HasPrefix(validator.TalosVersion, "v") {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("version should start with 'v'"))
+			}
+		}
+	}
+
+	if multiErr != nil {
+		return fmt.Errorf("error validating Talos version: %w", multiErr)
+	}
+
+	return nil
+}
+
+func (validator ClusterValidator) validateEncryption() error {
+	if !validator.EncryptionEnabled {
+		return nil
+	}
+
+	var (
+		encryptionSupport = semver.MustParse("1.5.0")
+		version           semver.Version
+		err               error
+	)
+
+	if version, err = semver.ParseTolerant(validator.TalosVersion); err != nil {
+		return err
+	}
+
+	if version.Compare(encryptionSupport) < 0 {
+		return errors.New("disk encryption is supported only for Talos version >= 1.5.0")
+	}
+
+	return nil
 }

--- a/client/pkg/template/template_test.go
+++ b/client/pkg/template/template_test.go
@@ -233,7 +233,11 @@ machine:
 		{
 			name: "clusterInvalid4",
 			data: clusterInvalid4,
-			expectedError: `1 error occurred:
+			expectedError: `2 errors occurred:
+	* error validating cluster "my-first-cluster": 1 error occurred:
+	* disk encryption is supported only for Talos version >= 1.5.0
+
+
 	* workers is invalid: 1 error occurred:
 	* machine set can not have both machines and machine class defined`,
 		},

--- a/client/pkg/template/testdata/cluster1-resources.yaml
+++ b/client/pkg/template/testdata/cluster1-resources.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
     installimage: ""
     kubernetesversion: 1.18.2
-    talosversion: 1.3.0
+    talosversion: 1.5.0
     features:
         enableworkloadproxy: false
         diskencryption: true

--- a/client/pkg/template/testdata/cluster1.yaml
+++ b/client/pkg/template/testdata/cluster1.yaml
@@ -3,7 +3,7 @@ name: my-first-cluster
 kubernetes:
   version: v1.18.2
 talos:
-  version: v1.3.0
+  version: v1.5.0
 features:
   diskEncryption: true
 patches:


### PR DESCRIPTION
Move the cluster validations which do not require server-side information (access to resources) to a common place.

Use this new validator both from the server side validations and from the cluster templates validations.

This makes the validations consistent, resolving the inconsistency where cluster names (ID) were validated on templates but not by the server.

Closes #1198.