### PR TITLE
fix: inline the css from clusters-grid

### DIFF
--- a/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
@@ -230,7 +230,7 @@ const sectionHeadingId = useId()
     :aria-labelledby="sectionHeadingId"
   >
     <div class="flex items-center border-b border-naturals-n4 pl-3 text-naturals-n14">
-      <div class="clusters-grid flex-1 items-center py-2">
+      <div class="grid flex-1 grid-cols-4 items-center gap-2 py-2 pr-2 *:truncate *:text-xs">
         <div class="col-span-2 flex flex-wrap items-center justify-between gap-2">
           <div class="flex flex-1 items-center">
             <header class="flex w-40 items-center gap-2 truncate rounded bg-naturals-n4 px-3 py-2">
@@ -302,7 +302,7 @@ const sectionHeadingId = useId()
       v-for="machine in machines"
       :id="machine.metadata.id"
       :key="itemID(machine)"
-      class="machine-item"
+      class="border-naturals-n4 not-last-of-type:border-b last-of-type:rounded-b-md"
       :machine-set="machineSet"
       :has-diagnostic-info="nodesWithDiagnostics?.has(machine.metadata.id!)"
       :machine="machine"
@@ -311,7 +311,7 @@ const sectionHeadingId = useId()
     <MachineRequest
       v-for="request in pendingRequests"
       :key="itemID(request)"
-      class="machine-item"
+      class="border-naturals-n4 not-last-of-type:border-b last-of-type:rounded-b-md"
       :request-status="request"
     />
     <div
@@ -325,15 +325,3 @@ const sectionHeadingId = useId()
     </div>
   </section>
 </template>
-
-<style scoped>
-@reference "../../../index.css";
-
-.machine-item:not(:last-of-type) {
-  @apply border-b border-naturals-n4;
-}
-
-.machine-item:last-of-type {
-  @apply rounded-b-md;
-}
-</style>

--- a/frontend/src/views/omni/Clusters/ClusterItem.vue
+++ b/frontend/src/views/omni/Clusters/ClusterItem.vue
@@ -123,7 +123,7 @@ const labelId = useId()
     :label-id="labelId"
   >
     <template #default>
-      <div class="clusters-grid flex-1">
+      <div class="grid flex-1 grid-cols-4 items-center gap-2 pr-2 *:truncate *:text-xs">
         <div class="flex items-center gap-1">
           <RouterLink
             :id="labelId"
@@ -224,15 +224,3 @@ const labelId = useId()
     </template>
   </ListItemBox>
 </template>
-
-<style>
-@reference "../../../index.css";
-
-.clusters-grid {
-  @apply grid grid-cols-4 items-center gap-2 pr-2;
-}
-
-.clusters-grid > * {
-  @apply truncate text-xs;
-}
-</style>

--- a/frontend/src/views/omni/Clusters/Clusters.vue
+++ b/frontend/src/views/omni/Clusters/Clusters.vue
@@ -124,8 +124,8 @@ const filterOptions = [
       <template #default="{ items, searchQuery }">
         <div class="flex flex-col gap-2">
           <div class="max-lg:hidden">
-            <div class="clusters-header">
-              <div class="clusters-grid">
+            <div class="mb-1 flex items-center bg-naturals-n2 px-3 py-2.5 *:text-xs">
+              <div class="grid flex-1 grid-cols-4 items-center gap-2 pr-2 *:truncate *:text-xs">
                 <div class="pl-6">Name</div>
                 <div class="pl-6">Machines Healthy</div>
                 <div class="pl-6">Phase</div>
@@ -147,19 +147,3 @@ const filterOptions = [
     </TList>
   </div>
 </template>
-
-<style scoped>
-@reference "../../../index.css";
-
-.clusters-grid {
-  @apply grid flex-1 grid-cols-4 pr-2;
-}
-
-.clusters-header {
-  @apply mb-1 flex items-center bg-naturals-n2 px-3 py-2.5;
-}
-
-.clusters-header > * {
-  @apply text-xs;
-}
-</style>


### PR DESCRIPTION
Inline the CSS from the .clusters-grid class as it may not yet exist when consumers are loaded