### PR TITLE
fix: do not try running debug server in the prod builds

### DIFF
--- a/internal/backend/runtime/omni/state.go
+++ b/internal/backend/runtime/omni/state.go
@@ -96,6 +96,8 @@ func (s *State) Close() error {
 func (s *State) HandleErrors(ctx context.Context) error {
 	select {
 	case err := <-s.defaultPersistentState.errors:
+		s.logger.Error("state failed", zap.Error(err))
+
 		return err
 	case <-ctx.Done():
 	}


### PR DESCRIPTION
Otherwise the debug server stops returning `nil` and that stops the entire Omni instance.
Also refactor the fns list in the `server.go` to give more idea on which subsystem is stopped first. Otherwise it's really hard to understand what caused Omni to stop.