### PR TITLE
fix: fix nil dereference in machine status controller

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -218,7 +218,7 @@ func (ctrl *MachineStatusController) reconcileRunning(ctx context.Context, r con
 	if inputs.machineStatusSnapshot != nil {
 		reportingEvents = true
 
-		maintenanceMode = inputs.machineStatusSnapshot.TypedSpec().Value.MachineStatus.Stage == machineapi.MachineStatusEvent_MAINTENANCE
+		maintenanceMode = inputs.machineStatusSnapshot.TypedSpec().Value.MachineStatus.GetStage() == machineapi.MachineStatusEvent_MAINTENANCE
 	}
 
 	var params *siderolink.ConnectionParams


### PR DESCRIPTION
When reconciling a `MachineStatus`, we look at the `MachineStatus` field on the `MachineStatusSnapshot` resource. This field can be nil if the snapshot contains a power stage event - i.e., when the bare-metal infra provider is used, and a power status change is happened on `InfraMachineStatus`.

Use the nil-safe getter on the spec field to avoid crashing `MachineStatusController`.

Probably closes https://github.com/siderolabs/omni-infra-provider-bare-metal/issues/55 - this I believe was most likely the issue.