### PR TITLE
feat(frontend): improve chart colors for more intuitive status visual…

### DIFF
--- a/frontend/src/components/common/Charts/RadialBar.vue
+++ b/frontend/src/components/common/Charts/RadialBar.vue
@@ -18,6 +18,7 @@ interface Props {
   items: {
     label: string
     value: number
+    color?: string
   }[]
   legendFormatter?: (value: number) => string
 }
@@ -46,7 +47,7 @@ const legendItems = computed(() => [
   ...props.items.map((item, i) => ({
     label: item.label,
     value: props.legendFormatter(item.value),
-    color: colors[i],
+    color: item.color || colors[i],
   })),
 ])
 
@@ -90,7 +91,7 @@ const options = computed<ApexOptions>(() => ({
     },
   },
   fill: {
-    colors: colors,
+    colors: props.items.map((item, i) => item.color || colors[i]),
   },
   stroke: {
     lineCap: 'round',

--- a/frontend/src/views/omni/Home/HomeClustersChart.vue
+++ b/frontend/src/views/omni/Home/HomeClustersChart.vue
@@ -52,11 +52,11 @@ const counts = computed(() => {
       title="Clusters"
       show-hollow-total
       :items="[
-        { label: 'Healthy', value: counts.healthyCount },
-        { label: 'Unhealthy', value: counts.unhealthyCount },
-        { label: 'Scaling Up', value: counts.scalingUpCount },
-        { label: 'Scaling Down', value: counts.scalingDownCount },
-        { label: 'Destroying', value: counts.destroyingCount },
+        { label: 'Healthy', value: counts.healthyCount, color: 'var(--color-green-g1)' },
+        { label: 'Unhealthy', value: counts.unhealthyCount, color: 'var(--color-red-r1)' },
+        { label: 'Scaling Up', value: counts.scalingUpCount, color: 'var(--color-blue-b1)' },
+        { label: 'Scaling Down', value: counts.scalingDownCount, color: 'var(--color-yellow-y1)' },
+        { label: 'Destroying', value: counts.destroyingCount, color: 'var(--color-red-r2)' },
       ]"
     />
   </Card>

--- a/frontend/src/views/omni/Home/HomeMachinesChart.vue
+++ b/frontend/src/views/omni/Home/HomeMachinesChart.vue
@@ -53,11 +53,11 @@ const counts = computed(() => {
       show-hollow-total
       :total="counts.totalCount"
       :items="[
-        { label: 'Connected', value: counts.connectedCount },
-        { label: 'Not Connected', value: counts.notConnectedCount },
-        { label: 'In Cluster', value: counts.inClusterCount },
-        { label: 'Free Machine', value: counts.freeMachineCount },
-        { label: 'Pending', value: counts.pendingCount },
+        { label: 'Connected', value: counts.connectedCount, color: 'var(--color-green-g1)' },
+        { label: 'Not Connected', value: counts.notConnectedCount, color: 'var(--color-red-r1)' },
+        { label: 'In Cluster', value: counts.inClusterCount, color: 'var(--color-blue-b1)' },
+        { label: 'Free Machine', value: counts.freeMachineCount, color: 'var(--color-primary-p3)' },
+        { label: 'Pending', value: counts.pendingCount, color: 'var(--color-yellow-y1)' },
       ]"
     />
   </Card>


### PR DESCRIPTION
Add custom color support to RadialBar component:

   - Update Clusters chart with intuitive colors (green=healthy, red=unhealthy)
   - Update Machines chart with intuitive colors (green=connected, red=disconnected)
   - Useing more intuitive colors for status: green for positive states, red for problems, yellow for warnings, blue for operations