### PR TITLE
backports: for v1.1.5 (2)

### DIFF
--- a/internal/integration/suites_test.go
+++ b/internal/integration/suites_test.go
@@ -1121,7 +1121,12 @@ Test authorization on accessing Omni API, some tests run without a cluster, some
 
 		t.Run(
 			"AnonymousRequestShouldBeDenied",
-			AssertAnonymousAuthenication(t.Context(), options.omniClient),
+			AssertAnonymousAuthentication(t.Context(), options.omniClient),
+		)
+
+		t.Run(
+			"UnauthenticatedRequestsShouldBeAllowedByLocalResourceServer",
+			AssertUnauthenticatedLocalResourceServerAccess(t.Context()),
 		)
 
 		t.Run(

--- a/internal/pkg/auth/interceptor/auth_config.go
+++ b/internal/pkg/auth/interceptor/auth_config.go
@@ -18,6 +18,7 @@ import (
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit"
 	"github.com/siderolabs/omni/internal/pkg/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 
@@ -77,6 +78,10 @@ func (c *AuthConfig) intercept(ctx context.Context, isGetAuthConfigRequest bool,
 	}
 
 	msg := message.NewGRPC(md, method, message.WithSignatureRequiredCheck(func() (bool, error) {
+		if actor.ContextIsInternalActor(ctx) {
+			return false, nil
+		}
+
 		return !isGetAuthConfigRequest, nil
 	}))
 


### PR DESCRIPTION
PRs backported:
- #1621 

See also the previous backports: https://github.com/siderolabs/omni/pull/1617