### PR TITLE
feat: add jitter and lazy health checks to exposed services

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -655,6 +655,13 @@ func defineFeatureFlags() {
 		"workload proxying subdomain.",
 	)
 
+	rootCmd.Flags().DurationVar(
+		&cmdConfig.Services.WorkloadProxy.StopLBsAfter,
+		"workload-proxying-stop-lbs-after",
+		cmdConfig.Services.WorkloadProxy.StopLBsAfter,
+		"stop load balancers after this duration when workload proxying is enabled. Set to 0 to disable.",
+	)
+
 	rootCmd.Flags().BoolVar(
 		&cmdConfig.Features.EnableBreakGlassConfigs,
 		"enable-break-glass-configs",

--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -64,7 +64,8 @@ func Run(ctx context.Context, state *omni.State, config *config.Params, logger *
 	prometheus.MustRegister(talosClientFactory)
 
 	dnsService := dns.NewService(state.Default(), logger)
-	workloadProxyReconciler := workloadproxy.NewReconciler(logger.With(logging.Component("workload_proxy_reconciler")), zapcore.DebugLevel)
+	workloadProxyReconciler := workloadproxy.NewReconciler(logger.With(logging.Component("workload_proxy_reconciler")),
+		zapcore.DebugLevel, config.Services.WorkloadProxy.StopLBsAfter)
 
 	var (
 		resourceLogger *resourcelogger.Logger

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/siderolabs/go-circular v0.2.3
 	github.com/siderolabs/go-debug v0.6.0
 	github.com/siderolabs/go-kubernetes v0.2.25
-	github.com/siderolabs/go-loadbalancer v0.4.0
+	github.com/siderolabs/go-loadbalancer v0.5.0
 	github.com/siderolabs/go-pointer v1.0.1
 	github.com/siderolabs/go-procfs v0.1.2
 	github.com/siderolabs/go-retry v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/siderolabs/go-kubeconfig v0.1.1 h1:tZlgpelj/OqrcHVUwISPN0NRgObcflpH9W
 github.com/siderolabs/go-kubeconfig v0.1.1/go.mod h1:QaGp4i9L95oDbcU7jDn30aw4gnREkb3O5otgxw8imOk=
 github.com/siderolabs/go-kubernetes v0.2.25 h1:UZ2dNlgqDvGG3pyfwBJNsYCsvrMrIbDtec3w41FR91I=
 github.com/siderolabs/go-kubernetes v0.2.25/go.mod h1:iFJsycHXGtEyBDRlDyopAMS7UuzyiHeYl7lWjK8ZdxA=
-github.com/siderolabs/go-loadbalancer v0.4.0 h1:nqZC4x1yZAFAtkb7eu5T1IoPaMDKu5jgQQGkk6rZa9s=
-github.com/siderolabs/go-loadbalancer v0.4.0/go.mod h1:tRVouZ9i2R/TRbNUF9MqyBlV2wsjX0cxkYTjPXcI9P0=
+github.com/siderolabs/go-loadbalancer v0.5.0 h1:0v7E6GrxoONyqwcmHiA+J0vIDPWbkTmevHGCFb4tjdc=
+github.com/siderolabs/go-loadbalancer v0.5.0/go.mod h1:tRVouZ9i2R/TRbNUF9MqyBlV2wsjX0cxkYTjPXcI9P0=
 github.com/siderolabs/go-pointer v1.0.1 h1:f7Yi4IK1jptS8yrT9GEbwhmGcVxvPQgBUG/weH3V3DM=
 github.com/siderolabs/go-pointer v1.0.1/go.mod h1:C8Q/3pNHT4RE9e4rYR9PHeS6KPMlStRBgYrJQJNy/vA=
 github.com/siderolabs/go-procfs v0.1.2 h1:bDs9hHyYGE2HO1frpmUsD60yg80VIEDrx31fkbi4C8M=

--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -164,6 +164,7 @@ services:
   workloadProxy:
     enabled: true
     subdomain: proxy-us
+    stopLBsAfter: 15s # use a short duration to test turning lazy LBs on/off
 auth:
   auth0:
     enabled: true

--- a/internal/backend/grpc/grpc_test.go
+++ b/internal/backend/grpc/grpc_test.go
@@ -92,7 +92,7 @@ func (suite *GrpcSuite) SetupTest() {
 	imageFactoryClient, err := imagefactory.NewClient(suite.state, suite.imageFactory.address)
 	suite.Require().NoError(err)
 
-	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zap.InfoLevel)
+	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zap.InfoLevel, 30*time.Second)
 
 	suite.runtime, err = omniruntime.NewRuntime(
 		clientFactory, dnsService, workloadProxyReconciler, nil,

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -447,6 +447,7 @@ func (r *Runtime) Run(ctx context.Context, eg newgroup.EGroup) {
 	newgroup.GoWithContext(ctx, eg, makeWrap(r.talosClientFactory.StartCacheManager, "talos client factory failed"))
 	newgroup.GoWithContext(ctx, eg, makeWrap(r.dnsService.Start, "dns service failed"))
 	newgroup.GoWithContext(ctx, eg, makeWrap(r.controllerRuntime.Run, "controller runtime failed"))
+	newgroup.GoWithContext(ctx, eg, makeWrap(r.workloadProxyReconciler.Run, "workload proxy reconciler failed"))
 
 	newgroup.GoWithContext(ctx, eg, func() error { return r.storeFactory.Start(ctx, r.state, r.logger) })
 

--- a/internal/backend/runtime/omni/omni_test.go
+++ b/internal/backend/runtime/omni/omni_test.go
@@ -84,7 +84,7 @@ func (suite *OmniRuntimeSuite) SetupTest() {
 	clientFactory := talos.NewClientFactory(resourceState, logger)
 	dnsService := dns.NewService(resourceState, logger)
 	discoveryClientCache := &discoveryClientCacheMock{}
-	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel)
+	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel, 30*time.Second)
 
 	suite.runtime, err = omniruntime.NewRuntime(clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
 		omniruntime.NewMockState(resourceState), prometheus.NewRegistry(), discoveryClientCache, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))

--- a/internal/backend/runtime/omni/talosconfig_test.go
+++ b/internal/backend/runtime/omni/talosconfig_test.go
@@ -38,7 +38,7 @@ func TestOperatorTalosconfig(t *testing.T) {
 	clientFactory := talos.NewClientFactory(st.Default(), logger)
 	dnsService := dns.NewService(st.Default(), logger)
 	discoveryClientCache := &discoveryClientCacheMock{}
-	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel)
+	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel, 30*time.Second)
 
 	r, err := omniruntime.NewRuntime(clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
 		st, prometheus.NewRegistry(), discoveryClientCache, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))

--- a/internal/backend/services/workloadproxy/reconciler.go
+++ b/internal/backend/services/workloadproxy/reconciler.go
@@ -7,7 +7,9 @@ package workloadproxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -25,11 +27,18 @@ import (
 	"github.com/siderolabs/omni/internal/backend/workloadproxy/lb"
 )
 
+type loadBalancer interface {
+	Reconcile(upstreamAddresses []string) error
+	PickAddress(ctx context.Context) (string, error)
+	Notify() error
+	Shutdown()
+}
+
 const aliasClusterIDSeparator = ":"
 
 // Reconciler reconciles the load balancers for a cluster.
 type Reconciler struct {
-	clusterToAliasToLB map[resource.ID]map[string]*lb.LB
+	clusterToAliasToLB map[resource.ID]map[string]loadBalancer
 	aliasToCluster     map[string]resource.ID
 
 	logger      *zap.Logger
@@ -38,16 +47,18 @@ type Reconciler struct {
 
 	logLevel zapcore.Level
 	mu       sync.Mutex
+
+	lazyStopAfter time.Duration
 }
 
 // NewReconciler creates a new Reconciler.
-func NewReconciler(logger *zap.Logger, logLevel zapcore.Level) *Reconciler {
+func NewReconciler(logger *zap.Logger, logLevel zapcore.Level, lazyStopAfter time.Duration) *Reconciler {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 
 	return &Reconciler{
-		clusterToAliasToLB: map[resource.ID]map[string]*lb.LB{},
+		clusterToAliasToLB: map[resource.ID]map[string]loadBalancer{},
 		aliasToCluster:     map[string]resource.ID{},
 		logger:             logger,
 		lbLogger:           logger.WithOptions(zap.IncreaseLevel(zapcore.ErrorLevel)),
@@ -56,7 +67,70 @@ func NewReconciler(logger *zap.Logger, logLevel zapcore.Level) *Reconciler {
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
 		},
+		lazyStopAfter: lazyStopAfter,
 	}
+}
+
+// Run starts the reconciler, periodically notifying all load balancers to refresh their state.
+func (registry *Reconciler) Run(ctx context.Context) error {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			registry.shutdown()
+
+			return nil
+		case <-ticker.C:
+			if err := registry.notifyAll(); err != nil {
+				return fmt.Errorf("failed to notify all LBs: %w", err)
+			}
+		}
+	}
+}
+
+func (registry *Reconciler) shutdown() {
+	registry.logger.Debug("shutting down reconciler")
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	for cluster, aliasToLB := range registry.clusterToAliasToLB {
+		for alias := range aliasToLB {
+			registry.removeLB(cluster, alias)
+		}
+	}
+}
+
+func (registry *Reconciler) notifyAll() error {
+	registry.mu.Lock()
+	clusterToAliasToLB := maps.Clone(registry.clusterToAliasToLB)
+	registry.mu.Unlock()
+
+	count := 0
+
+	for _, aliasToLB := range clusterToAliasToLB {
+		for _, aliasLB := range aliasToLB {
+			if aliasLB != nil {
+				if err := aliasLB.Notify(); err != nil {
+					if errors.Is(err, lb.ErrShutdown) {
+						registry.logger.Warn("load balancer is already shut down", zap.Error(err))
+
+						continue
+					}
+
+					return err
+				}
+
+				count++
+			}
+		}
+	}
+
+	registry.logger.Debug("notified all LBs", zap.Int("count", count))
+
+	return nil
 }
 
 // Reconcile reconciles the workload proxy load balancers for a cluster.
@@ -96,27 +170,51 @@ func (registry *Reconciler) ensureLB(cluster resource.ID, alias string, upstream
 
 	if aliasLB == nil { // no LB yet, create it
 		var err error
-
-		aliasLB, err = lb.New(upstreamAddresses, registry.lbLogger,
-			upstream.WithHealthcheckTimeout(time.Second),
-			upstream.WithHealthcheckInterval(time.Minute),
-		)
-		if err != nil {
+		if aliasLB, err = registry.newLB(upstreamAddresses); err != nil {
 			return fmt.Errorf("failed to create LB for %q/%q: %w", cluster, alias, err)
 		}
 	}
 
-	aliasLB.Reconcile(upstreamAddresses)
+	if err := aliasLB.Reconcile(upstreamAddresses); err != nil {
+		return fmt.Errorf("failed to reconcile LB for %q/%q: %w", cluster, alias, err)
+	}
 
 	registry.aliasToCluster[alias] = cluster
 
 	if aliasToLB := registry.clusterToAliasToLB[cluster]; aliasToLB == nil {
-		registry.clusterToAliasToLB[cluster] = map[string]*lb.LB{}
+		registry.clusterToAliasToLB[cluster] = map[string]loadBalancer{}
 	}
 
 	registry.clusterToAliasToLB[cluster][alias] = aliasLB
 
 	return nil
+}
+
+func (registry *Reconciler) newLB(upstreamAddresses []string) (loadBalancer, error) {
+	opts := []upstream.ListOption{
+		upstream.WithHealthcheckTimeout(time.Second),
+		upstream.WithHealthcheckInterval(time.Minute),
+		upstream.WithHealthCheckJitter(0.1),
+		// Start with a zero score - we wait for the first health check to complete on .Pick(),
+		// after that is done, the score of non-healthy remotes will be negative, so it won't be picked.
+		upstream.WithInitialScore(0),
+	}
+
+	if registry.lazyStopAfter > 0 {
+		lazyLB, err := lb.NewLazy(upstreamAddresses, registry.lazyStopAfter, registry.lbLogger, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create lazy LB: %w", err)
+		}
+
+		return lazyLB, nil
+	}
+
+	newLB, err := lb.New(upstreamAddresses, registry.lbLogger, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create LB: %w", err)
+	}
+
+	return newLB, nil
 }
 
 // GetProxy returns a proxy for the exposed service, targeting the load balancer for the given alias.
@@ -168,7 +266,10 @@ func (registry *Reconciler) dialProxy(ctx context.Context, network, address stri
 	alias := parts[0]
 	clusterID := parts[1]
 
-	destAddress, err := registry.pickDestAddress(clusterID, alias)
+	pickCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	destAddress, err := registry.pickDestAddress(pickCtx, clusterID, alias)
 	if err != nil {
 		return nil, fmt.Errorf("failed to pick destination address for alias %s in cluster %s: %w", alias, clusterID, err)
 	}
@@ -176,7 +277,7 @@ func (registry *Reconciler) dialProxy(ctx context.Context, network, address stri
 	return registry.proxyDialer.DialContext(ctx, network, destAddress)
 }
 
-func (registry *Reconciler) pickDestAddress(cluster resource.ID, alias string) (string, error) {
+func (registry *Reconciler) pickDestAddress(ctx context.Context, cluster resource.ID, alias string) (string, error) {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
 
@@ -185,7 +286,7 @@ func (registry *Reconciler) pickDestAddress(cluster resource.ID, alias string) (
 		return "", fmt.Errorf("no load balancer found for cluster %s and alias %s", cluster, alias)
 	}
 
-	destAddress, err := aliasLB.PickAddress()
+	destAddress, err := aliasLB.PickAddress(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to pick address for alias %s: %w", alias, err)
 	}

--- a/internal/backend/services/workloadproxy/reconciler_test.go
+++ b/internal/backend/services/workloadproxy/reconciler_test.go
@@ -7,6 +7,7 @@ package workloadproxy_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
@@ -18,7 +19,7 @@ import (
 func TestReconciler(t *testing.T) {
 	t.Parallel()
 
-	reconciler := workloadproxy.NewReconciler(zaptest.NewLogger(t), zapcore.InfoLevel)
+	reconciler := workloadproxy.NewReconciler(zaptest.NewLogger(t), zapcore.InfoLevel, 30*time.Second)
 
 	err := reconciler.Reconcile("cluster1", map[string][]string{
 		"alias1": {

--- a/internal/backend/workloadproxy/lb/lazy.go
+++ b/internal/backend/workloadproxy/lb/lazy.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lb
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/siderolabs/go-loadbalancer/upstream"
+	"go.uber.org/zap"
+)
+
+// ErrShutdown is returned when the load balancer is already shut down and cannot be used anymore.
+var ErrShutdown = fmt.Errorf("load balancer is shut down")
+
+// Lazy wraps the regular LB and adds lazy initialization and automatic shutdown
+// after a specified duration of inactivity functionalities.
+type Lazy struct {
+	lastPickAttempt   time.Time
+	log               *zap.Logger
+	lb                *LB
+	upstreamAddresses []string
+	options           []upstream.ListOption
+	stopAfter         time.Duration
+	mu                sync.Mutex
+	isShutdown        bool
+}
+
+// NewLazy creates a new Lazy load balancer.
+func NewLazy(upstreamAddresses []string, stopAfter time.Duration, logger *zap.Logger, options ...upstream.ListOption) (*Lazy, error) {
+	if stopAfter <= 0 {
+		return nil, fmt.Errorf("invalid stopAfter value: %s", stopAfter)
+	}
+
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &Lazy{
+		upstreamAddresses: upstreamAddresses,
+		options:           options,
+		stopAfter:         stopAfter,
+		log:               logger,
+	}, nil
+}
+
+// Reconcile updates the upstream addresses and notifies the load balancer to reconcile them.
+func (l *Lazy) Reconcile(upstreamAddresses []string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.logger().Debug("reconcile")
+
+	if l.isShutdown {
+		return ErrShutdown
+	}
+
+	l.upstreamAddresses = upstreamAddresses
+
+	if l.lb != nil {
+		if err := l.lb.Reconcile(upstreamAddresses); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PickAddress picks an upstream address from the load balancer, initializing it if necessary.
+func (l *Lazy) PickAddress(ctx context.Context) (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.logger().Debug("pick address")
+
+	l.lastPickAttempt = time.Now()
+
+	if l.isShutdown {
+		return "", ErrShutdown
+	}
+
+	l.stopIfNeeded()
+
+	if len(l.upstreamAddresses) == 0 {
+		return "", upstream.ErrNoUpstreams
+	}
+
+	if err := l.init(); err != nil {
+		return "", err
+	}
+
+	return l.lb.PickAddress(ctx)
+}
+
+// Notify notifies the load balancer to refresh its internal state.
+func (l *Lazy) Notify() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.logger().Debug("notify")
+
+	if l.isShutdown {
+		return ErrShutdown
+	}
+
+	l.stopIfNeeded()
+
+	return nil
+}
+
+func (l *Lazy) stopIfNeeded() {
+	if len(l.upstreamAddresses) == 0 {
+		l.logger().Debug("no upstream addresses, stop")
+
+		l.stop()
+
+		return
+	}
+
+	if !l.lastPickAttempt.IsZero() && time.Since(l.lastPickAttempt) > l.stopAfter {
+		l.logger().Debug("inactive, stop")
+
+		l.stop()
+	}
+}
+
+// Shutdown stops the load balancer and cleans up resources.
+func (l *Lazy) Shutdown() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.logger().Debug("shutdown")
+
+	if l.isShutdown {
+		return
+	}
+
+	l.stop()
+
+	l.isShutdown = true
+}
+
+func (l *Lazy) init() error {
+	l.logger().Debug("init")
+
+	if l.lb != nil {
+		return nil
+	}
+
+	var err error
+
+	l.logger().Debug("create new LB")
+
+	l.lb, err = New(l.upstreamAddresses, l.log, l.options...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *Lazy) stop() {
+	l.logger().Debug("stop")
+
+	if l.lb == nil {
+		return
+	}
+
+	l.lb.Shutdown()
+
+	l.lb = nil
+}
+
+func (l *Lazy) logger() *zap.Logger {
+	return l.log.With(
+		zap.Strings("upstream_addresses", l.upstreamAddresses),
+		zap.Time("last_pick", l.lastPickAttempt),
+		zap.Bool("is_running", l.lb != nil),
+		zap.Duration("stop_after", l.stopAfter),
+		zap.Bool("is_shutdown", l.isShutdown),
+	)
+}

--- a/internal/backend/workloadproxy/lb/probe_all.go
+++ b/internal/backend/workloadproxy/lb/probe_all.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build !windows
+
+package lb
+
+import (
+	"net"
+	"syscall"
+)
+
+func probeDialer() *net.Dialer {
+	return &net.Dialer{
+		// The dialer reduces the TIME-WAIT period to 1 seconds instead of the OS default of 60 seconds.
+		Control: func(_, _ string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				syscall.SetsockoptLinger(int(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1}) //nolint: errcheck
+			})
+		},
+	}
+}

--- a/internal/backend/workloadproxy/lb/probe_windows.go
+++ b/internal/backend/workloadproxy/lb/probe_windows.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build windows
+
+package lb
+
+import (
+	"net"
+	"syscall"
+)
+
+func probeDialer() *net.Dialer {
+	return &net.Dialer{
+		// The dialer reduces the TIME-WAIT period to 1 seconds instead of the OS default of 60 seconds.
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				syscall.SetsockoptLinger(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &syscall.Linger{Onoff: 1, Linger: 1}) //nolint: errcheck
+			})
+		},
+	}
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -121,8 +121,9 @@ func Default() *Params {
 				LogLevel:          zapcore.WarnLevel.String(),
 			},
 			WorkloadProxy: &WorkloadProxy{
-				Subdomain: "proxy-us",
-				Enabled:   true,
+				Subdomain:    "proxy-us",
+				Enabled:      true,
+				StopLBsAfter: 5 * time.Minute,
 			},
 		},
 		Auth: Auth{

--- a/internal/pkg/config/services.go
+++ b/internal/pkg/config/services.go
@@ -227,8 +227,9 @@ type LoadBalancerService struct {
 
 // WorkloadProxy configures workload proxy.
 type WorkloadProxy struct {
-	Subdomain string `yaml:"subdomain"`
-	Enabled   bool   `yaml:"enabled"`
+	Subdomain    string        `yaml:"subdomain"`
+	Enabled      bool          `yaml:"enabled"`
+	StopLBsAfter time.Duration `yaml:"stopLBsAfter"`
 }
 
 const (


### PR DESCRIPTION
- Add jitter to the exposed service health checks, so they spread evenly even when the services are all reconciled at the exact same time.
- Add the "lazy" logic to the current workload proxy health checks by wrapping the "regular" LB with a lazy LB wrapper. With this, we gain:
  - Health checks are started only when an exposed service is attempted to be accessed ("dialed").
  - They are stopped after 5 minutes of inactivity.

Depends on siderolabs/go-loadbalancer#24.

Part of #1255.