### PR TITLE
refactor(frontend): use auth flow constants

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -8,6 +8,7 @@ import { Userpilot } from 'userpilot'
 import type { RouteRecordRaw } from 'vue-router'
 import { createRouter, createWebHistory, RouterView } from 'vue-router'
 
+import { AuthFlowQueryParam, RedirectQueryParam } from '@/api/resources'
 import { current } from '@/context'
 import { AuthType, authType } from '@/methods'
 import { loadCurrentUser } from '@/methods/auth'
@@ -62,7 +63,10 @@ const routes: RouteRecordRaw[] = [
         return true
       }
 
-      return { name: 'Authenticate', query: { flow: FrontendAuthFlow, redirect: to.fullPath } }
+      return {
+        name: 'Authenticate',
+        query: { [AuthFlowQueryParam]: FrontendAuthFlow, [RedirectQueryParam]: to.fullPath },
+      }
     },
     children: [
       {

--- a/frontend/src/views/omni/Auth/Authenticate.vue
+++ b/frontend/src/views/omni/Auth/Authenticate.vue
@@ -86,7 +86,7 @@ onMounted(() => {
 
       if (authType.value === AuthType.OIDC) {
         logout = () => {
-          redirectToURL(`/logout?flow=frontend`)
+          redirectToURL(`/logout?${AuthFlowQueryParam}=${FrontendAuthFlow}`)
         }
 
         return


### PR DESCRIPTION
Refactor the auth flow redirects to use constants instead of hardcoded strings