### PR TITLE
fix: use correct order to determine SideroV1 keys directory path

### DIFF
--- a/client/pkg/omnictl/config/config.go
+++ b/client/pkg/omnictl/config/config.go
@@ -277,10 +277,19 @@ func copyConfig(src, dstDir string) (string, error) {
 }
 
 // CustomSideroV1KeysDirPath returns the custom SideroV1 auth keys directory path if it's provided as command line flag or with environment variable.
-func CustomSideroV1KeysDirPath(path string) string {
-	if path != "" {
+func CustomSideroV1KeysDirPath(customPath string) string {
+	if path, ok := os.LookupEnv(constants.SideroV1KeysDirEnvVar); ok {
 		return path
 	}
 
-	return os.Getenv(constants.SideroV1KeysDirEnvVar)
+	if customPath != "" {
+		return customPath
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(home, constants.TalosDir, constants.SideroV1KeysDir)
 }

--- a/client/pkg/omnictl/internal/access/client.go
+++ b/client/pkg/omnictl/internal/access/client.go
@@ -100,7 +100,10 @@ func WithClient(f func(ctx context.Context, client *client.Client) error, client
 				fmt.Fprintf(os.Stderr, "[WARN] basic auth is deprecated and has no effect\n")
 			}
 
-			opts = append(opts, client.WithUserAccount(contextName, configCtx.Auth.SideroV1.Identity), client.WithCustomKeysDir(CmdFlags.SideroV1KeysDir))
+			opts = append(opts,
+				client.WithUserAccount(contextName, configCtx.Auth.SideroV1.Identity),
+				client.WithCustomKeysDir(config.CustomSideroV1KeysDirPath(CmdFlags.SideroV1KeysDir)),
+			)
 
 			if configCtx.URL == config.PlaceholderURL {
 				return fmt.Errorf("context %q has not been configured, you will need to set it manually", contextName)


### PR DESCRIPTION
Use correct order to determine SideroV1KeysDirPath:
* Use env variable `SIDEROV1_KEYS_DIR`
* If not set, use cli flag`--siderov1-keys-dir`
* If empty, use default dir `$HOME/.talos/keys`