### PR TITLE
test: use clustermachineconfig sha for omni upgrade e2e test

### DIFF
--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -296,6 +296,10 @@ func (s *managementServer) collectClusterResources(ctx context.Context, cluster 
 			listOptions: clusterQuery,
 		},
 		{
+			rt:          omni.ClusterMachineConfigStatusType,
+			listOptions: clusterQuery,
+		},
+		{
 			rt:          omni.ClusterMachineTalosVersionType,
 			listOptions: clusterQuery,
 		},

--- a/internal/backend/runtime/omni/state_access.go
+++ b/internal/backend/runtime/omni/state_access.go
@@ -57,7 +57,6 @@ var (
 	// clusterLabelTypeSet is the set of resource types which have the related cluster's ID as a label.
 	clusterLabelTypeSet = xslices.ToSet([]resource.Type{
 		omni.ClusterMachineConfigType,
-		omni.ClusterMachineConfigStatusType,
 		omni.ClusterMachineIdentityType,
 		omni.ClusterMachineType,
 		omni.ClusterMachineConfigPatchesType,
@@ -382,6 +381,7 @@ func filterAccess(ctx context.Context, access state.Access) error {
 		omni.ClusterMachineTalosVersionType,
 		omni.ClusterMachineType,
 		omni.ClusterMachineConfigPatchesType,
+		omni.ClusterMachineConfigStatusType,
 		omni.ClusterMachineTemplateType,
 		omni.ClusterStatusType,
 		omni.ClusterDiagnosticsType,
@@ -546,6 +546,7 @@ func filterAccessByType(access state.Access) error {
 		omni.ClusterMachineTalosVersionType,
 		omni.ClusterMachineType,
 		omni.ClusterMachineConfigPatchesType,
+		omni.ClusterMachineConfigStatusType,
 		omni.ClusterMachineTemplateType,
 		omni.ClusterStatusMetricsType,
 		omni.ClusterStatusType,

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -805,6 +805,10 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				allowedVerbSet: readOnlyVerbSet,
 			},
 			{
+				resource:       omni.NewClusterMachineConfigStatus(resources.DefaultNamespace, uuid.New().String()),
+				allowedVerbSet: readOnlyVerbSet,
+			},
+			{
 				resource:       omni.NewClusterMachineRequestStatus(resources.DefaultNamespace, uuid.New().String()),
 				allowedVerbSet: readOnlyVerbSet,
 			},
@@ -1081,9 +1085,6 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 			},
 			{
 				resource: authres.NewPublicKey(resources.DefaultNamespace, uuid.New().String()),
-			},
-			{
-				resource: omni.NewClusterMachineConfigStatus(resources.DefaultNamespace, uuid.New().String()),
 			},
 			{
 				resource: omni.NewEtcdAuditResult(resources.DefaultNamespace, uuid.New().String()),


### PR DESCRIPTION
Save `ClusterMachineConfigStatus.ClusterMachineConfigSha256` on SaveClusterStatus e2e test. We will later compare this with actual value on AssertClusterStatus e2e test.
