### PR TITLE
fix: keep query parameters encoded in the oidc/saml login flows

### DIFF
--- a/frontend/src/views/omni/Auth/Authenticate.vue
+++ b/frontend/src/views/omni/Auth/Authenticate.vue
@@ -77,12 +77,7 @@ onMounted(() => {
     case AuthType.OIDC:
     case AuthType.SAML:
       const navigateToLogin = () => {
-        const query: string[] = []
-        for (const key in route.query) {
-          query.push(`${key}=${route.query[key]}`)
-        }
-
-        redirectToURL(`/login?${query.join('&')}`)
+        redirectToURL(`/login${window.location.search}`)
       }
 
       if (!identity.value) {
@@ -91,11 +86,6 @@ onMounted(() => {
 
       if (authType.value === AuthType.OIDC) {
         logout = () => {
-          const query: string[] = []
-          for (const key in route.query) {
-            query.push(`${key}=${route.query[key]}`)
-          }
-
           redirectToURL(`/logout?flow=frontend`)
         }
 


### PR DESCRIPTION
We were setting the query parameters in the login flow incorrectly - we were reading the decoded query via `route.query` and setting them without re-encoding them.

This caused `redirect` query param, which is used in the workload proxy flow, to be double-decoded: once by the frontend and then by the server. The second decoding converted `+` to a ` ` (space), which caused base64 decoding to fail (`+` is a valid base64 char, while space is not).

Fix this by copying the raw query params as-is.

Fixes siderolabs/omni#1596.