### PR TITLE
fix: install frontend dependencies from lockfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-07-28T10:01:30Z by kres a3d02c0.
+# Generated on 2025-08-04T18:17:12Z by kres 95bf7d7.
 
 *
 !frontend/src
@@ -11,6 +11,7 @@
 !internal
 !docs
 !frontend/*.json
+!frontend/*.lock
 !frontend/*.toml
 !frontend/*.js
 !frontend/*.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-07-18T15:48:02Z by kres b869533.
+# Generated on 2025-08-04T18:17:12Z by kres 95bf7d7.
 
 ARG JS_TOOLCHAIN
 ARG TOOLCHAIN
@@ -86,7 +86,8 @@ ARG PROTOBUF_GRPC_GATEWAY_TS_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg go install github.com/siderolabs/protoc-gen-grpc-gateway-ts@v${PROTOBUF_GRPC_GATEWAY_TS_VERSION}
 RUN mv /go/bin/protoc-gen-grpc-gateway-ts /bin
 COPY frontend/package.json ./
-RUN --mount=type=cache,target=/src/node_modules,id=omni/src/node_modules,sharing=locked bun install
+COPY frontend/bun.lock ./
+RUN --mount=type=cache,target=/src/node_modules,id=omni/src/node_modules,sharing=locked bun install --frozen-lockfile
 COPY frontend/tsconfig*.json ./
 COPY frontend/bunfig.toml ./
 COPY frontend/*.html ./


### PR DESCRIPTION
`bun.lock` was not being copied over to the container, so inside the container dependencies were being quietly updated. In this instance, typescript was quietly updated from `5.8.3` to `5.9` which introduces a [change](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/) that resulted in this error during build:

<details>
<summary>
Output
</summary>

```
 => ERROR [omni frontend 1/3] RUN --mount=type=cache,target=/src/node_modules,id=omni/src/node_modules bun run build ${JS_BUILD_ARGS}                                            1.3s
------
 > [omni frontend 1/3] RUN --mount=type=cache,target=/src/node_modules,id=omni/src/node_modules bun run build ${JS_BUILD_ARGS}:
0.069 $ vue-tsc && vite build
1.129 src/methods/index.ts(144,53): error TS2345: Argument of type 'Uint8Array<ArrayBufferLike>[]' is not assignable to parameter of type 'BlobPart[]'.
1.129   Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'BlobPart'.
1.129     Type 'Uint8Array<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
1.129       Types of property 'buffer' are incompatible.
1.129         Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
1.129           Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
1.129             Types of property '[Symbol.toStringTag]' are incompatible.
1.129               Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.
1.138 error: script "build" exited with code 1
------
failed to solve: process "/bin/sh -c bun run build ${JS_BUILD_ARGS}" did not complete successfully: exit code: 1
make: *** [Makefile:398: docker-compose-up] Error 1
```
</details>

With this PR I copy over `bun.lock` and for good measure I added [`--frozen-lockfile`](https://bun.com/docs/cli/install#production-mode) which will throw an error if the `bun.lock` is out of date with `package.json` - to prevent this from happening by adding something to `package.json` without updating the lockfile.

Related:
- https://github.com/siderolabs/kres/pull/543