### PR TITLE
refactor: make cluster/machineset destroy status controllers QController

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_destroy_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_destroy_status_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+)
+
+func TestClusterDestroyStatusController(t *testing.T) {
+	t.Parallel()
+
+	sb := dynamicStateBuilder{m: map[resource.Namespace]state.CoreState{}}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	withRuntime(
+		ctx,
+		t,
+		sb.Builder,
+		func(_ context.Context, _ state.State, rt *runtime.Runtime, _ *zap.Logger) { // prepare - register controllers
+			require.NoError(t, rt.RegisterQController(omnictrl.NewClusterDestroyStatusController()))
+		},
+		func(ctx context.Context, st state.State, _ *runtime.Runtime, _ *zap.Logger) {
+			c := omni.NewCluster(resources.DefaultNamespace, "c1")
+			c.Metadata().Finalizers().Add("foo") // put a finalizer to mimic the cluster teardown
+			c.Metadata().Finalizers().Add(omnictrl.ClusterStatusControllerName)
+			require.NoError(t, st.Create(ctx, c))
+
+			machineSet := omni.NewMachineSetStatus(resources.DefaultNamespace, "ms1")
+			machineSet.Metadata().Labels().Set(omni.LabelCluster, c.Metadata().ID())
+			require.NoError(t, st.Create(ctx, machineSet))
+
+			for i := range 2 {
+				cms := omni.NewClusterMachineStatus(resources.DefaultNamespace, "cm"+strconv.Itoa(i))
+				cms.Metadata().Labels().Set(omni.LabelCluster, c.Metadata().ID())
+				cms.Metadata().Labels().Set(omni.LabelMachineSet, machineSet.Metadata().ID())
+				require.NoError(t, st.Create(ctx, cms))
+			}
+
+			rtestutils.AssertResource(ctx, t, st, c.Metadata().ID(), func(res *omni.Cluster, asrt *assert.Assertions) {
+				asrt.True(res.Metadata().Finalizers().Has(omnictrl.NewClusterDestroyStatusController().Name()))
+			})
+
+			rtestutils.AssertNoResource[*omni.ClusterDestroyStatus](ctx, t, st, c.Metadata().ID())
+
+			_, err := st.Teardown(ctx, c.Metadata())
+			require.NoError(t, err)
+
+			rtestutils.AssertResource(ctx, t, st, c.Metadata().ID(), func(res *omni.ClusterDestroyStatus, asrt *assert.Assertions) {
+				asrt.Equal("Destroying: 1 machine set, 2 machines", res.TypedSpec().Value.Phase)
+			})
+
+			rtestutils.Destroy[*omni.MachineSetStatus](ctx, t, st, []string{machineSet.Metadata().ID()})
+
+			rtestutils.AssertResource(ctx, t, st, c.Metadata().ID(), func(res *omni.ClusterDestroyStatus, asrt *assert.Assertions) {
+				asrt.Equal("Destroying: 0 machine sets, 0 machines", res.TypedSpec().Value.Phase)
+			})
+
+			require.NoError(t, st.RemoveFinalizer(ctx, c.Metadata(), "foo"))
+
+			rtestutils.AssertNoResource[*omni.ClusterDestroyStatus](ctx, t, st, c.Metadata().ID())
+		},
+	)
+}

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_destroy_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_destroy_status.go
@@ -8,121 +8,99 @@ package omni
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
 	"github.com/cosi-project/runtime/pkg/resource"
-	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/gertd/go-pluralize"
+	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/mappers"
 )
 
-// MachineSetDestroyStatusController manages MachineSet resource lifecycle.
-type MachineSetDestroyStatusController struct{}
-
-// Name implements controller.Controller interface.
-func (ctrl *MachineSetDestroyStatusController) Name() string {
-	return "MachineSetDestroyStatusController"
-}
-
-// Inputs implements controller.Controller interface.
-func (ctrl *MachineSetDestroyStatusController) Inputs() []controller.Input {
-	return []controller.Input{
-		{
-			Type:      omni.MachineSetType,
-			Kind:      controller.InputDestroyReady,
-			Namespace: resources.DefaultNamespace,
-		},
-		{
-			Type:      omni.ClusterMachineStatusType,
-			Kind:      controller.InputWeak,
-			Namespace: resources.DefaultNamespace,
-		},
-	}
-}
-
-// Outputs implements controller.Controller interface.
-func (ctrl *MachineSetDestroyStatusController) Outputs() []controller.Output {
-	return []controller.Output{
-		{
-			Type: omni.MachineSetDestroyStatusType,
-			Kind: controller.OutputExclusive,
-		},
-		{
-			Type: omni.MachineSetType,
-			Kind: controller.OutputShared,
-		},
-	}
-}
-
-// Run implements controller.Controller interface.
+// MachineSetDestroyStatusController manages MachineSetDestroyStatus resource.
 //
-//nolint:dupl
-func (ctrl *MachineSetDestroyStatusController) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-r.EventCh():
-		}
+// MachineSetDestroyStatusController aggregates the machineset state based on the cluster machines states.
+type MachineSetDestroyStatusController = qtransform.QController[*omni.MachineSet, *omni.MachineSetDestroyStatus]
 
-		tracker := trackResource(r, resources.EphemeralNamespace, omni.MachineSetDestroyStatusType)
+// MachineSetDestroyStatusControllerName is the name of the MachineSetDestroyStatusController.
+const MachineSetDestroyStatusControllerName = "MachineSetDestroyStatusController"
 
-		machineSets, err := safe.ReaderListAll[*omni.MachineSet](ctx, r)
-		if err != nil {
-			return fmt.Errorf("error listing Machine Set resources: %w", err)
-		}
-
-		for machineSet := range machineSets.All() {
-			if machineSet.Metadata().Phase() != resource.PhaseTearingDown {
-				continue
-			}
-
-			tracker.keep(machineSet)
-
-			if err = ctrl.collectDestroyStatus(ctx, machineSet, r); err != nil {
-				return err
-			}
-
-			if machineSet.Metadata().Finalizers().Empty() {
-				if err = r.Destroy(ctx, machineSet.Metadata(), controller.WithOwner("")); err != nil {
-					if state.IsNotFoundError(err) {
-						continue
-					}
-
-					return fmt.Errorf("failed to destroy machine set: %w", err)
+// NewMachineSetDestroyStatusController initializes MachineSetDestroyStatusController.
+//
+//nolint:gocognit
+func NewMachineSetDestroyStatusController() *MachineSetDestroyStatusController {
+	return qtransform.NewQController(
+		qtransform.Settings[*omni.MachineSet, *omni.MachineSetDestroyStatus]{
+			Name: MachineSetDestroyStatusControllerName,
+			MapMetadataFunc: func(machineSet *omni.MachineSet) *omni.MachineSetDestroyStatus {
+				return omni.NewMachineSetDestroyStatus(resources.EphemeralNamespace, machineSet.Metadata().ID())
+			},
+			UnmapMetadataFunc: func(machineSetDestroyStatus *omni.MachineSetDestroyStatus) *omni.MachineSet {
+				return omni.NewMachineSet(resources.DefaultNamespace, machineSetDestroyStatus.Metadata().ID())
+			},
+			TransformExtraOutputFunc: func(ctx context.Context, r controller.ReaderWriter, _ *zap.Logger, machineSet *omni.MachineSet, machineSetDestroyStatus *omni.MachineSetDestroyStatus) error {
+				cmStatuses, err := r.List(ctx, omni.NewClusterMachineStatus(resources.DefaultNamespace, "").Metadata(),
+					state.WithLabelQuery(resource.LabelEqual(
+						omni.LabelMachineSet, machineSet.Metadata().ID()),
+					),
+				)
+				if err != nil {
+					return err
 				}
-			}
-		}
 
-		if err = tracker.cleanup(ctx); err != nil {
-			return err
-		}
-	}
+				remainingMachines := 0
+				for _, cmStatus := range cmStatuses.Items {
+					switch cmStatus.Metadata().Phase() {
+					case resource.PhaseRunning:
+						if !cmStatus.Metadata().Finalizers().Has(MachineSetDestroyStatusControllerName) {
+							if err = r.AddFinalizer(ctx, cmStatus.Metadata(), MachineSetDestroyStatusControllerName); err != nil {
+								return err
+							}
+						}
+						remainingMachines++
+					case resource.PhaseTearingDown:
+						if cmStatus.Metadata().Finalizers().Has(MachineSetDestroyStatusControllerName) {
+							if hasOnlyDestroyStatusFinalizers(cmStatus.Metadata()) {
+								if err = r.RemoveFinalizer(ctx, cmStatus.Metadata(), MachineSetDestroyStatusControllerName); err != nil {
+									return err
+								}
+
+								continue
+							}
+							remainingMachines++
+						}
+					}
+				}
+
+				if machineSet.Metadata().Phase() != resource.PhaseTearingDown {
+					return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("not tearing down")
+				}
+
+				machineSetDestroyStatus.TypedSpec().Value.Phase = fmt.Sprintf("Destroying: %s", pluralize.NewClient().Pluralize("machine", remainingMachines, true))
+
+				return nil
+			},
+		},
+		qtransform.WithExtraMappedInput(mappers.MapByMachineSetLabel[*omni.ClusterMachineStatus, *omni.MachineSet]()),
+		qtransform.WithIgnoreTeardownUntil(),
+	)
 }
 
-func (ctrl *MachineSetDestroyStatusController) collectDestroyStatus(ctx context.Context, machineSet *omni.MachineSet, r controller.Runtime) error {
-	var err error
+// hasOnlyDestroyStatusFinalizers reports if ClusterMachineStatus resource has only specified DestroyStatusControllers* as finalizer.
+func hasOnlyDestroyStatusFinalizers(clusterMachineStatusMD *resource.Metadata) bool {
+	destroyStatusControllers := []string{ClusterDestroyStatusControllerName, MachineSetDestroyStatusControllerName}
 
-	machines, err := r.List(ctx, omni.NewClusterMachineStatus(resources.DefaultNamespace, machineSet.Metadata().ID()).Metadata(),
-		state.WithLabelQuery(resource.LabelEqual(
-			omni.LabelMachineSet, machineSet.Metadata().ID()),
-		),
-	)
-	if err != nil {
-		return err
+	for _, fin := range *clusterMachineStatusMD.Finalizers() {
+		if !slices.Contains(destroyStatusControllers, fin) { // there is a finalizer that is not a destroy status controller
+			return false
+		}
 	}
 
-	remainingMachines := len(machines.Items)
-
-	return safe.WriterModify(ctx, r, omni.NewMachineSetDestroyStatus(resources.EphemeralNamespace, machineSet.Metadata().ID()), func(status *omni.MachineSetDestroyStatus) error {
-		status.TypedSpec().Value.Phase = fmt.Sprintf("Destroying: %s",
-			pluralize.NewClient().Pluralize("machine", remainingMachines, true),
-		)
-
-		return nil
-	})
+	return true
 }

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_destroy_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_destroy_status_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+)
+
+func TestMachineSetDestroyStatusController(t *testing.T) {
+	t.Parallel()
+
+	sb := dynamicStateBuilder{m: map[resource.Namespace]state.CoreState{}}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	withRuntime(
+		ctx,
+		t,
+		sb.Builder,
+		func(_ context.Context, _ state.State, rt *runtime.Runtime, _ *zap.Logger) { // prepare - register controllers
+			require.NoError(t, rt.RegisterQController(omnictrl.NewMachineSetDestroyStatusController()))
+		},
+		func(ctx context.Context, st state.State, _ *runtime.Runtime, _ *zap.Logger) {
+			machineSet := omni.NewMachineSet(resources.DefaultNamespace, "ms1")
+			machineSet.Metadata().Finalizers().Add("foo") // put a finalizer to mimic the machine set teardown
+			require.NoError(t, st.Create(ctx, machineSet))
+
+			for i := range 2 {
+				cms := omni.NewClusterMachineStatus(resources.DefaultNamespace, "cm"+strconv.Itoa(i))
+				cms.Metadata().Labels().Set(omni.LabelMachineSet, machineSet.Metadata().ID())
+				require.NoError(t, st.Create(ctx, cms))
+			}
+
+			rtestutils.AssertResource(ctx, t, st, machineSet.Metadata().ID(), func(res *omni.MachineSet, asrt *assert.Assertions) {
+				asrt.True(res.Metadata().Finalizers().Has(omnictrl.NewMachineSetDestroyStatusController().Name()))
+			})
+
+			rtestutils.AssertNoResource[*omni.MachineSetDestroyStatus](ctx, t, st, machineSet.Metadata().ID())
+
+			_, err := st.Teardown(ctx, machineSet.Metadata())
+			require.NoError(t, err)
+
+			rtestutils.AssertResource(ctx, t, st, machineSet.Metadata().ID(), func(res *omni.MachineSetDestroyStatus, asrt *assert.Assertions) {
+				asrt.Equal("Destroying: 2 machines", res.TypedSpec().Value.Phase)
+			})
+
+			rtestutils.AssertResource(ctx, t, st, "cm0", func(res *omni.ClusterMachineStatus, asrt *assert.Assertions) {
+				asrt.True(res.Metadata().Finalizers().Has(omnictrl.NewMachineSetDestroyStatusController().Name()))
+			})
+
+			rtestutils.Destroy[*omni.ClusterMachineStatus](ctx, t, st, []string{"cm0"})
+
+			rtestutils.AssertResource(ctx, t, st, machineSet.Metadata().ID(), func(res *omni.MachineSetDestroyStatus, asrt *assert.Assertions) {
+				asrt.Equal("Destroying: 1 machine", res.TypedSpec().Value.Phase)
+			})
+
+			_, err = st.UpdateWithConflicts(ctx, machineSet.Metadata(), func(ms resource.Resource) error {
+				ms.Metadata().Labels().Set("foo", "bar")
+
+				return nil
+			}, state.WithExpectedPhaseAny())
+			require.NoError(t, err)
+
+			rtestutils.Destroy[*omni.ClusterMachineStatus](ctx, t, st, []string{"cm1"})
+
+			rtestutils.AssertResource(ctx, t, st, machineSet.Metadata().ID(), func(res *omni.MachineSetDestroyStatus, asrt *assert.Assertions) {
+				asrt.Equal("Destroying: 0 machines", res.TypedSpec().Value.Phase)
+			})
+
+			require.NoError(t, st.RemoveFinalizer(ctx, machineSet.Metadata(), "foo"))
+
+			rtestutils.AssertNoResource[*omni.MachineSetDestroyStatus](ctx, t, st, machineSet.Metadata().ID())
+		},
+	)
+}

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -214,7 +214,6 @@ func NewRuntime(talosClientFactory *talos.ClientFactory, dnsService *dns.Service
 		omnictrl.NewCertRefreshTickController(constants.CertificateValidityTime / 10), // issue ticks at 10% of the validity, as we refresh certificates at 50% of the validity
 		omnictrl.NewClusterController(),
 		omnictrl.NewMachineSetController(),
-		&omnictrl.ClusterDestroyStatusController{},
 		&omnictrl.ClusterMachineIdentityController{},
 		&omnictrl.ClusterMachineStatusMetricsController{},
 		omnictrl.NewClusterMachineController(),
@@ -232,7 +231,6 @@ func NewRuntime(talosClientFactory *talos.ClientFactory, dnsService *dns.Service
 		omnictrl.NewKubernetesStatusController(config.Config.Services.API.URL(), config.Config.Services.WorkloadProxy.Subdomain),
 		&omnictrl.LoadBalancerController{},
 		&omnictrl.MachineSetNodeController{},
-		&omnictrl.MachineSetDestroyStatusController{},
 		omnictrl.NewMachineCleanupController(),
 		omnictrl.NewMachineStatusLinkController(linkCounterDeltaCh),
 		&omnictrl.MachineStatusMetricsController{},
@@ -256,10 +254,14 @@ func NewRuntime(talosClientFactory *talos.ClientFactory, dnsService *dns.Service
 
 	qcontrollers := []controller.QController{
 		destroy.NewController[*siderolinkres.Link](optional.Some[uint](4)),
+		destroy.NewController[*omni.Cluster](optional.Some[uint](4)),
+		destroy.NewController[*omni.MachineSet](optional.Some[uint](4)),
 
 		omnictrl.NewBackupDataController(),
 		omnictrl.NewClusterBootstrapStatusController(storeFactory),
 		omnictrl.NewClusterConfigVersionController(),
+		omnictrl.NewClusterDestroyStatusController(),
+		omnictrl.NewMachineSetDestroyStatusController(),
 		omnictrl.NewClusterEndpointController(),
 		omnictrl.NewClusterKubernetesNodesController(),
 		omnictrl.NewClusterMachineConfigController(


### PR DESCRIPTION
Use generic `destroy` controller to kill tearing down resources with no finalizers (`cluster` and `machineset`). 

Rewrite DestroyStatus controllers to be QControllers, and just manage the status of the destroy process.