### PR TITLE
feat: support commands for getting kernel args and join configs in CLI

### DIFF
--- a/client/pkg/client/management/management.go
+++ b/client/pkg/client/management/management.go
@@ -419,3 +419,16 @@ func (client *Client) CreateJoinToken(ctx context.Context, name string, ttl time
 
 	return resp.Id, nil
 }
+
+// GetMachineJoinConfig generates the partial machine config for joining Omni.
+func (client *Client) GetMachineJoinConfig(ctx context.Context, tokenID string, useGRPCTunnel bool) (*management.GetMachineJoinConfigResponse, error) {
+	resp, err := client.conn.GetMachineJoinConfig(ctx, &management.GetMachineJoinConfigRequest{
+		UseGrpcTunnel: useGRPCTunnel,
+		JoinToken:     tokenID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
Two new commands for getting the partial machine join config and kernel args for a particular token ID:
- `omnictl jointoken machine-config <token-id>`
- `omnictl jointoken kernel-args <token-id>`