### PR TITLE
fix: do not try to encode `v1/v2` tokens in siderolink.NewJoinToken

### DIFF
--- a/client/pkg/siderolink/siderolink.go
+++ b/client/pkg/siderolink/siderolink.go
@@ -261,6 +261,16 @@ func (opts *JoinOptions) RenderJoinConfig() ([]byte, error) {
 }
 
 func encodeToken(options JoinConfigOptions) (string, error) {
+	token, err := jointoken.Parse(options.joinToken)
+	if err != nil {
+		return "", err
+	}
+
+	// if the token is already encoded do nothing
+	if token.Version != jointoken.VersionPlain {
+		return options.joinToken, nil
+	}
+
 	if len(options.extraTokenData) != 0 {
 		jt, err := jointoken.NewWithExtraData(options.joinToken, options.extraTokenData)
 		if err != nil {

--- a/client/pkg/siderolink/siderolink_test.go
+++ b/client/pkg/siderolink/siderolink_test.go
@@ -118,6 +118,24 @@ func TestConnectionParamsKernelArgs(t *testing.T) {
 			eventSinkPort: 8091,
 			logServerPort: 8092,
 		},
+		{
+			joinToken: "v1:eyJleHRyYV9kYXRhIjp7Im9tbmkuc2lkZXJvLmRldi9pbmZyYS1wcm92a" +
+				"WRlci1pZCI6InRlc3QifSwic2lnbmF0dXJlIjoiWTNpZ285V2xJSVZOWWpXZmgyWlg5NnpnWW5UQjlwWTI3ZEJaVnJwNDJMZz0ifQ==",
+			name:   "already encoded",
+			apiURL: "https://127.0.0.1:8099",
+			expectedArgs: []string{
+				"siderolink.api=https://127.0.0.1:8099?jointoken=" +
+					"v1%3AeyJleHRyYV9kYXRhIjp7Im9tbmkuc2lkZXJvLmRldi9pbmZyYS1wcm92a" +
+					"WRlci1pZCI6InRlc3QifSwic2lnbmF0dXJlIjoiWTNpZ285V2xJSVZOWWpXZmgyWlg5NnpnWW5UQjlwWTI3ZEJaVnJwNDJMZz0ifQ%3D%3D",
+				"talos.events.sink=[fdae:41e4:649b:9303::1]:8091",
+				"talos.logging.kernel=tcp://[fdae:41e4:649b:9303::1]:8092",
+			},
+			eventSinkPort: 8091,
+			logServerPort: 8092,
+			machine: &machine{
+				providerID: "test",
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			options := []siderolink.JoinConfigOption{


### PR DESCRIPTION
If the token is already encoded using `v1` or `v2` method we should ignore any extra args, as otherwise already encoded token is used for encoding the new one.

Make the code always use the token without changes if it's already encoded.