### PR TITLE
fix: make sure `powering on` stage is correctly set on infra machines

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -6875,7 +6875,9 @@ type MachineStatusSpec_Schematic struct {
 	// FullId is the full id of the schematic - including the kernel command line arguments, META content etc.
 	//
 	// It is used instead of Id primarily when the machine has secure boot enabled.
-	FullId        string `protobuf:"bytes,9,opt,name=full_id,json=fullId,proto3" json:"full_id,omitempty"`
+	FullId string `protobuf:"bytes,9,opt,name=full_id,json=fullId,proto3" json:"full_id,omitempty"`
+	// InAgentMode indicates that the machine is running in agent mode.
+	InAgentMode   bool `protobuf:"varint,10,opt,name=in_agent_mode,json=inAgentMode,proto3" json:"in_agent_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6964,6 +6966,13 @@ func (x *MachineStatusSpec_Schematic) GetFullId() string {
 		return x.FullId
 	}
 	return ""
+}
+
+func (x *MachineStatusSpec_Schematic) GetInAgentMode() bool {
+	if x != nil {
+		return x.InAgentMode
+	}
+	return false
 }
 
 type MachineStatusSpec_Diagnostic struct {
@@ -8740,7 +8749,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x05image\x18\x02 \x01(\tR\x05image\"3\n" +
 	"\tMetaValue\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\rR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"\xfa\x17\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"\x9e\x18\n" +
 	"\x11MachineStatusSpec\x12#\n" +
 	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12C\n" +
 	"\bhardware\x18\x02 \x01(\v2'.specs.MachineStatusSpec.HardwareStatusR\bhardware\x12@\n" +
@@ -8820,7 +8829,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"instanceId\x12\x1f\n" +
 	"\vprovider_id\x18\a \x01(\tR\n" +
 	"providerId\x12\x12\n" +
-	"\x04spot\x18\b \x01(\bR\x04spot\x1a\x9f\x02\n" +
+	"\x04spot\x18\b \x01(\bR\x04spot\x1a\xc3\x02\n" +
 	"\tSchematic\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\ainvalid\x18\x02 \x01(\bR\ainvalid\x12\x1e\n" +
@@ -8833,7 +8842,9 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"kernelArgs\x121\n" +
 	"\vmeta_values\x18\b \x03(\v2\x10.specs.MetaValueR\n" +
 	"metaValues\x12\x17\n" +
-	"\afull_id\x18\t \x01(\tR\x06fullIdJ\x04\b\x05\x10\x06\x1aP\n" +
+	"\afull_id\x18\t \x01(\tR\x06fullId\x12\"\n" +
+	"\rin_agent_mode\x18\n" +
+	" \x01(\bR\vinAgentModeJ\x04\b\x05\x10\x06\x1aP\n" +
 	"\n" +
 	"Diagnostic\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -182,6 +182,9 @@ message MachineStatusSpec {
     //
     // It is used instead of Id primarily when the machine has secure boot enabled.
     string full_id = 9;
+
+    // InAgentMode indicates that the machine is running in agent mode.
+    bool in_agent_mode = 10;
   }
 
   message Diagnostic {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -294,6 +294,7 @@ func (m *MachineStatusSpec_Schematic) CloneVT() *MachineStatusSpec_Schematic {
 	r.InitialSchematic = m.InitialSchematic
 	r.Overlay = m.Overlay.CloneVT()
 	r.FullId = m.FullId
+	r.InAgentMode = m.InAgentMode
 	if rhs := m.Extensions; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -2993,6 +2994,9 @@ func (this *MachineStatusSpec_Schematic) EqualVT(that *MachineStatusSpec_Schemat
 		}
 	}
 	if this.FullId != that.FullId {
+		return false
+	}
+	if this.InAgentMode != that.InAgentMode {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -6760,6 +6764,16 @@ func (m *MachineStatusSpec_Schematic) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.InAgentMode {
+		i--
+		if m.InAgentMode {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x50
 	}
 	if len(m.FullId) > 0 {
 		i -= len(m.FullId)
@@ -13129,6 +13143,9 @@ func (m *MachineStatusSpec_Schematic) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.InAgentMode {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -17684,6 +17701,26 @@ func (m *MachineStatusSpec_Schematic) UnmarshalVT(dAtA []byte) error {
 			}
 			m.FullId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InAgentMode", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.InAgentMode = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -263,6 +263,7 @@ export type MachineStatusSpecSchematic = {
   kernel_args?: string[]
   meta_values?: MetaValue[]
   full_id?: string
+  in_agent_mode?: boolean
 }
 
 export type MachineStatusSpecDiagnostic = {

--- a/internal/backend/powerstage/watcher.go
+++ b/internal/backend/powerstage/watcher.go
@@ -20,79 +20,139 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
+// WatcherOptions contains additional options for the Watcher.
+type WatcherOptions struct {
+	// StartCh will be closed when the watcher starts running.
+	StartCh chan<- struct{}
+
+	// PostHandleNotifyCh is a channel to send a copy of raw state.Event notifications after they are processed.
+	PostHandleNotifyCh chan<- state.Event
+}
+
 // Watcher watches the infra.MachineStatus resources and sends MachineStatusSnapshot resources with the power stage information to the snapshot channel.
 type Watcher struct {
 	state      state.State
 	snapshotCh chan<- *omni.MachineStatusSnapshot
 	logger     *zap.Logger
+	options    WatcherOptions
 }
 
 // NewWatcher creates a new Watcher.
-func NewWatcher(state state.State, snapshotCh chan<- *omni.MachineStatusSnapshot, logger *zap.Logger) *Watcher {
+func NewWatcher(state state.State, snapshotCh chan<- *omni.MachineStatusSnapshot, logger *zap.Logger, options WatcherOptions) *Watcher {
 	return &Watcher{
 		state:      state,
 		snapshotCh: snapshotCh,
 		logger:     logger,
+		options:    options,
 	}
 }
 
 // Run runs the Watcher.
 func (watcher *Watcher) Run(ctx context.Context) error {
-	eventCh := make(chan safe.WrappedStateEvent[*infra.MachineStatus])
+	eventCh := make(chan state.Event)
 
-	if err := safe.StateWatchKind[*infra.MachineStatus](ctx, watcher.state, infra.NewMachineStatus("").Metadata(), eventCh); err != nil {
+	if err := watcher.state.WatchKind(ctx, infra.NewMachineStatus("").Metadata(), eventCh); err != nil {
 		return err
 	}
 
-	for {
-		var event safe.WrappedStateEvent[*infra.MachineStatus]
+	if err := watcher.state.WatchKind(ctx, omni.NewClusterMachine(resources.DefaultNamespace, "").Metadata(), eventCh); err != nil {
+		return fmt.Errorf("failed to watch cluster machines: %w", err)
+	}
 
+	if watcher.options.StartCh != nil {
+		close(watcher.options.StartCh)
+	}
+
+	for {
 		select {
 		case <-ctx.Done():
 			watcher.logger.Info("power status watcher stopped")
 
 			return nil
-		case event = <-eventCh:
-		}
-
-		switch event.Type() { //nolint:exhaustive
-		case state.Created, state.Updated:
-		default: // ignore other events
-			continue
-		}
-
-		if err := event.Error(); err != nil {
-			return fmt.Errorf("failed to watch machine status: %w", err)
-		}
-
-		resource, err := event.Resource()
-		if err != nil {
-			return fmt.Errorf("failed to read resource from the event: %w", err)
-		}
-
-		if resource.TypedSpec().Value.PowerState == specs.InfraMachineStatusSpec_POWER_STATE_OFF {
-			snapshot := omni.NewMachineStatusSnapshot(resources.DefaultNamespace, resource.Metadata().ID())
-
-			// find out if it is assigned to a cluster, and if so, mark it as "powering on"
-			if _, err = watcher.state.Get(ctx, omni.NewClusterMachine(resources.DefaultNamespace, resource.Metadata().ID()).Metadata()); err != nil {
-				if !state.IsNotFoundError(err) {
-					return err
-				}
-
-				snapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF
-			} else {
-				snapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERING_ON
+		case event := <-eventCh:
+			if err := watcher.handleEvent(ctx, event); err != nil {
+				return err
 			}
-
-			select {
-			case <-ctx.Done():
-				watcher.logger.Info("power status watcher stopped before sending a snapshot")
-			case watcher.snapshotCh <- snapshot:
-			}
-
-			watcher.logger.Debug("sent power stage snapshot",
-				zap.String("machine_id", resource.Metadata().ID()),
-				zap.Stringer("power_stage", snapshot.TypedSpec().Value.PowerStage))
 		}
+	}
+}
+
+func (watcher *Watcher) handleEvent(ctx context.Context, event state.Event) error {
+	defer watcher.notify(ctx, event)
+
+	var (
+		clusterMachineExists bool
+		infraMachineStatus   *infra.MachineStatus
+		err                  error
+	)
+
+	if event.Error != nil {
+		return fmt.Errorf("power status watcher failed: %w", event.Error)
+	}
+
+	switch res := event.Resource.(type) {
+	case *omni.ClusterMachine:
+		if event.Type != state.Created {
+			return nil
+		}
+
+		clusterMachineExists = true
+
+		if infraMachineStatus, err = safe.StateGetByID[*infra.MachineStatus](ctx, watcher.state, res.Metadata().ID()); err != nil && !state.IsNotFoundError(err) {
+			return fmt.Errorf("failed to get infra machine status for cluster machine %s: %w", res.Metadata().ID(), err)
+		}
+
+		if infraMachineStatus == nil {
+			return nil
+		}
+	case *infra.MachineStatus:
+		if event.Type != state.Created && event.Type != state.Updated {
+			return nil
+		}
+
+		infraMachineStatus = res
+
+		_, err = watcher.state.Get(ctx, omni.NewClusterMachine(resources.DefaultNamespace, infraMachineStatus.Metadata().ID()).Metadata())
+		if err != nil && !state.IsNotFoundError(err) {
+			return fmt.Errorf("failed to get cluster machine for infra machine status %s: %w", infraMachineStatus.Metadata().ID(), err)
+		}
+
+		clusterMachineExists = err == nil
+	}
+
+	if infraMachineStatus.TypedSpec().Value.PowerState != specs.InfraMachineStatusSpec_POWER_STATE_OFF {
+		return nil
+	}
+
+	snapshot := omni.NewMachineStatusSnapshot(resources.DefaultNamespace, infraMachineStatus.Metadata().ID())
+
+	if clusterMachineExists { // the machine is assigned to a cluster, mark it as "powering on"
+		snapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERING_ON
+	} else { // the machine is not assigned to a cluster, mark it as "powered off"
+		snapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF
+	}
+
+	select {
+	case <-ctx.Done():
+		watcher.logger.Info("power status watcher stopped before sending a snapshot")
+	case watcher.snapshotCh <- snapshot:
+	}
+
+	watcher.logger.Debug("sent power stage snapshot",
+		zap.String("machine_id", infraMachineStatus.Metadata().ID()),
+		zap.Stringer("power_stage", snapshot.TypedSpec().Value.PowerStage))
+
+	return nil
+}
+
+func (watcher *Watcher) notify(ctx context.Context, event state.Event) {
+	if watcher.options.PostHandleNotifyCh == nil {
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case watcher.options.PostHandleNotifyCh <- event:
 	}
 }

--- a/internal/backend/powerstage/watcher_test.go
+++ b/internal/backend/powerstage/watcher_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package powerstage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/powerstage"
+)
+
+func TestWatcher(t *testing.T) {
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+	snapshotCh := make(chan *omni.MachineStatusSnapshot)
+	logger := zaptest.NewLogger(t)
+
+	notifyCh := make(chan state.Event)
+	startCh := make(chan struct{})
+	watcherOpts := powerstage.WatcherOptions{
+		StartCh:            startCh,
+		PostHandleNotifyCh: notifyCh,
+	}
+
+	watcher := powerstage.NewWatcher(st, snapshotCh, logger, watcherOpts)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var eg errgroup.Group
+
+	eg.Go(func() error {
+		return watcher.Run(ctx)
+	})
+
+	expectStart(ctx, t, startCh)
+
+	status := infra.NewMachineStatus("test")
+	status.TypedSpec().Value.PowerState = specs.InfraMachineStatusSpec_POWER_STATE_OFF
+
+	require.NoError(t, st.Create(ctx, status))
+
+	expectSnapshot(ctx, t, snapshotCh, status.Metadata().ID(), specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF)
+	expectNotification(ctx, t, notifyCh)
+
+	clusterMachine := omni.NewClusterMachine(resources.DefaultNamespace, status.Metadata().ID())
+	require.NoError(t, st.Create(ctx, clusterMachine))
+
+	expectSnapshot(ctx, t, snapshotCh, clusterMachine.Metadata().ID(), specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERING_ON)
+	expectNotification(ctx, t, notifyCh)
+
+	_, err := safe.StateUpdateWithConflicts(ctx, st, clusterMachine.Metadata(), func(res *omni.ClusterMachine) error {
+		res.TypedSpec().Value.KubernetesVersion = "1.25.0"
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	expectNotification(ctx, t, notifyCh)
+
+	require.NoError(t, st.Destroy(ctx, status.Metadata()))
+
+	expectNotification(ctx, t, notifyCh)
+
+	require.NoError(t, st.Destroy(ctx, clusterMachine.Metadata()))
+
+	expectNotification(ctx, t, notifyCh)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func expectStart(ctx context.Context, t *testing.T, startCh chan struct{}) {
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "context timed out before watcher started")
+	case <-startCh:
+	}
+}
+
+func expectSnapshot(ctx context.Context, t *testing.T, ch <-chan *omni.MachineStatusSnapshot, id string, powerStage specs.MachineStatusSnapshotSpec_PowerStage) {
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "context timed out before snapshot received")
+	case snapshot := <-ch:
+		assert.Equal(t, id, snapshot.Metadata().ID())
+		assert.Equal(t, powerStage, snapshot.TypedSpec().Value.PowerStage)
+	}
+}
+
+func expectNotification(ctx context.Context, t *testing.T, notifyCh chan state.Event) {
+	select {
+	case <-ctx.Done():
+		require.Fail(t, "context timed out before notification received")
+	case <-notifyCh:
+	}
+}

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_status.go
@@ -115,6 +115,12 @@ func NewClusterMachineConfigStatusController(imageFactoryHost string) *ClusterMa
 					return xerrors.NewTagged[qtransform.SkipReconcileTag](fmt.Errorf("machine status '%s' does not have schematic information", machineConfig.Metadata().ID()))
 				}
 
+				if machineStatus.TypedSpec().Value.Schematic.InAgentMode {
+					logger.Error("machine is in agent mode, skip reconcile")
+
+					return xerrors.NewTagged[qtransform.SkipReconcileTag](fmt.Errorf("machine status '%s' schematic is in agent mode", machineConfig.Metadata().ID()))
+				}
+
 				// if the machine is managed by a static infra provider, we need to ensure that the infra machine is ready to use
 				if _, isManagedByStaticInfraProvider := machineStatus.Metadata().Labels().Get(omni.LabelIsManagedByStaticInfraProvider); isManagedByStaticInfraProvider {
 					var infraMachineStatus *infra.MachineStatus

--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
@@ -26,12 +26,13 @@ var ErrInvalidSchematic = fmt.Errorf("invalid schematic")
 
 // SchematicInfo contains the information about the schematic - the plain schematic ID and the extensions.
 type SchematicInfo struct {
-	ID         string
-	FullID     string
-	Overlay    schematic.Overlay
-	Extensions []string
-	KernelArgs []string
-	MetaValues []schematic.MetaValue
+	ID          string
+	FullID      string
+	Overlay     schematic.Overlay
+	Extensions  []string
+	KernelArgs  []string
+	MetaValues  []schematic.MetaValue
+	InAgentMode bool
 }
 
 // Equal compares schematic id with both extensions ID and Full ID.
@@ -98,8 +99,9 @@ func GetSchematicInfo(ctx context.Context, c *client.Client, defaultKernelArgs [
 		}
 
 		return SchematicInfo{
-			ID:     id,
-			FullID: id,
+			ID:          id,
+			FullID:      id,
+			InAgentMode: true,
 		}, nil
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
@@ -489,7 +489,8 @@ func pollExtensions(ctx context.Context, c *client.Client, info *Info) error {
 		return err
 	}
 
-	if schematicInfo.Overlay.Name == "" {
+	// In the agent mode, the Read API is not supported, so we can skip the overlay detection.
+	if !schematicInfo.InAgentMode && schematicInfo.Overlay.Name == "" {
 		overlay, err := detectOverlay(ctx, c)
 		if err != nil && status.Code(err) != codes.Unimplemented {
 			return err

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -511,6 +511,8 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 			} else if spec.Schematic.InitialSchematic == "" {
 				spec.Schematic.InitialSchematic = spec.Schematic.FullId
 			}
+
+			spec.Schematic.InAgentMode = event.Schematic.InAgentMode
 		}
 
 		spec.Maintenance = event.MaintenanceMode

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
@@ -424,6 +424,7 @@ func (suite *MachineStatusSuite) TestMachineSchematic() {
 				Id:               defaultSchematic,
 				InitialSchematic: defaultSchematic,
 				FullId:           defaultSchematic,
+				InAgentMode:      true,
 			},
 		},
 	} {

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -166,7 +166,7 @@ func New(talosClientFactory *talos.ClientFactory, dnsService *dns.Service, workl
 	}
 
 	powerStageEventsCh := make(chan *omni.MachineStatusSnapshot)
-	powerStageWatcher := powerstage.NewWatcher(resourceState, powerStageEventsCh, logger.With(logging.Component("power_stage_watcher")))
+	powerStageWatcher := powerstage.NewWatcher(resourceState, powerStageEventsCh, logger.With(logging.Component("power_stage_watcher")), powerstage.WatcherOptions{})
 
 	controllerRuntime, err := cosiruntime.NewRuntime(resourceState, logger, opts...)
 	if err != nil {


### PR DESCRIPTION
Power stage watcher was working by coincidence, only when waking up at the right time. This was because it was not getting notified when a machine was allocated to a cluster.

Fix this by also getting notified on `Created` events on `ClusterMachine`s. Also rework the watcher, make it testable and add a unit test for it.

Additionally: Store the agent mode info in machine status, and if it is in agent mode, skip attempting to call unsupported APIs.

Closes #1228.