### PR TITLE
fix: fix switch user button for Auth0

### DIFF
--- a/frontend/src/views/omni/Auth/Authenticate.vue
+++ b/frontend/src/views/omni/Auth/Authenticate.vue
@@ -72,6 +72,8 @@ onMounted(() => {
           })
         }
       }
+
+      break
     case AuthType.OIDC:
     case AuthType.SAML:
       const navigateToLogin = () => {


### PR DESCRIPTION
There was a missing `break` that was making it fall through to the SAML and OIDC implementations.