### PR TITLE
fix: fix the order in the grpc interceptor chain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/siderolabs/discovery-client v0.1.13
 	github.com/siderolabs/discovery-service v1.0.11
 	github.com/siderolabs/gen v0.8.5
-	github.com/siderolabs/go-api-signature v0.3.7
+	github.com/siderolabs/go-api-signature v0.3.8
 	github.com/siderolabs/go-circular v0.2.3
 	github.com/siderolabs/go-debug v0.6.0
 	github.com/siderolabs/go-kubernetes v0.2.26

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/siderolabs/discovery-service v1.0.11 h1:+ymDXKhPL2f1c5MIO559wciA38PcQ
 github.com/siderolabs/discovery-service v1.0.11/go.mod h1:pUTOYgtYasO/T02zJNNfw0SCP8hDbIgFIvdm+Fn1UKo=
 github.com/siderolabs/gen v0.8.5 h1:xlWXTynnGD/epaj7uplvKvmAkBH+Fp51bLnw1JC0xME=
 github.com/siderolabs/gen v0.8.5/go.mod h1:CRrktDXQf3yDJI7xKv+cDYhBbKdfd/YE16OpgcHoT9E=
-github.com/siderolabs/go-api-signature v0.3.7 h1:Qx5NH3BrtYucCgiLObAJhx7pouLR4tivr1moOClII3M=
-github.com/siderolabs/go-api-signature v0.3.7/go.mod h1:MQy+DcXCQIFFXZr+E4tbMmnQSQs7WpubSpJFRN694mI=
+github.com/siderolabs/go-api-signature v0.3.8 h1:0iTcOWIxOAc7M8aB2L+WScUd4BoqdXshvQ4h9tSSeF8=
+github.com/siderolabs/go-api-signature v0.3.8/go.mod h1:MQy+DcXCQIFFXZr+E4tbMmnQSQs7WpubSpJFRN694mI=
 github.com/siderolabs/go-circular v0.2.3 h1:GKkA1Tw79kEFGtWdl7WTxEUTbwtklITeiRT0V1McHrA=
 github.com/siderolabs/go-circular v0.2.3/go.mod h1:YBN/q9YpQphUYnBtBgPsngauSHj1TEZfgQZWZVjk1WE=
 github.com/siderolabs/go-debug v0.6.0 h1:wcftcXv3fFeUHwsj4bJpHaXRJ6JJXL+eeaY69fCtHoY=

--- a/hack/generate-certs/main.go
+++ b/hack/generate-certs/main.go
@@ -157,7 +157,7 @@ func generate() (err error) {
 }
 
 func runApp(app string, args ...string) error {
-	cmd := exec.Command(app, args...)
+	cmd := exec.Command(app, args...) //nolint:noctx
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/backend/grpc/resource.go
+++ b/internal/backend/grpc/resource.go
@@ -317,7 +317,7 @@ func (s *ResourceServer) Teardown(ctx context.Context, in *resources.DeleteReque
 
 func getSource(ctx context.Context) common.Runtime {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		source := md.Get(message.RuntimeHeaderHey)
+		source := md.Get(message.RuntimeHeaderKey)
 		if source != nil {
 			if res, ok := common.Runtime_value[source[0]]; ok {
 				return common.Runtime(res)
@@ -361,6 +361,14 @@ func withResource(r res) []runtime.QueryOption {
 
 // CreateResource creates a resource from a resource proto representation.
 func CreateResource(resource *resources.Resource) (cosiresource.Resource, error) { //nolint:ireturn
+	if resource == nil {
+		return nil, errors.New("resource is nil")
+	}
+
+	if resource.Metadata == nil {
+		return nil, errors.New("resource metadata is nil")
+	}
+
 	if resource.Metadata.Version == "" {
 		resource.Metadata.Version = "1"
 	}

--- a/internal/backend/grpc/router/router.go
+++ b/internal/backend/grpc/router/router.go
@@ -154,7 +154,7 @@ func (r *Router) Director(ctx context.Context, fullMethodName string) (proxy.Mod
 		return proxy.One2One, []proxy.Backend{r.omniBackend}, nil
 	}
 
-	if runtime := md.Get(message.RuntimeHeaderHey); runtime != nil && runtime[0] == common.Runtime_Talos.String() {
+	if runtime := md.Get(message.RuntimeHeaderKey); runtime != nil && runtime[0] == common.Runtime_Talos.String() {
 		backends, err := r.getTalosBackend(ctx, md)
 		if err != nil {
 			return proxy.One2One, nil, err

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -424,6 +424,8 @@ func (s *Server) buildServerOptions(ctx context.Context) ([]grpc.ServerOption, e
 		grpc_ctxtags.UnaryServerInterceptor(),
 		logLevelOverrideUnaryInterceptor,
 		grpc_zap.UnaryServerInterceptor(s.logger, grpc_zap.WithMessageProducer(messageProducer)),
+		grpc_prometheus.UnaryServerInterceptor,
+		grpc_recovery.UnaryServerInterceptor(recoveryOpt),
 		grpcutil.SetUserAgent(),
 		grpcutil.SetRealPeerAddress(),
 		grpcutil.SetAuditData(),
@@ -436,14 +438,14 @@ func (s *Server) buildServerOptions(ctx context.Context) ([]grpc.ServerOption, e
 			),
 			1024,
 		),
-		grpc_prometheus.UnaryServerInterceptor,
-		grpc_recovery.UnaryServerInterceptor(recoveryOpt),
 	}
 
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		grpc_ctxtags.StreamServerInterceptor(),
 		logLevelOverrideStreamInterceptor,
 		grpc_zap.StreamServerInterceptor(s.logger, grpc_zap.WithMessageProducer(messageProducer)),
+		grpc_prometheus.StreamServerInterceptor,
+		grpc_recovery.StreamServerInterceptor(recoveryOpt),
 		grpcutil.StreamSetUserAgent(),
 		grpcutil.StreamSetRealPeerAddress(),
 		grpcutil.StreamSetAuditData(),
@@ -460,8 +462,6 @@ func (s *Server) buildServerOptions(ctx context.Context) ([]grpc.ServerOption, e
 				),
 			},
 		),
-		grpc_prometheus.StreamServerInterceptor,
-		grpc_recovery.StreamServerInterceptor(recoveryOpt),
 	}
 
 	authInterceptors, err := s.getAuthInterceptors(ctx)
@@ -777,12 +777,12 @@ func resourceServerUpdate(resCopy *resapi.UpdateRequest) (*resapi.UpdateRequest,
 func isSensitiveResource(res *v1alpha1.Resource) bool {
 	protoR, err := protobuf.Unmarshal(res)
 	if err != nil {
-		return false
+		return true
 	}
 
 	properResource, err := protobuf.UnmarshalResource(protoR)
 	if err != nil {
-		return false
+		return true
 	}
 
 	resDef, ok := properResource.(meta.ResourceDefinitionProvider)
@@ -797,7 +797,7 @@ func isSensitiveResource(res *v1alpha1.Resource) bool {
 func isSensitiveSpec(resource *resapi.Resource) bool {
 	res, err := grpcomni.CreateResource(resource)
 	if err != nil {
-		return false
+		return true
 	}
 
 	resDef, ok := res.(meta.ResourceDefinitionProvider)

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -946,11 +946,6 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				allowedVerbSet: readOnlyVerbSet,
 			},
 			{
-				resource:       authres.NewAuthConfig(),
-				allowedVerbSet: readOnlyVerbSet,
-				isPublic:       true,
-			},
-			{
 				resource:       siderolink.NewConnectionParams(resources.DefaultNamespace, uuid.New().String()),
 				allowedVerbSet: readOnlyVerbSet,
 			},
@@ -1155,6 +1150,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 		// delete excluded resources from the untested set
 		delete(untestedResourceTypes, k8s.KubernetesResourceType)
 		delete(untestedResourceTypes, siderolink.DeprecatedLinkCounterType)
+		delete(untestedResourceTypes, authres.AuthConfigType)
 
 		for _, tc := range testCases {
 			for _, testVerb := range allVerbs {
@@ -1179,17 +1175,17 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 
 						accessErr := accessResource(noSignatureCtx, t, rootCli, scopedCli, tc.resource, testVerb)
 
+						if !tc.isPublic {
+							assert.ErrorContains(t, accessErr, "invalid signature")
+
+							// refresh the error but with a signature this time
+							accessErr = accessResource(rootCtx, t, rootCli, scopedCli, tc.resource, testVerb)
+						}
+
 						if len(tc.allowedVerbSet) == 0 {
 							assert.ErrorContains(t, accessErr, "no access is permitted")
 
 							return
-						}
-
-						if !tc.isPublic {
-							assert.ErrorContains(t, accessErr, "missing valid signature")
-
-							// refresh the error but with a signature this time
-							accessErr = accessResource(rootCtx, t, rootCli, scopedCli, tc.resource, testVerb)
 						}
 
 						isVerbError := accessErr != nil && strings.Contains(accessErr.Error(), "only") && strings.Contains(accessErr.Error(), "access is permitted")

--- a/internal/pkg/auth/handler/signature.go
+++ b/internal/pkg/auth/handler/signature.go
@@ -25,14 +25,16 @@ type Signature struct {
 	authenticatorFunc auth.AuthenticatorFunc
 	next              http.Handler
 	logger            *zap.Logger
+	options           []message.Option
 }
 
 // NewSignature returns a new signature handler.
-func NewSignature(handler http.Handler, authenticatorFunc auth.AuthenticatorFunc, logger *zap.Logger) *Signature {
+func NewSignature(handler http.Handler, authenticatorFunc auth.AuthenticatorFunc, logger *zap.Logger, messageOptions ...message.Option) *Signature {
 	return &Signature{
 		next:              handler,
 		authenticatorFunc: authenticatorFunc,
 		logger:            logger,
+		options:           messageOptions,
 	}
 }
 
@@ -57,7 +59,7 @@ func (s *Signature) ServeHTTP(writer http.ResponseWriter, request *http.Request)
 }
 
 func (s *Signature) intercept(request *http.Request) (*http.Request, error) {
-	msg, err := message.NewHTTP(request)
+	msg, err := message.NewHTTP(request, s.options...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Change the interceptor order to move the Prometheus metrics collector earlier, so that we can get metrics for the calls that fail early. Related to siderolabs/omni#1606.

Additionally, ensure that `get` access to the `AuthConfig` resource does not require a GRPC signature.