### PR TITLE
fix: correctly detect installation status for bare-metal machines

### DIFF
--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -149,6 +149,7 @@ import {
   PatchBaseWeightCluster,
   LabelNoManualAllocation,
   MachineStatusLabelReadyToUse,
+  MachineStatusLabelInstalled,
 } from "@/api/resources";
 import { MachineStatusSpec, TalosVersionSpec } from "@/api/omni/specs/omni.pb";
 import WatchResource, { itemID } from "@/api/watch";
@@ -299,7 +300,7 @@ const detectVersionMismatch = (machine: Resource<MachineStatusSpec>) => {
   const clusterVersion = semver.parse(state.value.cluster.talosVersion);
   const machineVersion = semver.parse(machine.spec.talos_version);
 
-  const installed = machine.spec.hardware?.blockdevices?.find(item => item.system_disk);
+  const installed = machine.metadata.labels?.[MachineStatusLabelInstalled] !== undefined;
 
   if (!machineVersion || !clusterVersion) {
     return null;

--- a/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
@@ -83,6 +83,7 @@ import {
   MachineStatusLabelReportingEvents,
   LabelNoManualAllocation,
   MachineStatusLabelReadyToUse,
+  MachineStatusLabelInstalled,
 } from "@/api/resources";
 import { showError, showSuccess } from "@/notification";
 import { useRoute, useRouter } from "vue-router";
@@ -160,7 +161,7 @@ const detectVersionMismatch = (machine: Resource<MachineStatusSpec>) => {
   const clusterVersion = semver.parse(state.value.cluster.talosVersion);
   const machineVersion = semver.parse(machine.spec.talos_version);
 
-  const installed = machine.spec.hardware?.blockdevices?.find(item => item.system_disk);
+  const installed = machine.metadata.labels?.[MachineStatusLabelInstalled] !== undefined;
 
   if (!installed) {
     if (machineVersion?.major == clusterVersion?.major && machineVersion?.minor == clusterVersion?.minor) {

--- a/frontend/src/views/omni/Machines/MachineItem.vue
+++ b/frontend/src/views/omni/Machines/MachineItem.vue
@@ -165,6 +165,7 @@ import WordHighlighter from "vue-word-highlighter";
 import { addMachineLabels, removeMachineLabels } from "@/methods/machine";
 import { canReadClusters, canReadMachineLogs, canRemoveMachines, canAccessMaintenanceNodes } from "@/methods/auth";
 import { MachineStatusSpecPowerState } from "@/api/omni/specs/omni.pb";
+import { MachineStatusLabelInstalled } from "@/api/resources";
 
 type MachineWithLinkCounter = Resource<MachineStatusLinkSpec>;
 const props = defineProps<{
@@ -271,7 +272,7 @@ const canDoMaintenanceUpdate = computed(() => {
     return false;
   }
 
-  return machine.value.spec.message_status?.hardware?.blockdevices?.findIndex(disk => disk.system_disk) !== -1;
+  return machine.value.metadata.labels?.[MachineStatusLabelInstalled] !== undefined;
 });
 
 const maintenanceUpdateDescription = computed(() => {

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/machine.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	talosschematic "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/talos"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
@@ -43,9 +44,10 @@ type SchematicInfo struct {
 
 // Info contains information gathered about a machine.
 type Info struct { //nolint:govet
-	TalosVersion  *string
-	Arch          *string
-	MachineLabels *omni.MachineLabels
+	TalosVersion       *string
+	Arch               *string
+	MachineLabels      *omni.MachineLabels
+	InfraMachineStatus *infra.MachineStatus
 
 	Hostname        *string
 	Domainname      *string
@@ -81,6 +83,7 @@ type CollectTaskSpec struct {
 
 	TalosConfig                *omni.TalosConfig
 	MachineLabels              *omni.MachineLabels
+	InfraMachineStatus         *infra.MachineStatus
 	Endpoint                   string
 	MachineID                  string
 	DefaultSchematicKernelArgs []string
@@ -372,7 +375,8 @@ func (spec CollectTaskSpec) poll(ctx context.Context, c *client.Client, pollers 
 		// set this early to make pollers act on the machine labels
 		MachineLabels: spec.MachineLabels,
 		// set this early to allow machine schematic collector to be able to fall back to the default kernel args if they cannot be read from the Talos API
-		DefaultKernelArgs: spec.DefaultSchematicKernelArgs,
+		DefaultKernelArgs:  spec.DefaultSchematicKernelArgs,
+		InfraMachineStatus: spec.InfraMachineStatus,
 	}
 
 	for _, poller := range pollers {

--- a/internal/integration/omni_upgrade_test.go
+++ b/internal/integration/omni_upgrade_test.go
@@ -17,14 +17,15 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/siderolabs/omni/client/pkg/client"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
-	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/resources/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/client"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
 const annotationSnapshot = "snapshot"


### PR DESCRIPTION
We read the block disks on the machine status if there is a system disk to detect if Talos is installed on the machine. Based on this, we allow or disallow maintenance updates.

This value might be stale when the bare-metal provider is used, as it powers off the machines when they are idle, and this causes their hw information to not be updated. So, the disk might be wiped, but machine status poller might not catch the change in the block devices before it is powered off.

Instead, take the `installed` flag on the infra.MachineStatus resource as the source of truth for the machines managed by the bare metal infra provider. Update the `installed` label based on that.

Change the logic in the frontend for installation detection to use this label instead of checking block devices directly.