### PR TITLE
chore: replace deprecated libraries with vueuse

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,8 +13,9 @@
         "@heroicons/vue": "^2.2.0",
         "@jsonforms/vue": "^3.5.1",
         "@jsonforms/vue-vanilla": "^3.5.1",
+        "@vueuse/components": "^13.9.0",
+        "@vueuse/core": "^13.9.0",
         "apexcharts": "^5.3.2",
-        "click-outside-vue3": "^4.0.1",
         "fetch-intercept": "^2.4.0",
         "js-yaml": "^4.1.0",
         "jwt-decode": "^4.0.0",
@@ -30,7 +31,6 @@
         "vue-virtual-scroller": "^2.0.0-beta.8",
         "vue-word-highlighter": "^1.2.5",
         "vue3-apexcharts": "^1.8.0",
-        "vue3-clipboard": "^1.0.0",
         "vue3-popper": "^1.5.0",
         "whatwg-fetch": "^3.6.20"
       },
@@ -4667,6 +4667,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
@@ -5554,6 +5560,57 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vueuse/components": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-13.9.0.tgz",
+      "integrity": "sha512-0DDFpjG3hEEK+3YgSzE/OzOGqpo/KmxcXWzW2YdmgahZvaoUdegn68GmbdcHRJE7CH55dDj13Cz47iN8QoI3jQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/core": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
+      "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
+      "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
+      "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/@yr/monotone-cubic-spline": {
@@ -6565,26 +6622,6 @@
         "consola": "^3.2.3"
       }
     },
-    "node_modules/click-outside-vue3": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/click-outside-vue3/-/click-outside-vue3-4.0.1.tgz",
-      "integrity": "sha512-sbplNecrup5oGqA3o4bo8XmvHRT6q9fvw21Z67aDbTqB9M6LF7CuYLTlLvNtOgKU6W3zst5H5zJuEh4auqA34g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clipboard": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
-      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "license": "MIT",
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "node_modules/clipboardy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
@@ -7553,12 +7590,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "license": "MIT"
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "license": "MIT"
     },
     "node_modules/denque": {
@@ -8869,15 +8900,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "license": "MIT",
-      "dependencies": {
-        "delegate": "^3.1.2"
       }
     },
     "node_modules/gopd": {
@@ -13077,12 +13099,6 @@
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "license": "MIT"
     },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -13871,12 +13887,6 @@
       "engines": {
         "node": ">=0.6.0"
       }
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -15381,18 +15391,6 @@
       "peerDependencies": {
         "apexcharts": ">=4.0.0",
         "vue": ">=3.0.0"
-      }
-    },
-    "node_modules/vue3-clipboard": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue3-clipboard/-/vue3-clipboard-1.0.0.tgz",
-      "integrity": "sha512-GUqKh1oO79xDpq0z+cCv/NDVTpcJGNDzeNgT3PmTdTp/WJh3gcTrDqIYKycKhzMFOtIFJ7hO/+usgyWtT+fNhA==",
-      "license": "ISC",
-      "dependencies": {
-        "clipboard": "^2.0.6"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
       }
     },
     "node_modules/vue3-popper": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,8 +20,9 @@
     "@heroicons/vue": "^2.2.0",
     "@jsonforms/vue": "^3.5.1",
     "@jsonforms/vue-vanilla": "^3.5.1",
+    "@vueuse/components": "^13.9.0",
+    "@vueuse/core": "^13.9.0",
     "apexcharts": "^5.3.2",
-    "click-outside-vue3": "^4.0.1",
     "fetch-intercept": "^2.4.0",
     "js-yaml": "^4.1.0",
     "jwt-decode": "^4.0.0",
@@ -37,7 +38,6 @@
     "vue-virtual-scroller": "^2.0.0-beta.8",
     "vue-word-highlighter": "^1.2.5",
     "vue3-apexcharts": "^1.8.0",
-    "vue3-clipboard": "^1.0.0",
     "vue3-popper": "^1.5.0",
     "whatwg-fetch": "^3.6.20"
   },

--- a/frontend/src/components/common/ActionsBox/TActionsBox.vue
+++ b/frontend/src/components/common/ActionsBox/TActionsBox.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { vOnClickOutside } from '@vueuse/components'
 import { ref } from 'vue'
 import Popper from 'vue3-popper'
 
@@ -39,7 +40,7 @@ const open = ref(false)
 </script>
 
 <template>
-  <div v-click-outside="() => (open = false)" class="actions-box">
+  <div v-on-click-outside="() => (open = false)" class="actions-box">
     <Popper
       offset-distance="10"
       :placement="placement"

--- a/frontend/src/components/common/CopyButton/CopyButton.vue
+++ b/frontend/src/components/common/CopyButton/CopyButton.vue
@@ -5,18 +5,19 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { copyText } from 'vue3-clipboard'
+import { useClipboard } from '@vueuse/core'
 
 import TIcon from '@/components/common/Icon/TIcon.vue'
 
 const { text = '' } = defineProps<{ text?: string }>()
+const { copy } = useClipboard()
 </script>
 
 <template>
   <button
     aria-label="copy"
     class="text-primary-p2 hover:text-primary-p1 active:text-primary-p3"
-    @click.stop="copyText(text, undefined, () => {})"
+    @click.stop="copy(text)"
   >
     <TIcon icon="copy" class="size-4" />
   </button>

--- a/frontend/src/components/common/Labels/Code.vue
+++ b/frontend/src/components/common/Labels/Code.vue
@@ -5,8 +5,8 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import { ref, toRefs } from 'vue'
-import { copyText } from 'vue3-clipboard'
 
 import TAnimation from '@/components/common/Animation/TAnimation.vue'
 
@@ -15,25 +15,9 @@ const props = defineProps<{
 }>()
 
 const { text } = toRefs(props)
+const { copy, copied } = useClipboard({ copiedDuring: 400 })
 
 const showCopyButton = ref(false)
-const copyState = ref('Copy')
-
-let timeout: number
-
-const copyKey = () => {
-  copyText(text.value, undefined, () => {})
-
-  copyState.value = 'Copied'
-
-  if (timeout !== undefined) {
-    clearTimeout(timeout)
-  }
-
-  timeout = setTimeout(() => {
-    copyState.value = 'Copy'
-  }, 400)
-}
 </script>
 
 <template>
@@ -48,7 +32,7 @@ const copyKey = () => {
         class="absolute top-0 right-0 left-0 flex h-14 justify-end rounded bg-linear-to-b from-naturals-n0 p-1"
       >
         <span class="rounded">
-          <button @click="copyKey">{{ copyState }}</button>
+          <button @click="copy(text)">{{ copied ? 'Copied' : 'Copy' }}</button>
         </span>
       </div>
     </TAnimation>

--- a/frontend/src/components/common/LogViewer/LogViewer.vue
+++ b/frontend/src/components/common/LogViewer/LogViewer.vue
@@ -7,11 +7,11 @@ included in the LICENSE file.
 <script setup lang="ts">
 import 'vue-virtual-scroller/dist/vue-virtual-scroller.css'
 
+import { useClipboard } from '@vueuse/core'
 import type { Component } from 'vue'
 import { computed, nextTick, onMounted, onUpdated, ref, toRefs, watch } from 'vue'
 import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller'
 import WordHighlighter from 'vue-word-highlighter'
-import { copyText } from 'vue3-clipboard'
 
 import TButton from '@/components/common/Button/TButton.vue'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
@@ -24,6 +24,7 @@ type Props = {
 }
 
 const props = withDefaults(defineProps<Props>(), {})
+const { copy } = useClipboard()
 
 const follow = ref(true)
 const logView: Component = ref(null)
@@ -62,7 +63,7 @@ const filteredLogs = computed(() => {
 })
 
 const copyLogs = () => {
-  return copyText(
+  return copy(
     filteredLogs.value
       .map((item: LogLine) => {
         const arr: string[] = []
@@ -75,8 +76,6 @@ const copyLogs = () => {
         return arr.join(' ')
       })
       .join('\n'),
-    undefined,
-    () => {},
   )
 }
 

--- a/frontend/src/components/common/OngoingTasks/OngoingTasks.vue
+++ b/frontend/src/components/common/OngoingTasks/OngoingTasks.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { vOnClickOutside } from '@vueuse/components'
 import { computed, ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -43,7 +44,7 @@ const onClickOutside = () => {
 </script>
 
 <template>
-  <div v-click-outside="onClickOutside" class="relative flex items-center">
+  <div v-on-click-outside="onClickOutside" class="relative flex items-center">
     <Watch v-if="watchOpts" :opts="watchOpts" display-always>
       <template #default="{ data }">
         <div

--- a/frontend/src/components/common/TInput/TInput.vue
+++ b/frontend/src/components/common/TInput/TInput.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { vOnClickOutside } from '@vueuse/components'
 import type { Ref } from 'vue'
 import { computed, onMounted, ref, toRefs, watch } from 'vue'
 
@@ -113,7 +114,7 @@ onMounted(() => {
 
 <template>
   <label
-    v-click-outside="() => (isFocused = false)"
+    v-on-click-outside="() => (isFocused = false)"
     class="input-box"
     :class="[{ focused: isFocused, secondary, primary: !secondary, compact, disabled }]"
     @click.prevent="

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,11 +6,9 @@
 import '@/index.css'
 
 import { createAuth0 } from '@auth0/auth0-vue'
-import vClickOutside from 'click-outside-vue3'
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 import yamlWorker from 'monaco-yaml/yaml.worker?worker'
 import { createApp } from 'vue'
-import VueClipboard from 'vue3-clipboard'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
@@ -66,10 +64,7 @@ const setupApp = async () => {
     authType.value = AuthType.Auth0
   }
 
-  let app = createApp(App).use(router).use(VueClipboard, {
-    autoSetContainer: true,
-    appendToBody: true,
-  })
+  let app = createApp(App).use(router)
 
   if (authType.value === AuthType.Auth0) {
     app = app.use(
@@ -84,7 +79,6 @@ const setupApp = async () => {
     )
   }
 
-  app.use(vClickOutside)
   app.mount('#app')
 }
 

--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -2,11 +2,9 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
-
 import type { Node as V1Node } from 'kubernetes-types/core/v1'
 import type { ComputedRef, Ref } from 'vue'
 import { computed, ref } from 'vue'
-import { copyText } from 'vue3-clipboard'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { fetchOption } from '@/api/fetch.pb'
@@ -218,13 +216,13 @@ export const isChrome = () => {
   return navigator.userAgent.toLowerCase().includes('chrome')
 }
 
-export const copyKernelArgs = async (joinToken?: string, useGRPCTunnel: boolean = false) => {
+export const getKernelArgs = async (joinToken?: string, useGRPCTunnel: boolean = false) => {
   const response = await ManagementService.GetMachineJoinConfig({
     join_token: joinToken,
     use_grpc_tunnel: useGRPCTunnel,
   })
 
-  copyText(response.kernel_args!.join(' '), undefined, () => {})
+  return response.kernel_args?.join(' ') ?? ''
 }
 
 export const downloadMachineJoinConfig = async (

--- a/frontend/src/types/external-libs.d.ts
+++ b/frontend/src/types/external-libs.d.ts
@@ -2,6 +2,4 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
-declare module 'click-outside-vue3'
 declare module 'vue-virtual-scroller'
-declare module 'vue3-clipboard'

--- a/frontend/src/views/cluster/Backups/Backups.vue
+++ b/frontend/src/views/cluster/Backups/Backups.vue
@@ -5,9 +5,9 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import { onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { copyText } from 'vue3-clipboard'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
@@ -22,6 +22,8 @@ import { setupBackupStatus } from '@/methods'
 import { triggerEtcdBackup } from '@/methods/cluster'
 import { showError } from '@/notification'
 import BackupsList from '@/views/cluster/Backups/BackupsList.vue'
+
+const { copy } = useClipboard()
 
 const startingEtcdBackup = ref(false)
 const route = useRoute()
@@ -61,7 +63,7 @@ const runEtcdBackup = async () => {
       <div class="flex items-center gap-1 text-xs">
         Cluster UUID:
         <div>{{ clusterUUID }}</div>
-        <IconButton icon="copy" @click="() => copyText(clusterUUID, undefined, () => {})" />
+        <IconButton icon="copy" @click="() => copy(clusterUUID)" />
         <TButton
           type="highlighted"
           class="ml-2"

--- a/frontend/src/views/cluster/Backups/BackupsList.vue
+++ b/frontend/src/views/cluster/Backups/BackupsList.vue
@@ -5,10 +5,10 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import WordHighlighter from 'vue-word-highlighter'
-import { copyText } from 'vue3-clipboard'
 
 import { Runtime } from '@/api/common/omni.pb'
 import {
@@ -32,6 +32,7 @@ import { formatISO } from '@/methods/time'
 
 const dateFormat = 'HH:mm MMM d y'
 const route = useRoute()
+const { copy } = useClipboard()
 
 const sortOptions = [
   { id: 'id', desc: 'Creation Time ⬇', descending: true },
@@ -133,10 +134,7 @@ const openDocs = () => {
                     </div>
                     <div class="flex items-center gap-2 text-naturals-n14">
                       {{ item.spec.snapshot }}
-                      <IconButton
-                        icon="copy"
-                        @click="copyText(item.spec.snapshot, undefined, () => {})"
-                      />
+                      <IconButton icon="copy" @click="copy(item.spec.snapshot)" />
                     </div>
                   </div>
                 </div>

--- a/frontend/src/views/common/NodeContextMenu.vue
+++ b/frontend/src/views/common/NodeContextMenu.vue
@@ -5,9 +5,9 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { copyText } from 'vue3-clipboard'
 
 import type { Resource } from '@/api/grpc'
 import type { ClusterMachineStatusSpec } from '@/api/omni/specs/omni.pb'
@@ -17,6 +17,8 @@ import TActionsBoxItem from '@/components/common/ActionsBox/TActionsBoxItem.vue'
 import { setupClusterPermissions } from '@/methods/auth'
 
 const router = useRouter()
+const { copy } = useClipboard()
+
 const props = defineProps<{
   clusterName: string
   deleteDisabled?: boolean
@@ -72,7 +74,7 @@ const restoreNode = () => {
 }
 
 const copyMachineID = () => {
-  copyText(props.clusterMachineStatus.metadata.id!, undefined, () => {})
+  copy(props.clusterMachineStatus.metadata.id!)
 }
 </script>
 

--- a/frontend/src/views/omni/Auth/OIDC.vue
+++ b/frontend/src/views/omni/Auth/OIDC.vue
@@ -5,9 +5,9 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import { ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { copyText } from 'vue3-clipboard'
 
 import { OIDCService } from '@/api/omni/oidc/oidc.pb'
 import TButton from '@/components/common/Button/TButton.vue'
@@ -17,6 +17,7 @@ import { avatar, fullname, identity } from '@/methods/key'
 import { showError } from '@/notification'
 
 const route = useRoute()
+const { copy, copied } = useClipboard({ copiedDuring: 1000 })
 
 const authRequestId = route.params.authRequestId as string
 
@@ -42,20 +43,8 @@ const confirmOIDCRequest = async () => {
   }
 }
 
-const copied = ref(false)
-
-let timeout: number
-
 const copyCode = () => {
-  clearTimeout(timeout)
-
-  copied.value = true
-
-  timeout = setTimeout(() => {
-    copied.value = false
-  }, 1000)
-
-  copyText(authCode.value, undefined, () => {})
+  if (authCode.value) copy(authCode.value)
 }
 </script>
 

--- a/frontend/src/views/omni/Clusters/ClusterEtcdBackupCheckbox.vue
+++ b/frontend/src/views/omni/Clusters/ClusterEtcdBackupCheckbox.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { vOnClickOutside } from '@vueuse/components'
 import { Duration } from 'luxon'
 import pluralize from 'pluralize'
 import { computed, ref, toRefs } from 'vue'
@@ -120,7 +121,7 @@ const updateBackupInterval = () => {
         <div class="w-12">
           <TInput
             v-model="backupIntervalPreview"
-            v-click-outside="() => (editingBackupConfig = false)"
+            v-on-click-outside="() => (editingBackupConfig = false)"
             type="number"
             compact
             focus

--- a/frontend/src/views/omni/Clusters/Management/MachineSetPicker.vue
+++ b/frontend/src/views/omni/Clusters/Management/MachineSetPicker.vue
@@ -6,6 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { RadioGroup, RadioGroupOption } from '@headlessui/vue'
+import { vOnClickOutside } from '@vueuse/components'
 import { computed, ref, toRefs, watch } from 'vue'
 import Popper from 'vue3-popper'
 
@@ -107,7 +108,7 @@ const menuHovered = ref(false)
     </RadioGroup>
 
     <div v-else class="relative flex h-8 items-center justify-center rounded bg-naturals-n3">
-      <Popper v-click-outside="() => (showPicker = false)" :show="showPicker" placement="left">
+      <Popper v-on-click-outside="() => (showPicker = false)" :show="showPicker" placement="left">
         <template #content>
           <div class="flex flex-col items-center gap-1 rounded bg-naturals-n3 p-1">
             <IconButton

--- a/frontend/src/views/omni/Home/HomeGeneralInformation.vue
+++ b/frontend/src/views/omni/Home/HomeGeneralInformation.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import { onBeforeMount, ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -22,21 +23,26 @@ import TButton from '@/components/common/Button/TButton.vue'
 import Card from '@/components/common/Card/Card.vue'
 import Watch from '@/components/common/Watch/Watch.vue'
 import {
-  copyKernelArgs,
   downloadAuditLog,
   downloadMachineJoinConfig,
   downloadOmniconfig,
   downloadTalosconfig,
+  getKernelArgs,
 } from '@/methods'
 import { canReadAuditLog } from '@/methods/auth'
 import { auditLogEnabled } from '@/methods/features'
 import HomeGeneralInformationCopyable from '@/views/omni/Home/HomeGeneralInformationCopyable.vue'
 
 const auditLogAvailable = ref(false)
+const { copy } = useClipboard()
 
 onBeforeMount(async () => {
   auditLogAvailable.value = await auditLogEnabled()
 })
+
+async function copyKernelArgs() {
+  copy(await getKernelArgs())
+}
 </script>
 
 <template>
@@ -122,7 +128,7 @@ onBeforeMount(async () => {
         Download Machine Join Config
       </TButton>
 
-      <TButton icon="copy" icon-position="left" @click="copyKernelArgs()">
+      <TButton icon="copy" icon-position="left" @click="copyKernelArgs">
         Copy Kernel Parameters
       </TButton>
     </section>

--- a/frontend/src/views/omni/ItemLabels/LabelsInput.vue
+++ b/frontend/src/views/omni/ItemLabels/LabelsInput.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { vOnClickOutside } from '@vueuse/components'
 import { ref, toRefs, watch } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -220,7 +221,7 @@ watch(filterValue, async (val: string, old: string) => {
   >
     <TInput
       ref="input"
-      v-click-outside="() => (showCompletions = false)"
+      v-on-click-outside="() => (showCompletions = false)"
       class="h-full flex-1 flex-wrap text-xs"
       icon="search"
       :model-value="filterValue"

--- a/frontend/src/views/omni/Machines/MachineItem.vue
+++ b/frontend/src/views/omni/Machines/MachineItem.vue
@@ -5,10 +5,10 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
 import WordHighlighter from 'vue-word-highlighter'
-import { copyText } from 'vue3-clipboard'
 
 import type { Resource } from '@/api/grpc'
 import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
@@ -42,6 +42,8 @@ defineEmits<{
 }>()
 
 const selected = defineModel<boolean>('selected')
+
+const { copy } = useClipboard()
 
 const machineName = computed(() => {
   return machine.spec.message_status?.network?.hostname ?? machine.metadata.id
@@ -171,10 +173,7 @@ const maintenanceUpdateDescription = computed(() => {
               Config Patches
             </TActionsBoxItem>
 
-            <TActionsBoxItem
-              icon="copy"
-              @click="copyText(machine.metadata.id, undefined, () => {})"
-            >
+            <TActionsBoxItem icon="copy" @click="copy(machine.metadata.id!)">
               Copy Machine ID
             </TActionsBoxItem>
 

--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -6,12 +6,12 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { DocumentArrowDownIcon } from '@heroicons/vue/24/outline'
+import { useClipboard } from '@vueuse/core'
 import yaml from 'js-yaml'
 import * as semver from 'semver'
 import type { Ref } from 'vue'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { copyText } from 'vue3-clipboard'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
@@ -65,6 +65,8 @@ enum Phase {
 const installExtensions = ref<Record<string, boolean>>({})
 const router = useRouter()
 const route = useRoute()
+const { copy, copied: copiedPXEURL } = useClipboard({ copiedDuring: 2000 })
+
 const phase = ref(Phase.Idle)
 const showDescriptions = ref(false)
 const fileSizeLoaded = ref(0)
@@ -435,17 +437,12 @@ const setTalosVersion = (value: string) => {
   selectedTalosVersion.value = value
 }
 
-const copiedPXEURL = ref(false)
-
 const copyPXEURL = async () => {
   if (!pxeURL.value) {
     await createSchematic()
   }
 
-  copyText(pxeURL.value, undefined, () => {})
-
-  copiedPXEURL.value = true
-  setTimeout(() => (copiedPXEURL.value = false), 2000)
+  if (pxeURL.value) copy(pxeURL.value)
 }
 
 const downloaded = computed(() => {

--- a/frontend/src/views/omni/Settings/JoinTokens.vue
+++ b/frontend/src/views/omni/Settings/JoinTokens.vue
@@ -5,9 +5,9 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { copyText } from 'vue3-clipboard'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { type Resource, ResourceService } from '@/api/grpc'
@@ -28,12 +28,14 @@ import TListItem from '@/components/common/List/TListItem.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TStatus from '@/components/common/Status/TStatus.vue'
 import { TCommonStatuses } from '@/constants'
-import { copyKernelArgs, downloadMachineJoinConfig } from '@/methods'
+import { downloadMachineJoinConfig, getKernelArgs } from '@/methods'
 import { canManageUsers, unrevokeJoinToken } from '@/methods/auth'
 import { relativeISO } from '@/methods/time'
 import { showError } from '@/notification'
 
 const router = useRouter()
+const { copy } = useClipboard()
+
 const showTokens = ref(false)
 
 const watchOpts = [
@@ -66,11 +68,11 @@ const openUserCreate = () => {
 }
 
 const copyValue = (value: string) => {
-  return copyText(value, undefined, () => {})
+  return copy(value)
 }
 
-const copyKernelParams = (token: string) => {
-  copyKernelArgs(token)
+const copyKernelParams = async (token: string) => {
+  copy(await getKernelArgs(token))
 }
 
 const makeDefault = async (token: string) => {


### PR DESCRIPTION
Replace deprecated libraries `vue3-clipboard` and `click-outside-vue3` with [vueuse](https://vueuse.org)

Fixes https://github.com/siderolabs/omni/issues/1523