### PR TITLE
test: test updating from old Omni version to the current

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-06-09T15:23:59Z by kres 37c4809-dirty.
+# Generated on 2025-06-20T12:53:11Z by kres 5128bc1.
 
 name: default
 concurrency:
@@ -391,6 +391,87 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-forced-removal
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+            /tmp/integration-test
+          retention-days: "5"
+        continue-on-error: true
+  e2e-omni-upgrade:
+    runs-on:
+      - self-hosted
+      - omni
+    if: contains(fromJSON(needs.default.outputs.labels), 'integration/e2e') || contains(fromJSON(needs.default.outputs.labels), 'integration/e2e-omni-upgrade')
+    needs:
+      - default
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.3.1
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Mask secrets
+        run: |
+          echo "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
+      - name: Set secrets for job
+        run: |
+          sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts
+          path: _out
+      - name: Fix artifact permissions
+        run: |
+          xargs -a _out/executable-artifacts -I {} chmod +x {}
+      - name: run-integration-test
+        env:
+          INTEGRATION_PREPARE_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|OmniUpgradePrepare)$
+          INTEGRATION_RUN_E2E_TEST: "false"
+          INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(OmniUpgradeVerify)$
+          RUN_TALEMU_TESTS: "false"
+          TALEMU_TEST_ARGS: --test.run TestIntegration/Suites/(ImmediateClusterDestruction|EncryptedCluster|SinglenodeCluster|ScaleUpAndDown|ScaleUpAndDownMachineClassBasedMachineSets|TalosUpgrades|KubernetesUpgrades|MaintenanceUpgrade|ClusterTemplate|ScaleUpAndDownAutoProvisionMachineSets)$
+          WITH_DEBUG: "true"
+          WITH_RACE: "true"
+        run: |
+          sudo -E make run-integration-test
+      - name: save-integration-test-artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-e2e-omni-upgrade
           path: |-
             ~/.talos/clusters/**/*.log
             !~/.talos/clusters/**/swtpm.log

--- a/.github/workflows/e2e-omni-upgrade-cron.yaml
+++ b/.github/workflows/e2e-omni-upgrade-cron.yaml
@@ -1,0 +1,81 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2025-06-20T12:53:11Z by kres 5128bc1.
+
+name: e2e-omni-upgrade-cron
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+"on":
+  schedule:
+    - cron: 30 1 * * *
+jobs:
+  default:
+    runs-on:
+      - self-hosted
+      - omni
+    steps:
+      - name: gather-system-info
+        id: system-info
+        uses: kenchan0130/actions-system-info@v1.3.1
+        continue-on-error: true
+      - name: print-system-info
+        run: |
+          MEMORY_GB=$((${{ steps.system-info.outputs.totalmem }}/1024/1024/1024))
+
+          OUTPUTS=(
+            "CPU Core: ${{ steps.system-info.outputs.cpu-core }}"
+            "CPU Model: ${{ steps.system-info.outputs.cpu-model }}"
+            "Hostname: ${{ steps.system-info.outputs.hostname }}"
+            "NodeName: ${NODE_NAME}"
+            "Kernel release: ${{ steps.system-info.outputs.kernel-release }}"
+            "Kernel version: ${{ steps.system-info.outputs.kernel-version }}"
+            "Name: ${{ steps.system-info.outputs.name }}"
+            "Platform: ${{ steps.system-info.outputs.platform }}"
+            "Release: ${{ steps.system-info.outputs.release }}"
+            "Total memory: ${MEMORY_GB} GB"
+          )
+
+          for OUTPUT in "${OUTPUTS[@]}";do
+            echo "${OUTPUT}"
+          done
+        continue-on-error: true
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Unshallow
+        run: |
+          git fetch --prune --unshallow
+      - name: Set up Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkit-amd64.ci.svc.cluster.local:1234
+        timeout-minutes: 10
+      - name: Mask secrets
+        run: |
+          echo "$(sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | "::add-mask::" + .value')"
+      - name: Set secrets for job
+        run: |
+          sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
+      - name: run-integration-test
+        env:
+          INTEGRATION_PREPARE_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|OmniUpgradePrepare)$
+          INTEGRATION_RUN_E2E_TEST: "false"
+          INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(OmniUpgradeVerify)$
+          RUN_TALEMU_TESTS: "false"
+          TALEMU_TEST_ARGS: --test.run TestIntegration/Suites/(ImmediateClusterDestruction|EncryptedCluster|SinglenodeCluster|ScaleUpAndDown|ScaleUpAndDownMachineClassBasedMachineSets|TalosUpgrades|KubernetesUpgrades|MaintenanceUpgrade|ClusterTemplate|ScaleUpAndDownAutoProvisionMachineSets)$
+          WITH_DEBUG: "true"
+          WITH_RACE: "true"
+        run: |
+          sudo -E make run-integration-test
+      - name: save-integration-test-artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test
+          path: |-
+            ~/.talos/clusters/**/*.log
+            !~/.talos/clusters/**/swtpm.log
+            /tmp/integration-test
+          retention-days: "5"

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-05-30T19:29:08Z by kres 9f64b0d-dirty.
+# Generated on 2025-06-20T12:04:15Z by kres 5128bc1.
 
 name: slack-notify
 "on":
@@ -15,6 +15,7 @@ name: slack-notify
       - e2e-templates-cron
       - e2e-backups-cron
       - e2e-workload-proxy-cron
+      - e2e-omni-upgrade-cron
     types:
       - completed
 jobs:

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -311,6 +311,19 @@ spec:
           INTEGRATION_RUN_E2E_TEST: "false"
           INTEGRATION_TEST_ARGS: "--test.run TestIntegration/Suites/(CleanState|WorkloadProxy)$"
           RUN_TALEMU_TESTS: false
+      - name: e2e-omni-upgrade
+        crons:
+          - '30 1 * * *'
+        runnerLabels:
+          - omni
+        triggerLabels:
+          - integration/e2e
+          - integration/e2e-omni-upgrade
+        environmentOverride:
+          INTEGRATION_RUN_E2E_TEST: "false"
+          INTEGRATION_PREPARE_TEST_ARGS: "--test.run TestIntegration/Suites/(CleanState|OmniUpgradePrepare)$"
+          INTEGRATION_TEST_ARGS: "--test.run TestIntegration/Suites/(OmniUpgradeVerify)$"
+          RUN_TALEMU_TESTS: false
 ---
 kind: common.Build
 spec:

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -233,6 +233,8 @@ func TestIntegration(t *testing.T) {
 		t.Run("ClusterTemplate", testClusterTemplate(testOptions))
 		t.Run("WorkloadProxy", testWorkloadProxy(testOptions))
 		t.Run("StaticInfraProvider", testStaticInfraProvider(testOptions))
+		t.Run("OmniUpgradePrepare", testOmniUpgradePrepare(testOptions))
+		t.Run("OmniUpgradeVerify", testOmniUpgradeVerify(testOptions))
 	})
 
 	postRunHooks(t, testOptions)

--- a/internal/integration/omni_upgrade_test.go
+++ b/internal/integration/omni_upgrade_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/omni/client/pkg/client"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const annotationSnapshot = "snapshot"
+
+type clusterSnapshot struct {
+	Versions  map[string]string
+	BootTimes map[string]time.Time
+}
+
+func (vs clusterSnapshot) saveVersion(res resource.Resource) {
+	vs.Versions[res.Metadata().Type()+"/"+res.Metadata().ID()] = res.Metadata().Version().Next().String()
+}
+
+func (vs clusterSnapshot) getVersion(res resource.Resource) (string, bool) {
+	val, ok := vs.Versions[res.Metadata().Type()+"/"+res.Metadata().ID()]
+
+	return val, ok
+}
+
+// SaveClusterSnapshot saves resources versions as the annotations for the given cluster.
+func SaveClusterSnapshot(testCtx context.Context, client *client.Client, clusterName string) TestFunc {
+	return func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(testCtx, time.Minute)
+		defer cancel()
+
+		st := client.Omni().State()
+
+		snapshot := clusterSnapshot{
+			Versions:  map[string]string{},
+			BootTimes: map[string]time.Time{},
+		}
+
+		ids := rtestutils.ResourceIDs[*omni.RedactedClusterMachineConfig](ctx, t, st,
+			state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, clusterName)),
+		)
+
+		rtestutils.AssertResources(ctx, t, st, ids, func(res *omni.RedactedClusterMachineConfig, _ *assert.Assertions) {
+			snapshot.saveVersion(res)
+		})
+
+		require := require.New(t)
+		assert := assert.New(t)
+
+		data, err := client.Management().Talosconfig(ctx)
+		require.NoError(err)
+		assert.NotEmpty(data)
+
+		config, err := clientconfig.FromBytes(data)
+		require.NoError(err)
+
+		c, err := talosclient.New(ctx, talosclient.WithConfig(config), talosclient.WithCluster(clusterName))
+		require.NoError(err)
+
+		t.Cleanup(func() {
+			require.NoError(c.Close())
+		})
+
+		machineIDs := rtestutils.ResourceIDs[*omni.ClusterMachine](ctx, t, client.Omni().State(),
+			state.WithLabelQuery(
+				resource.LabelEqual(omni.LabelCluster, clusterName),
+				resource.LabelExists(omni.LabelControlPlaneRole),
+			),
+		)
+
+		for _, machineID := range machineIDs {
+			var ms *runtime.MachineStatus
+
+			ms, err = safe.ReaderGetByID[*runtime.MachineStatus](talosclient.WithNode(ctx, machineID), c.COSI, runtime.MachineStatusID)
+
+			require.NoError(err)
+
+			snapshot.BootTimes[machineID] = ms.Metadata().Created()
+		}
+
+		snapshotData, err := json.Marshal(snapshot)
+
+		require.NoError(err)
+
+		_, err = safe.StateUpdateWithConflicts(ctx,
+			client.Omni().State(),
+			omni.NewCluster(resources.DefaultNamespace, clusterName).Metadata(),
+			func(res *omni.Cluster) error {
+				res.Metadata().Annotations().Set(annotationSnapshot, string(snapshotData))
+
+				return nil
+			},
+		)
+
+		require.NoError(err)
+	}
+}
+
+// AssertClusterSnapshot reads the snapshot from the cluster resource and asserts that versions did not change
+// and the last events still can be found in the node events.
+func AssertClusterSnapshot(testCtx context.Context, client *client.Client, clusterName string) TestFunc {
+	return func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(testCtx, time.Minute)
+		defer cancel()
+
+		st := client.Omni().State()
+
+		require := require.New(t)
+
+		var snapshot clusterSnapshot
+
+		cluster, err := safe.ReaderGetByID[*omni.Cluster](ctx, st, clusterName)
+		require.NoError(err)
+
+		snapshotData, ok := cluster.Metadata().Annotations().Get(annotationSnapshot)
+
+		require.True(ok, "cluster does not have snapshot annotation")
+
+		require.NoError(json.Unmarshal([]byte(snapshotData), &snapshot))
+
+		ids := rtestutils.ResourceIDs[*omni.RedactedClusterMachineConfig](ctx, t, st,
+			state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, clusterName)),
+		)
+
+		rtestutils.AssertResources(ctx, t, st, ids, func(res *omni.RedactedClusterMachineConfig, assert *assert.Assertions) {
+			version, ok := snapshot.getVersion(res)
+
+			assert.True(ok)
+			require.Equal(version, res.Metadata().Version().String())
+		})
+
+		data, err := client.Management().Talosconfig(ctx)
+		require.NoError(err)
+		assert.NotEmpty(t, data)
+
+		config, err := clientconfig.FromBytes(data)
+		require.NoError(err)
+
+		c, err := talosclient.New(ctx, talosclient.WithConfig(config), talosclient.WithCluster(clusterName))
+		require.NoError(err)
+
+		t.Cleanup(func() {
+			require.NoError(c.Close())
+		})
+
+		for machineID, bootTime := range snapshot.BootTimes {
+			var ms *runtime.MachineStatus
+
+			ms, err = safe.ReaderGetByID[*runtime.MachineStatus](talosclient.WithNode(ctx, machineID), c.COSI, runtime.MachineStatusID)
+
+			require.NoError(err)
+
+			require.True(ms.TypedSpec().Status.Ready)
+			require.Equal(runtime.MachineStageRunning, ms.TypedSpec().Stage)
+
+			require.Equal(bootTime, ms.Metadata().Created(), "the machine was rebooted")
+		}
+	}
+}


### PR DESCRIPTION
CI will run integration tests from the previous release first, then run them from the current commit using other set of tests.

Fixes: https://github.com/siderolabs/omni/issues/1132