### PR TITLE
Fix: Typo in Helm chart readme service name for API Ingress example

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -75,7 +75,7 @@ spec:
       paths:
       - backend:
           service:
-            name: omni-internal-grpc
+            name: internal-grpc
             port:
               number: 8080
         path: /cosi.resource.State


### PR DESCRIPTION
Deploying it this way results in a HTTP 503 error. Might prevent others having to fix it themselves.