### PR TITLE
fix: update home page wording as SideroLink

### DIFF
--- a/frontend/src/views/omni/Home/HomeGeneralInformation.vue
+++ b/frontend/src/views/omni/Home/HomeGeneralInformation.vue
@@ -101,7 +101,7 @@ watch(apiConfigErr, (err) => err && showError(err))
       />
 
       <HomeGeneralInformationCopyable
-        title="WireGuard Endpoint"
+        title="SideroLink Endpoint"
         :value="apiConfigData?.spec.wireguard_advertised_endpoint"
       />
 


### PR DESCRIPTION
Make it more clear with docs references the endpoint is for the SideroLink connection.

I might have missed other references to WireGuard but didn't see any obvious ones we'd want to replace.