### PR TITLE
fix(frontend): fix alignment of provisioning machines

### DIFF
--- a/frontend/src/views/cluster/ClusterMachines/MachineRequest.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineRequest.vue
@@ -40,16 +40,14 @@ const stage = computed(() => {
 </script>
 
 <template>
-  <div
-    class="col-span-full grid grid-cols-subgrid items-center gap-1 py-6 pr-11 pl-3 text-xs text-naturals-n14"
-  >
-    <div class="col-span-2 ml-5 flex items-center gap-2">
+  <div class="col-span-full grid grid-cols-subgrid items-center p-2 pr-4 text-xs text-naturals-n14">
+    <div class="col-span-2 ml-6 flex items-center gap-2">
       <IconHeaderDropdownLoading
         v-if="stage !== TCommonStatuses.PROVISIONED"
         active
-        class="ml-2 h-4 w-4"
+        class="size-4"
       />
-      <TIcon v-else icon="cloud-connection" class="ml-2 h-4 w-4" />
+      <TIcon v-else icon="cloud-connection" class="size-4" />
       {{ requestStatus.metadata.id }}
     </div>
 

--- a/frontend/src/views/omni/Clusters/Clusters.vue
+++ b/frontend/src/views/omni/Clusters/Clusters.vue
@@ -9,6 +9,7 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
+import type { ClusterStatusMetricsSpec } from '@/api/omni/specs/omni.pb'
 import {
   ClusterStatusMetricsID,
   ClusterStatusMetricsType,
@@ -24,7 +25,7 @@ import TButton from '@/components/common/Button/TButton.vue'
 import TList from '@/components/common/List/TList.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
-import Watch from '@/components/common/Watch/Watch.vue'
+import { useWatch } from '@/components/common/Watch/useWatch'
 import { canCreateClusters } from '@/methods/auth'
 import type { Label } from '@/methods/labels'
 import { addLabel, selectors } from '@/methods/labels'
@@ -44,6 +45,15 @@ const watchOpts = computed<WatchOptions>(() => {
     selectors: selectors(filterLabels.value),
     sortByField: 'created',
   }
+})
+
+const { data } = useWatch<ClusterStatusMetricsSpec>({
+  resource: {
+    type: ClusterStatusMetricsType,
+    id: ClusterStatusMetricsID,
+    namespace: EphemeralNamespace,
+  },
+  runtime: Runtime.Omni,
 })
 
 const filterValue = ref('')
@@ -84,25 +94,12 @@ const filterOptions = [
         <div class="flex items-start gap-1">
           <PageHeader title="Clusters" class="flex-1">
             <StatsItem title="Clusters" :value="itemsCount" icon="clusters" />
-            <Watch
-              :opts="{
-                resource: {
-                  type: ClusterStatusMetricsType,
-                  id: ClusterStatusMetricsID,
-                  namespace: EphemeralNamespace,
-                },
-                runtime: Runtime.Omni,
-              }"
-            >
-              <template #default="{ data }">
-                <StatsItem
-                  v-if="data?.spec.not_ready_count"
-                  title="Not Ready"
-                  :value="data.spec.not_ready_count"
-                  icon="warning"
-                />
-              </template>
-            </Watch>
+            <StatsItem
+              v-if="data?.spec.not_ready_count"
+              title="Not Ready"
+              :value="data.spec.not_ready_count"
+              icon="warning"
+            />
           </PageHeader>
           <TButton :disabled="!canCreateClusters" type="highlighted" @click="openClusterCreate">
             Create Cluster


### PR DESCRIPTION
Fix the alignment of provisioning machines on the clusters page. Also refactored some `Watch` into `useWatch`

Fixes #1659 

<table>
  <tr>
    <th>Before</th>
    <td><img width="1020" height="360" alt="image" src="https://github.com/user-attachments/assets/967849be-e469-44cc-ace6-f7dcc01354a2" /></td>
  </tr>
  <tr>
    <th>After</th>
    <td><img width="1018" height="307" alt="image" src="https://github.com/user-attachments/assets/b1edee3d-0503-4d4d-872e-00545017f430" /></td>
  </tr>
</table>
