### PR TITLE
fix: preserve encoded join token version

### DIFF
--- a/client/pkg/jointoken/jointoken.go
+++ b/client/pkg/jointoken/jointoken.go
@@ -74,10 +74,15 @@ func NewPlain(token string) JoinToken {
 }
 
 // NewWithExtraData creates the token with extra data.
-func NewWithExtraData(token string, extraData map[string]string) (JoinToken, error) {
+func NewWithExtraData(token, version string, extraData map[string]string) (JoinToken, error) {
+	if _, err := versionToPrefix(version); err != nil {
+		return JoinToken{}, err
+	}
+
 	t := JoinToken{
 		ExtraData: extraData,
 		token:     token,
+		Version:   version,
 	}
 
 	var err error
@@ -160,5 +165,23 @@ func (t JoinToken) Encode() (string, error) {
 		return "", err
 	}
 
-	return v2Prefix + base64.StdEncoding.EncodeToString(data), nil
+	prefix, err := versionToPrefix(t.Version)
+	if err != nil {
+		return "", err
+	}
+
+	return prefix + base64.StdEncoding.EncodeToString(data), nil
+}
+
+func versionToPrefix(version string) (string, error) {
+	switch version {
+	case Version1:
+		return v1Prefix, nil
+	case Version2:
+		return v2Prefix, nil
+	case VersionPlain:
+		return "", fmt.Errorf("version %q does not have a prefix", VersionPlain)
+	default:
+		return "", fmt.Errorf("unsupported version %q", version)
+	}
 }

--- a/client/pkg/jointoken/jointoken_test.go
+++ b/client/pkg/jointoken/jointoken_test.go
@@ -14,38 +14,54 @@ import (
 	"github.com/siderolabs/omni/client/pkg/jointoken"
 )
 
-func TestParse(t *testing.T) {
-	token := jointoken.NewPlain("1234")
+func TestEncodeParse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plain", func(t *testing.T) {
+		t.Parallel()
+
+		token := jointoken.NewPlain("1234")
+
+		encoded, err := token.Encode()
+
+		require.NoError(t, err)
+
+		assert.True(t, token.IsValid("1234"))
+
+		parsed, err := jointoken.Parse(encoded)
+
+		require.NoError(t, err)
+
+		assert.True(t, parsed.IsValid("1234"))
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
+
+		tokenWithExtraData(t, jointoken.Version1)
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
+
+		tokenWithExtraData(t, jointoken.Version2)
+	})
+}
+
+func tokenWithExtraData(t *testing.T, version string) {
+	token, err := jointoken.NewWithExtraData("1234", version, map[string]string{
+		"a": "b",
+	})
+
+	require.NoError(t, err)
 
 	encoded, err := token.Encode()
 
 	require.NoError(t, err)
 
-	assert.True(t, token.IsValid("1234"))
+	assert.True(t, strings.HasPrefix(encoded, "v"+version+":"))
 
 	parsed, err := jointoken.Parse(encoded)
-
-	require.NoError(t, err)
-
-	assert.True(t, parsed.IsValid("1234"))
-
-	token, err = jointoken.NewWithExtraData("1234", map[string]string{
-		"a": "b",
-	})
-
-	require.NotEmpty(t, token.Signature)
-
-	require.NoError(t, err)
-
-	encoded, err = token.Encode()
-
-	require.NoError(t, err)
-
-	assert.True(t, strings.HasPrefix(encoded, "v2:"))
-
-	parsed, err = jointoken.Parse(encoded)
-
-	require.NotEmpty(t, parsed.Signature)
 
 	require.NoError(t, err)
 

--- a/client/pkg/siderolink/siderolink.go
+++ b/client/pkg/siderolink/siderolink.go
@@ -32,6 +32,7 @@ type JoinConfigOptions struct {
 	extraTokenData              map[string]string
 	joinToken                   string
 	machineAPIURL               string
+	version                     string
 	useGRPCTunnel               bool
 	withoutSiderolinkJoinConfig bool
 	logServerPort               int
@@ -72,6 +73,15 @@ func WithMachine(machine *omni.Machine) JoinConfigOption {
 		if providerID, ok := machine.Metadata().Annotations().Get(omni.LabelInfraProviderID); ok {
 			opts.extraTokenData[omni.LabelInfraProviderID] = providerID
 		}
+	}
+}
+
+// WithVersion sets the version of the join token.
+//
+// If not set, it will default to jointoken.Version2.
+func WithVersion(version string) JoinConfigOption {
+	return func(opts *JoinConfigOptions) {
+		opts.version = version
 	}
 }
 
@@ -145,6 +155,10 @@ func NewJoinOptions(opts ...JoinConfigOption) (*JoinOptions, error) {
 
 	for _, o := range opts {
 		o(&options)
+	}
+
+	if options.version == "" {
+		options.version = jointoken.Version2
 	}
 
 	if options.logServerPort == 0 {
@@ -262,7 +276,7 @@ func (opts *JoinOptions) RenderJoinConfig() ([]byte, error) {
 
 func encodeToken(options JoinConfigOptions) (string, error) {
 	if len(options.extraTokenData) != 0 {
-		jt, err := jointoken.NewWithExtraData(options.joinToken, options.extraTokenData)
+		jt, err := jointoken.NewWithExtraData(options.joinToken, options.version, options.extraTokenData)
 		if err != nil {
 			return "", err
 		}

--- a/internal/backend/runtime/omni/controllers/omni/machine_join_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_join_config.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/jointoken"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
@@ -40,6 +41,11 @@ func NewMachineJoinConfigController() *MachineJoinConfigController {
 					return err
 				}
 
+				parsedTokenUsage, err := jointoken.Parse(tokenUsage.TypedSpec().Value.TokenId)
+				if err != nil {
+					return err
+				}
+
 				siderolinkAPIConfig, err := safe.ReaderGetByID[*siderolinkres.APIConfig](ctx, r, siderolinkres.ConfigID)
 				if err != nil {
 					return err
@@ -51,6 +57,7 @@ func NewMachineJoinConfigController() *MachineJoinConfigController {
 					siderolink.WithLogServerPort(int(siderolinkAPIConfig.TypedSpec().Value.LogsPort)),
 					siderolink.WithMachineAPIURL(siderolinkAPIConfig.TypedSpec().Value.MachineApiAdvertisedUrl),
 					siderolink.WithMachine(machine),
+					siderolink.WithVersion(parsedTokenUsage.Version),
 				)
 				if err != nil {
 					return err

--- a/internal/backend/runtime/omni/controllers/omni/provider_join_config_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/provider_join_config_test.go
@@ -61,7 +61,7 @@ func (suite *ProviderJoinConfigSuite) TestReconcile() {
 		},
 	)
 
-	jt, err := jointoken.NewWithExtraData(token, map[string]string{
+	jt, err := jointoken.NewWithExtraData(token, jointoken.Version2, map[string]string{
 		omni.LabelInfraProviderID: provider.Metadata().ID(),
 	})
 

--- a/internal/pkg/siderolink/provision_test.go
+++ b/internal/pkg/siderolink/provision_test.go
@@ -572,7 +572,7 @@ func TestProvision(t *testing.T) {
 
 		state, provisionHandler := setup(ctx, t, config.JoinTokensModeStrict)
 
-		token, err := jointoken.NewWithExtraData(validToken, map[string]string{
+		token, err := jointoken.NewWithExtraData(validToken, jointoken.Version2, map[string]string{
 			omni.LabelMachineRequest: "hi",
 		})
 
@@ -628,7 +628,7 @@ func TestProvision(t *testing.T) {
 			providerUniqueToken = cfg.TypedSpec().Value.JoinToken
 		})
 
-		token, err := jointoken.NewWithExtraData(providerUniqueToken, map[string]string{
+		token, err := jointoken.NewWithExtraData(providerUniqueToken, jointoken.Version2, map[string]string{
 			omni.LabelInfraProviderID: providerID,
 		})
 
@@ -680,7 +680,7 @@ func TestProvision(t *testing.T) {
 			assert.NotEmpty(cfg.TypedSpec().Value.JoinToken)
 		})
 
-		token, err := jointoken.NewWithExtraData("meow", map[string]string{
+		token, err := jointoken.NewWithExtraData("meow", jointoken.Version2, map[string]string{
 			omni.LabelInfraProviderID: providerID,
 		})
 
@@ -703,7 +703,7 @@ func TestProvision(t *testing.T) {
 		_, err = provisionHandler.Provision(ctx, request)
 		require.Equal(t, codes.PermissionDenied, status.Code(err))
 
-		token, err = jointoken.NewWithExtraData(validToken, map[string]string{
+		token, err = jointoken.NewWithExtraData(validToken, jointoken.Version2, map[string]string{
 			omni.LabelInfraProviderID: "nonexistent",
 		})
 


### PR DESCRIPTION
If a machine is using a v1 token, generate its join config to also use the v1 version, do not promote it to be v2. This is needed for the existing bare-metal provider machines to not lose connectivity, because their tokens now are validated against v2 logic.


@Unix4ever I did this fix to make bare metal provider able to work again as-is, with their v1 tokens. But not exactly sure how much sense I am making. Can you check if I understood the problem right?