### PR TITLE
chore: rekres providing `lint-fmt` and fixing frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-09T11:07:14Z by kres 9ebde93.
+# Generated on 2025-09-09T14:12:27Z by kres ba56673.
 
 # common variables
 
@@ -315,6 +315,9 @@ lint-markdown:  ## Runs markdownlint.
 
 .PHONY: lint
 lint: lint-eslint lint-golangci-lint-client lint-gofumpt-client lint-govulncheck-client lint-golangci-lint lint-gofumpt lint-govulncheck lint-markdown  ## Run all linters for the project.
+
+.PHONY: lint-fmt
+lint-fmt: lint-eslint-fmt lint-golangci-lint-client-fmt lint-golangci-lint-fmt  ## Run all linter formatters and fix up the source tree.
 
 .PHONY: image-omni
 image-omni:  ## Builds image for omni.


### PR DESCRIPTION
This pulls in two kres changes:

* https://github.com/siderolabs/kres/pull/562
* https://github.com/siderolabs/kres/pull/563