### PR TITLE
test: reduce the log verbosity in unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-06-11T18:28:11Z by kres 37c4809-dirty.
+# Generated on 2025-07-09T11:15:01Z by kres 1700045.
 
 ARG JS_TOOLCHAIN
 ARG TOOLCHAIN
@@ -293,25 +293,25 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build
 FROM base AS unit-tests-client-race
 WORKDIR /src/client
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg --mount=type=cache,target=/tmp,id=omni/tmp CGO_ENABLED=1 go test -v -race -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg --mount=type=cache,target=/tmp,id=omni/tmp CGO_ENABLED=1 go test -race ${TESTPKGS}
 
 # runs unit-tests
 FROM base AS unit-tests-client-run
 WORKDIR /src/client
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg --mount=type=cache,target=/tmp,id=omni/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg --mount=type=cache,target=/tmp,id=omni/tmp go test -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} ${TESTPKGS}
 
 # runs unit-tests with race detector
 FROM base AS unit-tests-race
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg --mount=type=cache,target=/tmp,id=omni/tmp CGO_ENABLED=1 go test -v -race -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg --mount=type=cache,target=/tmp,id=omni/tmp CGO_ENABLED=1 go test -race ${TESTPKGS}
 
 # runs unit-tests
 FROM base AS unit-tests-run
 WORKDIR /src
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg --mount=type=cache,target=/tmp,id=omni/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg --mount=type=cache,target=/tmp,id=omni/tmp go test -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} ${TESTPKGS}
 
 # cleaned up specs and compiled versions
 FROM scratch AS generate

--- a/internal/backend/grpc/configs_test.go
+++ b/internal/backend/grpc/configs_test.go
@@ -23,6 +23,7 @@ import (
 	machineryconfig "github.com/siderolabs/talos/pkg/machinery/config"
 	talossecrets "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -57,7 +58,7 @@ func TestGenerateConfigs(t *testing.T) {
 	st := omniruntime.NewTestState(logger)
 
 	rt, err := omniruntime.NewRuntime(nil, nil, nil, nil,
-		nil, nil, nil, nil, st, prometheus.NewRegistry(), nil, logger)
+		nil, nil, nil, nil, st, prometheus.NewRegistry(), nil, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 	require.NoError(t, err)
 
 	runtime.Install(omniruntime.Name, rt)

--- a/internal/backend/grpc/grpc_test.go
+++ b/internal/backend/grpc/grpc_test.go
@@ -95,7 +95,7 @@ func (suite *GrpcSuite) SetupTest() {
 
 	suite.runtime, err = omniruntime.NewRuntime(
 		clientFactory, dnsService, workloadProxyReconciler, nil,
-		imageFactoryClient, nil, nil, nil, st, prometheus.NewRegistry(), discoveryClientCache, logger,
+		imageFactoryClient, nil, nil, nil, st, prometheus.NewRegistry(), discoveryClientCache, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)),
 	)
 	suite.Require().NoError(err)
 	runtime.Install(omniruntime.Name, suite.runtime)

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/resources/etcd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -429,7 +430,7 @@ func (suite *OmniSuite) SetupTest() {
 
 	logger := zaptest.NewLogger(suite.T())
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 	suite.Require().NoError(err)
 
 	k8s, err := kubernetes.NewWithTTL(suite.state, 0)

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
@@ -87,7 +88,7 @@ func (suite *MigrationSuite) SetupTest() {
 
 	suite.logger = zaptest.NewLogger(suite.T())
 
-	suite.manager = migration.NewManager(suite.state, suite.logger)
+	suite.manager = migration.NewManager(suite.state, suite.logger.WithOptions(zap.IncreaseLevel(zapcore.WarnLevel)))
 }
 
 func (suite *MigrationSuite) TestClusterInfo() {
@@ -1116,7 +1117,7 @@ func (suite *MigrationSuite) TestInstallDiskPatchMigration() {
 	oldVer := config.Metadata().Version()
 
 	// run controllers and verify that the config resource hasn't changed
-	runtime, err := runtime.NewRuntime(suite.state, suite.logger)
+	runtime, err := runtime.NewRuntime(suite.state, suite.logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 	suite.Require().NoError(err)
 
 	suite.Require().NoError(runtime.RegisterQController(omnictrl.NewMachineConfigGenOptionsController()))

--- a/internal/backend/runtime/omni/omni_test.go
+++ b/internal/backend/runtime/omni/omni_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
@@ -85,7 +86,7 @@ func (suite *OmniRuntimeSuite) SetupTest() {
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel)
 
 	suite.runtime, err = omniruntime.NewRuntime(clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
-		omniruntime.NewMockState(resourceState), prometheus.NewRegistry(), discoveryClientCache, logger)
+		omniruntime.NewMockState(resourceState), prometheus.NewRegistry(), discoveryClientCache, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 
 	suite.Require().NoError(err)
 

--- a/internal/backend/runtime/omni/talosconfig_test.go
+++ b/internal/backend/runtime/omni/talosconfig_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config"
 	talossecrets "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 
@@ -40,7 +41,7 @@ func TestOperatorTalosconfig(t *testing.T) {
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel)
 
 	r, err := omniruntime.NewRuntime(clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
-		st, prometheus.NewRegistry(), discoveryClientCache, logger)
+		st, prometheus.NewRegistry(), discoveryClientCache, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 
 	require.NoError(t, err)
 

--- a/internal/backend/runtime/talos/clients_test.go
+++ b/internal/backend/runtime/talos/clients_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/talos/pkg/machinery/config/bundle"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/omni/client/pkg/constants"
@@ -49,7 +50,7 @@ func (suite *ClientsSuite) SetupTest() {
 
 	logger := zaptest.NewLogger(suite.T()).With(logging.Component("clients"))
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 	suite.Require().NoError(err)
 
 	suite.wg.Add(1)

--- a/internal/pkg/siderolink/provision_test.go
+++ b/internal/pkg/siderolink/provision_test.go
@@ -91,7 +91,7 @@ func TestProvision(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(ctx)
 
-		runtime, err := runtime.NewRuntime(state, logger)
+		runtime, err := runtime.NewRuntime(state, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 		require.NoError(t, err)
 
 		peers := siderolink.NewPeersPool(logger, &fakeWireguardHandler{peers: map[string]wgtypes.Peer{}})

--- a/internal/pkg/siderolink/siderolink_test.go
+++ b/internal/pkg/siderolink/siderolink_test.go
@@ -144,7 +144,7 @@ func (suite *SiderolinkSuite) SetupTest() {
 
 	logger := zaptest.NewLogger(suite.T())
 
-	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 	suite.Require().NoError(err)
 
 	suite.wg.Add(1)


### PR DESCRIPTION
Our unit test logs are too verbose/excessive because:

- COSI runtime writes a lot of `reconcile succeeded` logs
- migration tests were too spammy

This caused the logs to get clipped by docker/buildx in the CI:
```
[output clipped, log limit 2MiB reached]
```
and resulted in mysterious test failures without the failure reason being printed.

With these changes we pull our unit test logs a bit below the 2MiB limit (1.7MiB).