### PR TITLE
fix: properly handle empty configs in `omnictl config merge` CLI command

### DIFF
--- a/client/pkg/omnictl/config/config.go
+++ b/client/pkg/omnictl/config/config.go
@@ -180,6 +180,10 @@ func (c *Config) Merge(additionalConfigPath string) ([]Rename, error) {
 			renames = append(renames, Rename{name, mergedName})
 		}
 
+		if c.Contexts == nil {
+			c.Contexts = map[string]*Context{}
+		}
+
 		c.Contexts[mergedName] = ctx
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/omni/issues/683