### PR TITLE
fix: do not make not running lazy workload proxy healthchecker block

### DIFF
--- a/internal/backend/workloadproxy/lb/lazy.go
+++ b/internal/backend/workloadproxy/lb/lazy.go
@@ -6,7 +6,6 @@
 package lb
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -72,7 +71,7 @@ func (l *Lazy) Reconcile(upstreamAddresses []string) error {
 }
 
 // PickAddress picks an upstream address from the load balancer, initializing it if necessary.
-func (l *Lazy) PickAddress(ctx context.Context) (string, error) {
+func (l *Lazy) PickAddress() (string, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -94,7 +93,7 @@ func (l *Lazy) PickAddress(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return l.lb.PickAddress(ctx)
+	return l.lb.PickAddress()
 }
 
 // Notify notifies the load balancer to refresh its internal state.

--- a/internal/backend/workloadproxy/lb/lb.go
+++ b/internal/backend/workloadproxy/lb/lb.go
@@ -57,11 +57,7 @@ func (lb *LB) Reconcile(upstreamAddresses []string) error {
 }
 
 // PickAddress picks a healthy upstream address from the load balancer.
-func (lb *LB) PickAddress(ctx context.Context) (string, error) {
-	if err := lb.upstreams.WaitForInitialHealthcheck(ctx); err != nil {
-		return "", err
-	}
-
+func (lb *LB) PickAddress() (string, error) {
 	pickedNode, err := lb.upstreams.Pick()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Drop `WaitForInitialHealthcheck` from the `PickAddress` call. This will make `PickAddress` pick a random address if the healtchecks are not running yet.


(cherry picked from commit 43ec5b041d2162a6a827dc74463d059c428dc669)