### PR TITLE
fix: console warning about invalid watch value

### DIFF
--- a/frontend/src/methods/auth.ts
+++ b/frontend/src/methods/auth.ts
@@ -34,7 +34,7 @@ export const permissions: Ref<Resource<PermissionsSpec> | undefined> = ref()
 
 const clusterPermissionsCache: Record<string, Resource<ClusterPermissionsSpec>> = {}
 
-export const setupClusterPermissions = (cluster: { value: string }) => {
+export const setupClusterPermissions = (cluster: Ref<string>) => {
   const result = {
     canUpdateKubernetes: ref(false),
     canUpdateTalos: ref(false),

--- a/frontend/src/views/common/NodeContextMenu.vue
+++ b/frontend/src/views/common/NodeContextMenu.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { copyText } from 'vue3-clipboard'
 
@@ -22,9 +23,9 @@ const props = defineProps<{
   clusterMachineStatus: Resource<ClusterMachineStatusSpec>
 }>()
 
-const { canRebootMachines, canAddClusterMachines, canRemoveMachines } = setupClusterPermissions({
-  value: props.clusterName,
-})
+const { canRebootMachines, canAddClusterMachines, canRemoveMachines } = setupClusterPermissions(
+  computed(() => props.clusterName),
+)
 
 const deleteNode = () => {
   router.push({


### PR DESCRIPTION
Fixes a console warning about an invalid watch value being sent to vue.


```
[Vue warn]: Invalid watch source:  {value: 'talos-default-1'}
A watch source can only be a getter/effect function, a ref, a reactive object, or an array of these types. 
  at <NodeContextMenu cluster-machine-status=...
```