### PR TITLE
fix: alignment of oidc login not being centered

### DIFF
--- a/frontend/src/views/omni/Auth/OIDC.vue
+++ b/frontend/src/views/omni/Auth/OIDC.vue
@@ -49,7 +49,7 @@ const copyCode = () => {
 </script>
 
 <template>
-  <div class="flex items-center justify-center">
+  <div class="flex h-full items-center justify-center">
     <div class="flex flex-col gap-2 rounded-md bg-naturals-n3 px-8 py-8 drop-shadow-md">
       <div class="flex items-center gap-4">
         <TIcon icon="kubernetes" class="fill-color h-6 w-6" />


### PR DESCRIPTION
Fix alignment of OIDC login not being centered