### PR TITLE
feat: implement user consent form for the `UserPilot`

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,6 +10,7 @@ import { useRouter } from 'vue-router'
 
 import AppToast from '@/components/common/AppToast/AppToast.vue'
 import TSuspended from '@/components/common/Suspended/TSuspended.vue'
+import UserConsent from '@/components/common/UserConsent/UserConsent.vue'
 import TSideBar from '@/components/SideBar/TSideBar.vue'
 import THeader from '@/components/THeader/THeader.vue'
 import TModal from '@/components/TModal.vue'
@@ -23,6 +24,7 @@ router.afterEach(() => (isSidebarOpen.value = false))
 
 <template>
   <main class="flex h-screen flex-col">
+    <UserConsent />
     <AppToast />
 
     <THeader

--- a/frontend/src/components/common/UserConsent/UserConsent.vue
+++ b/frontend/src/components/common/UserConsent/UserConsent.vue
@@ -1,0 +1,66 @@
+<!--
+Copyright (c) 2025 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+import TButton from '@/components/common/Button/TButton.vue'
+import { currentUser } from '@/methods/auth'
+import { getUserPilotToken, initializeUserPilot } from '@/methods/features'
+import { trackingState } from '@/methods/features'
+
+const enableTracking = async () => {
+  if (!currentUser.value) {
+    return
+  }
+
+  trackingState.value = true
+
+  await initializeUserPilot(currentUser.value)
+}
+
+const trackerToken = ref<string | undefined>()
+
+const fetchTrackingToken = async () => {
+  if (!currentUser.value) {
+    return
+  }
+
+  trackerToken.value = await getUserPilotToken()
+}
+
+watch(() => currentUser.value, fetchTrackingToken)
+</script>
+
+<template>
+  <div v-if="trackingState === undefined && trackerToken">
+    <div class="absolute top-0 left-0 z-50 flex h-screen w-screen flex-col justify-stretch">
+      <div class="flex-1 bg-black opacity-25" />
+      <div class="border-t border-primary-p3 bg-naturals-n6 p-4">
+        <p class="text-lg text-naturals-n13">Cookies for a Better Experience</p>
+        <div class="flex items-center justify-between">
+          <p class="text-sm">
+            We use cookies to improve our website's interface and onboarding experience. We don't
+            use them for ads or share your data with third parties.
+            <a
+              type="subtle"
+              class="list-item-link cursor-pointer"
+              rel="noopener noreferrer"
+              href="https://www.siderolabs.com/privacy-policy/"
+              target="_blank"
+            >
+              Learn more
+            </a>
+          </p>
+          <div class="flex gap-2">
+            <TButton @click="trackingState = false">Decline</TButton>
+            <TButton type="highlighted" @click="enableTracking">Accept</TButton>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/methods/auth.ts
+++ b/frontend/src/methods/auth.ts
@@ -169,7 +169,11 @@ const refreshCurrentUser = async () => {
       withRuntime(Runtime.Omni),
     )
 
-    await initializeUserPilot(currentUser.value)
+    try {
+      await initializeUserPilot(currentUser.value)
+    } catch (e) {
+      console.error('failed to initialize user pilot', e)
+    }
   } catch {
     currentUser.value = undefined
   }


### PR DESCRIPTION
The form allows to agree or decline data collection. When declined UserPilot library is not activated.

Tracker state is saved in the local storage.

Fixes: https://github.com/siderolabs/omni/issues/1446