### PR TITLE
fix: keep control plane status up to date

### DIFF
--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -331,6 +331,10 @@ func (s *managementServer) collectClusterResources(ctx context.Context, cluster 
 			rt:          infra.InfraMachineStatusType,
 			listOptions: clusterQuery,
 		},
+		{
+			rt:          omni.ControlPlaneStatusType,
+			listOptions: clusterQuery,
+		},
 	}
 
 	machineIDs := map[string]struct{}{}


### PR DESCRIPTION
- Regularly wake up ControlPlaneStatusController to ensure the status
- Add ControlPlaneStatusType to SupportBundle
- Decrease the wait time if ControlPlaneStatus has errors, so we can reflect the actual state faster
 
Fixes #1404
