### PR TITLE
test: use latest Talemu infra provider version in the integration tests

### DIFF
--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -29,7 +29,7 @@ RUN_DIR=$(pwd)
 ENABLE_SECUREBOOT=${ENABLE_SECUREBOOT:-false}
 KERNEL_ARGS_WORKERS_COUNT=2
 TALEMU_CONTAINER_NAME=talemu
-TALEMU_INFRA_PROVIDER_IMAGE=ghcr.io/unix4ever/talemu-infra-provider:v1.8.0-alpha.1-19-g52c73bc-dirty
+TALEMU_INFRA_PROVIDER_IMAGE=ghcr.io/siderolabs/talemu-infra-provider:latest
 TEST_OUTPUTS_DIR=/tmp/integration-test
 
 mkdir -p $TEST_OUTPUTS_DIR


### PR DESCRIPTION
The latest Talemu got updated to support new infra provider schema.

As Talemu registers itself (apart from the other providers), it needs to be able to create `infra.Provider` resource, which was introduced in the latest Omni. Which was kinda chicken and egg problem as Omni needed updated Talemu for the tests to pass, that's why it had this temp override.