### PR TITLE
fix: stop enforcing talos version check on machine allocation

### DIFF
--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -301,6 +301,7 @@ const detectVersionMismatch = (machine: Resource<MachineStatusSpec>) => {
   const machineVersion = semver.parse(machine.spec.talos_version);
 
   const installed = machine.metadata.labels?.[MachineStatusLabelInstalled] !== undefined;
+  const inAgentMode = !!machine.spec.schematic?.in_agent_mode;
 
   if (!machineVersion || !clusterVersion) {
     return null;
@@ -308,6 +309,10 @@ const detectVersionMismatch = (machine: Resource<MachineStatusSpec>) => {
 
   if (!installed) {
     if (machineVersion?.major == clusterVersion?.major && machineVersion?.minor == clusterVersion?.minor) {
+      return null;
+    }
+
+    if (inAgentMode) {
       return null;
     }
 

--- a/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
@@ -162,9 +162,14 @@ const detectVersionMismatch = (machine: Resource<MachineStatusSpec>) => {
   const machineVersion = semver.parse(machine.spec.talos_version);
 
   const installed = machine.metadata.labels?.[MachineStatusLabelInstalled] !== undefined;
+  const inAgentMode = !!machine.spec.schematic?.in_agent_mode;
 
   if (!installed) {
     if (machineVersion?.major == clusterVersion?.major && machineVersion?.minor == clusterVersion?.minor) {
+      return null;
+    }
+
+    if (inAgentMode) {
       return null;
     }
 

--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -617,7 +617,9 @@ func machineSetNodeValidationOptions(st state.State) []validated.StateOption {
 			return err
 		}
 
-		if machineTalosVersion.Major > clusterTalosVersion.Major || machineTalosVersion.Minor > clusterTalosVersion.Minor {
+		inAgentMode := machineStatus.TypedSpec().Value.Schematic.GetInAgentMode()
+
+		if !inAgentMode && (machineTalosVersion.Major > clusterTalosVersion.Major || machineTalosVersion.Minor > clusterTalosVersion.Minor) {
 			return fmt.Errorf(
 				"cannot add machine set node to the cluster %s as it will trigger Talos downgrade on the node (%s -> %s)",
 				clusterName,
@@ -628,7 +630,7 @@ func machineSetNodeValidationOptions(st state.State) []validated.StateOption {
 
 		installed := omni.GetMachineStatusSystemDisk(machineStatus) != ""
 
-		if !installed && (machineTalosVersion.Major != clusterTalosVersion.Major || machineTalosVersion.Minor != clusterTalosVersion.Minor) {
+		if !installed && !inAgentMode && (machineTalosVersion.Major != clusterTalosVersion.Major || machineTalosVersion.Minor != clusterTalosVersion.Minor) {
 			return errors.New(
 				"machines which are running Talos without installation can be added only to Talos clusters with the same major and minor versions",
 			)


### PR DESCRIPTION
Do not enforce major.minor version check for talos on machine allocation if the machine is running in agent mode

Fixes #1358
