### PR TITLE
fix: check config patch creation time as well as updated on orphan check

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/config_patch_cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/config_patch_cleanup.go
@@ -179,7 +179,7 @@ func (ctrl *ConfigPatchCleanupController) isOrphan(ctx context.Context, r contro
 		return false, nil
 	}
 
-	if time.Since(configPatch.Metadata().Updated()) < ctrl.DeleteOlderThan {
+	if time.Since(configPatch.Metadata().Updated()) < ctrl.DeleteOlderThan || time.Since(configPatch.Metadata().Created()) < ctrl.DeleteOlderThan {
 		return false, nil
 	}
 


### PR DESCRIPTION
In the config patch cleanup controller, we falsely assumed that the resource update time was set to be the same as the creation time.

This in very rare cases caused the cleanup controller started by the runtime in the tests to prune the config patch created by the test itself, failing it sporadically.

This should fix the rare test flake we have:

```text
#66 4.431     grpc_test.go:266:
#66 4.431         	Error Trace:	/src/internal/backend/grpc/grpc_test.go:266
#66 4.431         	Error:      	Received unexpected error:
#66 4.431         	            	rpc error: code = NotFound desc = resource ConfigPatches.omni.sidero.dev(default/1@undefined) doesn't exist
#66 4.431         	Test:       	TestGrpcSuite/TestCrud
```