### PR TITLE
fix: add `oidc-redirect-url` arg to the generated kubeconfigs

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -10,6 +10,19 @@ previous = "v1.1.0"
 
 [notes]
 
+[notes.kubeconfig]
+title = "`kubeconfig` with `grant-type=authcode-keyboard`"
+description = """\
+New configs generated with the latest Omni version and `authcode-keyboard`
+enabled now work for `oidc-login` `v1.33+`.
+See https://github.com/int128/kubelogin/pull/1263
+
+Newly generated configs won't work for `oidc-login` below `v1.33`. You can:
+- keep using the old configs.
+- generate the new configs and drop `oidc-redirect-url` param.
+- update the `oidc-login` module.
+"""
+
 [notes.user-consent-form-for-userpilot]
 title = "User Consent Form for Userpilot"
 description = """\

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -166,7 +166,8 @@ func (s *managementServer) Kubeconfig(ctx context.Context, req *management.Kubec
 		}
 
 		extraOptions = []string{
-			fmt.Sprintf("grant-type=%s", req.GrantType),
+			"grant-type=" + req.GrantType,
+			"oidc-redirect-url=urn:ietf:wg:oauth:2.0:oob",
 		}
 	}
 


### PR DESCRIPTION
If `grant-type=authcode-keyboard` is requested.
Fixes: https://github.com/siderolabs/omni/issues/1476

> [!Note]
> configs generated with the new Omni and `authcode-keyboard`
> enabled won't work for `oidc-login` below `v1.33`. See https://github.com/int128/kubelogin/pull/1263