### PR TITLE
fix: fix exposed service prefix conflict resolution

### DIFF
--- a/internal/backend/runtime/omni/controllers/helpers/helpers.go
+++ b/internal/backend/runtime/omni/controllers/helpers/helpers.go
@@ -86,6 +86,23 @@ func CopyLabels(src, dst resource.Resource, keys ...string) {
 	})
 }
 
+// SyncAllLabels synchronizes all labels from one resource to another.
+// It copies all labels from the source resource to the destination resource
+// and removes any labels from the destination resource that are not present in the source resource.
+func SyncAllLabels(src, dst resource.Resource) {
+	dst.Metadata().Labels().Do(func(tmp kvutils.TempKV) {
+		for key, value := range src.Metadata().Labels().Raw() {
+			tmp.Set(key, value)
+		}
+
+		for key := range dst.Metadata().Labels().Raw() {
+			if _, ok := src.Metadata().Labels().Get(key); !ok {
+				tmp.Delete(key)
+			}
+		}
+	})
+}
+
 // CopyAllAnnotations copies all annotations from one resource to another.
 func CopyAllAnnotations(src, dst resource.Resource) {
 	dst.Metadata().Annotations().Do(func(tmp kvutils.TempKV) {
@@ -101,6 +118,23 @@ func CopyAnnotations(src, dst resource.Resource, annotations ...string) {
 		for _, key := range annotations {
 			if label, ok := src.Metadata().Annotations().Get(key); ok {
 				tmp.Set(key, label)
+			}
+		}
+	})
+}
+
+// SyncAllAnnotations synchronizes all annotations from one resource to another.
+// It copies all annotations from the source resource to the destination resource
+// and removes any annotations from the destination resource that are not present in the source resource.
+func SyncAllAnnotations(src, dst resource.Resource) {
+	dst.Metadata().Annotations().Do(func(tmp kvutils.TempKV) {
+		for key, value := range src.Metadata().Annotations().Raw() {
+			tmp.Set(key, value)
+		}
+
+		for key := range dst.Metadata().Annotations().Raw() {
+			if _, ok := src.Metadata().Annotations().Get(key); !ok {
+				tmp.Delete(key)
 			}
 		}
 	})

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package exposedservice_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/siderolabs/omni/client/pkg/constants"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/exposedservice"
+)
+
+func TestReconcilerAddRemove(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	cluster := "test-cluster"
+	workloadProxySubdomain := "test"
+	advertisedAPIURL := "https://api.test"
+
+	var exposedServices []*omni.ExposedService
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{"default", "test-service-1", "11111", "", ""},
+		kubernetesService{"default", "test-service-2", "22222", "", ""},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2, "expected two ExposedServices to be created")
+	assert.Empty(t, exposedServices[0].TypedSpec().Value.Error)
+	assert.Empty(t, exposedServices[1].TypedSpec().Value.Error)
+
+	// remove one service
+	kubernetesServices = kubernetesServices[:1]
+
+	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 1, "expected one ExposedService to remain after removal")
+	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
+
+	// add a new service
+	kubernetesServices = append(kubernetesServices, makeKubernetesServices(kubernetesService{"default", "test-service-3", "33333", "foobar", "Some Label"})...)
+
+	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2, "expected two ExposedServices after adding a new one")
+
+	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
+	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], true)
+}
+
+func TestReconcilerConflictResolution(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	cluster := "test-cluster"
+	workloadProxySubdomain := "test"
+	advertisedAPIURL := "https://api.test"
+
+	var exposedServices []*omni.ExposedService
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{"default", "test-service-1", "11111", "testprefix", ""},
+		kubernetesService{"default", "test-service-2", "11111", "testprefix", ""},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2, "expected two ExposedServices to be created")
+	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
+	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], false)
+	assert.Contains(t, exposedServices[1].TypedSpec().Value.Error, "used by another service")
+
+	// resolve the conflict
+	kubernetesServices[0].Annotations[constants.ExposedServicePrefixAnnotationKey] = "newprefix"
+
+	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2, "expected two ExposedServices to be created after conflict resolution")
+	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
+	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], true)
+}
+
+//nolint:unparam
+func assertReconcile(t *testing.T, cluster string, svc *omni.ExposedService, kubernetesSvc *corev1.Service, success bool) {
+	t.Helper()
+
+	expectedID := cluster + "/" + kubernetesSvc.Name + "." + kubernetesSvc.Namespace
+
+	assert.Equal(t, expectedID, svc.Metadata().ID())
+
+	if !success {
+		assert.NotEmpty(t, svc.TypedSpec().Value.Error)
+
+		return
+	}
+
+	assert.Empty(t, svc.TypedSpec().Value.Error)
+	assert.Equal(t, kubernetesSvc.Annotations[constants.ExposedServicePortAnnotationKey], strconv.Itoa(int(svc.TypedSpec().Value.Port)))
+
+	prefix, ok := kubernetesSvc.Annotations[constants.ExposedServicePrefixAnnotationKey]
+	assert.Equal(t, ok, svc.TypedSpec().Value.HasExplicitAlias)
+
+	if ok {
+		assert.Contains(t, svc.TypedSpec().Value.Url, prefix)
+	}
+
+	if ok {
+		assert.True(t, svc.TypedSpec().Value.HasExplicitAlias)
+	} else {
+		assert.False(t, svc.TypedSpec().Value.HasExplicitAlias)
+	}
+
+	label := kubernetesSvc.Annotations[constants.ExposedServiceLabelAnnotationKey]
+	if label == "" {
+		label = kubernetesSvc.Name + "." + kubernetesSvc.Namespace
+	}
+
+	assert.Equal(t, label, svc.TypedSpec().Value.Label)
+}
+
+type kubernetesService struct {
+	ns, name, port, prefix, label string
+}
+
+func makeKubernetesServices(kubernetesServices ...kubernetesService) []*corev1.Service {
+	services := make([]*corev1.Service, 0, len(kubernetesServices))
+
+	for _, s := range kubernetesServices {
+		service := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: s.ns,
+				Name:      s.name,
+				Annotations: map[string]string{
+					constants.ExposedServicePortAnnotationKey: s.port,
+				},
+			},
+		}
+
+		if s.prefix != "" {
+			service.Annotations[constants.ExposedServicePrefixAnnotationKey] = s.prefix
+		}
+
+		if s.label != "" {
+			service.Annotations[constants.ExposedServiceLabelAnnotationKey] = s.label
+		}
+
+		services = append(services, &service)
+	}
+
+	return services
+}


### PR DESCRIPTION
Exposed services with user-specified (explicit) prefixes had a problem with their reconciliation in the following scenario:
- service A has explicit prefix X
- service B also has explicit prefix X -> service B is marked as in error state because the prefix X is already owned by another service
- service A is updated to have a new prefix, Y
- service B is still in the error state, until a new reconciliation is triggered (e.g., a service C is introduced or any other change)

Fix this by removing the freed prefix (X) from the "used prefixes" list during reconciliation. Add a unit test for it.

Rework the `exposedservice.Reconciler` to make it testable by simplifying it.