### PR TITLE
fix: do not filter out noop events in the infra provider state

### DIFF
--- a/internal/backend/runtime/omni/infraprovider/state_test.go
+++ b/internal/backend/runtime/omni/infraprovider/state_test.go
@@ -368,7 +368,7 @@ func TestInfraProviderIDChecks(t *testing.T) {
 
 	eventCh = make(chan state.Event)
 
-	err = st.WatchKind(watchCtx, infra.NewMachineRequest("").Metadata(), eventCh, state.WithBootstrapContents(true))
+	err = st.WatchKind(watchCtx, infra.NewMachineRequest("").Metadata(), eventCh, state.WithBootstrapContents(true), state.WithBootstrapBookmark(true))
 	require.NoError(t, err)
 
 	assertEvents(watchCtx, t, eventCh, []eventInfo{
@@ -378,6 +378,9 @@ func TestInfraProviderIDChecks(t *testing.T) {
 		},
 		{
 			Type: state.Bootstrapped,
+		},
+		{
+			Type: state.Noop,
 		},
 	})
 


### PR DESCRIPTION
Infra provider state is a bit special - when an infra provider attempts an operation on a resource, we do an authorization check: is the provider allowed to be able to access this resource at all.

For the resources in their dedicated namespaces (e.g., `infra-provider:<id-of-the-provider>`), it is easy, but for the ones in common namespaces (e.g., `infra-provider`), we filter the returned resources.

When doing this filtering, we were wrongly not passing through the `state.Noop` events.

This caused the bookmark information to not be delivered to the clients, which broke the reconnection logic on the affected clients (infra providers).

Fix this and refactor the state to unify the filtering logic into common functions.