### PR TITLE
fix: do more fixes on config backward-compatibility

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -107,11 +107,13 @@ var rootCmdArgs struct {
 // RootCmd returns the root command.
 func RootCmd() *cobra.Command { return initOnce() }
 
+var cmdConfig = config.InitDefault()
+
 var initOnce = sync.OnceValue(func() *cobra.Command {
 	rootCmd.Flags().BoolVar(&rootCmdArgs.debug, "debug", false, "enable debug logs.")
 
-	rootCmd.Flags().StringVar(&config.Config.Account.ID, "account-id", config.Config.Account.ID, "instance account ID, should never be changed.")
-	rootCmd.Flags().StringVar(&config.Config.Account.Name, "name", config.Config.Account.Name, "instance user-facing name.")
+	rootCmd.Flags().StringVar(&cmdConfig.Account.ID, "account-id", cmdConfig.Account.ID, "instance account ID, should never be changed.")
+	rootCmd.Flags().StringVar(&cmdConfig.Account.Name, "name", cmdConfig.Account.Name, "instance user-facing name.")
 
 	defineServiceFlags()
 	defineAuthFlags()
@@ -126,8 +128,6 @@ var initOnce = sync.OnceValue(func() *cobra.Command {
 
 	return rootCmd
 })
-
-var cmdConfig = config.InitDefault()
 
 func defineServiceFlags() {
 	// API

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -171,7 +171,8 @@ func InitDefault() *Params {
 		},
 		Services: Services{
 			API: Service{
-				BindEndpoint: net.JoinHostPort("localhost", "8080"),
+				BindEndpoint:  net.JoinHostPort("0.0.0.0", "8080"),
+				AdvertisedURL: "http://localhost:8080",
 			},
 			KubernetesProxy: KubernetesProxyService{
 				BindEndpoint:  net.JoinHostPort("0.0.0.0", "8095"),

--- a/internal/pkg/config/logs.go
+++ b/internal/pkg/config/logs.go
@@ -58,7 +58,7 @@ type ResourceLoggerConfig struct {
 	// LogLevel is the level of the logs to use when writing the data.
 	LogLevel string `yaml:"logLevel"`
 	// Types is the list of the resource types to log to stdout.
-	Types []string `yaml:"types"`
+	Types []string `yaml:"types" merge:"replace"`
 }
 
 // LogsStripe report usage metrics to stripe.

--- a/internal/pkg/config/storage.go
+++ b/internal/pkg/config/storage.go
@@ -40,7 +40,7 @@ type BoltDB struct {
 // EtcdParams defines etcd storage configs.
 type EtcdParams struct { ///nolint:govet
 	// External etcd: list of endpoints, as host:port pairs.
-	Endpoints            []string      `yaml:"endpoints"`
+	Endpoints            []string      `yaml:"endpoints" merge:"replace"`
 	DialKeepAliveTime    time.Duration `yaml:"dialKeepAliveTime"`
 	DialKeepAliveTimeout time.Duration `yaml:"dialKeepAliveTimeout"`
 	CAFile               string        `yaml:"caFile"`
@@ -53,5 +53,5 @@ type EtcdParams struct { ///nolint:govet
 	EmbeddedUnsafeFsync bool   `yaml:"embeddedUnsafeFsync"`
 
 	PrivateKeySource string   `yaml:"privateKeySource" validate:"required"`
-	PublicKeyFiles   []string `yaml:"publicKeyFiles"`
+	PublicKeyFiles   []string `yaml:"publicKeyFiles" merge:"replace"`
 }


### PR DESCRIPTION
- Make sure to write the account ID passed via `--account-id` into the correct struct so it will land into the final config as expected.

- Add `merge:"replace"` directives on a few `[]string` fields in the config, so that when the user sets overrides, they won't be merged with the base/default values. This is specifically important for the etcd endpoints, as with the default config merge behavior, we end up with an endpoint set of default + command-line args, like: `["http://localhost:2379","https://omni-etcd-0.omni-etcd.svc:2379","https://omni-etcd-1.omni-etcd.svc:2379","https://omni-etcd-2.omni-etcd.svc:2379"]`.

