### PR TITLE
fix: use `0.0.0.0:8095` as the default bind endpoint for Kubernetes

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -174,7 +174,8 @@ func InitDefault() *Params {
 				BindEndpoint: net.JoinHostPort("localhost", "8080"),
 			},
 			KubernetesProxy: KubernetesProxyService{
-				BindEndpoint: net.JoinHostPort("localhost", "8095"),
+				BindEndpoint:  net.JoinHostPort("0.0.0.0", "8095"),
+				AdvertisedURL: "https://localhost:8095",
 			},
 			Metrics: Service{
 				BindEndpoint: net.JoinHostPort("0.0.0.0", "2122"),


### PR DESCRIPTION
Previously it was `0.0.0.0:8095`. Missed that in the config rewrite.