### PR TITLE
feat: show the actual node name in the node overview breadcrumbs

### DIFF
--- a/frontend/src/components/TBreadcrumbs.vue
+++ b/frontend/src/components/TBreadcrumbs.vue
@@ -11,7 +11,7 @@ included in the LICENSE file.
         <router-link
           v-if="idx !== breadcrumbs.length - 1"
           class="all transition"
-          :to="crumb.to"
+          :to="crumb.to!"
           >{{
             crumb.text === $route.params.machine && !!nodeName
               ? nodeName


### PR DESCRIPTION
Load the nodename from the `MachineStatus` as soon as the page loads.

Fixes: https://github.com/siderolabs/omni/issues/865