### PR TITLE
fix: properly detect infra provider service accounts

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -12,7 +12,7 @@ policies:
           gitHubOrganization: siderolabs
       spellcheck:
         locale: US
-      maximumOfOneCommit: true
+      maximumOfOneCommit: false 
       header:
         length: 89
         imperative: true

--- a/client/pkg/access/serviceaccount.go
+++ b/client/pkg/access/serviceaccount.go
@@ -20,8 +20,8 @@ const (
 	// InfraProviderServiceAccountPrefix is the prefix required for infra provider service accounts.
 	InfraProviderServiceAccountPrefix = "infra-provider:"
 
-	// infraProviderServiceAccountNameSuffix is appended to the name of all infra provider service accounts.
-	infraProviderServiceAccountNameSuffix = "@" + infraProviderServiceAccountDomain
+	// InfraProviderServiceAccountNameSuffix is appended to the name of all infra provider service accounts.
+	InfraProviderServiceAccountNameSuffix = "@" + infraProviderServiceAccountDomain
 )
 
 // ServiceAccount represents a service account.
@@ -71,7 +71,7 @@ func ParseServiceAccountFromName(name string) ServiceAccount {
 	if strings.HasPrefix(name, InfraProviderServiceAccountPrefix) {
 		isInfraProvider = true
 		baseName = strings.TrimPrefix(name, InfraProviderServiceAccountPrefix)
-		suffix = infraProviderServiceAccountNameSuffix
+		suffix = InfraProviderServiceAccountNameSuffix
 	}
 
 	return ServiceAccount{
@@ -88,7 +88,7 @@ func ParseServiceAccountFromName(name string) ServiceAccount {
 // Result: ServiceAccount{BaseName: "aws-1", Suffix: "@infra-provider.serviceaccount.omni.sidero.dev", IsInfraProvider: true}.
 func ParseServiceAccountFromFullID(fullID string) (sa ServiceAccount, isSa bool) {
 	hasServiceAccountSuffix := strings.HasSuffix(fullID, ServiceAccountNameSuffix)
-	hasInfraProviderServiceAccountSuffix := strings.HasSuffix(fullID, infraProviderServiceAccountNameSuffix)
+	hasInfraProviderServiceAccountSuffix := strings.HasSuffix(fullID, InfraProviderServiceAccountNameSuffix)
 
 	if !hasServiceAccountSuffix && !hasInfraProviderServiceAccountSuffix {
 		return ServiceAccount{}, false
@@ -99,7 +99,7 @@ func ParseServiceAccountFromFullID(fullID string) (sa ServiceAccount, isSa bool)
 
 	if hasInfraProviderServiceAccountSuffix {
 		isInfraProvider = true
-		suffix = infraProviderServiceAccountNameSuffix
+		suffix = InfraProviderServiceAccountNameSuffix
 	}
 
 	return ServiceAccount{

--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -29,7 +29,7 @@ RUN_DIR=$(pwd)
 ENABLE_SECUREBOOT=${ENABLE_SECUREBOOT:-false}
 KERNEL_ARGS_WORKERS_COUNT=2
 TALEMU_CONTAINER_NAME=talemu
-TALEMU_INFRA_PROVIDER_IMAGE=ghcr.io/unix4ever/talemu-infra-provider:v1.8.0-alpha.1-19-g52c73bc-dirty
+TALEMU_INFRA_PROVIDER_IMAGE=ghcr.io/siderolabs/talemu-infra-provider:latest
 TEST_OUTPUTS_DIR=/tmp/integration-test
 
 mkdir -p $TEST_OUTPUTS_DIR

--- a/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
+	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+	"github.com/siderolabs/omni/internal/pkg/auth/role"
+)
+
+type ClusterServiceAccountStatusSuite struct {
+	OmniSuite
+}
+
+func (suite *ClusterServiceAccountStatusSuite) TestReconcile() {
+	require := suite.Require()
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
+	defer cancel()
+
+	suite.startRuntime()
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewServiceAccountStatusController()))
+
+	infraProviderServiceAccount := auth.NewIdentity(resources.DefaultNamespace, "p1"+access.InfraProviderServiceAccountNameSuffix)
+	infraProviderServiceAccount.TypedSpec().Value.UserId = "user2"
+	infraProviderServiceAccount.Metadata().Labels().Set(auth.LabelIdentityTypeServiceAccount, "")
+
+	serviceAccount := auth.NewIdentity(resources.DefaultNamespace, "u1"+access.ServiceAccountNameSuffix)
+	serviceAccount.TypedSpec().Value.UserId = "user1"
+	serviceAccount.Metadata().Labels().Set(auth.LabelIdentityTypeServiceAccount, "")
+
+	userIdentity := auth.NewIdentity(resources.DefaultNamespace, "p1")
+	userIdentity.TypedSpec().Value.UserId = "user1"
+
+	user1 := auth.NewUser(resources.DefaultNamespace, serviceAccount.TypedSpec().Value.UserId)
+	user1.TypedSpec().Value.Role = string(role.Admin)
+
+	user2 := auth.NewUser(resources.DefaultNamespace, infraProviderServiceAccount.TypedSpec().Value.UserId)
+	user2.TypedSpec().Value.Role = string(role.InfraProvider)
+
+	publicKey := auth.NewPublicKey(resources.DefaultNamespace, "asdf")
+	publicKey.Metadata().Labels().Set(auth.LabelPublicKeyUserID, user1.Metadata().ID())
+	publicKey.TypedSpec().Value.Identity = &specs.Identity{
+		Email: serviceAccount.Metadata().ID(),
+	}
+
+	require.NoError(suite.state.Create(suite.ctx, infraProviderServiceAccount))
+	require.NoError(suite.state.Create(suite.ctx, serviceAccount))
+	require.NoError(suite.state.Create(suite.ctx, userIdentity))
+
+	require.NoError(suite.state.Create(suite.ctx, user1))
+	require.NoError(suite.state.Create(suite.ctx, user2))
+
+	require.NoError(suite.state.Create(suite.ctx, publicKey))
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{serviceAccount.Metadata().ID()}, func(res *auth.ServiceAccountStatus, assert *assert.Assertions) {
+		assert.Equal(string(role.Admin), res.TypedSpec().Value.Role)
+		assert.Len(res.TypedSpec().Value.PublicKeys, 1)
+	})
+
+	rtestutils.AssertNoResource[*auth.ServiceAccountStatus](ctx, suite.T(), suite.state, userIdentity.Metadata().ID())
+	rtestutils.AssertNoResource[*auth.ServiceAccountStatus](ctx, suite.T(), suite.state, infraProviderServiceAccount.Metadata().ID())
+
+	rtestutils.Destroy[*auth.PublicKey](ctx, suite.T(), suite.state, []string{publicKey.Metadata().ID()})
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{serviceAccount.Metadata().ID()}, func(res *auth.ServiceAccountStatus, assert *assert.Assertions) {
+		assert.Equal(string(role.Admin), res.TypedSpec().Value.Role)
+		assert.Len(res.TypedSpec().Value.PublicKeys, 0)
+	})
+
+	require.NoError(suite.state.Create(suite.ctx, publicKey))
+
+	rtestutils.Destroy[*auth.Identity](ctx, suite.T(), suite.state, []string{serviceAccount.Metadata().ID()})
+	rtestutils.Destroy[*auth.PublicKey](ctx, suite.T(), suite.state, []string{publicKey.Metadata().ID()})
+}
+
+func TestClusterServiceAccountStatusSuite(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, new(ClusterServiceAccountStatusSuite))
+}

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -40,6 +40,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
@@ -2083,9 +2084,9 @@ func (suite *MigrationSuite) TestCreateProviders() {
 	p3status := infra.NewProviderStatus("p3")
 	p3status.Metadata().SetPhase(resource.PhaseTearingDown)
 
-	identity1 := authres.NewIdentity(resources.DefaultNamespace, "infra-provider:p1")
-	identity4 := authres.NewIdentity(resources.DefaultNamespace, "infra-provider:p4")
-	identityServiceAccount := authres.NewIdentity(resources.DefaultNamespace, "p5")
+	identity1 := authres.NewIdentity(resources.DefaultNamespace, "p1"+access.InfraProviderServiceAccountNameSuffix)
+	identity4 := authres.NewIdentity(resources.DefaultNamespace, "p4"+access.InfraProviderServiceAccountNameSuffix)
+	identityServiceAccount := authres.NewIdentity(resources.DefaultNamespace, "p5"+access.ServiceAccountNameSuffix)
 
 	suite.Require().NoError(suite.state.Create(ctx, p1status))
 	suite.Require().NoError(suite.state.Create(ctx, p2status))

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1786,7 +1786,7 @@ func createProviders(ctx context.Context, st state.State, logger *zap.Logger, _ 
 						return false
 					}
 
-					if res.Metadata().Type() == auth.IdentityType && !strings.HasPrefix(res.Metadata().ID(), access.InfraProviderServiceAccountPrefix) {
+					if res.Metadata().Type() == auth.IdentityType && !strings.HasSuffix(res.Metadata().ID(), access.InfraProviderServiceAccountNameSuffix) {
 						return false
 					}
 
@@ -1795,7 +1795,9 @@ func createProviders(ctx context.Context, st state.State, logger *zap.Logger, _ 
 			),
 			func(res resource.Resource) string {
 				if res.Metadata().Type() == auth.IdentityType {
-					return strings.TrimPrefix(res.Metadata().ID(), access.InfraProviderServiceAccountPrefix)
+					sa, _ := access.ParseServiceAccountFromFullID(res.Metadata().ID())
+
+					return sa.BaseName
 				}
 
 				return res.Metadata().ID()


### PR DESCRIPTION
The suffix should be checked there, not prefix.
Also write the tests to verify service account status controller. Found couple more issues with the finalizers flow in the controller.


(cherry picked from commit e5d1b4b0837c3cae9a1ae2347fdc9cf71a35f4fe)