### PR TITLE
fix: add missing card styles to machines list

### DIFF
--- a/frontend/src/views/cluster/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewContent.vue
@@ -351,7 +351,7 @@ onMounted(async () => {
             />
           </div>
         </div>
-        <div class="overview-machines-list">
+        <div class="overview-card overview-machines-list">
           <div class="overview-box-header">
             <span class="overview-box-title">Machines</span>
           </div>


### PR DESCRIPTION
Add the missing card styles on the machines list in cluster overview. They were lost during tailwind v4 upgrade.