### PR TITLE
fix: remove `required` config validation from k8s proxy cert and key

### DIFF
--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -30,6 +30,9 @@ var backups []byte
 //go:embed testdata/unknown-keys.yaml
 var unknownKeys []byte
 
+//go:embed testdata/config-no-tls-certs.yaml
+var configNoTLSCerts []byte
+
 func TestValidateConfig(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
@@ -65,6 +68,12 @@ func TestValidateConfig(t *testing.T) {
 			name:    "unknown keys",
 			config:  unknownKeys,
 			loadErr: "unknown keys found",
+		},
+		{
+			// Having no TLS cert/key neither for the API nor for Kubernetes Proxy Server is NOT an error,
+			// as Omni might be running behind a reverse proxy that handles the TLS termination.
+			name:   "no tls certs",
+			config: configNoTLSCerts,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pkg/config/services.go
+++ b/internal/pkg/config/services.go
@@ -106,9 +106,9 @@ type KubernetesProxyService struct {
 	// This value is used in the machine join config, kernel params and schematics generation.
 	AdvertisedURL string `yaml:"advertisedURL"`
 	// CertFile is the TLS cert.
-	CertFile string `yaml:"certFile" validate:"required"`
+	CertFile string `yaml:"certFile"`
 	// KeyFile is the TLS key.
-	KeyFile string `yaml:"keyFile" validate:"required"`
+	KeyFile string `yaml:"keyFile"`
 }
 
 // GetBindEndpoint implements HTTPService.

--- a/internal/pkg/config/testdata/config-no-tls-certs.yaml
+++ b/internal/pkg/config/testdata/config-no-tls-certs.yaml
@@ -1,0 +1,31 @@
+account:
+  id:  some-id 
+  name:  some-name 
+
+services:
+  api:
+    endpoint:  localhost:8080 
+  siderolink:
+    joinTokensMode:  strict 
+  kubernetesProxy:
+    endpoint: 0.0.0.0:8095
+
+auth:
+  keyPruner:
+    interval:  10m 
+
+logs:
+  audit:
+    path:  _out/audit 
+
+storage:
+  secondary:
+    path:  _out/secondary-storage/bolt.db 
+  default:
+    kind:  etcd 
+    etcd:
+      privateKeySource: some-source
+registries:
+  talos:  factory.talos.dev 
+  kubernetes:  registry.k8s.io 
+  imageFactoryBaseURL:  https://factory.talos.dev 


### PR DESCRIPTION
- With the config rewrite, it is possible to pass cert and key file paths for the Kubernetes Proxy component specifically (only to the Kubernetes proxy), just like all the other http server components. These fields are marked as required and we validate them.

- They can only be passed through the config file, there is no command line arg defined for those.

- When they are not defined, they will fall back to the `--cert` and `--key` passed to Omni itself - to the whole Omni API cert and key.

- This is wrong, as Omni might be run without `--cert` and `--key` flags, e.g., if it is running behind a reverse proxt that handling TLS termination.

Fix this by removing the required validation annotation, and add a test for it.