### PR TITLE
feat: log and store redacted machine config diffs

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -6595,6 +6595,50 @@ func (x *InfraProviderCombinedStatusSpec) GetHealth() *InfraProviderCombinedStat
 	return nil
 }
 
+type MachineConfigDiffSpec struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Diff          string                 `protobuf:"bytes,1,opt,name=diff,proto3" json:"diff,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MachineConfigDiffSpec) Reset() {
+	*x = MachineConfigDiffSpec{}
+	mi := &file_omni_specs_omni_proto_msgTypes[86]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MachineConfigDiffSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MachineConfigDiffSpec) ProtoMessage() {}
+
+func (x *MachineConfigDiffSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_specs_omni_proto_msgTypes[86]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MachineConfigDiffSpec.ProtoReflect.Descriptor instead.
+func (*MachineConfigDiffSpec) Descriptor() ([]byte, []int) {
+	return file_omni_specs_omni_proto_rawDescGZIP(), []int{86}
+}
+
+func (x *MachineConfigDiffSpec) GetDiff() string {
+	if x != nil {
+		return x.Diff
+	}
+	return ""
+}
+
 // HardwareStatus describes machine hardware status.
 type MachineStatusSpec_HardwareStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -6612,7 +6656,7 @@ type MachineStatusSpec_HardwareStatus struct {
 
 func (x *MachineStatusSpec_HardwareStatus) Reset() {
 	*x = MachineStatusSpec_HardwareStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[86]
+	mi := &file_omni_specs_omni_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6624,7 +6668,7 @@ func (x *MachineStatusSpec_HardwareStatus) String() string {
 func (*MachineStatusSpec_HardwareStatus) ProtoMessage() {}
 
 func (x *MachineStatusSpec_HardwareStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[86]
+	mi := &file_omni_specs_omni_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6687,7 +6731,7 @@ type MachineStatusSpec_NetworkStatus struct {
 
 func (x *MachineStatusSpec_NetworkStatus) Reset() {
 	*x = MachineStatusSpec_NetworkStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[87]
+	mi := &file_omni_specs_omni_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6699,7 +6743,7 @@ func (x *MachineStatusSpec_NetworkStatus) String() string {
 func (*MachineStatusSpec_NetworkStatus) ProtoMessage() {}
 
 func (x *MachineStatusSpec_NetworkStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[87]
+	mi := &file_omni_specs_omni_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6775,7 +6819,7 @@ type MachineStatusSpec_PlatformMetadata struct {
 
 func (x *MachineStatusSpec_PlatformMetadata) Reset() {
 	*x = MachineStatusSpec_PlatformMetadata{}
-	mi := &file_omni_specs_omni_proto_msgTypes[88]
+	mi := &file_omni_specs_omni_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6787,7 +6831,7 @@ func (x *MachineStatusSpec_PlatformMetadata) String() string {
 func (*MachineStatusSpec_PlatformMetadata) ProtoMessage() {}
 
 func (x *MachineStatusSpec_PlatformMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[88]
+	mi := &file_omni_specs_omni_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6893,7 +6937,7 @@ type MachineStatusSpec_Schematic struct {
 
 func (x *MachineStatusSpec_Schematic) Reset() {
 	*x = MachineStatusSpec_Schematic{}
-	mi := &file_omni_specs_omni_proto_msgTypes[89]
+	mi := &file_omni_specs_omni_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6905,7 +6949,7 @@ func (x *MachineStatusSpec_Schematic) String() string {
 func (*MachineStatusSpec_Schematic) ProtoMessage() {}
 
 func (x *MachineStatusSpec_Schematic) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[89]
+	mi := &file_omni_specs_omni_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6995,7 +7039,7 @@ type MachineStatusSpec_Diagnostic struct {
 
 func (x *MachineStatusSpec_Diagnostic) Reset() {
 	*x = MachineStatusSpec_Diagnostic{}
-	mi := &file_omni_specs_omni_proto_msgTypes[90]
+	mi := &file_omni_specs_omni_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7007,7 +7051,7 @@ func (x *MachineStatusSpec_Diagnostic) String() string {
 func (*MachineStatusSpec_Diagnostic) ProtoMessage() {}
 
 func (x *MachineStatusSpec_Diagnostic) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[90]
+	mi := &file_omni_specs_omni_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7063,7 +7107,7 @@ type MachineStatusSpec_HardwareStatus_Processor struct {
 
 func (x *MachineStatusSpec_HardwareStatus_Processor) Reset() {
 	*x = MachineStatusSpec_HardwareStatus_Processor{}
-	mi := &file_omni_specs_omni_proto_msgTypes[92]
+	mi := &file_omni_specs_omni_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7075,7 +7119,7 @@ func (x *MachineStatusSpec_HardwareStatus_Processor) String() string {
 func (*MachineStatusSpec_HardwareStatus_Processor) ProtoMessage() {}
 
 func (x *MachineStatusSpec_HardwareStatus_Processor) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[92]
+	mi := &file_omni_specs_omni_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7139,7 +7183,7 @@ type MachineStatusSpec_HardwareStatus_MemoryModule struct {
 
 func (x *MachineStatusSpec_HardwareStatus_MemoryModule) Reset() {
 	*x = MachineStatusSpec_HardwareStatus_MemoryModule{}
-	mi := &file_omni_specs_omni_proto_msgTypes[93]
+	mi := &file_omni_specs_omni_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7151,7 +7195,7 @@ func (x *MachineStatusSpec_HardwareStatus_MemoryModule) String() string {
 func (*MachineStatusSpec_HardwareStatus_MemoryModule) ProtoMessage() {}
 
 func (x *MachineStatusSpec_HardwareStatus_MemoryModule) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[93]
+	mi := &file_omni_specs_omni_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7214,7 +7258,7 @@ type MachineStatusSpec_HardwareStatus_BlockDevice struct {
 
 func (x *MachineStatusSpec_HardwareStatus_BlockDevice) Reset() {
 	*x = MachineStatusSpec_HardwareStatus_BlockDevice{}
-	mi := &file_omni_specs_omni_proto_msgTypes[94]
+	mi := &file_omni_specs_omni_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7226,7 +7270,7 @@ func (x *MachineStatusSpec_HardwareStatus_BlockDevice) String() string {
 func (*MachineStatusSpec_HardwareStatus_BlockDevice) ProtoMessage() {}
 
 func (x *MachineStatusSpec_HardwareStatus_BlockDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[94]
+	mi := &file_omni_specs_omni_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7345,7 +7389,7 @@ type MachineStatusSpec_NetworkStatus_NetworkLinkStatus struct {
 
 func (x *MachineStatusSpec_NetworkStatus_NetworkLinkStatus) Reset() {
 	*x = MachineStatusSpec_NetworkStatus_NetworkLinkStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[95]
+	mi := &file_omni_specs_omni_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7357,7 +7401,7 @@ func (x *MachineStatusSpec_NetworkStatus_NetworkLinkStatus) String() string {
 func (*MachineStatusSpec_NetworkStatus_NetworkLinkStatus) ProtoMessage() {}
 
 func (x *MachineStatusSpec_NetworkStatus_NetworkLinkStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[95]
+	mi := &file_omni_specs_omni_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7422,7 +7466,7 @@ type ClusterSpec_Features struct {
 
 func (x *ClusterSpec_Features) Reset() {
 	*x = ClusterSpec_Features{}
-	mi := &file_omni_specs_omni_proto_msgTypes[96]
+	mi := &file_omni_specs_omni_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7434,7 +7478,7 @@ func (x *ClusterSpec_Features) String() string {
 func (*ClusterSpec_Features) ProtoMessage() {}
 
 func (x *ClusterSpec_Features) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[96]
+	mi := &file_omni_specs_omni_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7481,7 +7525,7 @@ type ClusterMachineStatusSpec_ProvisionStatus struct {
 
 func (x *ClusterMachineStatusSpec_ProvisionStatus) Reset() {
 	*x = ClusterMachineStatusSpec_ProvisionStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[97]
+	mi := &file_omni_specs_omni_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7493,7 +7537,7 @@ func (x *ClusterMachineStatusSpec_ProvisionStatus) String() string {
 func (*ClusterMachineStatusSpec_ProvisionStatus) ProtoMessage() {}
 
 func (x *ClusterMachineStatusSpec_ProvisionStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[97]
+	mi := &file_omni_specs_omni_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7538,7 +7582,7 @@ type MachineSetSpec_MachineClass struct {
 
 func (x *MachineSetSpec_MachineClass) Reset() {
 	*x = MachineSetSpec_MachineClass{}
-	mi := &file_omni_specs_omni_proto_msgTypes[98]
+	mi := &file_omni_specs_omni_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7550,7 +7594,7 @@ func (x *MachineSetSpec_MachineClass) String() string {
 func (*MachineSetSpec_MachineClass) ProtoMessage() {}
 
 func (x *MachineSetSpec_MachineClass) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[98]
+	mi := &file_omni_specs_omni_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7602,7 +7646,7 @@ type MachineSetSpec_MachineAllocation struct {
 
 func (x *MachineSetSpec_MachineAllocation) Reset() {
 	*x = MachineSetSpec_MachineAllocation{}
-	mi := &file_omni_specs_omni_proto_msgTypes[99]
+	mi := &file_omni_specs_omni_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7614,7 +7658,7 @@ func (x *MachineSetSpec_MachineAllocation) String() string {
 func (*MachineSetSpec_MachineAllocation) ProtoMessage() {}
 
 func (x *MachineSetSpec_MachineAllocation) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[99]
+	mi := &file_omni_specs_omni_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7665,7 +7709,7 @@ type MachineSetSpec_BootstrapSpec struct {
 
 func (x *MachineSetSpec_BootstrapSpec) Reset() {
 	*x = MachineSetSpec_BootstrapSpec{}
-	mi := &file_omni_specs_omni_proto_msgTypes[100]
+	mi := &file_omni_specs_omni_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7677,7 +7721,7 @@ func (x *MachineSetSpec_BootstrapSpec) String() string {
 func (*MachineSetSpec_BootstrapSpec) ProtoMessage() {}
 
 func (x *MachineSetSpec_BootstrapSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[100]
+	mi := &file_omni_specs_omni_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7719,7 +7763,7 @@ type MachineSetSpec_RollingUpdateStrategyConfig struct {
 
 func (x *MachineSetSpec_RollingUpdateStrategyConfig) Reset() {
 	*x = MachineSetSpec_RollingUpdateStrategyConfig{}
-	mi := &file_omni_specs_omni_proto_msgTypes[101]
+	mi := &file_omni_specs_omni_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7731,7 +7775,7 @@ func (x *MachineSetSpec_RollingUpdateStrategyConfig) String() string {
 func (*MachineSetSpec_RollingUpdateStrategyConfig) ProtoMessage() {}
 
 func (x *MachineSetSpec_RollingUpdateStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[101]
+	mi := &file_omni_specs_omni_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7766,7 +7810,7 @@ type MachineSetSpec_UpdateStrategyConfig struct {
 
 func (x *MachineSetSpec_UpdateStrategyConfig) Reset() {
 	*x = MachineSetSpec_UpdateStrategyConfig{}
-	mi := &file_omni_specs_omni_proto_msgTypes[102]
+	mi := &file_omni_specs_omni_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7778,7 +7822,7 @@ func (x *MachineSetSpec_UpdateStrategyConfig) String() string {
 func (*MachineSetSpec_UpdateStrategyConfig) ProtoMessage() {}
 
 func (x *MachineSetSpec_UpdateStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[102]
+	mi := &file_omni_specs_omni_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7813,7 +7857,7 @@ type ControlPlaneStatusSpec_Condition struct {
 
 func (x *ControlPlaneStatusSpec_Condition) Reset() {
 	*x = ControlPlaneStatusSpec_Condition{}
-	mi := &file_omni_specs_omni_proto_msgTypes[103]
+	mi := &file_omni_specs_omni_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7825,7 +7869,7 @@ func (x *ControlPlaneStatusSpec_Condition) String() string {
 func (*ControlPlaneStatusSpec_Condition) ProtoMessage() {}
 
 func (x *ControlPlaneStatusSpec_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[103]
+	mi := &file_omni_specs_omni_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7880,7 +7924,7 @@ type KubernetesStatusSpec_NodeStatus struct {
 
 func (x *KubernetesStatusSpec_NodeStatus) Reset() {
 	*x = KubernetesStatusSpec_NodeStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[104]
+	mi := &file_omni_specs_omni_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7892,7 +7936,7 @@ func (x *KubernetesStatusSpec_NodeStatus) String() string {
 func (*KubernetesStatusSpec_NodeStatus) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_NodeStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[104]
+	mi := &file_omni_specs_omni_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7940,7 +7984,7 @@ type KubernetesStatusSpec_StaticPodStatus struct {
 
 func (x *KubernetesStatusSpec_StaticPodStatus) Reset() {
 	*x = KubernetesStatusSpec_StaticPodStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[105]
+	mi := &file_omni_specs_omni_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7952,7 +7996,7 @@ func (x *KubernetesStatusSpec_StaticPodStatus) String() string {
 func (*KubernetesStatusSpec_StaticPodStatus) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_StaticPodStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[105]
+	mi := &file_omni_specs_omni_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7999,7 +8043,7 @@ type KubernetesStatusSpec_NodeStaticPods struct {
 
 func (x *KubernetesStatusSpec_NodeStaticPods) Reset() {
 	*x = KubernetesStatusSpec_NodeStaticPods{}
-	mi := &file_omni_specs_omni_proto_msgTypes[106]
+	mi := &file_omni_specs_omni_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8011,7 +8055,7 @@ func (x *KubernetesStatusSpec_NodeStaticPods) String() string {
 func (*KubernetesStatusSpec_NodeStaticPods) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_NodeStaticPods) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[106]
+	mi := &file_omni_specs_omni_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8055,7 +8099,7 @@ type MachineClassSpec_Provision struct {
 
 func (x *MachineClassSpec_Provision) Reset() {
 	*x = MachineClassSpec_Provision{}
-	mi := &file_omni_specs_omni_proto_msgTypes[107]
+	mi := &file_omni_specs_omni_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8067,7 +8111,7 @@ func (x *MachineClassSpec_Provision) String() string {
 func (*MachineClassSpec_Provision) ProtoMessage() {}
 
 func (x *MachineClassSpec_Provision) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[107]
+	mi := &file_omni_specs_omni_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8138,7 +8182,7 @@ type MachineConfigGenOptionsSpec_InstallImage struct {
 
 func (x *MachineConfigGenOptionsSpec_InstallImage) Reset() {
 	*x = MachineConfigGenOptionsSpec_InstallImage{}
-	mi := &file_omni_specs_omni_proto_msgTypes[108]
+	mi := &file_omni_specs_omni_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8150,7 +8194,7 @@ func (x *MachineConfigGenOptionsSpec_InstallImage) String() string {
 func (*MachineConfigGenOptionsSpec_InstallImage) ProtoMessage() {}
 
 func (x *MachineConfigGenOptionsSpec_InstallImage) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[108]
+	mi := &file_omni_specs_omni_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8219,7 +8263,7 @@ type KubernetesUsageSpec_Quantity struct {
 
 func (x *KubernetesUsageSpec_Quantity) Reset() {
 	*x = KubernetesUsageSpec_Quantity{}
-	mi := &file_omni_specs_omni_proto_msgTypes[109]
+	mi := &file_omni_specs_omni_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8231,7 +8275,7 @@ func (x *KubernetesUsageSpec_Quantity) String() string {
 func (*KubernetesUsageSpec_Quantity) ProtoMessage() {}
 
 func (x *KubernetesUsageSpec_Quantity) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[109]
+	mi := &file_omni_specs_omni_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8278,7 +8322,7 @@ type KubernetesUsageSpec_Pod struct {
 
 func (x *KubernetesUsageSpec_Pod) Reset() {
 	*x = KubernetesUsageSpec_Pod{}
-	mi := &file_omni_specs_omni_proto_msgTypes[110]
+	mi := &file_omni_specs_omni_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8290,7 +8334,7 @@ func (x *KubernetesUsageSpec_Pod) String() string {
 func (*KubernetesUsageSpec_Pod) ProtoMessage() {}
 
 func (x *KubernetesUsageSpec_Pod) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[110]
+	mi := &file_omni_specs_omni_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8330,7 +8374,7 @@ type ImagePullRequestSpec_NodeImageList struct {
 
 func (x *ImagePullRequestSpec_NodeImageList) Reset() {
 	*x = ImagePullRequestSpec_NodeImageList{}
-	mi := &file_omni_specs_omni_proto_msgTypes[111]
+	mi := &file_omni_specs_omni_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8342,7 +8386,7 @@ func (x *ImagePullRequestSpec_NodeImageList) String() string {
 func (*ImagePullRequestSpec_NodeImageList) ProtoMessage() {}
 
 func (x *ImagePullRequestSpec_NodeImageList) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[111]
+	mi := &file_omni_specs_omni_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8387,7 +8431,7 @@ type TalosExtensionsSpec_Info struct {
 
 func (x *TalosExtensionsSpec_Info) Reset() {
 	*x = TalosExtensionsSpec_Info{}
-	mi := &file_omni_specs_omni_proto_msgTypes[112]
+	mi := &file_omni_specs_omni_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8399,7 +8443,7 @@ func (x *TalosExtensionsSpec_Info) String() string {
 func (*TalosExtensionsSpec_Info) ProtoMessage() {}
 
 func (x *TalosExtensionsSpec_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[112]
+	mi := &file_omni_specs_omni_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8468,7 +8512,7 @@ type MachineExtensionsStatusSpec_Item struct {
 
 func (x *MachineExtensionsStatusSpec_Item) Reset() {
 	*x = MachineExtensionsStatusSpec_Item{}
-	mi := &file_omni_specs_omni_proto_msgTypes[113]
+	mi := &file_omni_specs_omni_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8480,7 +8524,7 @@ func (x *MachineExtensionsStatusSpec_Item) String() string {
 func (*MachineExtensionsStatusSpec_Item) ProtoMessage() {}
 
 func (x *MachineExtensionsStatusSpec_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[113]
+	mi := &file_omni_specs_omni_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8527,7 +8571,7 @@ type ClusterDiagnosticsSpec_Node struct {
 
 func (x *ClusterDiagnosticsSpec_Node) Reset() {
 	*x = ClusterDiagnosticsSpec_Node{}
-	mi := &file_omni_specs_omni_proto_msgTypes[115]
+	mi := &file_omni_specs_omni_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8539,7 +8583,7 @@ func (x *ClusterDiagnosticsSpec_Node) String() string {
 func (*ClusterDiagnosticsSpec_Node) ProtoMessage() {}
 
 func (x *ClusterDiagnosticsSpec_Node) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[115]
+	mi := &file_omni_specs_omni_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8581,7 +8625,7 @@ type InfraMachineBMCConfigSpec_IPMI struct {
 
 func (x *InfraMachineBMCConfigSpec_IPMI) Reset() {
 	*x = InfraMachineBMCConfigSpec_IPMI{}
-	mi := &file_omni_specs_omni_proto_msgTypes[116]
+	mi := &file_omni_specs_omni_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8593,7 +8637,7 @@ func (x *InfraMachineBMCConfigSpec_IPMI) String() string {
 func (*InfraMachineBMCConfigSpec_IPMI) ProtoMessage() {}
 
 func (x *InfraMachineBMCConfigSpec_IPMI) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[116]
+	mi := &file_omni_specs_omni_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8646,7 +8690,7 @@ type InfraMachineBMCConfigSpec_API struct {
 
 func (x *InfraMachineBMCConfigSpec_API) Reset() {
 	*x = InfraMachineBMCConfigSpec_API{}
-	mi := &file_omni_specs_omni_proto_msgTypes[117]
+	mi := &file_omni_specs_omni_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8658,7 +8702,7 @@ func (x *InfraMachineBMCConfigSpec_API) String() string {
 func (*InfraMachineBMCConfigSpec_API) ProtoMessage() {}
 
 func (x *InfraMachineBMCConfigSpec_API) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[117]
+	mi := &file_omni_specs_omni_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8692,7 +8736,7 @@ type InfraProviderCombinedStatusSpec_Health struct {
 
 func (x *InfraProviderCombinedStatusSpec_Health) Reset() {
 	*x = InfraProviderCombinedStatusSpec_Health{}
-	mi := &file_omni_specs_omni_proto_msgTypes[118]
+	mi := &file_omni_specs_omni_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8704,7 +8748,7 @@ func (x *InfraProviderCombinedStatusSpec_Health) String() string {
 func (*InfraProviderCombinedStatusSpec_Health) ProtoMessage() {}
 
 func (x *InfraProviderCombinedStatusSpec_Health) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[118]
+	mi := &file_omni_specs_omni_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9403,7 +9447,9 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x06Health\x12\x1c\n" +
 	"\tconnected\x18\x01 \x01(\bR\tconnected\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12 \n" +
-	"\vinitialized\x18\x03 \x01(\bR\vinitialized*F\n" +
+	"\vinitialized\x18\x03 \x01(\bR\vinitialized\"+\n" +
+	"\x15MachineConfigDiffSpec\x12\x12\n" +
+	"\x04diff\x18\x01 \x01(\tR\x04diff*F\n" +
 	"\x11ConfigApplyStatus\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aPENDING\x10\x01\x12\v\n" +
@@ -9442,7 +9488,7 @@ func file_omni_specs_omni_proto_rawDescGZIP() []byte {
 }
 
 var file_omni_specs_omni_proto_enumTypes = make([]protoimpl.EnumInfo, 22)
-var file_omni_specs_omni_proto_msgTypes = make([]protoimpl.MessageInfo, 119)
+var file_omni_specs_omni_proto_msgTypes = make([]protoimpl.MessageInfo, 120)
 var file_omni_specs_omni_proto_goTypes = []any{
 	(ConfigApplyStatus)(0),                                    // 0: specs.ConfigApplyStatus
 	(MachineSetPhase)(0),                                      // 1: specs.MachineSetPhase
@@ -9552,125 +9598,126 @@ var file_omni_specs_omni_proto_goTypes = []any{
 	(*NodeForceDestroyRequestSpec)(nil),                       // 105: specs.NodeForceDestroyRequestSpec
 	(*DiscoveryAffiliateDeleteTaskSpec)(nil),                  // 106: specs.DiscoveryAffiliateDeleteTaskSpec
 	(*InfraProviderCombinedStatusSpec)(nil),                   // 107: specs.InfraProviderCombinedStatusSpec
-	(*MachineStatusSpec_HardwareStatus)(nil),                  // 108: specs.MachineStatusSpec.HardwareStatus
-	(*MachineStatusSpec_NetworkStatus)(nil),                   // 109: specs.MachineStatusSpec.NetworkStatus
-	(*MachineStatusSpec_PlatformMetadata)(nil),                // 110: specs.MachineStatusSpec.PlatformMetadata
-	(*MachineStatusSpec_Schematic)(nil),                       // 111: specs.MachineStatusSpec.Schematic
-	(*MachineStatusSpec_Diagnostic)(nil),                      // 112: specs.MachineStatusSpec.Diagnostic
-	nil,                                                       // 113: specs.MachineStatusSpec.ImageLabelsEntry
-	(*MachineStatusSpec_HardwareStatus_Processor)(nil),        // 114: specs.MachineStatusSpec.HardwareStatus.Processor
-	(*MachineStatusSpec_HardwareStatus_MemoryModule)(nil),     // 115: specs.MachineStatusSpec.HardwareStatus.MemoryModule
-	(*MachineStatusSpec_HardwareStatus_BlockDevice)(nil),      // 116: specs.MachineStatusSpec.HardwareStatus.BlockDevice
-	(*MachineStatusSpec_NetworkStatus_NetworkLinkStatus)(nil), // 117: specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
-	(*ClusterSpec_Features)(nil),                              // 118: specs.ClusterSpec.Features
-	(*ClusterMachineStatusSpec_ProvisionStatus)(nil),          // 119: specs.ClusterMachineStatusSpec.ProvisionStatus
-	(*MachineSetSpec_MachineClass)(nil),                       // 120: specs.MachineSetSpec.MachineClass
-	(*MachineSetSpec_MachineAllocation)(nil),                  // 121: specs.MachineSetSpec.MachineAllocation
-	(*MachineSetSpec_BootstrapSpec)(nil),                      // 122: specs.MachineSetSpec.BootstrapSpec
-	(*MachineSetSpec_RollingUpdateStrategyConfig)(nil),        // 123: specs.MachineSetSpec.RollingUpdateStrategyConfig
-	(*MachineSetSpec_UpdateStrategyConfig)(nil),               // 124: specs.MachineSetSpec.UpdateStrategyConfig
-	(*ControlPlaneStatusSpec_Condition)(nil),                  // 125: specs.ControlPlaneStatusSpec.Condition
-	(*KubernetesStatusSpec_NodeStatus)(nil),                   // 126: specs.KubernetesStatusSpec.NodeStatus
-	(*KubernetesStatusSpec_StaticPodStatus)(nil),              // 127: specs.KubernetesStatusSpec.StaticPodStatus
-	(*KubernetesStatusSpec_NodeStaticPods)(nil),               // 128: specs.KubernetesStatusSpec.NodeStaticPods
-	(*MachineClassSpec_Provision)(nil),                        // 129: specs.MachineClassSpec.Provision
-	(*MachineConfigGenOptionsSpec_InstallImage)(nil),          // 130: specs.MachineConfigGenOptionsSpec.InstallImage
-	(*KubernetesUsageSpec_Quantity)(nil),                      // 131: specs.KubernetesUsageSpec.Quantity
-	(*KubernetesUsageSpec_Pod)(nil),                           // 132: specs.KubernetesUsageSpec.Pod
-	(*ImagePullRequestSpec_NodeImageList)(nil),                // 133: specs.ImagePullRequestSpec.NodeImageList
-	(*TalosExtensionsSpec_Info)(nil),                          // 134: specs.TalosExtensionsSpec.Info
-	(*MachineExtensionsStatusSpec_Item)(nil),                  // 135: specs.MachineExtensionsStatusSpec.Item
-	nil,                                                       // 136: specs.ClusterStatusMetricsSpec.PhasesEntry
-	(*ClusterDiagnosticsSpec_Node)(nil),                       // 137: specs.ClusterDiagnosticsSpec.Node
-	(*InfraMachineBMCConfigSpec_IPMI)(nil),                    // 138: specs.InfraMachineBMCConfigSpec.IPMI
-	(*InfraMachineBMCConfigSpec_API)(nil),                     // 139: specs.InfraMachineBMCConfigSpec.API
-	(*InfraProviderCombinedStatusSpec_Health)(nil),            // 140: specs.InfraProviderCombinedStatusSpec.Health
-	(*durationpb.Duration)(nil),                               // 141: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                             // 142: google.protobuf.Timestamp
-	(*machine.MachineStatusEvent)(nil),                        // 143: machine.MachineStatusEvent
+	(*MachineConfigDiffSpec)(nil),                             // 108: specs.MachineConfigDiffSpec
+	(*MachineStatusSpec_HardwareStatus)(nil),                  // 109: specs.MachineStatusSpec.HardwareStatus
+	(*MachineStatusSpec_NetworkStatus)(nil),                   // 110: specs.MachineStatusSpec.NetworkStatus
+	(*MachineStatusSpec_PlatformMetadata)(nil),                // 111: specs.MachineStatusSpec.PlatformMetadata
+	(*MachineStatusSpec_Schematic)(nil),                       // 112: specs.MachineStatusSpec.Schematic
+	(*MachineStatusSpec_Diagnostic)(nil),                      // 113: specs.MachineStatusSpec.Diagnostic
+	nil,                                                       // 114: specs.MachineStatusSpec.ImageLabelsEntry
+	(*MachineStatusSpec_HardwareStatus_Processor)(nil),        // 115: specs.MachineStatusSpec.HardwareStatus.Processor
+	(*MachineStatusSpec_HardwareStatus_MemoryModule)(nil),     // 116: specs.MachineStatusSpec.HardwareStatus.MemoryModule
+	(*MachineStatusSpec_HardwareStatus_BlockDevice)(nil),      // 117: specs.MachineStatusSpec.HardwareStatus.BlockDevice
+	(*MachineStatusSpec_NetworkStatus_NetworkLinkStatus)(nil), // 118: specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
+	(*ClusterSpec_Features)(nil),                              // 119: specs.ClusterSpec.Features
+	(*ClusterMachineStatusSpec_ProvisionStatus)(nil),          // 120: specs.ClusterMachineStatusSpec.ProvisionStatus
+	(*MachineSetSpec_MachineClass)(nil),                       // 121: specs.MachineSetSpec.MachineClass
+	(*MachineSetSpec_MachineAllocation)(nil),                  // 122: specs.MachineSetSpec.MachineAllocation
+	(*MachineSetSpec_BootstrapSpec)(nil),                      // 123: specs.MachineSetSpec.BootstrapSpec
+	(*MachineSetSpec_RollingUpdateStrategyConfig)(nil),        // 124: specs.MachineSetSpec.RollingUpdateStrategyConfig
+	(*MachineSetSpec_UpdateStrategyConfig)(nil),               // 125: specs.MachineSetSpec.UpdateStrategyConfig
+	(*ControlPlaneStatusSpec_Condition)(nil),                  // 126: specs.ControlPlaneStatusSpec.Condition
+	(*KubernetesStatusSpec_NodeStatus)(nil),                   // 127: specs.KubernetesStatusSpec.NodeStatus
+	(*KubernetesStatusSpec_StaticPodStatus)(nil),              // 128: specs.KubernetesStatusSpec.StaticPodStatus
+	(*KubernetesStatusSpec_NodeStaticPods)(nil),               // 129: specs.KubernetesStatusSpec.NodeStaticPods
+	(*MachineClassSpec_Provision)(nil),                        // 130: specs.MachineClassSpec.Provision
+	(*MachineConfigGenOptionsSpec_InstallImage)(nil),          // 131: specs.MachineConfigGenOptionsSpec.InstallImage
+	(*KubernetesUsageSpec_Quantity)(nil),                      // 132: specs.KubernetesUsageSpec.Quantity
+	(*KubernetesUsageSpec_Pod)(nil),                           // 133: specs.KubernetesUsageSpec.Pod
+	(*ImagePullRequestSpec_NodeImageList)(nil),                // 134: specs.ImagePullRequestSpec.NodeImageList
+	(*TalosExtensionsSpec_Info)(nil),                          // 135: specs.TalosExtensionsSpec.Info
+	(*MachineExtensionsStatusSpec_Item)(nil),                  // 136: specs.MachineExtensionsStatusSpec.Item
+	nil,                                                       // 137: specs.ClusterStatusMetricsSpec.PhasesEntry
+	(*ClusterDiagnosticsSpec_Node)(nil),                       // 138: specs.ClusterDiagnosticsSpec.Node
+	(*InfraMachineBMCConfigSpec_IPMI)(nil),                    // 139: specs.InfraMachineBMCConfigSpec.IPMI
+	(*InfraMachineBMCConfigSpec_API)(nil),                     // 140: specs.InfraMachineBMCConfigSpec.API
+	(*InfraProviderCombinedStatusSpec_Health)(nil),            // 141: specs.InfraProviderCombinedStatusSpec.Health
+	(*durationpb.Duration)(nil),                               // 142: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                             // 143: google.protobuf.Timestamp
+	(*machine.MachineStatusEvent)(nil),                        // 144: machine.MachineStatusEvent
 }
 var file_omni_specs_omni_proto_depIdxs = []int32{
-	108, // 0: specs.MachineStatusSpec.hardware:type_name -> specs.MachineStatusSpec.HardwareStatus
-	109, // 1: specs.MachineStatusSpec.network:type_name -> specs.MachineStatusSpec.NetworkStatus
+	109, // 0: specs.MachineStatusSpec.hardware:type_name -> specs.MachineStatusSpec.HardwareStatus
+	110, // 1: specs.MachineStatusSpec.network:type_name -> specs.MachineStatusSpec.NetworkStatus
 	4,   // 2: specs.MachineStatusSpec.role:type_name -> specs.MachineStatusSpec.Role
-	110, // 3: specs.MachineStatusSpec.platform_metadata:type_name -> specs.MachineStatusSpec.PlatformMetadata
-	113, // 4: specs.MachineStatusSpec.image_labels:type_name -> specs.MachineStatusSpec.ImageLabelsEntry
-	111, // 5: specs.MachineStatusSpec.schematic:type_name -> specs.MachineStatusSpec.Schematic
-	112, // 6: specs.MachineStatusSpec.diagnostics:type_name -> specs.MachineStatusSpec.Diagnostic
+	111, // 3: specs.MachineStatusSpec.platform_metadata:type_name -> specs.MachineStatusSpec.PlatformMetadata
+	114, // 4: specs.MachineStatusSpec.image_labels:type_name -> specs.MachineStatusSpec.ImageLabelsEntry
+	112, // 5: specs.MachineStatusSpec.schematic:type_name -> specs.MachineStatusSpec.Schematic
+	113, // 6: specs.MachineStatusSpec.diagnostics:type_name -> specs.MachineStatusSpec.Diagnostic
 	5,   // 7: specs.MachineStatusSpec.power_state:type_name -> specs.MachineStatusSpec.PowerState
 	23,  // 8: specs.MachineStatusSpec.security_state:type_name -> specs.SecurityState
-	118, // 9: specs.ClusterSpec.features:type_name -> specs.ClusterSpec.Features
+	119, // 9: specs.ClusterSpec.features:type_name -> specs.ClusterSpec.Features
 	30,  // 10: specs.ClusterSpec.backup_configuration:type_name -> specs.EtcdBackupConf
-	141, // 11: specs.EtcdBackupConf.interval:type_name -> google.protobuf.Duration
-	142, // 12: specs.EtcdBackupSpec.created_at:type_name -> google.protobuf.Timestamp
-	141, // 13: specs.BackupDataSpec.interval:type_name -> google.protobuf.Duration
+	142, // 11: specs.EtcdBackupConf.interval:type_name -> google.protobuf.Duration
+	143, // 12: specs.EtcdBackupSpec.created_at:type_name -> google.protobuf.Timestamp
+	142, // 13: specs.BackupDataSpec.interval:type_name -> google.protobuf.Duration
 	6,   // 14: specs.EtcdBackupStatusSpec.status:type_name -> specs.EtcdBackupStatusSpec.Status
-	142, // 15: specs.EtcdBackupStatusSpec.last_backup_time:type_name -> google.protobuf.Timestamp
-	142, // 16: specs.EtcdBackupStatusSpec.last_backup_attempt:type_name -> google.protobuf.Timestamp
-	142, // 17: specs.EtcdManualBackupSpec.backup_at:type_name -> google.protobuf.Timestamp
+	143, // 15: specs.EtcdBackupStatusSpec.last_backup_time:type_name -> google.protobuf.Timestamp
+	143, // 16: specs.EtcdBackupStatusSpec.last_backup_attempt:type_name -> google.protobuf.Timestamp
+	143, // 17: specs.EtcdManualBackupSpec.backup_at:type_name -> google.protobuf.Timestamp
 	36,  // 18: specs.EtcdBackupOverallStatusSpec.last_backup_status:type_name -> specs.EtcdBackupStatusSpec
 	7,   // 19: specs.ClusterMachineStatusSpec.stage:type_name -> specs.ClusterMachineStatusSpec.Stage
 	0,   // 20: specs.ClusterMachineStatusSpec.config_apply_status:type_name -> specs.ConfigApplyStatus
-	119, // 21: specs.ClusterMachineStatusSpec.provision_status:type_name -> specs.ClusterMachineStatusSpec.ProvisionStatus
+	120, // 21: specs.ClusterMachineStatusSpec.provision_status:type_name -> specs.ClusterMachineStatusSpec.ProvisionStatus
 	48,  // 22: specs.ClusterStatusSpec.machines:type_name -> specs.Machines
 	8,   // 23: specs.ClusterStatusSpec.phase:type_name -> specs.ClusterStatusSpec.Phase
 	9,   // 24: specs.MachineSetSpec.update_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	121, // 25: specs.MachineSetSpec.machine_class:type_name -> specs.MachineSetSpec.MachineAllocation
-	122, // 26: specs.MachineSetSpec.bootstrap_spec:type_name -> specs.MachineSetSpec.BootstrapSpec
+	122, // 25: specs.MachineSetSpec.machine_class:type_name -> specs.MachineSetSpec.MachineAllocation
+	123, // 26: specs.MachineSetSpec.bootstrap_spec:type_name -> specs.MachineSetSpec.BootstrapSpec
 	9,   // 27: specs.MachineSetSpec.delete_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	124, // 28: specs.MachineSetSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	124, // 29: specs.MachineSetSpec.delete_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	121, // 30: specs.MachineSetSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
+	125, // 28: specs.MachineSetSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	125, // 29: specs.MachineSetSpec.delete_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	122, // 30: specs.MachineSetSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
 	12,  // 31: specs.TalosUpgradeStatusSpec.phase:type_name -> specs.TalosUpgradeStatusSpec.Phase
 	1,   // 32: specs.MachineSetStatusSpec.phase:type_name -> specs.MachineSetPhase
 	48,  // 33: specs.MachineSetStatusSpec.machines:type_name -> specs.Machines
-	121, // 34: specs.MachineSetStatusSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
-	143, // 35: specs.MachineStatusSnapshotSpec.machine_status:type_name -> machine.MachineStatusEvent
+	122, // 34: specs.MachineSetStatusSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
+	144, // 35: specs.MachineStatusSnapshotSpec.machine_status:type_name -> machine.MachineStatusEvent
 	13,  // 36: specs.MachineStatusSnapshotSpec.power_stage:type_name -> specs.MachineStatusSnapshotSpec.PowerStage
-	125, // 37: specs.ControlPlaneStatusSpec.conditions:type_name -> specs.ControlPlaneStatusSpec.Condition
-	126, // 38: specs.KubernetesStatusSpec.nodes:type_name -> specs.KubernetesStatusSpec.NodeStatus
-	128, // 39: specs.KubernetesStatusSpec.static_pods:type_name -> specs.KubernetesStatusSpec.NodeStaticPods
+	126, // 37: specs.ControlPlaneStatusSpec.conditions:type_name -> specs.ControlPlaneStatusSpec.Condition
+	127, // 38: specs.KubernetesStatusSpec.nodes:type_name -> specs.KubernetesStatusSpec.NodeStatus
+	129, // 39: specs.KubernetesStatusSpec.static_pods:type_name -> specs.KubernetesStatusSpec.NodeStaticPods
 	16,  // 40: specs.KubernetesUpgradeStatusSpec.phase:type_name -> specs.KubernetesUpgradeStatusSpec.Phase
 	62,  // 41: specs.OngoingTaskSpec.talos_upgrade:type_name -> specs.TalosUpgradeStatusSpec
 	70,  // 42: specs.OngoingTaskSpec.kubernetes_upgrade:type_name -> specs.KubernetesUpgradeStatusSpec
 	72,  // 43: specs.OngoingTaskSpec.destroy:type_name -> specs.DestroyStatusSpec
 	78,  // 44: specs.FeaturesConfigSpec.etcd_backup_settings:type_name -> specs.EtcdBackupSettings
-	141, // 45: specs.EtcdBackupSettings.tick_interval:type_name -> google.protobuf.Duration
-	141, // 46: specs.EtcdBackupSettings.min_interval:type_name -> google.protobuf.Duration
-	141, // 47: specs.EtcdBackupSettings.max_interval:type_name -> google.protobuf.Duration
-	129, // 48: specs.MachineClassSpec.auto_provision:type_name -> specs.MachineClassSpec.Provision
-	130, // 49: specs.MachineConfigGenOptionsSpec.install_image:type_name -> specs.MachineConfigGenOptionsSpec.InstallImage
-	131, // 50: specs.KubernetesUsageSpec.cpu:type_name -> specs.KubernetesUsageSpec.Quantity
-	131, // 51: specs.KubernetesUsageSpec.mem:type_name -> specs.KubernetesUsageSpec.Quantity
-	131, // 52: specs.KubernetesUsageSpec.storage:type_name -> specs.KubernetesUsageSpec.Quantity
-	132, // 53: specs.KubernetesUsageSpec.pods:type_name -> specs.KubernetesUsageSpec.Pod
-	133, // 54: specs.ImagePullRequestSpec.node_image_list:type_name -> specs.ImagePullRequestSpec.NodeImageList
-	134, // 55: specs.TalosExtensionsSpec.items:type_name -> specs.TalosExtensionsSpec.Info
+	142, // 45: specs.EtcdBackupSettings.tick_interval:type_name -> google.protobuf.Duration
+	142, // 46: specs.EtcdBackupSettings.min_interval:type_name -> google.protobuf.Duration
+	142, // 47: specs.EtcdBackupSettings.max_interval:type_name -> google.protobuf.Duration
+	130, // 48: specs.MachineClassSpec.auto_provision:type_name -> specs.MachineClassSpec.Provision
+	131, // 49: specs.MachineConfigGenOptionsSpec.install_image:type_name -> specs.MachineConfigGenOptionsSpec.InstallImage
+	132, // 50: specs.KubernetesUsageSpec.cpu:type_name -> specs.KubernetesUsageSpec.Quantity
+	132, // 51: specs.KubernetesUsageSpec.mem:type_name -> specs.KubernetesUsageSpec.Quantity
+	132, // 52: specs.KubernetesUsageSpec.storage:type_name -> specs.KubernetesUsageSpec.Quantity
+	133, // 53: specs.KubernetesUsageSpec.pods:type_name -> specs.KubernetesUsageSpec.Pod
+	134, // 54: specs.ImagePullRequestSpec.node_image_list:type_name -> specs.ImagePullRequestSpec.NodeImageList
+	135, // 55: specs.TalosExtensionsSpec.items:type_name -> specs.TalosExtensionsSpec.Info
 	17,  // 56: specs.ExtensionsConfigurationStatusSpec.phase:type_name -> specs.ExtensionsConfigurationStatusSpec.Phase
-	135, // 57: specs.MachineExtensionsStatusSpec.extensions:type_name -> specs.MachineExtensionsStatusSpec.Item
-	136, // 58: specs.ClusterStatusMetricsSpec.phases:type_name -> specs.ClusterStatusMetricsSpec.PhasesEntry
+	136, // 57: specs.MachineExtensionsStatusSpec.extensions:type_name -> specs.MachineExtensionsStatusSpec.Item
+	137, // 58: specs.ClusterStatusMetricsSpec.phases:type_name -> specs.ClusterStatusMetricsSpec.PhasesEntry
 	25,  // 59: specs.MachineRequestSetSpec.meta_values:type_name -> specs.MetaValue
 	3,   // 60: specs.MachineRequestSetSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	137, // 61: specs.ClusterDiagnosticsSpec.nodes:type_name -> specs.ClusterDiagnosticsSpec.Node
+	138, // 61: specs.ClusterDiagnosticsSpec.nodes:type_name -> specs.ClusterDiagnosticsSpec.Node
 	19,  // 62: specs.ClusterMachineRequestStatusSpec.stage:type_name -> specs.ClusterMachineRequestStatusSpec.Stage
 	21,  // 63: specs.InfraMachineConfigSpec.power_state:type_name -> specs.InfraMachineConfigSpec.MachinePowerState
 	20,  // 64: specs.InfraMachineConfigSpec.acceptance_status:type_name -> specs.InfraMachineConfigSpec.AcceptanceStatus
-	138, // 65: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
-	139, // 66: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
-	140, // 67: specs.InfraProviderCombinedStatusSpec.health:type_name -> specs.InfraProviderCombinedStatusSpec.Health
-	114, // 68: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
-	115, // 69: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
-	116, // 70: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
-	117, // 71: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
+	139, // 65: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
+	140, // 66: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
+	141, // 67: specs.InfraProviderCombinedStatusSpec.health:type_name -> specs.InfraProviderCombinedStatusSpec.Health
+	115, // 68: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
+	116, // 69: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
+	117, // 70: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
+	118, // 71: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
 	24,  // 72: specs.MachineStatusSpec.Schematic.overlay:type_name -> specs.Overlay
 	25,  // 73: specs.MachineStatusSpec.Schematic.meta_values:type_name -> specs.MetaValue
 	10,  // 74: specs.MachineSetSpec.MachineClass.allocation_type:type_name -> specs.MachineSetSpec.MachineClass.Type
 	11,  // 75: specs.MachineSetSpec.MachineAllocation.allocation_type:type_name -> specs.MachineSetSpec.MachineAllocation.Type
-	123, // 76: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
+	124, // 76: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
 	2,   // 77: specs.ControlPlaneStatusSpec.Condition.type:type_name -> specs.ConditionType
 	14,  // 78: specs.ControlPlaneStatusSpec.Condition.status:type_name -> specs.ControlPlaneStatusSpec.Condition.Status
 	15,  // 79: specs.ControlPlaneStatusSpec.Condition.severity:type_name -> specs.ControlPlaneStatusSpec.Condition.Severity
-	127, // 80: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
+	128, // 80: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
 	25,  // 81: specs.MachineClassSpec.Provision.meta_values:type_name -> specs.MetaValue
 	3,   // 82: specs.MachineClassSpec.Provision.grpc_tunnel:type_name -> specs.GrpcTunnelMode
 	23,  // 83: specs.MachineConfigGenOptionsSpec.InstallImage.security_state:type_name -> specs.SecurityState
@@ -9698,7 +9745,7 @@ func file_omni_specs_omni_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_omni_specs_omni_proto_rawDesc), len(file_omni_specs_omni_proto_rawDesc)),
 			NumEnums:      22,
-			NumMessages:   119,
+			NumMessages:   120,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1356,3 +1356,7 @@ message InfraProviderCombinedStatusSpec {
 
   Health health = 4;
 }
+
+message MachineConfigDiffSpec {
+  string diff = 1;
+}

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -2550,6 +2550,23 @@ func (m *InfraProviderCombinedStatusSpec) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *MachineConfigDiffSpec) CloneVT() *MachineConfigDiffSpec {
+	if m == nil {
+		return (*MachineConfigDiffSpec)(nil)
+	}
+	r := new(MachineConfigDiffSpec)
+	r.Diff = m.Diff
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *MachineConfigDiffSpec) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *MachineSpec) EqualVT(that *MachineSpec) bool {
 	if this == that {
 		return true
@@ -5997,6 +6014,25 @@ func (this *InfraProviderCombinedStatusSpec) EqualVT(that *InfraProviderCombined
 
 func (this *InfraProviderCombinedStatusSpec) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*InfraProviderCombinedStatusSpec)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *MachineConfigDiffSpec) EqualVT(that *MachineConfigDiffSpec) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Diff != that.Diff {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *MachineConfigDiffSpec) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*MachineConfigDiffSpec)
 	if !ok {
 		return false
 	}
@@ -12810,6 +12846,46 @@ func (m *InfraProviderCombinedStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (i
 	return len(dAtA) - i, nil
 }
 
+func (m *MachineConfigDiffSpec) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MachineConfigDiffSpec) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *MachineConfigDiffSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Diff) > 0 {
+		i -= len(m.Diff)
+		copy(dAtA[i:], m.Diff)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Diff)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *MachineSpec) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -15471,6 +15547,20 @@ func (m *InfraProviderCombinedStatusSpec) SizeVT() (n int) {
 	}
 	if m.Health != nil {
 		l = m.Health.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *MachineConfigDiffSpec) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Diff)
+	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -32367,6 +32457,89 @@ func (m *InfraProviderCombinedStatusSpec) UnmarshalVT(dAtA []byte) error {
 			if err := m.Health.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MachineConfigDiffSpec) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MachineConfigDiffSpec: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MachineConfigDiffSpec: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Diff", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Diff = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/client/pkg/omni/resources/omni/machine_config_diff.go
+++ b/client/pkg/omni/resources/omni/machine_config_diff.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package omni
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+)
+
+// NewMachineConfigDiff creates a new MachineConfigDiff resource.
+func NewMachineConfigDiff(id resource.ID) *MachineConfigDiff {
+	return typed.NewResource[MachineConfigDiffSpec, MachineConfigDiffExtension](
+		resource.NewMetadata(resources.DefaultNamespace, MachineConfigDiffType, id, resource.VersionUndefined),
+		protobuf.NewResourceSpec(&specs.MachineConfigDiffSpec{}),
+	)
+}
+
+const (
+	// MachineConfigDiffType is the type of the MachineConfigDiff resource.
+	// tsgen:MachineConfigDiffType
+	MachineConfigDiffType = resource.Type("MachineConfigDiffs.omni.sidero.dev")
+)
+
+// MachineConfigDiff is the diff between two redacted machine configurations.
+type MachineConfigDiff = typed.Resource[MachineConfigDiffSpec, MachineConfigDiffExtension]
+
+// MachineConfigDiffSpec wraps specs.MachineConfigDiffSpec.
+type MachineConfigDiffSpec = protobuf.ResourceSpec[specs.MachineConfigDiffSpec, *specs.MachineConfigDiffSpec]
+
+// MachineConfigDiffExtension provides auxiliary methods for MachineConfigDiff resource.
+type MachineConfigDiffExtension struct{}
+
+// ResourceDefinition implements [typed.Extension] interface.
+func (MachineConfigDiffExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             MachineConfigDiffType,
+		DefaultNamespace: resources.DefaultNamespace,
+	}
+}

--- a/client/pkg/omni/resources/omni/omni.go
+++ b/client/pkg/omni/resources/omni/omni.go
@@ -58,6 +58,7 @@ func init() {
 	registry.MustRegisterResource(KubernetesUpgradeManifestStatusType, &KubernetesUpgradeManifestStatus{})
 	registry.MustRegisterResource(KubernetesUpgradeStatusType, &KubernetesUpgradeStatus{})
 	registry.MustRegisterResource(KubernetesVersionType, &KubernetesVersion{})
+	registry.MustRegisterResource(MachineConfigDiffType, &MachineConfigDiff{})
 	registry.MustRegisterResource(MachineLabelsType, &MachineLabels{})
 	registry.MustRegisterResource(MachineType, &Machine{})
 	registry.MustRegisterResource(MachineClassType, &MachineClass{})

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -893,3 +893,7 @@ export type InfraProviderCombinedStatusSpec = {
   icon?: string
   health?: InfraProviderCombinedStatusSpecHealth
 }
+
+export type MachineConfigDiffSpec = {
+  diff?: string
+}

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -162,6 +162,7 @@ export const ClusterMachineStatusLabelNodeName = "omni.sidero.dev/node-name";
 export const ExtensionsConfigurationLabel = "omni.sidero.dev/root-configuration";
 export const MachineType = "Machines.omni.sidero.dev";
 export const MachineClassType = "MachineClasses.omni.sidero.dev";
+export const MachineConfigDiffType = "MachineConfigDiffs.omni.sidero.dev";
 export const MachineConfigGenOptionsType = "MachineConfigGenOptions.omni.sidero.dev";
 export const MachineExtensionsType = "MachineExtensions.omni.sidero.dev";
 export const MachineExtensionsStatusType = "MachineExtensionsStatuses.omni.sidero.dev";

--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
@@ -316,6 +317,18 @@ func (s *managementServer) collectClusterResources(ctx context.Context, cluster 
 		},
 		{
 			rt:          omni.DiscoveryAffiliateDeleteTaskType,
+			listOptions: clusterQuery,
+		},
+		{
+			rt:          omni.MachineConfigDiffType,
+			listOptions: clusterQuery,
+		},
+		{
+			rt:          infra.InfraMachineType,
+			listOptions: clusterQuery,
+		},
+		{
+			rt:          infra.InfraMachineStatusType,
 			listOptions: clusterQuery,
 		},
 	}

--- a/internal/backend/runtime/omni/audit/data.go
+++ b/internal/backend/runtime/omni/audit/data.go
@@ -21,17 +21,18 @@ const (
 
 // Data contains the audit data.
 type Data struct {
-	NewUser        *NewUser        `json:"new_user,omitempty"`
-	Machine        *Machine        `json:"machine,omitempty"`
-	MachineLabels  *MachineLabels  `json:"machine_labels,omitempty"`
-	AccessPolicy   *AccessPolicy   `json:"access_policy,omitempty"`
-	Cluster        *Cluster        `json:"cluster,omitempty"`
-	MachineSet     *MachineSet     `json:"machine_set,omitempty"`
-	MachineSetNode *MachineSetNode `json:"machine_set_node,omitempty"`
-	ConfigPatch    *ConfigPatch    `json:"config_patch,omitempty"`
-	TalosAccess    *TalosAccess    `json:"talos_access,omitempty"`
-	K8SAccess      *K8SAccess      `json:"k8s_access,omitempty"`
-	Session        Session         `json:"session,omitempty"`
+	NewUser           *NewUser           `json:"new_user,omitempty"`
+	Machine           *Machine           `json:"machine,omitempty"`
+	MachineLabels     *MachineLabels     `json:"machine_labels,omitempty"`
+	AccessPolicy      *AccessPolicy      `json:"access_policy,omitempty"`
+	Cluster           *Cluster           `json:"cluster,omitempty"`
+	MachineSet        *MachineSet        `json:"machine_set,omitempty"`
+	MachineSetNode    *MachineSetNode    `json:"machine_set_node,omitempty"`
+	ConfigPatch       *ConfigPatch       `json:"config_patch,omitempty"`
+	MachineConfigDiff *MachineConfigDiff `json:"machine_config_diff,omitempty"`
+	TalosAccess       *TalosAccess       `json:"talos_access,omitempty"`
+	K8SAccess         *K8SAccess         `json:"k8s_access,omitempty"`
+	Session           Session            `json:"session,omitempty"`
 }
 
 // Session contains information about the current session.
@@ -109,6 +110,12 @@ type ConfigPatch struct {
 	Labels map[string]string `json:"labels,omitempty"`
 	ID     string            `json:"id,omitempty"`
 	Data   string            `json:"data,omitempty"`
+}
+
+// MachineConfigDiff struct contains information about the machine configuration diff.
+type MachineConfigDiff struct {
+	ID   resource.ID `json:"id,omitempty"`
+	Diff string      `json:"diff,omitempty"`
 }
 
 // TalosAccess struct contains information about the access to the Talos node.

--- a/internal/backend/runtime/omni/audit/hooks/hooks.go
+++ b/internal/backend/runtime/omni/audit/hooks/hooks.go
@@ -70,6 +70,8 @@ func Init(a *audit.Log) {
 	audit.ShouldLogUpdate(a, configPatchUpdate, audit.WithInternalAgent())
 	audit.ShouldLogUpdateWithConflicts(a, configPatchUpdate, audit.WithInternalAgent())
 	audit.ShouldLogDestroy(a, omni.ConfigPatchType, configPatchDestroy, audit.WithInternalAgent())
+
+	audit.ShouldLogCreate(a, machineConfigDiffCreate, audit.WithInternalAgent())
 }
 
 func publicKeyCreate(_ context.Context, data *audit.Data, res *auth.PublicKey, _ ...state.CreateOption) error {
@@ -385,6 +387,15 @@ func configPatchDestroy(_ context.Context, data *audit.Data, ptr resource.Pointe
 	initPtrField(&data.ConfigPatch)
 
 	data.ConfigPatch.ID = ptr.ID()
+
+	return nil
+}
+
+func machineConfigDiffCreate(_ context.Context, data *audit.Data, res *omni.MachineConfigDiff, _ ...state.CreateOption) error {
+	initPtrField(&data.MachineConfigDiff)
+
+	data.MachineConfigDiff.ID = res.Metadata().ID()
+	data.MachineConfigDiff.Diff = res.TypedSpec().Value.Diff
 
 	return nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -354,6 +354,8 @@ type OmniSuite struct { //nolint:govet
 
 	statesMu sync.Mutex
 	states   map[string]*server.State
+
+	runtimeErr error
 }
 
 // newServer starts a mock gRPC server on the unix socket which is using a temp file,
@@ -469,7 +471,7 @@ func (suite *OmniSuite) startRuntime() {
 	go func() {
 		defer suite.wg.Done()
 
-		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+		suite.runtimeErr = suite.runtime.Run(suite.ctx)
 	}()
 }
 
@@ -494,6 +496,8 @@ func (suite *OmniSuite) TearDownTest() {
 	suite.ctxCancel()
 
 	suite.wg.Wait()
+
+	suite.Require().NoError(suite.runtimeErr)
 
 	for _, s := range suite.grpcServers {
 		s.Stop()

--- a/internal/backend/runtime/omni/controllers/omni/redacted_cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/redacted_cluster_machine_config.go
@@ -7,12 +7,18 @@ package omni
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/jonboulle/clockwork"
 	"github.com/siderolabs/crypto/x509"
-	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"go.uber.org/zap"
@@ -25,59 +31,283 @@ import (
 // RedactedClusterMachineConfigController manages machine configurations for each ClusterMachine.
 //
 // RedactedClusterMachineConfigController generates machine configuration for each created machine.
-type RedactedClusterMachineConfigController = qtransform.QController[*omni.ClusterMachineConfig, *omni.RedactedClusterMachineConfig]
+type RedactedClusterMachineConfigController struct {
+	modifiedAtAnnotationKey string
+	options                 RedactedClusterMachineConfigControllerOptions
+}
 
-// NewRedactedClusterMachineConfigController initializes RedactedClusterMachineConfigController.
-func NewRedactedClusterMachineConfigController() *RedactedClusterMachineConfigController {
-	return qtransform.NewQController(
-		qtransform.Settings[*omni.ClusterMachineConfig, *omni.RedactedClusterMachineConfig]{
-			Name: "RedactedClusterMachineConfigController",
-			MapMetadataFunc: func(cmc *omni.ClusterMachineConfig) *omni.RedactedClusterMachineConfig {
-				return omni.NewRedactedClusterMachineConfig(resources.DefaultNamespace, cmc.Metadata().ID())
-			},
-			UnmapMetadataFunc: func(cmcr *omni.RedactedClusterMachineConfig) *omni.ClusterMachineConfig {
-				return omni.NewClusterMachineConfig(resources.DefaultNamespace, cmcr.Metadata().ID())
-			},
-			TransformFunc: func(_ context.Context, _ controller.Reader, _ *zap.Logger, cmc *omni.ClusterMachineConfig, cmcr *omni.RedactedClusterMachineConfig) error {
-				if !helpers.UpdateInputsVersions(cmcr, cmc) {
-					return xerrors.NewTagged[qtransform.SkipReconcileTag](errors.New("config input hasn't changed"))
-				}
+// RedactedClusterMachineConfigControllerOptions contains options for RedactedClusterMachineConfigController.
+type RedactedClusterMachineConfigControllerOptions struct {
+	Clock               clockwork.Clock
+	DiffCleanupInterval time.Duration
+	DiffMaxAge          time.Duration
+	DiffMaxCount        int
+}
 
-				buffer, err := cmc.TypedSpec().Value.GetUncompressedData()
-				if err != nil {
-					return err
-				}
+// NewRedactedClusterMachineConfigController creates a new instance of RedactedClusterMachineConfigController with the provided options.
+func NewRedactedClusterMachineConfigController(options RedactedClusterMachineConfigControllerOptions) *RedactedClusterMachineConfigController {
+	if options.DiffCleanupInterval == 0 {
+		options.DiffCleanupInterval = 24 * time.Hour
+	}
 
-				defer buffer.Free()
+	if options.DiffMaxAge == 0 {
+		options.DiffMaxAge = 30 * 24 * time.Hour
+	}
 
-				data := buffer.Data()
+	if options.DiffMaxCount == 0 {
+		options.DiffMaxCount = 1000
+	}
 
-				if data == nil {
-					if err = cmcr.TypedSpec().Value.SetUncompressedData(nil); err != nil {
+	if options.Clock == nil {
+		options.Clock = clockwork.NewRealClock()
+	}
+
+	return &RedactedClusterMachineConfigController{
+		options:                 options,
+		modifiedAtAnnotationKey: omni.SystemLabelPrefix + "modified-at",
+	}
+}
+
+// Name implements controller.QController interface.
+func (ctrl *RedactedClusterMachineConfigController) Name() string {
+	return "RedactedClusterMachineConfigController"
+}
+
+// Settings implements controller.QController interface.
+func (ctrl *RedactedClusterMachineConfigController) Settings() controller.QSettings {
+	return controller.QSettings{
+		RunHook: func(ctx context.Context, logger *zap.Logger, r controller.QRuntime) error {
+			ticker := ctrl.options.Clock.NewTicker(ctrl.options.DiffCleanupInterval)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-ticker.Chan():
+					if err := ctrl.cleanup(ctx, r, logger); err != nil {
 						return err
 					}
-
-					return nil
 				}
-
-				config, err := configloader.NewFromBytes(data)
-				if err != nil {
-					return err
-				}
-
-				redactedData, err := config.RedactSecrets(x509.Redacted).EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
-				if err != nil {
-					return err
-				}
-
-				if err = cmcr.TypedSpec().Value.SetUncompressedData(redactedData); err != nil {
-					return err
-				}
-
-				helpers.CopyAllLabels(cmc, cmcr)
-
-				return nil
+			}
+		},
+		Inputs: []controller.Input{
+			{
+				Namespace: resources.DefaultNamespace,
+				Type:      omni.ClusterMachineConfigType,
+				Kind:      controller.InputQPrimary,
 			},
 		},
-	)
+		Outputs: []controller.Output{
+			{
+				Type: omni.RedactedClusterMachineConfigType,
+				Kind: controller.OutputExclusive,
+			},
+			{
+				Type: omni.MachineConfigDiffType,
+				Kind: controller.OutputExclusive,
+			},
+		},
+	}
+}
+
+// Reconcile implements controller.QController interface.
+func (ctrl *RedactedClusterMachineConfigController) Reconcile(ctx context.Context, logger *zap.Logger, r controller.QRuntime, ptr resource.Pointer) error {
+	cmc, err := safe.ReaderGet[*omni.ClusterMachineConfig](ctx, r, ptr)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if cmc.Metadata().Phase() == resource.PhaseTearingDown {
+		return ctrl.reconcileTearingDown(ctx, r, cmc)
+	}
+
+	return ctrl.reconcileRunning(ctx, r, logger, cmc)
+}
+
+// MapInput implements controller.QController interface.
+func (ctrl *RedactedClusterMachineConfigController) MapInput(_ context.Context, _ *zap.Logger, _ controller.QRuntime, pointer resource.Pointer) ([]resource.Pointer, error) {
+	switch pointer.Type() {
+	case omni.ClusterMachineConfigType:
+		return []resource.Pointer{
+			omni.NewRedactedClusterMachineConfig(resources.DefaultNamespace, pointer.ID()).Metadata(),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected input type %q", pointer.Type())
+	}
+}
+
+func (ctrl *RedactedClusterMachineConfigController) reconcileRunning(ctx context.Context, r controller.ReaderWriter, logger *zap.Logger, cmc *omni.ClusterMachineConfig) error {
+	if !cmc.Metadata().Finalizers().Has(ctrl.Name()) {
+		if err := r.AddFinalizer(ctx, cmc.Metadata(), ctrl.Name()); err != nil {
+			return err
+		}
+	}
+
+	err := safe.WriterModify(ctx, r, omni.NewRedactedClusterMachineConfig(resources.DefaultNamespace, cmc.Metadata().ID()), func(res *omni.RedactedClusterMachineConfig) error {
+		if !helpers.UpdateInputsVersions(res, cmc) { // config input hasn't changed, skip the update
+			return nil
+		}
+
+		buffer, err := cmc.TypedSpec().Value.GetUncompressedData()
+		if err != nil {
+			return err
+		}
+
+		defer buffer.Free()
+
+		data := buffer.Data()
+
+		if data == nil {
+			if err = res.TypedSpec().Value.SetUncompressedData(nil); err != nil {
+				return err
+			}
+
+			return nil
+		}
+
+		config, err := configloader.NewFromBytes(data)
+		if err != nil {
+			return err
+		}
+
+		previousConfig, err := res.TypedSpec().Value.GetUncompressedData()
+		if err != nil {
+			return err
+		}
+
+		defer previousConfig.Free()
+
+		redactedData, err := config.RedactSecrets(x509.Redacted).EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
+		if err != nil {
+			return err
+		}
+
+		if err = res.TypedSpec().Value.SetUncompressedData(redactedData); err != nil {
+			return err
+		}
+
+		helpers.CopyAllLabels(cmc, res)
+
+		previousConfigData := previousConfig.Data()
+		if len(previousConfigData) > 0 { // compute and store the diff
+			if err = ctrl.saveDiff(ctx, r, res, previousConfigData, redactedData, logger); err != nil {
+				return fmt.Errorf("failed to save diff: %w", err)
+			}
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func (ctrl *RedactedClusterMachineConfigController) reconcileTearingDown(ctx context.Context, r controller.ReaderWriter, cmc *omni.ClusterMachineConfig) error {
+	list, err := safe.ReaderListAll[*omni.MachineConfigDiff](ctx, r, state.WithLabelQuery(resource.LabelEqual(omni.LabelMachine, cmc.Metadata().ID())))
+	if err != nil {
+		return fmt.Errorf("failed to list diffs for machine config %q: %w", cmc.Metadata().ID(), err)
+	}
+
+	if _, err = helpers.TeardownAndDestroyAll(ctx, r, list.Pointers()); err != nil {
+		return fmt.Errorf("failed to destroy diff for machine config %q: %w", cmc.Metadata().ID(), err)
+	}
+
+	cmcr := omni.NewRedactedClusterMachineConfig(resources.DefaultNamespace, cmc.Metadata().ID()).Metadata()
+
+	if _, err = helpers.TeardownAndDestroy(ctx, r, cmcr); err != nil {
+		return err
+	}
+
+	if cmc.Metadata().Finalizers().Has(ctrl.Name()) {
+		if err = r.RemoveFinalizer(ctx, cmc.Metadata(), ctrl.Name()); err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func (ctrl *RedactedClusterMachineConfigController) saveDiff(ctx context.Context, r controller.ReaderWriter,
+	cmcr *omni.RedactedClusterMachineConfig, previousData, newData []byte, logger *zap.Logger,
+) error {
+	oldConfig := string(previousData)
+	newConfig := string(newData)
+
+	edits := myers.ComputeEdits("", oldConfig, newConfig)
+	diff := gotextdiff.ToUnified("", "", oldConfig, edits)
+	diffStr := strings.TrimSpace(fmt.Sprint(diff))
+	diffStr = strings.Replace(diffStr, "--- \n+++ \n", "", 1) // trim the URIs, as they do not make sense in this context
+
+	if strings.TrimSpace(diffStr) == "" {
+		return nil
+	}
+
+	const rfc3339Millis = "2006-01-02T15:04:05.000Z07:00"
+	diffID := cmcr.Metadata().ID() + "-" + ctrl.options.Clock.Now().UTC().Format(rfc3339Millis)
+	diffRes := omni.NewMachineConfigDiff(diffID)
+
+	if err := safe.WriterModify(ctx, r, diffRes, func(res *omni.MachineConfigDiff) error {
+		res.Metadata().Annotations().Set(ctrl.modifiedAtAnnotationKey, ctrl.options.Clock.Now().UTC().Format(time.RFC3339Nano))
+		res.Metadata().Labels().Set(omni.LabelMachine, cmcr.Metadata().ID())
+
+		res.TypedSpec().Value.Diff = diffStr
+
+		helpers.CopyAllLabels(cmcr, res)
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to write diff: %w", err)
+	}
+
+	diffLines := strings.Split(diffStr, "\n")
+
+	logger.Info("saved machine config diff", zap.Strings("diff", diffLines))
+
+	return nil
+}
+
+func (ctrl *RedactedClusterMachineConfigController) cleanup(ctx context.Context, r controller.ReaderWriter, logger *zap.Logger) error {
+	logger.Info("run cleanup")
+
+	list, err := safe.ReaderListAll[*omni.MachineConfigDiff](ctx, r)
+	if err != nil {
+		return fmt.Errorf("failed to list machine config diffs: %w", err)
+	}
+
+	now := ctrl.options.Clock.Now()
+
+	i := list.Len() - 1
+
+	for diff := range list.All() {
+		modified := diff.Metadata().Created()
+
+		if modifiedStr, ok := diff.Metadata().Annotations().Get(ctrl.modifiedAtAnnotationKey); ok {
+			if modified, err = time.Parse(time.RFC3339Nano, modifiedStr); err != nil {
+				return fmt.Errorf("failed to parse modified time for diff %q: %w", diff.Metadata().ID(), err)
+			}
+		}
+
+		switch {
+		case now.Sub(modified) > ctrl.options.DiffMaxAge:
+			logger.Debug("clean up old machine config diff", zap.String("diff_id", diff.Metadata().ID()))
+
+			if _, err = helpers.TeardownAndDestroy(ctx, r, diff.Metadata()); err != nil {
+				return fmt.Errorf("failed to teardown and destroy diff %q: %w", diff.Metadata().ID(), err)
+			}
+		case i >= ctrl.options.DiffMaxCount:
+			logger.Debug("clean up machine config diff above max count", zap.String("diff_id", diff.Metadata().ID()))
+
+			if _, err = helpers.TeardownAndDestroy(ctx, r, diff.Metadata()); err != nil {
+				return fmt.Errorf("failed to teardown and destroy diff %q: %w", diff.Metadata().ID(), err)
+			}
+		}
+
+		i--
+	}
+
+	return nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/redacted_cluster_machine_config_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/redacted_cluster_machine_config_test.go
@@ -6,14 +6,19 @@
 package omni_test
 
 import (
+	"context"
+	_ "embed"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
-	"github.com/siderolabs/crypto/x509"
-	"github.com/siderolabs/talos/pkg/machinery/config/generate"
-	"github.com/siderolabs/talos/pkg/machinery/config/machine"
-	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/jonboulle/clockwork"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -26,54 +31,215 @@ type RedactedClusterMachineConfigSuite struct {
 	OmniSuite
 }
 
+//nolint:lll
 func (suite *RedactedClusterMachineConfigSuite) TestReconcile() {
+	ctx, cancel := context.WithTimeout(suite.ctx, 10*time.Second)
+	defer cancel()
+
 	suite.startRuntime()
 
-	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(imageFactoryHost, nil)))
-	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewRedactedClusterMachineConfigController()))
-	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineJoinConfigController()))
+	clock := clockwork.NewFakeClock()
+
+	controller := omnictrl.NewRedactedClusterMachineConfigController(omnictrl.RedactedClusterMachineConfigControllerOptions{
+		DiffCleanupInterval: 5 * time.Minute,
+		DiffMaxAge:          15 * time.Minute,
+		DiffMaxCount:        2,
+		Clock:               clock,
+	})
+
+	suite.Require().NoError(suite.runtime.RegisterQController(controller))
 
 	id := "test"
 
 	cmc := omni.NewClusterMachineConfig(resources.DefaultNamespace, id)
 
-	suite.Require().NoError(cmc.TypedSpec().Value.SetUncompressedData(suite.generateConfig()))
+	suite.Require().NoError(cmc.TypedSpec().Value.SetUncompressedData([]byte(`version: v1alpha1
+machine:
+  type: controlplane
+  token: 02v8bh.y8uqauhyzpksn075
+  ca:
+    crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJQakNCOGFBREFnRUNBaEEydVNNVDNETWhhc3VreUd1d3pZVXhNQVVHQXl0bGNEQVFNUTR3REFZRFZRUUsKRXdWMFlXeHZjekFlRncweU5UQTNNRGd4TWpFNE5EaGFGdzB6TlRBM01EWXhNakU0TkRoYU1CQXhEakFNQmdOVgpCQW9UQlhSaGJHOXpNQ293QlFZREsyVndBeUVBNU15S3FTY2RSUjJLRzBXS0dUTllrUjFmM0dBRkNtbVFvMTk5CmVsM0YwdUtqWVRCZk1BNEdBMVVkRHdFQi93UUVBd0lDaERBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjREFRWUkKS3dZQkJRVUhBd0l3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFkQmdOVkhRNEVGZ1FVRC9JQ0M4Mnl4QkFTOThRZQpaQzhneFVScUpVTXdCUVlESzJWd0EwRUFhSHM2S3Z1L0JDKzZzM2ZWQ1Y1NHRlQWpIZW5WTVdlcXFyb0V0bHBGCitDZXZQMlM3eHhXVU8zOTYzTjRxMFF1QzQvU2ZwVmFySzhmb1dKK0FBZ3pDQ3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0KTUM0Q0FRQXdCUVlESzJWd0JDSUVJRmN2TGVYT2pqaUJrQlZCQ1NwZkxxWVNGNVM5dGIraDVnd2Vjc3cyT3YrUAotLS0tLUVORCBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0K
+cluster:
+  id: 1vUXXJzS9ahM3TE70vm29k6weYtYgGDxxY-edDjvf_k=
+  secret: n8eg5gx1fuumcig98VJqBE34CavL8XFGPGBw8M/p/MQ=
+  controlPlane:
+    endpoint: https://doesntmatter:6443
+  token: l94i8b.8cl0f2k09h4tyga3
+  secretboxEncryptionSecret: U3BEYHqEGj+SRiNRuWosaEjh4xHDrxhHT9TILBwFrVE=
+  ca:
+    crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJpVENDQVMrZ0F3SUJBZ0lRSDV6TUR3SjhDdlpicEMwV2RZN2ZuakFLQmdncWhrak9QUVFEQWpBVk1STXcKRVFZRFZRUUtFd3ByZFdKbGNtNWxkR1Z6TUI0WERUSTFNRGN3T0RFeU1UZzBPRm9YRFRNMU1EY3dOakV5TVRnMApPRm93RlRFVE1CRUdBMVVFQ2hNS2EzVmlaWEp1WlhSbGN6QlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VICkEwSUFCUFg2bE5CMXBNdFAzMzdRb3orZUVnaWgwMDIzTkEzRWczNVZmQldYdnJ6aG5SNkU0SXIyaHJkRDhzOFcKK1hMMWllUDdKUlFmWklORVBVVzZjeExNakR5allUQmZNQTRHQTFVZER3RUIvd1FFQXdJQ2hEQWRCZ05WSFNVRQpGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZEJnTlZIUTRFCkZnUVVrYmQvN1pFYWVrb0tIYVptdUVJMXVnN3d6QTR3Q2dZSUtvWkl6ajBFQXdJRFNBQXdSUUloQU56ZTFiNjEKdS9UV0tVU09mZ3JjVC9URTZYLytETGdDbXNDQU01OEg5Q3JtQWlCZlJXYktjVVpzWm9hOEZ6R1liNkNDL1V6bwozb3YwVDlSb2c3ZlJwM2tnaFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUJhY1NhdDdGeFNLb0lQb3ZnTmVkREx6MS9qQlpTTnB0ZUR4dWNuNjdoajNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFOWZxVTBIV2t5MC9mZnRDalA1NFNDS0hUVGJjMERjU0RmbFY4RlplK3ZPR2RIb1RnaXZhRwp0MFB5enhiNWN2V0o0L3NsRkI5a2cwUTlSYnB6RXN5TVBBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+  aggregatorCA:
+    crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJZRENDQVFXZ0F3SUJBZ0lRTGRBcWdlUHQyUjg5dzZacTR5YUpmREFLQmdncWhrak9QUVFEQWpBQU1CNFgKRFRJMU1EY3dPREV5TVRnME9Gb1hEVE0xTURjd05qRXlNVGcwT0Zvd0FEQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxRwpTTTQ5QXdFSEEwSUFCQktnK3BadnVGd1NBZUpEYXA0K29FeEdEY05tWFR6d3hPSmtjVXZLSHVXTnQxNnY3b3EvCmtSb2JXYTlnSVZHVTlVYTNXYXg5ekc1SnFKL1duZGpEblIrallUQmZNQTRHQTFVZER3RUIvd1FFQXdJQ2hEQWQKQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZApCZ05WSFE0RUZnUVVxVy9kdW4wWGhETVgwaXUrTk5RbW50UHdvTEV3Q2dZSUtvWkl6ajBFQXdJRFNRQXdSZ0loCkFQWDNWM1R1TEdwZmc4Y21JWnFSMUZ2OFBWWE44cDgvaFR3Vk94clNMNlpkQWlFQTlCd0VzVGZDRWlUYm1vSFIKTmxPT3FmcndYQUtkZUxKeTJOZUdDdjZjV3JzPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSURBKzBtZEFmUUNQNEROa25pTXgvMGFzZUVOVFp2VjJJTGV6azVsaDR2QUtvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFRXFENmxtKzRYQklCNGtOcW5qNmdURVlOdzJaZFBQREU0bVJ4UzhvZTVZMjNYcS91aXIrUgpHaHRacjJBaFVaVDFScmRackgzTWJrbW9uOWFkMk1PZEh3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+  serviceAccount:
+    key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlKS1FJQkFBS0NBZ0VBMmtYSThDVEUyekNDNXEwQXQ0cUFoSGdob05CeWJrZkpBUHpndE5GeHZ2ZzRTeDJXCmpBTGpHaS8rRlEyQmFzblM3V1NsVHNVdEJ1OGUrUkVPM3llQWpSMnZNdGVvRzh6dnJpQ3VKRjZHUktEaGNGMFgKZU1LRXp4VjR3WkdNQ1RhZnNSUXNoVXArSDlUUkw2QlkvTFpYbi9LUWtwUlNwMTBEbkVkaTlBbit4NjlJSWFqYQp0V1d5aU5Zckd2ZTJ1WVBBMWp2UWg0TUtiWmZBZFpkNzROYWw4K0JnaGRBUEVtNzlHOWcxYlg1RkNTampzVWxvCkFnNnB5VDJpVlEycDBKSjArU3VtcE04bWFSZ3NFejl2V1hVRC9GVjZmYzlXK1BnZUJvc0ZhM2NVcGQ0U29IT2gKcFBlcllLU0JVVzB3QzhoQ0xoT0ZRR2NmVWNYYXVzOFRWQk0wdEJIYzZ0V1dEK1AwTmt6Q3F5RUZMWVVzOUJxdwpsenB5YThVb2RObDFoSnZvS1B0VlBPRllOaU5jZGlXcXBrTXNJYjA5T2pZQjdOK2Y3cnNsbkJiM1VuOGJQb1J5CnN1cnY4eUN3L3hKTnpLbzdnYlAyT0VMY3FCZ0lXSVB1cS9sa2ZSK2VNd2I5eDJDeXdGOG4rYm1PMXgxNWtWNWcKV2tTZ0s5Unkva3lFdGxFZEx2NVVmc1FPWiszdjFLZnJGVmRPdGlYd1pDbndvcGRKTFVlWjl0ZENESFdlQjkwTwpheC9GR1BKT2QzTzZ5ZlVpOThHSHRTV0p1c3NwaXF6bkF0VkZqWlNtZEpQenVmb1Y2RU5QRTNoRHVrTXBnZkpFCnRRcjkyR1Jkc0thTDM2VUR5L0JYQ0ozRHoyN1RaZVJaYkdlQmpMRVpabG1BQUZndjRMOUQ2blRIYVFFQ0F3RUEKQVFLQ0FnQXdUeXUzQXR4VEN2eWQ0NEo2SFB4dTFVdlVGTzZPdS9LZjlsZ2hqUTJZejhWZDByR2tVV3RFTzRVSAowZEpuK1QxbTcxU3JCM2I4eHVYYkNFeDdWWG5kUWNtcC9oTWwvQWk4U0YxaWpVMDRXVWNzSUY1MmlzN3NLbnRzCmxETWpRdVM3UTVUSzkzN011c1NGdnY2VENDU0NzU1FRWFNXaUJ6TXFYcDVuRnVNOS9PeUJEcWRCYUwzSURXYkMKOURxTCtyNHViRlN0K1hIUWFicmVDK1lPRUZQd2t5T3AyaS9MeTZiWGg5WGpZd1FTaitzOUxOc0pRWWVRazhTZgpBSVFxTnBBUEtmc2JGUUlTVnBoQ3RsS0Z3U0Zkc3VtR2VPSnQvalJmREZ2cHVoUm0xYXpYdUYvNWJCdVJLemUzCjl1dWdYL1ZOejJJNXE5bEJ0d0cvUU4rdFJ3YnR2elVITnBBTUQ5eEZTR09jaGZFaXRyallKREVacTc0MmtqeGwKRkRXUGV5ZmtxVld6ZDRXUDl4MVNLWGlyZkpKOHJXWVNiN0N6c251WEJwTWp6TkswWEYwNkx6Y08vZDRlajExbwpuVXkrSGdUMC91SHpJY0ZaK2JvN2lRVkVVMEdPZFdheXJUVlVPYVZaY1ZnNUFseTdoYy90VXFHVnFrVERaWmFHCm9vUnpDVlg4R0ZISkdIdXRqU0Zrc1BnaDR1eUV6bGxsSGJYMUNXeld3cVNnVTJDSVVmYkExVzV5L08xSTRKMDAKZERYMDl5Lzc0ZTZrMTYvZkJGaXZ0Ulc2bFNYeUowNWwwUnVTNDMrWWpsU2hVSXI4RFBmRGRZTit0cW5KSVpGWQoxVjUrZGdkdU9NSXQ2dlQyTWVzeGhINWZnSUx6bHFXUDEyY2l5ajNSMXJIVHZYSXJNUUtDQVFFQTZXcEQxeEVtCjhQUHZWVXdXQm9XUno4M3NPQjhscWR1YWFCVGtFUWN0MU91U3M2U0U4c2hMNHpUWGRlSmk4b1BkL3ExRWQ1ZWgKUVFVbWxXbCtET0tNWnJrUHcwV0EwQVhFNGhFQkZQNENPWW1vMHByRkttVDJ6STVzRUEyT0RoVCthMzJYa2JKeApENHFhYlVnZGkvbldzTVNOWnJRcHVRc1dXVFZodUdCOVJDOUgzQUN2eVZvaEpmRDV5UWhWYlRRWDl2U0s4Mi9OClJtdHNyYVBaeW1Qa28vSjBUeDFEUEE4UUVkUkFycEhVR29CbXd0WnlVZDMxMjd4YmtUMzM2bmZMcjhQVEpNN2QKeXFrZXhBb2FCUm5SVmNZUWVRakVZUHRCNndWSUVubjdWTjlXalptRU9UY1E0MDhlYWg4cHpiUmFuS2NFaDg3SwpjSEhwSU1RR3lIWng5UUtDQVFFQTcyUnYrTG5HallOUnRBdXFjdnEzZVJiNDFHaklWSm9ZVXBmdG0wRjJldVVVCjZJQ2NUcUFwUi94a2NzVzQ0NVlkOFNxc3U5WUV3VlU4Um9ZZlJvVTJnRVg0UHhTeDlOZittZWdXeXFjS1hwRmEKM21BZ1dCNkl2Rit4UlZNV3JIL2dTVUpuWlNDcjgybVNZdDZyM0xmdVpUTERTcGJ6MmtXbXVpazVGd3NVcmZXTwpFa2xWMU14SFZPeXBjbUhjWml0K3hUNmJWVlc5R0RjQUlTNk9TV2diTEd1bnE5RWlDbis3WFNZcTlLRDRsa3gwCmk4bWU2ZmVCdVVSRndZQkhkS3RJalZxTjBTMkNHbUR4ajlheENGaWQxTTU2T1A0RjZTclpWeFI4M0xtenpkdlkKaEd6aVdxYVkrT0daa2FIWHZOTzAxTlk3WmMzRGJUWWFhZi9hN3BjWFhRS0NBUUVBMDJQcTVxYmhCbzFWTG9IRwozTWN4QStyeHlPM2tkVTJ1TEI3blljaUhxSEprblE4ZFhLY3JteXlyQ1ZjcTE0bTNqa09yWTBmT3dZMEJvWVUxCnBFTzBkZithRi9ZbEw4Qlp5NGNzM0s4aW9xdGFXc25TVUkrNXVBNHdMZVdveG5ZYTZJeUlyV25XM1FWZzBDSGsKcUhWdkN3NG5KV0Y2Kzl2ZnRKRVUzQjkrc3piQ3RLdG1pRXQ1QTl5V3k0c2htdEgzOWk4SWZHbS9sY3dLVThPMQpwWWNNZGJKSnhiQ3h5SDIzeHYzY1NuMUZnMjdRSWhxRzFEL1p2dFI2ZFRLVENTVFBNbkorRWJMTHlST2JDbDQvCnJHanlYZVVQM0IybGhGTnBJb2pZK2VyQlJOOHppdkFDZ0xLdk43M2F4SzlPYzc2bjVZR1pKOG1QSzREdWFqOCsKQ1dURDFRS0NBUUVBdi9xdTVTdXV0RndFa0x2dVJHa1Y3QkRsR2dxeDVVN3loSUg4ZGM2b3dtT21RZEtxQjAvZgo2eS9ZS2thd1FDdHA5YmJBY1o1dmo4L1lGOEtGb0Z0Q1d0cEIrK3lQemdmTjBRVlVDYzZ0dlNzYVVVMkxncjl4CjdvZGJOWG90cThhZFNvTHJRaWxTWEZGa3FNOWp5Z3pqTE5ycHpJNkVIcDVPMStvcE0zYWFiZXVIdE5pRThiT2sKM05FeURsMjJqMlVBTkJSQ0k4d3ZhaFRwa0xLeVB1SXpNSXRoR3FRTGhabnIyd2E1MmhhaFpIOEowL1NyOFh1ZwoxNytOcFdGSGJLUFQrakFOblJ1K3c0TE5GZ29aVE5Vc05iWWtSRUpLNFRPUXVvbmVuSEI4Wm5HUkVKbjFhTGRECjVBdWZ5UytlUUhzVEFNQ1JQOUlra0JlY1ZUZHZEbm15clFLQ0FRQlYzWmtNaFB0NUJMZ0lSRit5K3F1M3VBZVUKUTBPN2hhanpTdGZVa1JqQ2xoOFM5aERnWjRyTlZDYWkyTitnYnV6TTRIVFZJSUlSK1grV2dEQWV4NG1CTXk1eApHcFBOaDZ0VVlIamRPcSt6YzJRcEpCejZPazlscHFTRUZRSEl0c2tGamV4SFA1QXdteFFsa0xzb3NXQlJud3RIClBCSi9GcWtvNVMvMG8xS24yaHB1bGdUcit0V3ZaSkZMOTVpdzJScWZ6ZldRWjFVRG90SFZWRE12Vzg1U0t5Z3QKV2E0QjFtUWdZaWQwUVZZVE1jcGNEaXZzZEFqYktuZnMvM21JcUhJbWJSd2JvZEsxV1FNZlVqUDE2Y1NmUVc5NgpNS282Z0FUUi8xL2pVdElvWEdSUjlvOVBuYjQ4ZWlzcE1HVGp6M3o2Q3IvZ3hXbDlNczNTM2xRRjlzUWUKLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K
+  etcd:
+    ca:
+      crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJmVENDQVNPZ0F3SUJBZ0lRRVEyU3FYYkhUc1cyQWVLejlZMlA2akFLQmdncWhrak9QUVFEQWpBUE1RMHcKQ3dZRFZRUUtFd1JsZEdOa01CNFhEVEkxTURjd09ERXlNVGcwT0ZvWERUTTFNRGN3TmpFeU1UZzBPRm93RHpFTgpNQXNHQTFVRUNoTUVaWFJqWkRCWk1CTUdCeXFHU000OUFnRUdDQ3FHU000OUF3RUhBMElBQkV6YkwyWjI2QlFzCmU2MHB6c3l4Wm1kK01FeFRrOUFLSUtGdVRBbmN4TWI5RE9CUHFwOE02ZFVyUnB5UUw2TTdVR1RxWkJGSlZYeUcKRGkyTXBGRVNWR3FqWVRCZk1BNEdBMVVkRHdFQi93UUVBd0lDaERBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjRApBUVlJS3dZQkJRVUhBd0l3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFkQmdOVkhRNEVGZ1FVM01nQ3c4RWFjbGY4CnFjZ1dJTHR5VWxMTGVYY3dDZ1lJS29aSXpqMEVBd0lEU0FBd1JRSWdVN3llYU90enIrTUZrU0dHR2NlbWNNUCsKd1dUSVFOSzk5M3FnZWJlZHVlQUNJUURDODhnSlIwU1kxOWhDNkhmNlhZeHdQMlNiL2pMUTRpc3IrdGxFTG5odwpXQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+      key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUpkTERQQ2p0QWdTaWtZRU5GcHRIcjNDbllaSHFnenZkYlFucGFjb25qaHVvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFVE5zdlpuYm9GQ3g3clNuT3pMRm1aMzR3VEZPVDBBb2dvVzVNQ2R6RXh2ME00RStxbnd6cAoxU3RHbkpBdm96dFFaT3BrRVVsVmZJWU9MWXlrVVJKVWFnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+`)))
 
-	suite.Require().NoError(suite.state.Create(suite.ctx, cmc))
+	// t = 0
 
-	rtestutils.AssertResources(suite.ctx, suite.T(), suite.state, []string{id},
-		func(rcmc *omni.RedactedClusterMachineConfig, assert *assert.Assertions) {
-			buffer, err := rcmc.TypedSpec().Value.GetUncompressedData()
+	// create the config, assert that the redacted config is created
+	suite.Require().NoError(suite.state.Create(ctx, cmc))
+
+	rtestutils.AssertResource(ctx, suite.T(), suite.state, id,
+		func(cmcr *omni.RedactedClusterMachineConfig, assert *assert.Assertions) {
+			buffer, err := cmcr.TypedSpec().Value.GetUncompressedData()
 			assert.NoError(err)
 
 			defer buffer.Free()
 
 			data := string(buffer.Data())
 
-			assert.Contains(data, x509.Redacted)
+			assert.Equal(`version: v1alpha1
+machine:
+    type: controlplane
+    token: '******'
+    ca:
+        crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJQakNCOGFBREFnRUNBaEEydVNNVDNETWhhc3VreUd1d3pZVXhNQVVHQXl0bGNEQVFNUTR3REFZRFZRUUsKRXdWMFlXeHZjekFlRncweU5UQTNNRGd4TWpFNE5EaGFGdzB6TlRBM01EWXhNakU0TkRoYU1CQXhEakFNQmdOVgpCQW9UQlhSaGJHOXpNQ293QlFZREsyVndBeUVBNU15S3FTY2RSUjJLRzBXS0dUTllrUjFmM0dBRkNtbVFvMTk5CmVsM0YwdUtqWVRCZk1BNEdBMVVkRHdFQi93UUVBd0lDaERBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjREFRWUkKS3dZQkJRVUhBd0l3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFkQmdOVkhRNEVGZ1FVRC9JQ0M4Mnl4QkFTOThRZQpaQzhneFVScUpVTXdCUVlESzJWd0EwRUFhSHM2S3Z1L0JDKzZzM2ZWQ1Y1NHRlQWpIZW5WTVdlcXFyb0V0bHBGCitDZXZQMlM3eHhXVU8zOTYzTjRxMFF1QzQvU2ZwVmFySzhmb1dKK0FBZ3pDQ3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        key: '******'
+    certSANs: []
+cluster:
+    id: 1vUXXJzS9ahM3TE70vm29k6weYtYgGDxxY-edDjvf_k=
+    secret: '******'
+    controlPlane:
+        endpoint: https://doesntmatter:6443
+    token: '******'
+    secretboxEncryptionSecret: '******'
+    ca:
+        crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJpVENDQVMrZ0F3SUJBZ0lRSDV6TUR3SjhDdlpicEMwV2RZN2ZuakFLQmdncWhrak9QUVFEQWpBVk1STXcKRVFZRFZRUUtFd3ByZFdKbGNtNWxkR1Z6TUI0WERUSTFNRGN3T0RFeU1UZzBPRm9YRFRNMU1EY3dOakV5TVRnMApPRm93RlRFVE1CRUdBMVVFQ2hNS2EzVmlaWEp1WlhSbGN6QlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VICkEwSUFCUFg2bE5CMXBNdFAzMzdRb3orZUVnaWgwMDIzTkEzRWczNVZmQldYdnJ6aG5SNkU0SXIyaHJkRDhzOFcKK1hMMWllUDdKUlFmWklORVBVVzZjeExNakR5allUQmZNQTRHQTFVZER3RUIvd1FFQXdJQ2hEQWRCZ05WSFNVRQpGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZEJnTlZIUTRFCkZnUVVrYmQvN1pFYWVrb0tIYVptdUVJMXVnN3d6QTR3Q2dZSUtvWkl6ajBFQXdJRFNBQXdSUUloQU56ZTFiNjEKdS9UV0tVU09mZ3JjVC9URTZYLytETGdDbXNDQU01OEg5Q3JtQWlCZlJXYktjVVpzWm9hOEZ6R1liNkNDL1V6bwozb3YwVDlSb2c3ZlJwM2tnaFE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        key: '******'
+    aggregatorCA:
+        crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJZRENDQVFXZ0F3SUJBZ0lRTGRBcWdlUHQyUjg5dzZacTR5YUpmREFLQmdncWhrak9QUVFEQWpBQU1CNFgKRFRJMU1EY3dPREV5TVRnME9Gb1hEVE0xTURjd05qRXlNVGcwT0Zvd0FEQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxRwpTTTQ5QXdFSEEwSUFCQktnK3BadnVGd1NBZUpEYXA0K29FeEdEY05tWFR6d3hPSmtjVXZLSHVXTnQxNnY3b3EvCmtSb2JXYTlnSVZHVTlVYTNXYXg5ekc1SnFKL1duZGpEblIrallUQmZNQTRHQTFVZER3RUIvd1FFQXdJQ2hEQWQKQmdOVkhTVUVGakFVQmdnckJnRUZCUWNEQVFZSUt3WUJCUVVIQXdJd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZApCZ05WSFE0RUZnUVVxVy9kdW4wWGhETVgwaXUrTk5RbW50UHdvTEV3Q2dZSUtvWkl6ajBFQXdJRFNRQXdSZ0loCkFQWDNWM1R1TEdwZmc4Y21JWnFSMUZ2OFBWWE44cDgvaFR3Vk94clNMNlpkQWlFQTlCd0VzVGZDRWlUYm1vSFIKTmxPT3FmcndYQUtkZUxKeTJOZUdDdjZjV3JzPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        key: '******'
+    serviceAccount:
+        key: '******'
+    etcd:
+        ca:
+            crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJmVENDQVNPZ0F3SUJBZ0lRRVEyU3FYYkhUc1cyQWVLejlZMlA2akFLQmdncWhrak9QUVFEQWpBUE1RMHcKQ3dZRFZRUUtFd1JsZEdOa01CNFhEVEkxTURjd09ERXlNVGcwT0ZvWERUTTFNRGN3TmpFeU1UZzBPRm93RHpFTgpNQXNHQTFVRUNoTUVaWFJqWkRCWk1CTUdCeXFHU000OUFnRUdDQ3FHU000OUF3RUhBMElBQkV6YkwyWjI2QlFzCmU2MHB6c3l4Wm1kK01FeFRrOUFLSUtGdVRBbmN4TWI5RE9CUHFwOE02ZFVyUnB5UUw2TTdVR1RxWkJGSlZYeUcKRGkyTXBGRVNWR3FqWVRCZk1BNEdBMVVkRHdFQi93UUVBd0lDaERBZEJnTlZIU1VFRmpBVUJnZ3JCZ0VGQlFjRApBUVlJS3dZQkJRVUhBd0l3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFkQmdOVkhRNEVGZ1FVM01nQ3c4RWFjbGY4CnFjZ1dJTHR5VWxMTGVYY3dDZ1lJS29aSXpqMEVBd0lEU0FBd1JRSWdVN3llYU90enIrTUZrU0dHR2NlbWNNUCsKd1dUSVFOSzk5M3FnZWJlZHVlQUNJUURDODhnSlIwU1kxOWhDNkhmNlhZeHdQMlNiL2pMUTRpc3IrdGxFTG5odwpXQT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+            key: '******'
+`, data)
 		},
 	)
 
-	rtestutils.Destroy[*omni.ClusterMachineConfig](suite.ctx, suite.T(), suite.state, []resource.ID{id})
+	rtestutils.AssertResource(ctx, suite.T(), suite.state, id, func(res *omni.ClusterMachineConfig, assert *assert.Assertions) {
+		assert.True(res.Metadata().Finalizers().Has(controller.Name()), "expected controller name finalizer to be set")
+	})
 
-	rtestutils.AssertNoResource[*omni.RedactedClusterMachineConfig](suite.ctx, suite.T(), suite.state, id)
+	// no diffs should be saved on resource creation
+	suite.assertDiffCount(ctx, 0)
+
+	// update the config, it should generate a diff
+	diffID1 := suite.updateConfigAssertDiff(ctx, clock, cmc, "aaa", "bbb")
+
+	suite.assertDiffCount(ctx, 1)
+
+	clock.Advance(1 * time.Minute)
+
+	// t = 1m
+
+	// update the config again, it should generate another diff
+	diffID2 := suite.updateConfigAssertDiff(ctx, clock, cmc, "ccc", "ddd")
+	suite.assertDiffCount(ctx, 2)
+
+	clock.Advance(2 * time.Minute)
+
+	// t = 3m
+
+	// update the config again, it should generate a third diff
+	diffID3 := suite.updateConfigAssertDiff(ctx, clock, cmc, "eee", "fff")
+	suite.assertDiffCount(ctx, 3)
+
+	// move the clock forward so that the periodic cleanup task gets triggered (at t = 5m)
+	clock.Advance(3 * time.Minute)
+
+	// t = 6m
+
+	// assert that the oldest diff is removed, as we allow the max count of 2 diffs to be kept
+	rtestutils.AssertNoResource[*omni.MachineConfigDiff](ctx, suite.T(), suite.state, diffID1)
+
+	// assert that the other two diffs are still present
+	rtestutils.AssertResource[*omni.MachineConfigDiff](ctx, suite.T(), suite.state, diffID2, func(*omni.MachineConfigDiff, *assert.Assertions) {})
+	rtestutils.AssertResource[*omni.MachineConfigDiff](ctx, suite.T(), suite.state, diffID3, func(*omni.MachineConfigDiff, *assert.Assertions) {})
+
+	// move the clock forward so that diff2 will be old enough to be removed (at t = 16m, it'll be 15m old)
+	clock.Advance(11 * time.Minute)
+
+	// t = 17m
+
+	// assert that the second diff is removed, as it is older than 15 minutes
+	rtestutils.AssertNoResource[*omni.MachineConfigDiff](ctx, suite.T(), suite.state, diffID2)
+
+	// assert that the third diff is still present, as it is not old enough yet
+	rtestutils.AssertResource[*omni.MachineConfigDiff](ctx, suite.T(), suite.state, diffID3, func(*omni.MachineConfigDiff, *assert.Assertions) {})
+
+	// destroy the cluster machine config
+	rtestutils.Destroy[*omni.ClusterMachineConfig](ctx, suite.T(), suite.state, []resource.ID{id})
+
+	// assert that the redacted config is removed
+	rtestutils.AssertNoResource[*omni.RedactedClusterMachineConfig](ctx, suite.T(), suite.state, id)
+
+	// assert that the remaining diff is also removed
+	rtestutils.AssertNoResource[*omni.MachineConfigDiff](ctx, suite.T(), suite.state, diffID3)
+
+	// assert that there are no diffs left in the state
+	suite.assertDiffCount(ctx, 0)
 }
 
-func (suite *RedactedClusterMachineConfigSuite) generateConfig() []byte {
-	input, err := generate.NewInput(
-		"does-not-matter",
-		"https://doesntmatter:6443",
-		constants.DefaultKubernetesVersion,
-	)
+func (suite *RedactedClusterMachineConfigSuite) updateConfigAssertDiff(ctx context.Context, clock clockwork.Clock, cmc *omni.ClusterMachineConfig, testKey, testVal string) resource.ID {
+	_, err := safe.StateUpdateWithConflicts(ctx, suite.state, cmc.Metadata(), func(res *omni.ClusterMachineConfig) error {
+		data, err := res.TypedSpec().Value.GetUncompressedData()
+		if err != nil {
+			return err
+		}
+
+		defer data.Free()
+
+		updatedConfig := suite.updateConfig(data.Data(), map[string]string{testKey: testVal})
+
+		return res.TypedSpec().Value.SetUncompressedData(updatedConfig)
+	})
 	suite.Require().NoError(err)
 
-	config, err := input.Config(machine.TypeControlPlane)
+	const rfc3339Millis = "2006-01-02T15:04:05.000Z07:00"
+
+	expectedDiffID := cmc.Metadata().ID() + "-" + clock.Now().UTC().Format(rfc3339Millis)
+
+	rtestutils.AssertResource[*omni.MachineConfigDiff](ctx, suite.T(), suite.state, expectedDiffID, func(res *omni.MachineConfigDiff, assertion *assert.Assertions) {
+		diff := res.TypedSpec().Value.Diff
+
+		assertion.Contains(diff, fmt.Sprintf("+        %s: %s", testKey, testVal))
+	})
+
+	return expectedDiffID
+}
+
+func (suite *RedactedClusterMachineConfigSuite) assertDiffCount(ctx context.Context, count int) {
+	diffList, err := safe.StateListAll[*omni.MachineConfigDiff](ctx, suite.state)
 	suite.Require().NoError(err)
 
-	data, err := config.Bytes()
+	suite.Require().Equalf(count, diffList.Len(), "expected %d diffs, got %d", count, diffList.Len())
+}
+
+func (suite *RedactedClusterMachineConfigSuite) updateConfig(existingConfig []byte, nodeLabelsToAdd map[string]string) []byte {
+	config, err := configloader.NewFromBytes(existingConfig)
 	suite.Require().NoError(err)
 
-	return data
+	config, err = config.PatchV1Alpha1(func(config *v1alpha1.Config) error {
+		config.MachineConfig.MachineNodeLabels = nodeLabelsToAdd
+
+		return nil
+	})
+	suite.Require().NoError(err)
+
+	encoded, err := config.EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
+	suite.Require().NoError(err)
+
+	return encoded
 }
 
 func TestRedactedClusterMachineConfigSuite(t *testing.T) {

--- a/internal/backend/runtime/omni/state_access.go
+++ b/internal/backend/runtime/omni/state_access.go
@@ -78,6 +78,10 @@ var (
 		omni.ExtensionsConfigurationStatusType,
 		omni.NodeForceDestroyRequestType, // cluster label is not strictly required to be present on this resource, except when the cluster access is granted via ACLs
 		omni.DiscoveryAffiliateDeleteTaskType,
+		omni.RedactedClusterMachineConfigType,
+		omni.MachineConfigDiffType,
+		infra.InfraMachineType,
+		infra.InfraMachineStatusType,
 	})
 
 	// userManagedResourceTypeSet is the set of resource types that are managed by the user.
@@ -412,6 +416,7 @@ func filterAccess(ctx context.Context, access state.Access) error {
 		omni.NodeForceDestroyRequestType,
 		omni.TalosUpgradeStatusType,
 		omni.RedactedClusterMachineConfigType,
+		omni.MachineConfigDiffType,
 		siderolink.LinkType,
 		siderolink.PendingMachineType,
 		siderolink.LinkStatusType,
@@ -572,6 +577,7 @@ func filterAccessByType(access state.Access) error {
 		omni.InstallationMediaType,
 		omni.OngoingTaskType,
 		omni.RedactedClusterMachineConfigType,
+		omni.MachineConfigDiffType,
 		omni.SchematicType,
 		omni.SchematicConfigurationType,
 		omni.ExtensionsConfigurationStatusType,

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -900,6 +900,10 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				allowedVerbSet: readOnlyVerbSet,
 			},
 			{
+				resource:       omni.NewMachineConfigDiff(uuid.New().String()),
+				allowedVerbSet: readOnlyVerbSet,
+			},
+			{
 				resource:       omni.NewImagePullRequest(resources.DefaultNamespace, uuid.New().String()),
 				allowedVerbSet: readOnlyVerbSet,
 			},


### PR DESCRIPTION
Change the RedactedClusterMachineConfig controller to also compute diffs between each config change and store them in a new resource.

Additionally, log this diff and include its creation in the audit logs.

Clean up old diffs with both size (count) and time-based retention. Include these diffs in the support bundles.

The resource ID follows the following pattern: `<machine-id>-<timestamp>`, e.g., `34bafa44-e994-4911-9c1a-609cccefee93-2025-07-04T19:05:40.181Z`.

Closes #1119.

## Sample Diff Resource

```yaml
get machineconfigdiff -oyaml
metadata:
    namespace: default
    type: MachineConfigDiffs.omni.sidero.dev
    id: 34bafa44-e994-4911-9c1a-609cccefee93-2025-07-04T19:05:40.181Z
    version: 1
    owner: RedactedClusterMachineConfigController
    phase: running
    created: 2025-07-04T19:05:40Z
    updated: 2025-07-04T19:05:40Z
    labels:
        omni.sidero.dev/cluster: talos-default
        omni.sidero.dev/machine: 34bafa44-e994-4911-9c1a-609cccefee93
        omni.sidero.dev/machine-set: talos-default-control-planes
        omni.sidero.dev/role-controlplane:
    annotations:
        omni.sidero.dev/modified-at: 2025-07-04T19:05:40.181685358Z
spec:
    diff: |-
        @@ -49,6 +49,7 @@
                     enabled: true
                     forwardKubeDNSToHost: true
             nodeLabels:
        +        aaa: bbb
                 node.kubernetes.io/exclude-from-external-load-balancers: ""
         cluster:
             id: Dyt3vOPZ26gywnEh4PQgf7n37Dmvp4KR4pAnu8RP33w=
```