### PR TITLE
fix: prevent service account creation if name is already in use

### DIFF
--- a/internal/backend/grpc/serviceaccount.go
+++ b/internal/backend/grpc/serviceaccount.go
@@ -44,7 +44,7 @@ func (s *managementServer) CreateServiceAccount(ctx context.Context, req *manage
 
 	id, err := serviceaccount.Create(ctx, s.omniState, req.Name, req.Role, req.UseUserRole, []byte(req.ArmoredPgpPublicKey))
 	if err != nil {
-		return nil, err
+		return nil, wrapError(err)
 	}
 
 	return &management.CreateServiceAccountResponse{PublicKeyId: id}, nil

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -229,6 +229,12 @@ func AssertServiceAccountAPIFlow(testCtx context.Context, cli *client.Client) Te
 
 		assert.Equal(t, string(role.Admin), foundSA.Role)
 
+		// try to create a service account with the same name again
+		_, err = cli.Management().CreateServiceAccount(testCtx, name, armoredPublicKey, string(role.None), true)
+		assert.Equal(t, codes.AlreadyExists, status.Code(err), "error code should be codes.AlreadyExists")
+		assert.ErrorContains(t, err, "service account")
+		assert.ErrorContains(t, err, "already exists")
+
 		// destroy service account
 		err = cli.Management().DestroyServiceAccount(testCtx, name)
 		assert.NoError(t, err)

--- a/internal/pkg/auth/serviceaccount/serviceaccount.go
+++ b/internal/pkg/auth/serviceaccount/serviceaccount.go
@@ -60,7 +60,8 @@ func Create(ctx context.Context, st state.State, name, userRole string, useUserR
 	_, err := st.Get(ctx, ptr)
 	if err == nil {
 		return "", &eConflict{
-			res: ptr,
+			error: fmt.Errorf("service account %q already exists", id),
+			res:   ptr,
 		}
 	}
 


### PR DESCRIPTION
Prevent service account creation if name is already in use