### PR TITLE
fix: allow encoding join tokens using v1 version

### DIFF
--- a/client/pkg/infra/infra_test.go
+++ b/client/pkg/infra/infra_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/registry"
 	"github.com/google/uuid"
 	"github.com/siderolabs/gen/channel"
 	"github.com/siderolabs/image-factory/pkg/schematic"
@@ -37,6 +38,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/jointoken"
 	infrares "github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	resourceregistry "github.com/siderolabs/omni/client/pkg/omni/resources/registry"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 )
 
@@ -366,6 +368,15 @@ func TestInfra(t *testing.T) {
 
 func setupInfra(ctx context.Context, t *testing.T, p *provisioner, opts ...infra.Option) state.State {
 	state := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	resourceRegistry := registry.NewResourceRegistry(state)
+
+	require.NoError(t, resourceRegistry.RegisterDefault(ctx))
+
+	// register Omni resources
+	for _, r := range resourceregistry.Resources {
+		require.NoError(t, resourceRegistry.Register(ctx, r))
+	}
 
 	logger := zaptest.NewLogger(t)
 

--- a/client/pkg/jointoken/jointoken.go
+++ b/client/pkg/jointoken/jointoken.go
@@ -74,10 +74,15 @@ func NewPlain(token string) JoinToken {
 }
 
 // NewWithExtraData creates the token with extra data.
-func NewWithExtraData(token string, extraData map[string]string) (JoinToken, error) {
+func NewWithExtraData(token, version string, extraData map[string]string) (JoinToken, error) {
+	if _, err := versionToPrefix(version); err != nil {
+		return JoinToken{}, err
+	}
+
 	t := JoinToken{
 		ExtraData: extraData,
 		token:     token,
+		Version:   version,
 	}
 
 	var err error
@@ -160,5 +165,23 @@ func (t JoinToken) Encode() (string, error) {
 		return "", err
 	}
 
-	return v2Prefix + base64.StdEncoding.EncodeToString(data), nil
+	prefix, err := versionToPrefix(t.Version)
+	if err != nil {
+		return "", err
+	}
+
+	return prefix + base64.StdEncoding.EncodeToString(data), nil
+}
+
+func versionToPrefix(version string) (string, error) {
+	switch version {
+	case Version1:
+		return v1Prefix, nil
+	case Version2:
+		return v2Prefix, nil
+	case VersionPlain:
+		return "", fmt.Errorf("version %q does not have a prefix", VersionPlain)
+	default:
+		return "", fmt.Errorf("unsupported version %q", version)
+	}
 }

--- a/client/pkg/jointoken/jointoken_test.go
+++ b/client/pkg/jointoken/jointoken_test.go
@@ -14,38 +14,54 @@ import (
 	"github.com/siderolabs/omni/client/pkg/jointoken"
 )
 
-func TestParse(t *testing.T) {
-	token := jointoken.NewPlain("1234")
+func TestEncodeParse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plain", func(t *testing.T) {
+		t.Parallel()
+
+		token := jointoken.NewPlain("1234")
+
+		encoded, err := token.Encode()
+
+		require.NoError(t, err)
+
+		assert.True(t, token.IsValid("1234"))
+
+		parsed, err := jointoken.Parse(encoded)
+
+		require.NoError(t, err)
+
+		assert.True(t, parsed.IsValid("1234"))
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
+
+		tokenWithExtraData(t, jointoken.Version1)
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
+
+		tokenWithExtraData(t, jointoken.Version2)
+	})
+}
+
+func tokenWithExtraData(t *testing.T, version string) {
+	token, err := jointoken.NewWithExtraData("1234", version, map[string]string{
+		"a": "b",
+	})
+
+	require.NoError(t, err)
 
 	encoded, err := token.Encode()
 
 	require.NoError(t, err)
 
-	assert.True(t, token.IsValid("1234"))
+	assert.True(t, strings.HasPrefix(encoded, "v"+version+":"))
 
 	parsed, err := jointoken.Parse(encoded)
-
-	require.NoError(t, err)
-
-	assert.True(t, parsed.IsValid("1234"))
-
-	token, err = jointoken.NewWithExtraData("1234", map[string]string{
-		"a": "b",
-	})
-
-	require.NotEmpty(t, token.Signature)
-
-	require.NoError(t, err)
-
-	encoded, err = token.Encode()
-
-	require.NoError(t, err)
-
-	assert.True(t, strings.HasPrefix(encoded, "v2:"))
-
-	parsed, err = jointoken.Parse(encoded)
-
-	require.NotEmpty(t, parsed.Signature)
 
 	require.NoError(t, err)
 

--- a/internal/backend/runtime/omni/controllers/omni/provider_join_config_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/provider_join_config_test.go
@@ -61,7 +61,7 @@ func (suite *ProviderJoinConfigSuite) TestReconcile() {
 		},
 	)
 
-	jt, err := jointoken.NewWithExtraData(token, map[string]string{
+	jt, err := jointoken.NewWithExtraData(token, jointoken.Version2, map[string]string{
 		omni.LabelInfraProviderID: provider.Metadata().ID(),
 	})
 

--- a/internal/pkg/siderolink/provision.go
+++ b/internal/pkg/siderolink/provision.go
@@ -286,11 +286,19 @@ func updateResourceWithMatchingToken[T res](ctx context.Context, logger *zap.Log
 }
 
 func (h *ProvisionHandler) provision(ctx context.Context, provisionContext *provisionContext) (*pb.ProvisionResponse, error) {
-	logger := h.logger.With(zap.String("machine", provisionContext.request.NodeUuid))
+	logger := h.logger.With(
+		zap.String("machine", provisionContext.request.NodeUuid),
+		zap.Bool("node_unique_tokens_enabled", provisionContext.nodeUniqueTokensEnabled),
+		zap.Bool("supports_secure_join_tokens", provisionContext.supportsSecureJoinTokens),
+		zap.Bool("has_valid_join_token", provisionContext.hasValidJoinToken),
+		zap.Bool("has_link_node_unique_token", provisionContext.linkNodeUniqueToken != nil),
+	)
 
 	// legacy flow, let it join unconditionally
 	if !provisionContext.nodeUniqueTokensEnabled || !provisionContext.supportsSecureJoinTokens {
 		if !provisionContext.isAuthorizedLegacyJoin() {
+			logger.Warn("machine is not allowed to join using legacy join flow")
+
 			return nil, status.Error(codes.PermissionDenied, "unauthorized")
 		}
 
@@ -298,6 +306,8 @@ func (h *ProvisionHandler) provision(ctx context.Context, provisionContext *prov
 	}
 
 	if !provisionContext.isAuthorizedSecureFlow() {
+		logger.Warn("machine is not allowed to join using secure join flow")
+
 		return nil, status.Error(codes.PermissionDenied, "unauthorized")
 	}
 
@@ -663,6 +673,8 @@ func (h *ProvisionHandler) getJoinToken(ctx context.Context, tokenString string)
 
 	linkToken, err := jointoken.Parse(tokenString)
 	if err != nil {
+		h.logger.Warn("machine join token rejected: invalid join token", zap.Error(err))
+
 		return nil, status.Errorf(codes.PermissionDenied, "invalid join token %s", err)
 	}
 

--- a/internal/pkg/siderolink/provision_test.go
+++ b/internal/pkg/siderolink/provision_test.go
@@ -572,7 +572,7 @@ func TestProvision(t *testing.T) {
 
 		state, provisionHandler := setup(ctx, t, config.JoinTokensModeStrict)
 
-		token, err := jointoken.NewWithExtraData(validToken, map[string]string{
+		token, err := jointoken.NewWithExtraData(validToken, jointoken.Version1, map[string]string{
 			omni.LabelMachineRequest: "hi",
 		})
 
@@ -628,7 +628,7 @@ func TestProvision(t *testing.T) {
 			providerUniqueToken = cfg.TypedSpec().Value.JoinToken
 		})
 
-		token, err := jointoken.NewWithExtraData(providerUniqueToken, map[string]string{
+		token, err := jointoken.NewWithExtraData(providerUniqueToken, jointoken.Version2, map[string]string{
 			omni.LabelInfraProviderID: providerID,
 		})
 
@@ -680,7 +680,7 @@ func TestProvision(t *testing.T) {
 			assert.NotEmpty(cfg.TypedSpec().Value.JoinToken)
 		})
 
-		token, err := jointoken.NewWithExtraData("meow", map[string]string{
+		token, err := jointoken.NewWithExtraData("meow", jointoken.Version2, map[string]string{
 			omni.LabelInfraProviderID: providerID,
 		})
 
@@ -703,7 +703,7 @@ func TestProvision(t *testing.T) {
 		_, err = provisionHandler.Provision(ctx, request)
 		require.Equal(t, codes.PermissionDenied, status.Code(err))
 
-		token, err = jointoken.NewWithExtraData(validToken, map[string]string{
+		token, err = jointoken.NewWithExtraData(validToken, jointoken.Version2, map[string]string{
 			omni.LabelInfraProviderID: "nonexistent",
 		})
 


### PR DESCRIPTION
This can help to support compatibility for the newer providers vs older Omni versions.

Also support legacy flow in the infra providers common library: if the provider join config doesn't exist, fallback to using `ConnectionParams` along with join token version 1.