### PR TITLE
chore: lazy load routes, modals, and code editor

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#13141c" />
     <title>Omni</title>
   </head>
   <body>

--- a/frontend/src/components/TModal.vue
+++ b/frontend/src/components/TModal.vue
@@ -5,11 +5,68 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { type Component, type Ref, ref, shallowRef, watch } from 'vue'
+import { type Component, defineAsyncComponent, type Ref, ref, shallowRef, watch } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { modal } from '@/modal'
-import { modals } from '@/router'
+
+const modals: Record<string, Component> = {
+  reboot: defineAsyncComponent(() => import('@/views/omni/Modals/NodeReboot.vue')),
+  shutdown: defineAsyncComponent(() => import('@/views/omni/Modals/NodeShutdown.vue')),
+  clusterDestroy: defineAsyncComponent(() => import('@/views/omni/Modals/ClusterDestroy.vue')),
+  machineRemove: defineAsyncComponent(() => import('@/views/omni/Modals/MachineRemove.vue')),
+  machineClassDestroy: defineAsyncComponent(
+    () => import('@/views/omni/Modals/MachineClassDestroy.vue'),
+  ),
+  machineSetDestroy: defineAsyncComponent(
+    () => import('@/views/omni/Modals/MachineSetDestroy.vue'),
+  ),
+  maintenanceUpdate: defineAsyncComponent(
+    () => import('@/views/omni/Modals/MaintenanceUpdate.vue'),
+  ),
+  downloadInstallationMedia: defineAsyncComponent(
+    () => import('@/views/omni/Modals/DownloadInstallationMedia.vue'),
+  ),
+  downloadOmnictlBinaries: defineAsyncComponent(
+    () => import('@/views/omni/Modals/DownloadOmnictl.vue'),
+  ),
+  downloadSupportBundle: defineAsyncComponent(
+    () => import('@/views/omni/Modals/DownloadSupportBundle.vue'),
+  ),
+  downloadTalosctlBinaries: defineAsyncComponent(
+    () => import('@/views/omni/Modals/DownloadTalosctl.vue'),
+  ),
+  nodeDestroy: defineAsyncComponent(() => import('@/views/omni/Modals/NodeDestroy.vue')),
+  nodeDestroyCancel: defineAsyncComponent(
+    () => import('@/views/omni/Modals/NodeDestroyCancel.vue'),
+  ),
+  updateKubernetes: defineAsyncComponent(() => import('@/views/omni/Modals/UpdateKubernetes.vue')),
+  updateTalos: defineAsyncComponent(() => import('@/views/omni/Modals/UpdateTalos.vue')),
+  configPatchDestroy: defineAsyncComponent(
+    () => import('@/views/omni/Modals/ConfigPatchDestroy.vue'),
+  ),
+  userDestroy: defineAsyncComponent(() => import('@/views/omni/Modals/UserDestroy.vue')),
+  userCreate: defineAsyncComponent(() => import('@/views/omni/Modals/UserCreate.vue')),
+  joinTokenCreate: defineAsyncComponent(() => import('@/views/omni/Modals/JoinTokenCreate.vue')),
+  joinTokenRevoke: defineAsyncComponent(() => import('@/views/omni/Modals/JoinTokenRevoke.vue')),
+  joinTokenDelete: defineAsyncComponent(() => import('@/views/omni/Modals/JoinTokenDelete.vue')),
+  serviceAccountCreate: defineAsyncComponent(
+    () => import('@/views/omni/Modals/ServiceAccountCreate.vue'),
+  ),
+  serviceAccountRenew: defineAsyncComponent(
+    () => import('@/views/omni/Modals/ServiceAccountRenew.vue'),
+  ),
+  roleEdit: defineAsyncComponent(() => import('@/views/omni/Modals/RoleEdit.vue')),
+  machineAccept: defineAsyncComponent(() => import('@/views/omni/Modals/MachineAccept.vue')),
+  machineReject: defineAsyncComponent(() => import('@/views/omni/Modals/MachineReject.vue')),
+  updateExtensions: defineAsyncComponent(() => import('@/views/omni/Modals/UpdateExtensions.vue')),
+  infraProviderSetup: defineAsyncComponent(
+    () => import('@/views/omni/Modals/InfraProviderSetup.vue'),
+  ),
+  infraProviderDelete: defineAsyncComponent(
+    () => import('@/views/omni/Modals/InfraProviderDelete.vue'),
+  ),
+}
 
 const route = useRoute()
 const view: Ref<Component | null> = shallowRef(null)

--- a/frontend/src/components/common/Charts/RadialBar.vue
+++ b/frontend/src/components/common/Charts/RadialBar.vue
@@ -6,8 +6,9 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import type { ApexOptions } from 'apexcharts'
-import { computed } from 'vue'
-import ApexChart from 'vue3-apexcharts'
+import { computed, defineAsyncComponent } from 'vue'
+
+const ApexChart = defineAsyncComponent(() => import('vue3-apexcharts'))
 
 interface Props {
   title: string

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -14,89 +14,19 @@ import { loadCurrentUser } from '@/methods/auth'
 import { getAuthCookies, isAuthorized } from '@/methods/key'
 import { MachineFilterOption } from '@/methods/machine'
 import { refreshTitle } from '@/methods/title'
-import ClusterBackups from '@/views/cluster/Backups/Backups.vue'
-import ClusterScoped from '@/views/cluster/ClusterScoped.vue'
-import ClusterPatches from '@/views/cluster/Config/ClusterPatches.vue'
-import PatchEdit from '@/views/cluster/Config/PatchEdit.vue'
-import KubernetesManifestSync from '@/views/cluster/Manifest/Sync.vue'
-import NodeConfig from '@/views/cluster/Nodes/NodeConfig.vue'
-import NodeDetails from '@/views/cluster/Nodes/NodeDetails.vue'
-import NodeExtensions from '@/views/cluster/Nodes/NodeExtensions.vue'
-import NodeLogs from '@/views/cluster/Nodes/NodeLogs.vue'
-import NodeMonitor from '@/views/cluster/Nodes/NodeMonitor.vue'
-import NodeMounts from '@/views/cluster/Nodes/NodeMounts.vue'
-import NodeOverview from '@/views/cluster/Nodes/NodeOverview.vue'
-import NodePatches from '@/views/cluster/Nodes/NodePatches.vue'
-import NodesList from '@/views/cluster/Nodes/NodesList.vue'
-import ClusterOverview from '@/views/cluster/Overview/Overview.vue'
-import TPods from '@/views/cluster/Pods/TPods.vue'
-import ClusterSidebar from '@/views/cluster/SideBar.vue'
-import ClusterSidebarNode from '@/views/cluster/SideBarNode.vue'
-import BadRequest from '@/views/common/BadRequest.vue'
-import Forbidden from '@/views/common/Forbidden.vue'
-import PageNotFound from '@/views/common/PageNotFound.vue'
-import Authenticate from '@/views/omni/Auth/Authenticate.vue'
-import OIDC from '@/views/omni/Auth/OIDC.vue'
-import OmniClusters from '@/views/omni/Clusters/Clusters.vue'
-import OmniClusterCreate from '@/views/omni/Clusters/Management/ClusterCreate.vue'
-import OmniClusterScale from '@/views/omni/Clusters/Management/ClusterScale.vue'
-import Home from '@/views/omni/Home/Home.vue'
-import OmniMachineClass from '@/views/omni/MachineClasses/MachineClass.vue'
-import OmniMachineClasses from '@/views/omni/MachineClasses/MachineClasses.vue'
-import OmniMachine from '@/views/omni/Machines/Machine.vue'
-import OmniMachineLogs from '@/views/omni/Machines/MachineLogs.vue'
-import OmniMachinePatches from '@/views/omni/Machines/MachinePatches.vue'
-import OmniMachines from '@/views/omni/Machines/Machines.vue'
-import OmniMachinesPending from '@/views/omni/Machines/MachinesPending.vue'
-import ClusterDestroy from '@/views/omni/Modals/ClusterDestroy.vue'
-import ConfigPatchDestroy from '@/views/omni/Modals/ConfigPatchDestroy.vue'
-import DownloadInstallationMedia from '@/views/omni/Modals/DownloadInstallationMedia.vue'
-import DownloadOmnictl from '@/views/omni/Modals/DownloadOmnictl.vue'
-import DownloadSupportBundle from '@/views/omni/Modals/DownloadSupportBundle.vue'
-import DownloadTalosctl from '@/views/omni/Modals/DownloadTalosctl.vue'
-import InfraProviderDelete from '@/views/omni/Modals/InfraProviderDelete.vue'
-import InfraProviderSetup from '@/views/omni/Modals/InfraProviderSetup.vue'
-import JoinTokenCreate from '@/views/omni/Modals/JoinTokenCreate.vue'
-import JoinTokenDelete from '@/views/omni/Modals/JoinTokenDelete.vue'
-import JoinTokenRevoke from '@/views/omni/Modals/JoinTokenRevoke.vue'
-import MachineAccept from '@/views/omni/Modals/MachineAccept.vue'
-import MachineClassDestroy from '@/views/omni/Modals/MachineClassDestroy.vue'
-import MachineReject from '@/views/omni/Modals/MachineReject.vue'
-import MachineRemove from '@/views/omni/Modals/MachineRemove.vue'
-import MachineSetDestroy from '@/views/omni/Modals/MachineSetDestroy.vue'
-import MaintenanceUpdate from '@/views/omni/Modals/MaintenanceUpdate.vue'
-import NodeDestroy from '@/views/omni/Modals/NodeDestroy.vue'
-import NodeDestroyCancel from '@/views/omni/Modals/NodeDestroyCancel.vue'
-import NodeReboot from '@/views/omni/Modals/NodeReboot.vue'
-import NodeShutdown from '@/views/omni/Modals/NodeShutdown.vue'
-import RoleEdit from '@/views/omni/Modals/RoleEdit.vue'
-import ServiceAccountCreate from '@/views/omni/Modals/ServiceAccountCreate.vue'
-import ServiceAccountRenew from '@/views/omni/Modals/ServiceAccountRenew.vue'
-import UpdateExtensions from '@/views/omni/Modals/UpdateExtensions.vue'
-import UpdateKubernetes from '@/views/omni/Modals/UpdateKubernetes.vue'
-import UpdateTalos from '@/views/omni/Modals/UpdateTalos.vue'
-import UserCreate from '@/views/omni/Modals/UserCreate.vue'
-import UserDestroy from '@/views/omni/Modals/UserDestroy.vue'
-import OmniBackupStorageSettings from '@/views/omni/Settings/BackupStorage.vue'
-import OmniInfraProviders from '@/views/omni/Settings/InfraProviders.vue'
-import OmniJoinTokens from '@/views/omni/Settings/JoinTokens.vue'
-import OmniSettings from '@/views/omni/Settings/Settings.vue'
-import OmniSidebar from '@/views/omni/SideBar.vue'
-import OmniServiceAccounts from '@/views/omni/Users/ServiceAccounts.vue'
-import OmniUsers from '@/views/omni/Users/Users.vue'
 
 export const FrontendAuthFlow = 'frontend'
 const requireCookies = false
 
 const routes: RouteRecordRaw[] = [
   // Unauthenticated routes
-  { path: '/forbidden', component: Forbidden },
-  { path: '/badrequest', component: BadRequest },
-  { path: '/:catchAll(.*)', component: PageNotFound },
+  { path: '/forbidden', component: () => import('@/views/common/Forbidden.vue') },
+  { path: '/badrequest', component: () => import('@/views/common/BadRequest.vue') },
+  { path: '/:catchAll(.*)', component: () => import('@/views/common/PageNotFound.vue') },
   {
     path: '/authenticate',
     name: 'Authenticate',
-    component: Authenticate,
+    component: () => import('@/views/omni/Auth/Authenticate.vue'),
     beforeEnter: async (to) => {
       return authType.value === AuthType.Auth0 ? await authGuard(to) : true
     },
@@ -113,7 +43,7 @@ const routes: RouteRecordRaw[] = [
     path: '/',
     components: {
       default: RouterView,
-      sidebar: OmniSidebar,
+      sidebar: () => import('@/views/omni/SideBar.vue'),
     },
     beforeEnter: async (to) => {
       let authorized = await isAuthorized()
@@ -138,12 +68,12 @@ const routes: RouteRecordRaw[] = [
       {
         path: '',
         name: 'Home',
-        component: Home,
+        component: () => import('@/views/omni/Home/Home.vue'),
       },
       {
         path: 'oidc-login/:authRequestId',
         name: 'OIDC Login',
-        component: OIDC,
+        component: () => import('@/views/omni/Auth/OIDC.vue'),
       },
       {
         path: 'clusters',
@@ -151,111 +81,111 @@ const routes: RouteRecordRaw[] = [
           {
             path: '',
             name: 'Clusters',
-            component: OmniClusters,
+            component: () => import('@/views/omni/Clusters/Clusters.vue'),
           },
           {
             path: 'create',
             name: 'ClusterCreate',
-            component: OmniClusterCreate,
+            component: () => import('@/views/omni/Clusters/Management/ClusterCreate.vue'),
           },
           {
             path: ':cluster',
             components: {
-              default: ClusterScoped,
-              clusterSidebar: ClusterSidebar,
+              default: () => import('@/views/cluster/ClusterScoped.vue'),
+              clusterSidebar: () => import('@/views/cluster/SideBar.vue'),
             },
             children: [
               {
                 path: '',
                 name: 'ClusterOverview',
-                component: ClusterOverview,
+                component: () => import('@/views/cluster/Overview/Overview.vue'),
               },
               {
                 path: 'nodes',
                 name: 'Nodes',
-                component: NodesList,
+                component: () => import('@/views/cluster/Nodes/NodesList.vue'),
               },
               {
                 path: 'scale',
                 name: 'ClusterScale',
-                component: OmniClusterScale,
+                component: () => import('@/views/omni/Clusters/Management/ClusterScale.vue'),
               },
               {
                 path: 'pods',
                 name: 'Pods',
-                component: TPods,
+                component: () => import('@/views/cluster/Pods/TPods.vue'),
               },
               {
                 path: 'patches',
                 name: 'ClusterConfigPatches',
-                component: ClusterPatches,
+                component: () => import('@/views/cluster/Config/ClusterPatches.vue'),
               },
               {
                 path: 'patches/:patch',
                 name: 'ClusterPatchEdit',
-                component: PatchEdit,
+                component: () => import('@/views/cluster/Config/PatchEdit.vue'),
               },
               {
                 path: 'manifests',
                 name: 'KubernetesManifestSync',
-                component: KubernetesManifestSync,
+                component: () => import('@/views/cluster/Manifest/Sync.vue'),
               },
               {
                 path: 'backups',
                 name: 'Backups',
-                component: ClusterBackups,
+                component: () => import('@/views/cluster/Backups/Backups.vue'),
               },
               {
                 path: 'machine/:machine',
                 components: {
                   default: RouterView,
-                  nodeSidebar: ClusterSidebarNode,
+                  nodeSidebar: () => import('@/views/cluster/SideBarNode.vue'),
                 },
                 children: [
                   {
                     path: 'patches/:patch',
                     name: 'ClusterMachinePatchEdit',
-                    component: PatchEdit,
+                    component: () => import('@/views/cluster/Config/PatchEdit.vue'),
                   },
                   {
                     path: '',
                     name: 'NodeDetails',
-                    component: NodeDetails,
+                    component: () => import('@/views/cluster/Nodes/NodeDetails.vue'),
                     children: [
                       {
                         path: '',
                         name: 'NodeOverview',
-                        component: NodeOverview,
+                        component: () => import('@/views/cluster/Nodes/NodeOverview.vue'),
                       },
                       {
                         path: 'monitor',
                         name: 'NodeMonitor',
-                        component: NodeMonitor,
+                        component: () => import('@/views/cluster/Nodes/NodeMonitor.vue'),
                       },
                       {
                         path: 'logs/:service',
                         name: 'NodeLogs',
-                        component: NodeLogs,
+                        component: () => import('@/views/cluster/Nodes/NodeLogs.vue'),
                       },
                       {
                         path: 'config',
                         name: 'NodeConfig',
-                        component: NodeConfig,
+                        component: () => import('@/views/cluster/Nodes/NodeConfig.vue'),
                       },
                       {
                         path: 'patches',
                         name: 'NodePatches',
-                        component: NodePatches,
+                        component: () => import('@/views/cluster/Nodes/NodePatches.vue'),
                       },
                       {
                         path: 'mounts',
                         name: 'NodeMounts',
-                        component: NodeMounts,
+                        component: () => import('@/views/cluster/Nodes/NodeMounts.vue'),
                       },
                       {
                         path: 'extensions',
                         name: 'NodeExtensions',
-                        component: NodeExtensions,
+                        component: () => import('@/views/cluster/Nodes/NodeExtensions.vue'),
                       },
                     ],
                   },
@@ -268,12 +198,12 @@ const routes: RouteRecordRaw[] = [
       {
         path: 'machines',
         name: 'Machines',
-        component: OmniMachines,
+        component: () => import('@/views/omni/Machines/Machines.vue'),
       },
       {
         path: 'machines/manual',
         name: 'MachinesManual',
-        component: OmniMachines,
+        component: () => import('@/views/omni/Machines/Machines.vue'),
         props: {
           filter: MachineFilterOption.Manual,
         },
@@ -281,7 +211,7 @@ const routes: RouteRecordRaw[] = [
       {
         path: 'machines/managed',
         name: 'MachinesManaged',
-        component: OmniMachines,
+        component: () => import('@/views/omni/Machines/Machines.vue'),
         props: {
           filter: MachineFilterOption.Managed,
         },
@@ -289,27 +219,27 @@ const routes: RouteRecordRaw[] = [
       {
         path: 'machines/managed/:provider',
         name: 'MachinesManagedProvider',
-        component: OmniMachines,
+        component: () => import('@/views/omni/Machines/Machines.vue'),
       },
       {
         path: 'machines/pending',
         name: 'MachinesPending',
-        component: OmniMachinesPending,
+        component: () => import('@/views/omni/Machines/MachinesPending.vue'),
       },
       {
         path: 'machine-classes',
         name: 'MachineClasses',
-        component: OmniMachineClasses,
+        component: () => import('@/views/omni/MachineClasses/MachineClasses.vue'),
       },
       {
         path: 'machine-classes/create',
         name: 'MachineClassCreate',
-        component: OmniMachineClass,
+        component: () => import('@/views/omni/MachineClasses/MachineClass.vue'),
       },
       {
         path: 'machine-classes/:classname',
         name: 'MachineClassEdit',
-        component: OmniMachineClass,
+        component: () => import('@/views/omni/MachineClasses/MachineClass.vue'),
         props: {
           edit: true,
         },
@@ -317,17 +247,17 @@ const routes: RouteRecordRaw[] = [
       {
         path: 'machine/:machine/patches/:patch',
         name: 'MachinePatchEdit',
-        component: PatchEdit,
+        component: () => import('@/views/cluster/Config/PatchEdit.vue'),
       },
       {
         path: 'machine/jointokens',
         name: 'JoinTokens',
-        component: OmniJoinTokens,
+        component: () => import('@/views/omni/Settings/JoinTokens.vue'),
       },
       {
         path: 'settings',
         name: 'Settings',
-        component: OmniSettings,
+        component: () => import('@/views/omni/Settings/Settings.vue'),
         redirect: {
           name: 'Users',
         },
@@ -335,7 +265,7 @@ const routes: RouteRecordRaw[] = [
           {
             path: 'users',
             name: 'Users',
-            component: OmniUsers,
+            component: () => import('@/views/omni/Users/Users.vue'),
             meta: {
               title: 'Users',
             },
@@ -343,7 +273,7 @@ const routes: RouteRecordRaw[] = [
           {
             path: 'serviceaccounts',
             name: 'ServiceAccounts',
-            component: OmniServiceAccounts,
+            component: () => import('@/views/omni/Users/ServiceAccounts.vue'),
             meta: {
               title: 'Service Accounts',
             },
@@ -351,7 +281,7 @@ const routes: RouteRecordRaw[] = [
           {
             path: 'infraproviders',
             name: 'InfraProviders',
-            component: OmniInfraProviders,
+            component: () => import('@/views/omni/Settings/InfraProviders.vue'),
             meta: {
               title: 'Infra Providers',
             },
@@ -359,7 +289,7 @@ const routes: RouteRecordRaw[] = [
           {
             path: 'backups',
             name: 'BackupStorage',
-            component: OmniBackupStorageSettings,
+            component: () => import('@/views/omni/Settings/BackupStorage.vue'),
             meta: {
               title: 'Backup Storage',
             },
@@ -369,7 +299,7 @@ const routes: RouteRecordRaw[] = [
       {
         path: 'machine/:machine',
         name: 'Machine',
-        component: OmniMachine,
+        component: () => import('@/views/omni/Machines/Machine.vue'),
         redirect: {
           name: 'MachineLogs',
         },
@@ -377,12 +307,12 @@ const routes: RouteRecordRaw[] = [
           {
             path: 'logs',
             name: 'MachineLogs',
-            component: OmniMachineLogs,
+            component: () => import('@/views/omni/Machines/MachineLogs.vue'),
           },
           {
             path: 'patches',
             name: 'MachineConfigPatches',
-            component: OmniMachinePatches,
+            component: () => import('@/views/omni/Machines/MachinePatches.vue'),
           },
         ],
       },
@@ -409,37 +339,4 @@ router.afterEach(() => {
   Userpilot.reload()
 })
 
-const modals = {
-  reboot: NodeReboot,
-  shutdown: NodeShutdown,
-  clusterDestroy: ClusterDestroy,
-  machineRemove: MachineRemove,
-  machineClassDestroy: MachineClassDestroy,
-  machineSetDestroy: MachineSetDestroy,
-  maintenanceUpdate: MaintenanceUpdate,
-  downloadInstallationMedia: DownloadInstallationMedia,
-  downloadOmnictlBinaries: DownloadOmnictl,
-  downloadSupportBundle: DownloadSupportBundle,
-  downloadTalosctlBinaries: DownloadTalosctl,
-  nodeDestroy: NodeDestroy,
-  nodeDestroyCancel: NodeDestroyCancel,
-  updateKubernetes: UpdateKubernetes,
-  updateTalos: UpdateTalos,
-  configPatchDestroy: ConfigPatchDestroy,
-  userDestroy: UserDestroy,
-  userCreate: UserCreate,
-  joinTokenCreate: JoinTokenCreate,
-  joinTokenRevoke: JoinTokenRevoke,
-  joinTokenDelete: JoinTokenDelete,
-  serviceAccountCreate: ServiceAccountCreate,
-  serviceAccountRenew: ServiceAccountRenew,
-  roleEdit: RoleEdit,
-  machineAccept: MachineAccept,
-  machineReject: MachineReject,
-  updateExtensions: UpdateExtensions,
-  infraProviderSetup: InfraProviderSetup,
-  infraProviderDelete: InfraProviderDelete,
-}
-
-export { modals }
 export default router

--- a/frontend/src/views/cluster/Config/PatchEdit.vue
+++ b/frontend/src/views/cluster/Config/PatchEdit.vue
@@ -5,9 +5,10 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import type monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import { MarkerSeverity, MarkerTag } from 'monaco-editor/esm/vs/editor/editor.api'
 import type { Ref } from 'vue'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import Popper from 'vue3-popper'
 
@@ -36,7 +37,6 @@ import {
   VirtualNamespace,
 } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
-import CodeEditor from '@/components/common/CodeEditor/CodeEditor.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
@@ -48,6 +48,10 @@ import { showError } from '@/notification'
 import ManagedByTemplatesWarning from '@/views/cluster/ManagedByTemplatesWarning.vue'
 
 import Watch from '../../../api/watch'
+
+const CodeEditor = defineAsyncComponent(
+  () => import('@/components/common/CodeEditor/CodeEditor.vue'),
+)
 
 type Props = {
   currentCluster?: Resource<ClusterSpec>
@@ -163,10 +167,10 @@ const checkEncryption = (model: monaco.editor.ITextModel, tokens: monaco.Token[]
         endColumn: word.endColumn,
         message:
           'Will have no effect: KMS encryption is enabled.\nKMS encryption config patch always has a higher priority.',
-        severity: monaco.MarkerSeverity.Info,
+        severity: MarkerSeverity.Info,
         endLineNumber: pos.lineNumber,
         startLineNumber: pos.lineNumber,
-        tags: [monaco.MarkerTag.Unnecessary],
+        tags: [MarkerTag.Unnecessary],
       })
 
       break

--- a/frontend/src/views/cluster/Nodes/NodeConfig.vue
+++ b/frontend/src/views/cluster/Nodes/NodeConfig.vue
@@ -6,7 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { computed, ref } from 'vue'
+import { computed, defineAsyncComponent, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -14,8 +14,11 @@ import type { Resource } from '@/api/grpc'
 import type { RedactedClusterMachineConfigSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, RedactedClusterMachineConfigType } from '@/api/resources'
 import Watch from '@/api/watch'
-import CodeEditor from '@/components/common/CodeEditor/CodeEditor.vue'
 import { getContext } from '@/context'
+
+const CodeEditor = defineAsyncComponent(
+  () => import('@/components/common/CodeEditor/CodeEditor.vue'),
+)
 
 const route = useRoute()
 

--- a/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
@@ -8,8 +8,7 @@ included in the LICENSE file.
 import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
 import { DateTime } from 'luxon'
 import type { Ref } from 'vue'
-import { computed, ref, toRefs } from 'vue'
-import ApexChart from 'vue3-apexcharts'
+import { computed, defineAsyncComponent, ref, toRefs } from 'vue'
 
 import type { Runtime } from '@/api/common/omni.pb'
 import type { WatchResponse } from '@/api/omni/resources/resources.pb'
@@ -18,6 +17,8 @@ import type { Metadata } from '@/api/v1alpha1/resource.pb'
 import type { WatchContext, WatchEventSpec } from '@/api/watch'
 import { WatchFunc } from '@/api/watch'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
+
+const ApexChart = defineAsyncComponent(() => import('vue3-apexcharts'))
 
 type Props<T> = {
   name: string

--- a/frontend/src/views/omni/Modals/ConfigPatchEdit.vue
+++ b/frontend/src/views/omni/Modals/ConfigPatchEdit.vue
@@ -7,17 +7,20 @@ included in the LICENSE file.
 <script setup lang="ts">
 import { Tab, TabGroup, TabPanel, TabPanels } from '@headlessui/vue'
 import type { Ref } from 'vue'
-import { ref, toRefs } from 'vue'
+import { defineAsyncComponent, ref, toRefs } from 'vue'
 
 import { Code } from '@/api/google/rpc/code.pb'
 import { ManagementService } from '@/api/omni/management/management.pb'
 import TButton from '@/components/common/Button/TButton.vue'
-import CodeEditor from '@/components/common/CodeEditor/CodeEditor.vue'
 import TabButton from '@/components/common/Tabs/TabButton.vue'
 import TabList from '@/components/common/Tabs/TabList.vue'
 import TabsHeader from '@/components/common/Tabs/TabsHeader.vue'
 import TAlert from '@/components/TAlert.vue'
 import { closeModal } from '@/modal'
+
+const CodeEditor = defineAsyncComponent(
+  () => import('@/components/common/CodeEditor/CodeEditor.vue'),
+)
 
 interface Props {
   onSave: (config: string, id?: string) => void

--- a/internal/e2e-tests/main_test.go
+++ b/internal/e2e-tests/main_test.go
@@ -322,7 +322,7 @@ func (s *E2ESuite) TestClickViewAll() {
 		expectedURL, err := url.JoinPath(s.baseURL, "/clusters")
 		s.Require().NoError(err)
 
-		s.Equal(expectedURL, page.MainFrame().URL())
+		s.Require().NoError(page.WaitForURL(expectedURL))
 	})
 }
 


### PR DESCRIPTION
Lazy load routes, modals and code editor. Index JS bundle reduced from `5.5MB` -> `723kB`
(gzipped: `1.5MB` -> `238kB`)

Fixes https://github.com/siderolabs/omni/issues/1551

<details>
<summary>build output</summary>

```
vite v7.1.5 building for production...
✓ 3057 modules transformed.
dist/index.html                                                                                   0.71 kB │ gzip:   0.40 kB
dist/assets/KFOlCnqEu92Fr1MmSU5fCxc4EsA-CnPrVvBs.woff2                                            5.47 kB
dist/assets/KFOlCnqEu92Fr1MmWUlfCxc4EsA-SekShQfT.woff2                                            5.55 kB
dist/assets/KFOmCnqEu92Fr1Mu7WxKOzY-kCRe3VZk.woff2                                                5.56 kB
dist/assets/KFOlCnqEu92Fr1MmEU9fCxc4EsA-CcijQRVW.woff2                                            5.60 kB
dist/assets/KFOlCnqEu92Fr1MmWUlfBxc4EsA-Cc2Tq8FV.woff2                                            6.94 kB
dist/assets/KFOlCnqEu92Fr1MmEU9fBxc4EsA-CpESfwfG.woff2                                            7.02 kB
dist/assets/KFOmCnqEu92Fr1Mu4WxKOzY-BRWHCUYo.woff2                                                7.11 kB
dist/assets/KFOlCnqEu92Fr1MmSU5fBxc4EsA-ndiuWqED.woff2                                            7.12 kB
dist/assets/KFOlCnqEu92Fr1MmSU5fABc4EsA-D6mjswgs.woff2                                            9.58 kB
dist/assets/KFOmCnqEu92Fr1Mu5mxKOzY-DVDTZtmW.woff2                                                9.63 kB
dist/assets/KFOlCnqEu92Fr1MmWUlfABc4EsA-B5ZBKWCH.woff2                                            9.64 kB
dist/assets/KFOlCnqEu92Fr1MmEU9fABc4EsA-DAkZhMOh.woff2                                            9.84 kB
dist/assets/L0x5DF4xlVMF-BfR8bXMIjhEq3-OXg-B7nCECYT.woff2                                        10.26 kB
dist/assets/L0x7DF4xlVMF-BfR8bXMIjhOm3KWWoKC-RJ9-8Cs8.woff2                                      10.78 kB
dist/assets/KFOlCnqEu92Fr1MmSU5fChc4EsA-DEsNdRC-.woff2                                           11.80 kB
dist/assets/KFOlCnqEu92Fr1MmEU9fChc4EsA-BWKy6SgX.woff2                                           11.80 kB
dist/assets/KFOlCnqEu92Fr1MmWUlfChc4EsA-BYGCo3Go.woff2                                           11.82 kB
dist/assets/KFOmCnqEu92Fr1Mu7GxKOzY-4bLplyDh.woff2                                               11.87 kB
dist/assets/L0x5DF4xlVMF-BfR8bXMIjhIq3-OXg-C58MjUu-.woff2                                        14.09 kB
dist/assets/KFOlCnqEu92Fr1MmWUlfCRc4EsA-CsrCEJIc.woff2                                           14.68 kB
dist/assets/L0x7DF4xlVMF-BfR8bXMIjhOm36WWoKC-B1FP3lpF.woff2                                      14.84 kB
dist/assets/KFOlCnqEu92Fr1MmEU9fCRc4EsA-G9W8hgzQ.woff2                                           14.97 kB
dist/assets/KFOlCnqEu92Fr1MmSU5fCRc4EsA-TzZWIuiO.woff2                                           15.00 kB
dist/assets/KFOmCnqEu92Fr1Mu72xKOzY-DORK9bGA.woff2                                               15.34 kB
dist/assets/KFOlCnqEu92Fr1MmSU5fBBc4-ThHrQhYb.woff2                                              15.74 kB
dist/assets/KFOmCnqEu92Fr1Mu4mxK-mTIRXP6Y.woff2                                                  15.74 kB
dist/assets/KFOlCnqEu92Fr1MmWUlfBBc4-CeM5gOv8.woff2                                              15.86 kB
dist/assets/KFOlCnqEu92Fr1MmEU9fBBc4-Dxdx3aXO.woff2                                              15.92 kB
dist/assets/L0x5DF4xlVMF-BfR8bXMIjhPq3-OXg-CK9U7V71.woff2                                        18.60 kB
dist/assets/L0x7DF4xlVMF-BfR8bXMIjhOm3mWWoKC-DWyOcsq6.woff2                                      20.47 kB
dist/assets/L0x5DF4xlVMF-BfR8bXMIjhFq3-OXg-BWJwKVm9.woff2                                        22.87 kB
dist/assets/L0x7DF4xlVMF-BfR8bXMIjhOm3OWWoKC-BPAly87-.woff2                                      24.33 kB
dist/assets/L0x5DF4xlVMF-BfR8bXMIjhLq38-DGRqvGGI.woff2                                           32.94 kB
dist/assets/L0x7DF4xlVMF-BfR8bXMIjhOm32WWg-Bnhr4zwl.woff2                                        35.42 kB
dist/assets/L0x5DF4xlVMF-BfR8bXMIjhGq3-OXg-DPu6aEAn.woff2                                        35.89 kB
dist/assets/L0x7DF4xlVMF-BfR8bXMIjhOm3CWWoKC-DugjdJp3.woff2                                      38.65 kB
dist/assets/codicon-DCmgc-ay.ttf                                                                 80.34 kB
dist/assets/editor.worker-CuLqKeih.js                                                           263.79 kB
dist/assets/yaml.worker-D6TQ4Vii.js                                                             753.28 kB
dist/assets/Tooltip-BIJbCjDA.css                                                                  0.11 kB │ gzip:   0.10 kB
dist/assets/IconInProgress-zmdwP5FE.css                                                           0.11 kB │ gzip:   0.12 kB
dist/assets/TGroupAnimation-BPKuhRPy.css                                                          0.11 kB │ gzip:   0.10 kB
dist/assets/ClusterMachinePhase-DXb0jNG0.css                                                      0.15 kB │ gzip:   0.15 kB
dist/assets/NodeLogs-Bu3CkyMC.css                                                                 0.26 kB │ gzip:   0.20 kB
dist/assets/Authenticate-BZyI5i56.css                                                             0.27 kB │ gzip:   0.21 kB
dist/assets/OIDC-B-1Ljrwv.css                                                                     0.27 kB │ gzip:   0.21 kB
dist/assets/InfraProviders-CpzgglbW.css                                                           0.27 kB │ gzip:   0.22 kB
dist/assets/ClusterCreate-Cfqx9AFV.css                                                            0.34 kB │ gzip:   0.26 kB
dist/assets/MachineClassDestroy-DTQOD3YW.css                                                      0.34 kB │ gzip:   0.26 kB
dist/assets/MachineSetDestroy-Cx_nwFNi.css                                                        0.34 kB │ gzip:   0.26 kB
dist/assets/NodeDestroy-Cy1HFyEV.css                                                              0.34 kB │ gzip:   0.26 kB
dist/assets/NodeDestroyCancel-DvDoROec.css                                                        0.34 kB │ gzip:   0.26 kB
dist/assets/ConfigPatchDestroy-xXn_dxtP.css                                                       0.34 kB │ gzip:   0.26 kB
dist/assets/MachineAccept-ucfoeWGW.css                                                            0.34 kB │ gzip:   0.26 kB
dist/assets/MachineReject-B2JNapJT.css                                                            0.34 kB │ gzip:   0.26 kB
dist/assets/UserDestroy-DwkaTfZM.css                                                              0.35 kB │ gzip:   0.25 kB
dist/assets/JoinTokenRevoke-DmsK9tPT.css                                                          0.35 kB │ gzip:   0.25 kB
dist/assets/JoinTokenDelete-p00F_mVm.css                                                          0.35 kB │ gzip:   0.25 kB
dist/assets/TStatus-CmulRXdz.css                                                                  0.37 kB │ gzip:   0.25 kB
dist/assets/DownloadInstallationMedia-gAO0uJXh.css                                                0.39 kB │ gzip:   0.28 kB
dist/assets/UpdateExtensions-DM_d8ZdX.css                                                         0.39 kB │ gzip:   0.28 kB
dist/assets/NodeConfig-C3Nieic-.css                                                               0.43 kB │ gzip:   0.29 kB
dist/assets/DownloadOmnictl-D2L6EfB7.css                                                          0.44 kB │ gzip:   0.30 kB
dist/assets/DownloadTalosctl-BkIDO-E3.css                                                         0.50 kB │ gzip:   0.32 kB
dist/assets/MachinesPending-BN3Ky4IA.css                                                          0.50 kB │ gzip:   0.30 kB
dist/assets/NodeExtensions-D9C0iNob.css                                                           0.51 kB │ gzip:   0.32 kB
dist/assets/ClusterDestroy-B8pNT3z5.css                                                           0.54 kB │ gzip:   0.34 kB
dist/assets/UserCreate-CpfHiXPX.css                                                               0.54 kB │ gzip:   0.34 kB
dist/assets/RoleEdit-Dqvz91mF.css                                                                 0.54 kB │ gzip:   0.34 kB
dist/assets/Forbidden-CIG9MJzz.css                                                                0.57 kB │ gzip:   0.33 kB
dist/assets/BadRequest-jb65LClU.css                                                               0.57 kB │ gzip:   0.33 kB
dist/assets/PageNotFound-yfirKhB4.css                                                             0.57 kB │ gzip:   0.33 kB
dist/assets/Backups-t8V_ZJ8W.css                                                                  0.63 kB │ gzip:   0.35 kB
dist/assets/MachineClasses-BFREkmBk.css                                                           0.63 kB │ gzip:   0.35 kB
dist/assets/JoinTokens-BaWoTN8F.css                                                               0.65 kB │ gzip:   0.34 kB
dist/assets/ServiceAccountCreate-pJyvrlBS.css                                                     0.65 kB │ gzip:   0.38 kB
dist/assets/ServiceAccountRenew-Rb54MrQ-.css                                                      0.65 kB │ gzip:   0.38 kB
dist/assets/InfraProviderSetup-DloBt_de.css                                                       0.65 kB │ gzip:   0.38 kB
dist/assets/InfraProviderDelete-C--srqit.css                                                      0.65 kB │ gzip:   0.38 kB
dist/assets/Labels-DM4ATqVt.css                                                                   0.66 kB │ gzip:   0.35 kB
dist/assets/ItemLabels-BU0i7ArE.css                                                               0.69 kB │ gzip:   0.36 kB
dist/assets/ClusterMachines-BTMqJtzQ.css                                                          0.81 kB │ gzip:   0.44 kB
dist/assets/MaintenanceUpdate-DTJTwBg5.css                                                        0.82 kB │ gzip:   0.44 kB
dist/assets/UpdateKubernetes-B96iVxXz.css                                                         0.82 kB │ gzip:   0.44 kB
dist/assets/UpdateTalos-Bs2s6JYi.css                                                              0.82 kB │ gzip:   0.44 kB
dist/assets/ServiceAccounts-CWIW8KoU.css                                                          0.82 kB │ gzip:   0.38 kB
dist/assets/Clusters-mDWru6_e.css                                                                 0.95 kB │ gzip:   0.40 kB
dist/assets/Settings-Cvkq80zA.css                                                                 0.96 kB │ gzip:   0.51 kB
dist/assets/Machine-Cv-SlzTn.css                                                                  0.96 kB │ gzip:   0.51 kB
dist/assets/TSlideDownWrapper-CRwQQVp0.css                                                        1.00 kB │ gzip:   0.46 kB
dist/assets/Sync-Bayqjcz3.css                                                                     1.10 kB │ gzip:   0.56 kB
dist/assets/DownloadSupportBundle-Bbfc_7v9.css                                                    1.29 kB │ gzip:   0.56 kB
dist/assets/TCheckbox-jXlsY8Od.css                                                                1.39 kB │ gzip:   0.64 kB
dist/assets/Patches-D0Gh8hpl.css                                                                  1.42 kB │ gzip:   0.63 kB
dist/assets/Users-DV1dUhAe.css                                                                    1.43 kB │ gzip:   0.50 kB
dist/assets/NodeDetails-Bkl4RtXc.css                                                              1.48 kB │ gzip:   0.64 kB
dist/assets/ServiceAccountKey-CTrsTq6Y.css                                                        1.63 kB │ gzip:   0.66 kB
dist/assets/TabsHeader-CpVC3vJj.css                                                               1.64 kB │ gzip:   0.59 kB
dist/assets/TButtonGroup-CwcWkNxL.css                                                             1.89 kB │ gzip:   0.75 kB
dist/assets/NodeReboot-BKNzHYIf.css                                                               1.93 kB │ gzip:   0.70 kB
dist/assets/NodeShutdown-BuKivQuu.css                                                             1.93 kB │ gzip:   0.70 kB
dist/assets/ListItemBox-caT3YZHe.css                                                              1.93 kB │ gzip:   0.75 kB
dist/assets/MachineSets-BAMoWnda.css                                                              2.10 kB │ gzip:   0.69 kB
dist/assets/NodesList-DJkqgiuz.css                                                                2.18 kB │ gzip:   0.85 kB
dist/assets/TListItem-Dx_414Gw.css                                                                2.45 kB │ gzip:   0.86 kB
dist/assets/NodeMonitor-deJgmmkr.css                                                              2.48 kB │ gzip:   0.83 kB
dist/assets/MachineLogsContainer-siekVaPW.css                                                     2.51 kB │ gzip:   0.77 kB
dist/assets/TSelectList-AHU6dmiv.css                                                              3.11 kB │ gzip:   0.95 kB
dist/assets/SideBar-CebfOy1n.css                                                                  3.19 kB │ gzip:   0.88 kB
dist/assets/TInput-BmOKvXbO.css                                                                   3.72 kB │ gzip:   1.02 kB
dist/assets/Overview-DxDK4S2J.css                                                                 4.88 kB │ gzip:   1.15 kB
dist/assets/TSideBarList-D6OkUBcC.css                                                             5.06 kB │ gzip:   1.12 kB
dist/assets/NodeOverview-HdBCnUGZ.css                                                             5.36 kB │ gzip:   1.31 kB
dist/assets/MachineClass-Dzj3w8_b.css                                                             7.87 kB │ gzip:   1.40 kB
dist/assets/TPods-CKcKc7y9.css                                                                    9.34 kB │ gzip:   1.76 kB
dist/assets/PatchEdit-C5Q5bJmm.css                                                               13.92 kB │ gzip:   2.23 kB
dist/assets/CodeEditor-r8hSmONS.css                                                              65.17 kB │ gzip:  10.87 kB
dist/assets/editor-DyX1CsEw.css                                                                  68.26 kB │ gzip:  11.14 kB
dist/assets/index-C0CabLMb.css                                                                   86.20 kB │ gzip:  19.97 kB
dist/assets/TGroupAnimation-DbR2a2Bc.js                                                           0.21 kB │ gzip:   0.19 kB
dist/assets/storage-BRkt6KoL.js                                                                   0.22 kB │ gzip:   0.19 kB
dist/assets/node-DJO-O8Y4.js                                                                      0.25 kB │ gzip:   0.21 kB
dist/assets/Tag-DcKZzC5j.js                                                                       0.28 kB │ gzip:   0.23 kB
dist/assets/IconDot-QQu-NSLi.js                                                                   0.34 kB │ gzip:   0.27 kB
dist/assets/CloseButton.vue_vue_type_script_setup_true_lang-DSiwPqba.js                           0.34 kB │ gzip:   0.25 kB
dist/assets/IconHamburger-DFe_TogH.js                                                             0.35 kB │ gzip:   0.28 kB
dist/assets/Forbidden-B-xw1DFI.js                                                                 0.39 kB │ gzip:   0.28 kB
dist/assets/BadRequest-ByquK-TD.js                                                                0.39 kB │ gzip:   0.28 kB
dist/assets/IconActionVertical-CNKhYJyo.js                                                        0.41 kB │ gzip:   0.28 kB
dist/assets/StatsItem.vue_vue_type_script_setup_true_lang-C_X5ufIk.js                             0.43 kB │ gzip:   0.31 kB
dist/assets/IconMinus-lLfgbcPQ.js                                                                 0.48 kB │ gzip:   0.35 kB
dist/assets/IconArrowRightSquare-BzzuJecz.js                                                      0.50 kB │ gzip:   0.35 kB
dist/assets/TActionsBoxItem.vue_vue_type_script_setup_true_lang-JgcWdTSF.js                       0.51 kB │ gzip:   0.37 kB
dist/assets/IconDropRight-xNfTFOcY.js                                                             0.53 kB │ gzip:   0.38 kB
dist/assets/IconDropUp-CvFlZaj0.js                                                                0.53 kB │ gzip:   0.38 kB
dist/assets/Settings-Dk9bmMw2.js                                                                  0.54 kB │ gzip:   0.38 kB
dist/assets/IconDropdown-uWnOP2Cx.js                                                              0.54 kB │ gzip:   0.40 kB
dist/assets/IconExtensions-BeD0aDFK.js                                                            0.55 kB │ gzip:   0.34 kB
dist/assets/IconPlus-BOeTwvpe.js                                                                  0.58 kB │ gzip:   0.37 kB
dist/assets/TabsHeader-HrA7Avsy.js                                                                0.59 kB │ gzip:   0.41 kB
dist/assets/PageNotFound-BW0cKXvK.js                                                              0.59 kB │ gzip:   0.39 kB
dist/assets/IconArrowRight-C7Lkx7nk.js                                                            0.65 kB │ gzip:   0.45 kB
dist/assets/IconArrowUp-DYI-o32i.js                                                               0.66 kB │ gzip:   0.44 kB
dist/assets/IconArrowLeft-DTXcM5ri.js                                                             0.66 kB │ gzip:   0.44 kB
dist/assets/IconArrowDown-BRn8SOOu.js                                                             0.67 kB │ gzip:   0.41 kB
dist/assets/IconCheck-DXjKXyFv.js                                                                 0.67 kB │ gzip:   0.42 kB
dist/assets/IconPowerOff-DVmEqoV5.js                                                              0.68 kB │ gzip:   0.45 kB
dist/assets/IconActionHorizontal-C3yAfh6E.js                                                      0.68 kB │ gzip:   0.38 kB
dist/assets/PageHeader.vue_vue_type_script_setup_true_lang-199ToKBK.js                            0.68 kB │ gzip:   0.39 kB
dist/assets/open-closed-DXN5_tFD.js                                                               0.68 kB │ gzip:   0.42 kB
dist/assets/MachinePatches-DnA_yDPA.js                                                            0.70 kB │ gzip:   0.46 kB
dist/assets/MachineLogs-WaPV8uK2.js                                                               0.70 kB │ gzip:   0.46 kB
dist/assets/IconComplete-CCyWNMpK.js                                                              0.70 kB │ gzip:   0.46 kB
dist/assets/IconWarningClear-BZJDmqJA.js                                                          0.72 kB │ gzip:   0.42 kB
dist/assets/NodePatches-DM5kpGqY.js                                                               0.72 kB │ gzip:   0.48 kB
dist/assets/IconLongArrowDown-BfnZZLg_.js                                                         0.76 kB │ gzip:   0.45 kB
dist/assets/IconLongArrowTop-eM--YYXV.js                                                          0.76 kB │ gzip:   0.45 kB
dist/assets/ClusterScoped-D0li-CQK.js                                                             0.77 kB │ gzip:   0.51 kB
dist/assets/IconCopy-BbT3WdHM.js                                                                  0.77 kB │ gzip:   0.46 kB
dist/assets/IconExtensionsToggle-C426tyXI.js                                                      0.78 kB │ gzip:   0.46 kB
dist/assets/IconLockClosedToggle-DBJl4Of_.js                                                      0.79 kB │ gzip:   0.49 kB
dist/assets/IconClose-5SLNSIDU.js                                                                 0.81 kB │ gzip:   0.42 kB
dist/assets/IconInfo-CQxXhaMH.js                                                                  0.81 kB │ gzip:   0.46 kB
dist/assets/IconAttention-BC486IK7.js                                                             0.83 kB │ gzip:   0.45 kB
dist/assets/ClusterPatches-BLjoUKPk.js                                                            0.84 kB │ gzip:   0.51 kB
dist/assets/TSlideDownWrapper-Bz9nczIA.js                                                         0.85 kB │ gzip:   0.50 kB
dist/assets/NodeConfig-DObDROgW.js                                                                0.85 kB │ gzip:   0.53 kB
dist/assets/IconEdit-C62XwFto.js                                                                  0.86 kB │ gzip:   0.52 kB
dist/assets/CopyButton.vue_vue_type_script_setup_true_lang-C10tNwLL.js                            0.88 kB │ gzip:   0.53 kB
dist/assets/v4-BKrj-4V8.js                                                                        0.89 kB │ gzip:   0.48 kB
dist/assets/IconSearch-CyfGY7jl.js                                                                0.90 kB │ gzip:   0.47 kB
dist/assets/IconTime-CA8swwjy.js                                                                  0.91 kB │ gzip:   0.52 kB
dist/assets/TCheckbox-ChiIrI0D.js                                                                 0.97 kB │ gzip:   0.55 kB
dist/assets/IconExternalLink-Cw_cAubZ.js                                                          0.97 kB │ gzip:   0.51 kB
dist/assets/Tooltip-DOL9UGrG.js                                                                   0.99 kB │ gzip:   0.56 kB
dist/assets/IconLongArrowLeft-D2BUD-Kh.js                                                         0.99 kB │ gzip:   0.52 kB
dist/assets/TListItem-BCbd8Bn_.js                                                                 1.00 kB │ gzip:   0.58 kB
dist/assets/IconLongArrowRight-BAExxpKu.js                                                        1.00 kB │ gzip:   0.52 kB
dist/assets/SideBarNode-DIThpgiK.js                                                               1.03 kB │ gzip:   0.63 kB
dist/assets/IconChange-Dw6FzBxA.js                                                                1.04 kB │ gzip:   0.53 kB
dist/assets/azcli-BaLxmfj-.js                                                                     1.09 kB │ gzip:   0.46 kB
dist/assets/ClusterStatus.vue_vue_type_script_setup_true_lang-DzOzUsCL.js                         1.10 kB │ gzip:   0.52 kB
dist/assets/MachineClassDestroy-ByLkJ5X9.js                                                       1.12 kB │ gzip:   0.71 kB
dist/assets/IconError-LV4ENN1f.js                                                                 1.12 kB │ gzip:   0.58 kB
dist/assets/ListItemBox.vue_vue_type_style_index_0_lang-CSWcie8J.js                               1.16 kB │ gzip:   0.69 kB
dist/assets/MachineAccept-BONNI2Bc.js                                                             1.17 kB │ gzip:   0.72 kB
dist/assets/MachineReject-B7BhYD-a.js                                                             1.17 kB │ gzip:   0.72 kB
dist/assets/Machine-DNTGPIIP.js                                                                   1.19 kB │ gzip:   0.73 kB
dist/assets/JoinTokenRevoke-CDEtgbAA.js                                                           1.20 kB │ gzip:   0.74 kB
dist/assets/IconLog-DqP1KeY1.js                                                                   1.20 kB │ gzip:   0.62 kB
dist/assets/javascript-ByieohXN.js                                                                1.22 kB │ gzip:   0.64 kB
dist/assets/ConfigPatchDestroy-D7arRD-J.js                                                        1.23 kB │ gzip:   0.76 kB
dist/assets/InfraProviderDelete-DaluyxRP.js                                                       1.23 kB │ gzip:   0.76 kB
dist/assets/JoinTokenDelete-bW0Bl_ur.js                                                           1.24 kB │ gzip:   0.77 kB
dist/assets/IconKubeConfig-Cry39O8_.js                                                            1.26 kB │ gzip:   0.65 kB
dist/assets/IconPin-BvkTD88H.js                                                                   1.27 kB │ gzip:   0.62 kB
dist/assets/ManagedByTemplatesWarning.vue_vue_type_script_setup_true_lang-CLmqW0of.js             1.28 kB │ gzip:   0.64 kB
dist/assets/TButtonGroup-BQ4C2Wkh.js                                                              1.32 kB │ gzip:   0.75 kB
dist/assets/ini-Drc7WvVn.js                                                                       1.35 kB │ gzip:   0.68 kB
dist/assets/IconBox-C1zQGrwo.js                                                                   1.36 kB │ gzip:   0.76 kB
dist/assets/IconWaiting-DmGTKYP4.js                                                               1.37 kB │ gzip:   0.66 kB
dist/assets/IconMachinesAutoprovisioned-_von6_s5.js                                               1.41 kB │ gzip:   0.81 kB
dist/assets/MachineSetDestroy-C5hdKn43.js                                                         1.44 kB │ gzip:   0.86 kB
dist/assets/IconOngoingTasks-D2In3hAm.js                                                          1.50 kB │ gzip:   0.68 kB
dist/assets/ServiceAccountRenew-hkFlGJYU.js                                                       1.51 kB │ gzip:   0.90 kB
dist/assets/IconWarning--4N2O7_b.js                                                               1.54 kB │ gzip:   0.84 kB
dist/assets/ServiceAccountKey-BM_B2SLk.js                                                         1.55 kB │ gzip:   0.94 kB
dist/assets/IconReset-Cyv6aSzs.js                                                                 1.57 kB │ gzip:   0.92 kB
dist/assets/InfraProviderSetup-DSGX3Us5.js                                                        1.57 kB │ gzip:   0.93 kB
dist/assets/IconUnknown-CeU_yCci.js                                                               1.60 kB │ gzip:   0.74 kB
dist/assets/IconQuestion-B-VH8Xbl.js                                                              1.60 kB │ gzip:   0.88 kB
dist/assets/DownloadOmnictl-CpJgzkhJ.js                                                           1.61 kB │ gzip:   0.89 kB
dist/assets/IconNodes-BTiPmE9V.js                                                                 1.61 kB │ gzip:   0.64 kB
dist/assets/NodeReboot-C0Qs8Ppr.js                                                                1.65 kB │ gzip:   0.94 kB
dist/assets/JoinTokenWarnings.vue_vue_type_script_setup_true_lang-HPIlb_Lj.js                     1.65 kB │ gzip:   0.89 kB
dist/assets/UserCreate-D2V4W7cd.js                                                                1.65 kB │ gzip:   0.95 kB
dist/assets/IconGCP-jtq2mLjJ.js                                                                   1.65 kB │ gzip:   0.91 kB
dist/assets/UserDestroy-B1razjSq.js                                                               1.66 kB │ gzip:   0.90 kB
dist/assets/csp-5Rap-vPy.js                                                                       1.67 kB │ gzip:   0.66 kB
dist/assets/Labels.vue_vue_type_style_index_0_lang-Bafbekw1.js                                    1.67 kB │ gzip:   0.91 kB
dist/assets/IconRollback-CprZ4g4Q.js                                                              1.67 kB │ gzip:   0.95 kB
dist/assets/IconCloudConnection-u05khE_t.js                                                       1.68 kB │ gzip:   0.92 kB
dist/assets/NodeShutdown-mwNAywlB.js                                                              1.68 kB │ gzip:   0.96 kB
dist/assets/IconRefresh-DNQ6EaUw.js                                                               1.68 kB │ gzip:   0.93 kB
dist/assets/IconCheckInCircle-Cc5bI4pS.js                                                         1.70 kB │ gzip:   0.93 kB
dist/assets/RoleEdit-BcLfwq9o.js                                                                  1.80 kB │ gzip:   1.05 kB
dist/assets/user-B9CzU7yh.js                                                                      1.86 kB │ gzip:   0.85 kB
dist/assets/IconPods-DDJ5jVxV.js                                                                  1.90 kB │ gzip:   0.91 kB
dist/assets/pla-B03wrqEc.js                                                                       1.93 kB │ gzip:   0.79 kB
dist/assets/ClusterMachinePhase.vue_vue_type_style_index_0_lang-ZOAj-xY5.js                       1.94 kB │ gzip:   0.86 kB
dist/assets/NodeContextMenu.vue_vue_type_script_setup_true_lang-CNoxnZQD.js                       1.95 kB │ gzip:   0.79 kB
dist/assets/IconLinkDown-CTuhIg0B.js                                                              1.96 kB │ gzip:   0.78 kB
dist/assets/IconHome-CpeilL9d.js                                                                  1.97 kB │ gzip:   0.96 kB
dist/assets/JoinTokenCreate-DOcqFJSL.js                                                           1.98 kB │ gzip:   1.00 kB
dist/assets/NodeDestroyCancel-gP226P-f.js                                                         2.00 kB │ gzip:   1.05 kB
dist/assets/scheme-Bio4gycK.js                                                                    2.01 kB │ gzip:   0.96 kB
dist/assets/flow9-i9-g7ZhI.js                                                                     2.06 kB │ gzip:   1.00 kB
dist/assets/IconNoConnection-Cp-YTSb6.js                                                          2.07 kB │ gzip:   1.05 kB
dist/assets/sb-CDntyWJ8.js                                                                        2.08 kB │ gzip:   0.97 kB
dist/assets/bat-CFOPXBzS.js                                                                       2.09 kB │ gzip:   1.01 kB
dist/assets/MachinesPending-BoU043fy.js                                                           2.10 kB │ gzip:   1.05 kB
dist/assets/dockerfile-Zznr-cwX.js                                                                2.12 kB │ gzip:   0.82 kB
dist/assets/IconTerminal-hcWzmg-N.js                                                              2.13 kB │ gzip:   0.92 kB
dist/assets/IconReboot-CudNIqU1.js                                                                2.13 kB │ gzip:   1.12 kB
dist/assets/ServiceAccountCreate-_z18N653.js                                                      2.20 kB │ gzip:   1.15 kB
dist/assets/IconUpload-BW-qokb2.js                                                                2.21 kB │ gzip:   0.92 kB
dist/assets/IconKey-yiz75RgG.js                                                                   2.23 kB │ gzip:   1.16 kB
dist/assets/pascaligo-Bc-ZgV77.js                                                                 2.25 kB │ gzip:   1.05 kB
dist/assets/IconSideroMonochrome-DeZOqybb.js                                                      2.25 kB │ gzip:   1.07 kB
dist/assets/OIDC-CG0LOP5g.js                                                                      2.26 kB │ gzip:   1.13 kB
dist/assets/IconLoading-JRvxKNr9.js                                                               2.26 kB │ gzip:   0.83 kB
dist/assets/IconCheckInCircleClassic-B9MKHCco.js                                                  2.28 kB │ gzip:   1.03 kB
dist/assets/IconTalosConfig-CuWE5xVR.js                                                           2.30 kB │ gzip:   0.96 kB
dist/assets/IconUpgradeEmptyState-BX22CD0x.js                                                     2.30 kB │ gzip:   0.98 kB
dist/assets/NodeLogs-BWGfyS12.js                                                                  2.33 kB │ gzip:   1.14 kB
dist/assets/lua-nf6ki56Z.js                                                                       2.37 kB │ gzip:   1.07 kB
dist/assets/RadialBar.vue_vue_type_script_setup_true_lang-OjV2cnkS.js                             2.37 kB │ gzip:   1.16 kB
dist/assets/IconDashboard-GY6DFnP4.js                                                             2.38 kB │ gzip:   0.95 kB
dist/assets/index-BXcETctf.js                                                                     2.41 kB │ gzip:   1.24 kB
dist/assets/TInput-BVhNw-Vh.js                                                                    2.42 kB │ gzip:   1.19 kB
dist/assets/cameligo-BFG1Mk7z.js                                                                  2.43 kB │ gzip:   1.10 kB
dist/assets/IconDelete-B6Y0HU7Q.js                                                                2.48 kB │ gzip:   1.16 kB
dist/assets/IconFailAuth-BNTCAa3f.js                                                              2.48 kB │ gzip:   1.03 kB
dist/assets/MachineClasses-CEEQZecl.js                                                            2.49 kB │ gzip:   1.24 kB
dist/assets/ExtensionsPicker.vue_vue_type_script_setup_true_lang-Dg8K5sMq.js                      2.49 kB │ gzip:   1.22 kB
dist/assets/graphql-Cg7bfA9N.js                                                                   2.51 kB │ gzip:   1.17 kB
dist/assets/MachineRemove-PIE2_yvK.js                                                             2.51 kB │ gzip:   1.22 kB
dist/assets/DownloadTalosctl-CnM6eihh.js                                                          2.58 kB │ gzip:   1.27 kB
dist/assets/IconOverview-B6QExNNL.js                                                              2.58 kB │ gzip:   1.12 kB
dist/assets/UpdateExtensions-KtWaF_CB.js                                                          2.62 kB │ gzip:   1.33 kB
dist/assets/objective-c-B5zXfXm9.js                                                               2.65 kB │ gzip:   1.20 kB
dist/assets/IconSettings-BY7yOjYY.js                                                              2.66 kB │ gzip:   1.36 kB
dist/assets/lexon-YWi4-JPR.js                                                                     2.68 kB │ gzip:   1.07 kB
dist/assets/xml-DhDknGTt.js                                                                       2.70 kB │ gzip:   1.13 kB
dist/assets/SideBar-Ca4oqgvR.js                                                                   2.71 kB │ gzip:   1.16 kB
dist/assets/IconUnlink-DStKMYj4.js                                                                2.74 kB │ gzip:   1.25 kB
dist/assets/bicep-BfEKNvv3.js                                                                     2.78 kB │ gzip:   1.11 kB
dist/assets/sparql-DHaeiCBh.js                                                                    2.80 kB │ gzip:   1.30 kB
dist/assets/InfraProviders-Ct-PcAeJ.js                                                            2.82 kB │ gzip:   1.46 kB
dist/assets/mips-B_c3zf-v.js                                                                      2.83 kB │ gzip:   1.22 kB
dist/assets/ClusterDestroy-D_MFJGP1.js                                                            2.89 kB │ gzip:   1.39 kB
dist/assets/IconKubernetes-Dob9kg_-.js                                                            2.89 kB │ gzip:   1.47 kB
dist/assets/IconSettingsToggle-CnJ4ftcI.js                                                        2.90 kB │ gzip:   1.50 kB
dist/assets/IconInProgress-DG7mOp8r.js                                                            2.90 kB │ gzip:   1.04 kB
dist/assets/go-Cphgjts3.js                                                                        2.90 kB │ gzip:   1.29 kB
dist/assets/IconAWS-BQYE7z28.js                                                                   2.95 kB │ gzip:   1.37 kB
dist/assets/Users-Dz8zX7sQ.js                                                                     2.99 kB │ gzip:   1.45 kB
dist/assets/ServiceAccounts-DO9ilHSa.js                                                           2.99 kB │ gzip:   1.35 kB
dist/assets/IconServerNetwork-jIWi1vF5.js                                                         3.00 kB │ gzip:   0.95 kB
dist/assets/sophia-C5WLch3f.js                                                                    3.01 kB │ gzip:   1.35 kB
dist/assets/IconUpgradeAvailable-DNDud1hS.js                                                      3.02 kB │ gzip:   1.45 kB
dist/assets/IconUpgrade-BoSTZwya.js                                                               3.04 kB │ gzip:   1.45 kB
dist/assets/typespec-D-MeaMDU.js                                                                  3.04 kB │ gzip:   1.23 kB
dist/assets/UpdateTalos-Dc7ULkaU.js                                                               3.06 kB │ gzip:   1.57 kB
dist/assets/m3-Cpb6xl2v.js                                                                        3.06 kB │ gzip:   1.47 kB
dist/assets/MaintenanceUpdate-D249QNfc.js                                                         3.13 kB │ gzip:   1.59 kB
dist/assets/NodeMounts-DVmMgCCe.js                                                                3.14 kB │ gzip:   1.46 kB
dist/assets/IconClustersBig-B4aLErRw.js                                                           3.18 kB │ gzip:   1.12 kB
dist/assets/LabelsInput.vue_vue_type_script_setup_true_lang-xLp2yOYc.js                           3.18 kB │ gzip:   1.62 kB
dist/assets/fsharp-CzKuDChf.js                                                                    3.23 kB │ gzip:   1.46 kB
dist/assets/NodeDestroy-D1f32R5i.js                                                               3.23 kB │ gzip:   1.61 kB
dist/assets/pascal-CXOwvkN_.js                                                                    3.24 kB │ gzip:   1.54 kB
dist/assets/ItemLabels.vue_vue_type_script_setup_true_lang-CEhnGDV8.js                            3.25 kB │ gzip:   1.62 kB
dist/assets/shell-CX-rkNHf.js                                                                     3.32 kB │ gzip:   1.35 kB
dist/assets/BackupStorage-sFE6MPRe.js                                                             3.32 kB │ gzip:   1.33 kB
dist/assets/Sync-B-jfvcqd.js                                                                      3.34 kB │ gzip:   1.63 kB
dist/assets/r-CdQndTaG.js                                                                         3.38 kB │ gzip:   1.42 kB
dist/assets/TStatus-BK9a19a6.js                                                                   3.40 kB │ gzip:   0.95 kB
dist/assets/NodesList-DqJc7zNA.js                                                                 3.42 kB │ gzip:   1.49 kB
dist/assets/IconSidero-SjwzCCSD.js                                                                3.43 kB │ gzip:   1.23 kB
dist/assets/qsharp-DXyYeYxl.js                                                                    3.44 kB │ gzip:   1.56 kB
dist/assets/keyboard-DIsr461o.js                                                                  3.45 kB │ gzip:   1.72 kB
dist/assets/IconLogo-BJ8_pANF.js                                                                  3.47 kB │ gzip:   1.26 kB
dist/assets/java-B_fMsGYe.js                                                                      3.47 kB │ gzip:   1.55 kB
dist/assets/disclosure-CX0iNTSk.js                                                                3.50 kB │ gzip:   1.38 kB
dist/assets/powershell-Dd3NCNK9.js                                                                3.52 kB │ gzip:   1.53 kB
dist/assets/UpdateKubernetes-CxXK6432.js                                                          3.56 kB │ gzip:   1.78 kB
dist/assets/NodeExtensions-C1WiMiiI.js                                                            3.63 kB │ gzip:   1.64 kB
dist/assets/cypher-DrQuvNYM.js                                                                    3.63 kB │ gzip:   1.58 kB
dist/assets/TSideBarList.vue_vue_type_script_setup_true_lang-CkvT0pZx.js                          3.64 kB │ gzip:   1.64 kB
dist/assets/kotlin-BSkB5QuD.js                                                                    3.69 kB │ gzip:   1.63 kB
dist/assets/SideBar-DjNU02rl.js                                                                   3.69 kB │ gzip:   1.73 kB
dist/assets/noble_hashes.min-Iktgqe8W.js                                                          3.77 kB │ gzip:   1.76 kB
dist/assets/redis-CVwtpugi.js                                                                     3.80 kB │ gzip:   1.64 kB
dist/assets/tcl-DnHyzjbg.js                                                                       3.82 kB │ gzip:   1.52 kB
dist/assets/coffee-CDGzqUPQ.js                                                                    3.84 kB │ gzip:   1.45 kB
dist/assets/hcl-0cvrggvQ.js                                                                       3.84 kB │ gzip:   1.64 kB
dist/assets/IconMachinesManual-DpKM71YI.js                                                        3.90 kB │ gzip:   1.75 kB
dist/assets/markdown-DSZPf7rp.js                                                                  4.03 kB │ gzip:   1.53 kB
dist/assets/restructuredtext-DfzH4Xui.js                                                          4.14 kB │ gzip:   1.52 kB
dist/assets/less-BsTHnhdd.js                                                                      4.14 kB │ gzip:   1.57 kB
dist/assets/apex-DyP6w7ZV.js                                                                      4.20 kB │ gzip:   1.91 kB
dist/assets/Backups-DrzNMEki.js                                                                   4.24 kB │ gzip:   1.95 kB
dist/assets/liquid-DYItTBs_.js                                                                    4.25 kB │ gzip:   1.83 kB
dist/assets/ClusterScale-Cun6SP5W.js                                                              4.27 kB │ gzip:   2.09 kB
dist/assets/yaml-BEw5YRvU.js                                                                      4.31 kB │ gzip:   1.69 kB
dist/assets/EmbeddedDiscoveryServiceCheckbox.vue_vue_type_script_setup_true_lang-zV0lZXfA.js      4.34 kB │ gzip:   1.85 kB
dist/assets/rust-D5C2fndG.js                                                                      4.41 kB │ gzip:   1.97 kB
dist/assets/python-CjnS9Rqq.js                                                                    4.49 kB │ gzip:   1.85 kB
dist/assets/dart-CFKIUWau.js                                                                      4.50 kB │ gzip:   1.80 kB
dist/assets/NodeDetails-HHuKsdnP.js                                                               4.51 kB │ gzip:   1.77 kB
dist/assets/DownloadSupportBundle-a5jyxiOP.js                                                     4.53 kB │ gzip:   2.12 kB
dist/assets/JoinTokens-BGjTPhRY.js                                                                4.60 kB │ gzip:   1.93 kB
dist/assets/css-D3h14YRZ.js                                                                       4.76 kB │ gzip:   1.53 kB
dist/assets/csharp-dUCx_-0o.js                                                                    4.77 kB │ gzip:   1.87 kB
dist/assets/machine.pb-BGde-JIQ.js                                                                4.91 kB │ gzip:   0.74 kB
dist/assets/form-BCgdBPbt.js                                                                      5.04 kB │ gzip:   2.35 kB
dist/assets/pug-BaJupSGV.js                                                                       5.07 kB │ gzip:   1.80 kB
dist/assets/mdx-DWWT_yAk.js                                                                       5.16 kB │ gzip:   1.61 kB
dist/assets/msdax-rUNN04Wq.js                                                                     5.16 kB │ gzip:   2.11 kB
dist/assets/Authenticate-DPxXksNf.js                                                              5.30 kB │ gzip:   2.33 kB
dist/assets/html-0-ScNlVE.js                                                                      5.31 kB │ gzip:   1.56 kB
dist/assets/swift-DwJ7jVG9.js                                                                     5.42 kB │ gzip:   2.22 kB
dist/assets/cpp-CLLBncYj.js                                                                       5.55 kB │ gzip:   2.24 kB
dist/assets/ecl-Ce3n6wWz.js                                                                       5.59 kB │ gzip:   2.38 kB
dist/assets/typescript-DYPzW5LD.js                                                                5.70 kB │ gzip:   2.34 kB
dist/assets/Patches-B8Q4fz-b.js                                                                   5.94 kB │ gzip:   2.74 kB
dist/assets/IconClusters-LKOXk4fn.js                                                              5.94 kB │ gzip:   1.83 kB
dist/assets/TList.vue_vue_type_script_setup_true_lang-CkxLiSx9.js                                 6.02 kB │ gzip:   2.49 kB
dist/assets/vb-DgyLZaXg.js                                                                        6.04 kB │ gzip:   2.21 kB
dist/assets/pluralize-jamTuwMc.js                                                                 6.08 kB │ gzip:   2.57 kB
dist/assets/twig-CPajHgWi.js                                                                      6.22 kB │ gzip:   1.68 kB
dist/assets/scss-4Ik7cdeQ.js                                                                      6.66 kB │ gzip:   1.90 kB
dist/assets/TPods-C_tAZaWR.js                                                                     6.67 kB │ gzip:   2.61 kB
dist/assets/radio-group-BCM-Y3tz.js                                                               6.81 kB │ gzip:   2.62 kB
dist/assets/handlebars-UvH_VKYJ.js                                                                7.07 kB │ gzip:   1.78 kB
dist/assets/Clusters-BMoVIujl.js                                                                  7.27 kB │ gzip:   2.80 kB
dist/assets/julia-Bqgm2twL.js                                                                     7.40 kB │ gzip:   2.80 kB
dist/assets/scala-BoFRg7Ot.js                                                                     7.56 kB │ gzip:   2.25 kB
dist/assets/wgsl-BIv9DU6q.js                                                                      7.59 kB │ gzip:   2.89 kB
dist/assets/st-pnP8ivHi.js                                                                        7.65 kB │ gzip:   2.39 kB
dist/assets/systemverilog-B9Xyijhd.js                                                             7.85 kB │ gzip:   2.91 kB
dist/assets/PatchEdit-BYpq3_HN.js                                                                 7.92 kB │ gzip:   3.44 kB
dist/assets/IconHeaderLogo--o3UuDAd.js                                                            7.93 kB │ gzip:   3.12 kB
dist/assets/postiats-BKlk5iyT.js                                                                  8.10 kB │ gzip:   2.59 kB
dist/assets/vue-word-highlighter.esm-2WWV_rOt.js                                                  8.21 kB │ gzip:   3.87 kB
dist/assets/php-CpIb_Oan.js                                                                       8.27 kB │ gzip:   2.22 kB
dist/assets/perl-CwNk8-XU.js                                                                      8.50 kB │ gzip:   3.29 kB
dist/assets/ruby-Cp1zYvxS.js                                                                      8.75 kB │ gzip:   2.73 kB
dist/assets/razor-CCOtELGo.js                                                                     9.06 kB │ gzip:   2.46 kB
dist/assets/NodeMonitor-Kvj7iHEW.js                                                               9.18 kB │ gzip:   3.86 kB
dist/assets/protobuf-COyEY5Pt.js                                                                  9.29 kB │ gzip:   2.22 kB
dist/assets/DownloadInstallationMedia-CRlMHhM0.js                                                 9.52 kB │ gzip:   4.10 kB
dist/assets/ClusterCreate-DdwA7RPB.js                                                             9.74 kB │ gzip:   3.91 kB
dist/assets/clojure-DTECt2xU.js                                                                   9.89 kB │ gzip:   3.76 kB
dist/assets/elixir-deUWdS0T.js                                                                   10.50 kB │ gzip:   2.68 kB
dist/assets/sql-CCSDG5nI.js                                                                      10.54 kB │ gzip:   4.01 kB
dist/assets/seek-bzip.min-BVSBR0_g.js                                                            10.60 kB │ gzip:   4.91 kB
dist/assets/Home-DT3wdPdZ.js                                                                     10.94 kB │ gzip:   3.42 kB
dist/assets/mysql-DDwshQtU.js                                                                    11.52 kB │ gzip:   4.22 kB
dist/assets/NodeOverview-C-k037qa.js                                                             11.60 kB │ gzip:   4.11 kB
dist/assets/ClusterMachines.vue_vue_type_script_setup_true_lang-UiYLDhpD.js                      11.67 kB │ gzip:   4.16 kB
dist/assets/redshift-25W9uPmb.js                                                                 12.05 kB │ gzip:   4.48 kB
dist/assets/pgsql-tGk8EFnU.js                                                                    13.71 kB │ gzip:   4.65 kB
dist/assets/abap-BrgZPUOV.js                                                                     14.41 kB │ gzip:   5.46 kB
dist/assets/Machines-DzKbPo9C.js                                                                 14.76 kB │ gzip:   5.24 kB
dist/assets/sha512.min-D7EwqLYW.js                                                               15.67 kB │ gzip:   7.01 kB
dist/assets/TSelectList-BEDQXkIo.js                                                              16.10 kB │ gzip:   5.71 kB
dist/assets/freemarker2-AUOCm1Zx.js                                                              16.39 kB │ gzip:   4.33 kB
dist/assets/powerquery-Bhzvs7bI.js                                                               17.19 kB │ gzip:   5.00 kB
dist/assets/argon2id.min-DsZE3j1D.js                                                             18.64 kB │ gzip:   6.83 kB
dist/assets/solidity-Tw7wswEv.js                                                                 18.84 kB │ gzip:   4.62 kB
dist/assets/Overview-BWRcfcMR.js                                                                 20.35 kB │ gzip:   5.82 kB
dist/assets/tsMode-DIshNB1r.js                                                                   22.90 kB │ gzip:   6.54 kB
dist/assets/MachineLogsContainer.vue_vue_type_script_setup_true_lang-DN8Bi6cp.js                 27.39 kB │ gzip:   9.74 kB
dist/assets/cssMode-SyWBni0i.js                                                                  32.40 kB │ gzip:   8.82 kB
dist/assets/htmlMode-D5juCu1v.js                                                                 32.95 kB │ gzip:   8.94 kB
dist/assets/MachineSets.vue_vue_type_script_setup_true_lang-CefIXb5d.js                          38.88 kB │ gzip:  12.80 kB
dist/assets/js-yaml-Bi65IN6L.js                                                                  39.78 kB │ gzip:  13.48 kB
dist/assets/noble_curves.min-Ba3l5a-v.js                                                         41.36 kB │ gzip:  16.73 kB
dist/assets/jsonMode-CHIzYYNW.js                                                                 41.81 kB │ gzip:  12.15 kB
dist/assets/legacy_ciphers.min-DU3eQIJx.js                                                       51.71 kB │ gzip:  23.37 kB
dist/assets/MachineClass-CqcCggB2.js                                                            290.95 kB │ gzip:  90.52 kB
dist/assets/vue3-apexcharts-CXjL8X6q.js                                                         582.75 kB │ gzip: 158.65 kB
dist/assets/index-Bp3VoNhS.js                                                                   723.28 kB │ gzip: 238.81 kB
dist/assets/CodeEditor-7hxtXOqj.js                                                            1,216.26 kB │ gzip: 285.91 kB
dist/assets/editor.api-CK8ODYK5.js                                                            2,346.48 kB │ gzip: 611.57 kB
```
</details>