### PR TITLE
test: allow ignoring unknown config fields in the integration test

### DIFF
--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1851,7 +1851,7 @@ func migrateConnectionParamsToController(ctx context.Context, st state.State, _ 
 	return err
 }
 
-// populateJoinTokenUsage starting from 0.53 every machine provision request creates JoinTokenUsage resource.
+// populateJoinTokenUsage starting from 1.0 every machine provision request creates JoinTokenUsage resource.
 // Already existing machines won't call provision API, but should have resources created so we do it through migration.
 // As there was no multiple join token support in Omni they can be simply populated with the default token.
 func populateJoinTokenUsage(ctx context.Context, st state.State, _ *zap.Logger, _ migrationContext) error {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -72,9 +72,10 @@ var (
 	skipExtensionsCheckOnCreate bool
 	artifactsOutputDir          string
 
-	runEmbeddedOmni bool
-	omniConfigPath  string
-	omniLogOutput   string
+	runEmbeddedOmni     bool
+	ignoreUnknownFields bool
+	omniConfigPath      string
+	omniLogOutput       string
 )
 
 func TestIntegration(t *testing.T) {
@@ -273,6 +274,7 @@ func init() {
 	flag.BoolVar(&runEmbeddedOmni, "omni.embedded", false, "runs embedded Omni in the tests")
 	flag.StringVar(&omniConfigPath, "omni.config-path", "", "embedded Omni config path")
 	flag.StringVar(&omniLogOutput, "omni.log-output", "_out/omni-test.log", "output logs directory")
+	flag.BoolVar(&ignoreUnknownFields, "omni.ignore-unknown-fields", false, "makes Omni config loader ignore unknown fields")
 }
 
 func execCmd(ctx context.Context, parsedScript []string, args ...string) error {
@@ -391,7 +393,13 @@ func runOmni(t *testing.T) (string, error) {
 		return "", errors.New("omni.config-path must be set when running embedded Omni")
 	}
 
-	params, err := config.LoadFromFile(omniConfigPath)
+	var opts []config.ParseOption
+
+	if ignoreUnknownFields {
+		opts = append(opts, config.WithIgnoreUnknownFields())
+	}
+
+	params, err := config.LoadFromFile(omniConfigPath, opts...)
 	if err != nil {
 		return "", fmt.Errorf("failed to load omni config %w", err)
 	}


### PR DESCRIPTION
This is going to be enabled for the upgrade tests when we run the previous `integration-test` executable.
Otherwise new fields introduced in the config mess it up.