### PR TITLE
fix: remove dangling cluster taints

### DIFF
--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -1931,9 +1931,10 @@ func moveClusterTaintFromResourceToLabel(ctx context.Context, st state.State, _ 
 
 			return nil
 		}, state.WithExpectedPhaseAny(), state.WithUpdateOwner(omnictrl.ClusterStatusControllerName))
-		if err != nil {
+		if err != nil && !state.IsNotFoundError(err) {
 			return err
 		}
+		// cluster status does not exist, taint is dangling, just remove it
 
 		if err = st.TeardownAndDestroy(ctx, taint.Metadata()); err != nil {
 			return err


### PR DESCRIPTION
Because of an issue, after Cluster deletion, ClusterTaint resources were not cleaned up properly. This was discovered during the migration to move away from ClusterTaint resource. This commit will clean-up dangling taints.
