### PR TITLE
fix: use correct indentation in the `generate-certs` scripts

### DIFF
--- a/hack/generate-certs/main.go
+++ b/hack/generate-certs/main.go
@@ -280,7 +280,7 @@ services:
       {{- if ne .PprofBindAddress ""}}
       --pprof-bind-addr {{ .PprofBindAddress }}
       {{- end}}
-	omni-inspector:
-		environment:
-			- OMNI_ENDPOINT={{ .BindAddr }}
+  omni-inspector:
+    environment:
+      - OMNI_ENDPOINT={{ .BindAddr }}
 `


### PR DESCRIPTION
It was using tabs instead of spaces for the `docker-compose.override.yml` file template.