### PR TITLE
chore: strip comments from generated ClusterMachineConfig

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -2544,8 +2544,10 @@ type ClusterMachineConfigSpec struct {
 	//
 	// Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
 	CompressedData []byte `protobuf:"bytes,4,opt,name=compressed_data,json=compressedData,proto3" json:"compressed_data,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// WithoutComments indicates that the config was generated without comments.
+	WithoutComments bool `protobuf:"varint,5,opt,name=without_comments,json=withoutComments,proto3" json:"without_comments,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ClusterMachineConfigSpec) Reset() {
@@ -2604,6 +2606,13 @@ func (x *ClusterMachineConfigSpec) GetCompressedData() []byte {
 		return x.CompressedData
 	}
 	return nil
+}
+
+func (x *ClusterMachineConfigSpec) GetWithoutComments() bool {
+	if x != nil {
+		return x.WithoutComments
+	}
+	return false
 }
 
 // ClusterMachineConfigSpec stores generated Talos node machine config.
@@ -9092,12 +9101,13 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x12compressed_patches\x18\x02 \x03(\fR\x11compressedPatches\"h\n" +
 	"\x1eClusterMachineTalosVersionSpec\x12#\n" +
 	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12!\n" +
-	"\fschematic_id\x18\x02 \x01(\tR\vschematicId\"\xba\x01\n" +
+	"\fschematic_id\x18\x02 \x01(\tR\vschematicId\"\xe5\x01\n" +
 	"\x18ClusterMachineConfigSpec\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\fR\x04data\x126\n" +
 	"\x17cluster_machine_version\x18\x02 \x01(\tR\x15clusterMachineVersion\x12)\n" +
 	"\x10generation_error\x18\x03 \x01(\tR\x0fgenerationError\x12'\n" +
-	"\x0fcompressed_data\x18\x04 \x01(\fR\x0ecompressedData\"_\n" +
+	"\x0fcompressed_data\x18\x04 \x01(\fR\x0ecompressedData\x12)\n" +
+	"\x10without_comments\x18\x05 \x01(\bR\x0fwithoutComments\"_\n" +
 	" RedactedClusterMachineConfigSpec\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\tR\x04data\x12'\n" +
 	"\x0fcompressed_data\x18\x02 \x01(\fR\x0ecompressedData\"\xdc\x01\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -441,6 +441,9 @@ message ClusterMachineConfigSpec {
   //
   // Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
   bytes compressed_data = 4;
+
+  // WithoutComments indicates that the config was generated without comments.
+  bool without_comments = 5;
 }
 
 // ClusterMachineConfigSpec stores generated Talos node machine config.

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -734,6 +734,7 @@ func (m *ClusterMachineConfigSpec) CloneVT() *ClusterMachineConfigSpec {
 	r := new(ClusterMachineConfigSpec)
 	r.ClusterMachineVersion = m.ClusterMachineVersion
 	r.GenerationError = m.GenerationError
+	r.WithoutComments = m.WithoutComments
 	if rhs := m.Data; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
@@ -3616,6 +3617,9 @@ func (this *ClusterMachineConfigSpec) EqualVT(that *ClusterMachineConfigSpec) bo
 		return false
 	}
 	if string(this.CompressedData) != string(that.CompressedData) {
+		return false
+	}
+	if this.WithoutComments != that.WithoutComments {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -8157,6 +8161,16 @@ func (m *ClusterMachineConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, err
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.WithoutComments {
+		i--
+		if m.WithoutComments {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
 	}
 	if len(m.CompressedData) > 0 {
 		i -= len(m.CompressedData)
@@ -13887,6 +13901,9 @@ func (m *ClusterMachineConfigSpec) SizeVT() (n int) {
 	l = len(m.CompressedData)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.WithoutComments {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -21251,6 +21268,26 @@ func (m *ClusterMachineConfigSpec) UnmarshalVT(dAtA []byte) error {
 				m.CompressedData = []byte{}
 			}
 			iNdEx = postIndex
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field WithoutComments", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.WithoutComments = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -392,6 +392,7 @@ export type ClusterMachineConfigSpec = {
   cluster_machine_version?: string
   generation_error?: string
   compressed_data?: Uint8Array
+  without_comments?: boolean
 }
 
 export type RedactedClusterMachineConfigSpec = {


### PR DESCRIPTION
Do not include the comments to the generated ClusterMachineConfig to prevent triggering noop machine updates caused by changes on machine config comments

Fixes #1581 