### PR TITLE
fix: bump workload proxy healthcheck timeouts

### DIFF
--- a/internal/backend/services/workloadproxy/reconciler.go
+++ b/internal/backend/services/workloadproxy/reconciler.go
@@ -266,7 +266,7 @@ func (registry *Reconciler) dialProxy(ctx context.Context, network, address stri
 	alias := parts[0]
 	clusterID := parts[1]
 
-	pickCtx, cancel := context.WithTimeout(ctx, time.Second)
+	pickCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	destAddress, err := registry.pickDestAddress(pickCtx, clusterID, alias)


### PR DESCRIPTION
1 second is too aggressive so the first request on the not running healthcheck always fails.