### PR TITLE
chore: commit vscode settings for frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/frontend/.vscode/extensions.json
+++ b/frontend/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "Vue.volar",
+    "vitest.explorer",
+    "dbaeumer.vscode-eslint",
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode",
+    "bradlc.vscode-tailwindcss"
+  ]
+}

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "eslint.lintTask.options": "--flag unstable_native_nodejs_ts_config .",
+  "eslint.options": {
+    "flags": ["unstable_native_nodejs_ts_config"]
+  },
+  "eslint.runtime": "node",
+  "javascript.preferences.importModuleSpecifier": "non-relative",
+  "tailwindCSS.classFunctions": ["clsx"],
+  "typescript.preferences.preferTypeOnlyAutoImports": true
+}


### PR DESCRIPTION
Commit some recommended extensions and settings for frontend in vscode to the repository. After installing the recommended extensions, saving the file should automatically fix any style/code issues (if they are auto-fixable).

Can still run `npm run lint` to check for errors and/or `npm run lint:fix` to fix them. There will be some warning output for now for some small issues I haven't dealt with yet.

Will need to locally install node 22.18 or newer for the npm commands and/or extensions (particularly eslint, needs a funny flag for now that only that node supports).

Related:
- https://github.com/siderolabs/kres/pull/547