### PR TITLE
feat(frontend): add a skip parameter to skip watch dynamically

### DIFF
--- a/frontend/src/components/common/Watch/useWatch.ts
+++ b/frontend/src/components/common/Watch/useWatch.ts
@@ -2,7 +2,7 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
-import { type MaybeRefOrGetter, type Ref, ref, toRef, toValue } from 'vue'
+import { type MaybeRefOrGetter, type Ref, ref, toValue } from 'vue'
 
 import type { Resource } from '@/api/grpc'
 import type {
@@ -59,7 +59,7 @@ function useWatchSingle<TSpec = unknown, TStatus = unknown>(
   const data = ref<Resource<TSpec, TStatus>>()
 
   const watch = new Watch(data)
-  watch.setup(toRef(opts))
+  watch.setup(opts)
 
   return {
     data,
@@ -74,7 +74,7 @@ function useWatchMulti<TSpec = unknown, TStatus = unknown>(
   const data = ref<Resource<TSpec, TStatus>[]>([])
 
   const watch = new Watch(data)
-  watch.setup(toRef(opts))
+  watch.setup(opts)
 
   return {
     data,
@@ -90,11 +90,11 @@ function useWatchJoin<TSpec = unknown, TStatus = unknown>(
 
   const watch = new WatchJoin(data)
   watch.setup(
-    toRef(() => toValue(opts)[0]),
-    toRef(() => {
+    () => toValue(opts)[0],
+    () => {
       const [, ...rest] = toValue(opts)
       return rest
-    }),
+    },
   )
 
   return {


### PR DESCRIPTION
Add a skip parameter to watch to disable watching dynamically.

There are some `Watch` usages that return null/undefined options if they wanna skip, but that makes things complicated for things like `useWatch`, this is easier to manage. Also did a small refactor on `Watch` while I was at it to be more vue standard.

Related to #1471 