### PR TITLE
fix: fix the log spam caused by the expensive reqs to embedded etcd

### DIFF
--- a/internal/backend/runtime/omni/state_etcd.go
+++ b/internal/backend/runtime/omni/state_etcd.go
@@ -181,6 +181,7 @@ func getEmbeddedEtcdState(params *config.EtcdParams, logger *zap.Logger) (EtcdSt
 	cfg.ExperimentalCompactHashCheckEnabled = true
 	cfg.ExperimentalInitialCorruptCheck = true
 	cfg.UnsafeNoFsync = params.EmbeddedUnsafeFsync
+	cfg.WarningUnaryRequestDuration = embed.DefaultWarningUnaryRequestDuration
 
 	peerURL, err := url.Parse("http://localhost:0")
 	if err != nil {


### PR DESCRIPTION
The recent changes in the embedded etcd dependency caused it to log every request to it with the warning level due to the expensive request duration threshold being set to the zero value of duration. Fix this by setting the threshold to the default constant (300ms), which is the default for the etcd when it is run normally (not embedded).