### PR TITLE
fix: ignore `MachineStatus` having no TalosVersion in DNS service

### DIFF
--- a/internal/backend/dns/service.go
+++ b/internal/backend/dns/service.go
@@ -272,8 +272,6 @@ func (d *Service) updateEntryByMachineStatus(res *omni.MachineStatus) {
 	version := res.TypedSpec().Value.TalosVersion
 	if version == "" {
 		d.logger.Warn("no Talos version in the machine status", zap.String("id", res.Metadata().ID()))
-
-		return
 	}
 
 	d.lock.Lock()


### PR DESCRIPTION
We can probably tolerate it being empty in the Talos request proxying. Otherwise the behavior is confusing: the node is connected, but it's not possible to reach it with `talosctl` using the node UUID.