### PR TITLE
chore: use vue specific rules for dot-notation and eqeqeq

### DIFF
--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -31,8 +31,6 @@ export default defineConfigWithVueTs(
       'simple-import-sort': simpleImportSort,
     },
     rules: {
-      'dot-notation': 'error',
-      eqeqeq: 'error',
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
       'vue/block-lang': ['error', { script: { lang: 'ts' } }],
@@ -44,6 +42,8 @@ export default defineConfigWithVueTs(
         { registeredComponentsOnly: false },
       ],
       'vue/component-options-name-casing': 'error',
+      'vue/dot-notation': 'error',
+      'vue/eqeqeq': 'error',
       'vue/match-component-file-name': 'error',
       'vue/match-component-import-name': 'error',
       'vue/next-tick-style': 'error',

--- a/frontend/src/components/common/TInput/TInput.vue
+++ b/frontend/src/components/common/TInput/TInput.vue
@@ -134,7 +134,7 @@ onMounted(() => {
       :type="type"
       class="input-box-input"
       :placeholder="placeholder"
-      @input="updateValue($event.target?.['value'].trim())"
+      @input="updateValue(($event.target as HTMLInputElement)?.value.trim())"
       @focus="isFocused = true"
       @blur="blurHandler"
     />


### PR DESCRIPTION
Use vue specific rules for dot-notation and eqeqeq which extend the rules to inside templates