### PR TITLE
refactor(tbutton): separate type and size styles in tbutton

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -83,6 +83,7 @@
         "vite-plugin-node-polyfills": "^0.24.0",
         "vite-plugin-vue-devtools": "^8.0.2",
         "vitest": "^3.2.4",
+        "vue-component-type-helpers": "^3.1.1",
         "vue-tsc": "^3.1.1",
         "yaml": "^2.8.1"
       },
@@ -3878,6 +3879,13 @@
         "js-beautify": "^1.14.9",
         "vue-component-type-helpers": "^2.0.0"
       }
+    },
+    "node_modules/@vue/test-utils/node_modules/vue-component-type-helpers": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vue/tsconfig": {
       "version": "0.8.1",
@@ -11409,10 +11417,17 @@
         }
       }
     },
-    "node_modules/vue-component-type-helpers": {
+    "node_modules/vue-component-meta/node_modules/vue-component-type-helpers": {
       "version": "2.2.12",
       "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
       "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.1.1.tgz",
+      "integrity": "sha512-B0kHv7qX6E7+kdc5nsaqjdGZ1KwNKSUQDWGy7XkTYT7wFsOpkEyaJ1Vq79TjwrrtuLRgizrTV7PPuC4rRQo+vw==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -100,6 +100,7 @@
     "vite-plugin-node-polyfills": "^0.24.0",
     "vite-plugin-vue-devtools": "^8.0.2",
     "vitest": "^3.2.4",
+    "vue-component-type-helpers": "^3.1.1",
     "vue-tsc": "^3.1.1",
     "yaml": "^2.8.1"
   }

--- a/frontend/src/components/TAlert.vue
+++ b/frontend/src/components/TAlert.vue
@@ -45,7 +45,7 @@ const icons: Record<AlertType, IconType> = {
         </div>
       </div>
       <div v-if="dismiss" class="flex flex-1 justify-end pr-2">
-        <TButton type="compact" class="notification-right-button" @click="dismiss?.action">
+        <TButton size="sm" class="notification-right-button" @click="dismiss?.action">
           {{ dismiss.name }}
         </TButton>
       </div>

--- a/frontend/src/components/common/Button/TButton.stories.ts
+++ b/frontend/src/components/common/Button/TButton.stories.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import type { ComponentProps } from 'vue-component-type-helpers'
+
+import TButton from './TButton.vue'
+
+const types: ComponentProps<typeof TButton>['type'][] = [
+  'primary',
+  'secondary',
+  'highlighted',
+  'subtle',
+]
+
+const sizes: ComponentProps<typeof TButton>['size'][] = ['md', 'sm', 'xs', 'xxs']
+
+const iconPositions: ComponentProps<typeof TButton>['iconPosition'][] = ['left', 'right']
+
+const meta: Meta<typeof TButton> = {
+  component: TButton,
+  argTypes: {
+    type: {
+      control: 'select',
+      options: types,
+    },
+    size: {
+      control: 'inline-radio',
+      options: sizes,
+    },
+    iconPosition: {
+      control: 'inline-radio',
+      options: iconPositions,
+    },
+    icon: {
+      control: 'boolean',
+      mapping: {
+        true: 'delete',
+      },
+    },
+  },
+  args: {
+    icon: 'delete',
+  },
+  parameters: {
+    layout: 'centered',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => ({
+    components: { TButton },
+    setup: () => ({ args }),
+    template: `<TButton v-bind="args">Button</TButton>`,
+  }),
+}
+
+export const AllButtons: Story = {
+  decorators: [
+    () => ({ template: '<div class="grid grid-cols-4 items-center gap-2"><story/></div>' }),
+  ],
+  render: (args) => ({
+    components: { TButton },
+    setup: () => ({ args }),
+    template: iconPositions
+      .flatMap((iconPosition) =>
+        sizes.flatMap((size) =>
+          types.map(
+            (type) =>
+              `<TButton type="${type}" size="${size}" icon-position="${iconPosition}" v-bind="args">${type}-${size}</TButton>`,
+          ),
+        ),
+      )
+      .join(''),
+  }),
+}

--- a/frontend/src/components/common/Button/TButton.vue
+++ b/frontend/src/components/common/Button/TButton.vue
@@ -11,31 +11,37 @@ import type { IconType } from '@/components/common/Icon/TIcon.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 
 interface Props extends /* @vue-ignore */ Omit<ButtonHTMLAttributes, 'type'> {
-  type?: 'primary' | 'secondary' | 'subtle' | 'subtle-xs' | 'compact' | 'highlighted'
+  type?: 'primary' | 'secondary' | 'subtle' | 'highlighted'
+  size?: 'md' | 'sm' | 'xs' | 'xxs'
   icon?: IconType
   iconPosition?: 'left' | 'right'
 }
 
-const { type = 'primary', iconPosition = 'right', icon = undefined } = defineProps<Props>()
+const {
+  type = 'primary',
+  size = 'md',
+  iconPosition = 'right',
+  icon = undefined,
+} = defineProps<Props>()
 </script>
 
 <template>
   <button
     type="button"
-    class="flex items-center justify-center gap-1 rounded border px-4 py-1.5 text-sm transition-colors duration-200"
+    class="flex items-center justify-center gap-1 rounded border transition-colors duration-200"
     :class="{
       'border-naturals-n5 bg-naturals-n3 text-naturals-n12 hover:border-primary-p3 hover:bg-primary-p3 hover:text-naturals-n14 focus:border-primary-p2 focus:bg-primary-p2 focus:text-naturals-n14 active:border-primary-p4 active:bg-primary-p4 active:text-naturals-n14 disabled:cursor-not-allowed disabled:border-naturals-n6 disabled:bg-naturals-n4 disabled:text-naturals-n7':
         type === 'primary',
       'border-naturals-n5 bg-transparent text-naturals-n10 hover:bg-naturals-n5 hover:text-naturals-n14 focus:border-naturals-n7 focus:bg-naturals-n5 focus:text-naturals-n14 active:border-naturals-n5 active:bg-naturals-n4 active:text-naturals-n14 disabled:cursor-not-allowed disabled:border-naturals-n6 disabled:bg-transparent disabled:text-naturals-n6':
         type === 'secondary',
-      'border-none bg-transparent p-0! text-naturals-n13 hover:text-primary-p3 focus:text-primary-p2 focus:underline active:text-primary-p4 active:no-underline disabled:cursor-not-allowed disabled:text-naturals-n6':
+      'border-none bg-transparent text-naturals-n13 hover:text-primary-p3 focus:text-primary-p2 focus:underline active:text-primary-p4 active:no-underline disabled:cursor-not-allowed disabled:text-naturals-n6':
         type === 'subtle',
-      'border-none bg-transparent p-0! text-xs! text-naturals-n13 hover:text-primary-p3 focus:text-primary-p2 focus:underline active:text-primary-p4 active:no-underline disabled:cursor-not-allowed disabled:text-naturals-n6':
-        type === 'subtle-xs',
-      'h-6 border-naturals-n5 bg-naturals-n4 px-2! py-0.5! text-naturals-n10 hover:bg-naturals-n5 hover:text-naturals-n14 focus:border-naturals-n7 focus:bg-naturals-n5 focus:text-naturals-n14 active:border-primary-p4 active:bg-primary-p4 active:text-naturals-n14 disabled:cursor-not-allowed disabled:border-naturals-n6 disabled:bg-naturals-n4 disabled:text-naturals-n7':
-        type === 'compact',
       'border-primary-p2 bg-primary-p4 text-naturals-n14 hover:border-primary-p3 hover:bg-primary-p3 hover:text-naturals-n14 focus:border-primary-p2 focus:bg-primary-p2 focus:text-naturals-n14 active:border-primary-p4 active:bg-primary-p4 active:text-naturals-n14 disabled:cursor-not-allowed disabled:border-naturals-n6 disabled:bg-naturals-n4 disabled:text-naturals-n7':
         type === 'highlighted',
+      'px-4 py-1.5 text-sm': size === 'md',
+      'px-2 py-0.5 text-sm': size === 'sm',
+      'p-0 text-sm': size === 'xs',
+      'p-0 text-xs': size === 'xxs',
     }"
   >
     <span v-if="$slots.default" class="whitespace-nowrap">
@@ -44,11 +50,12 @@ const { type = 'primary', iconPosition = 'right', icon = undefined } = definePro
     <TIcon
       v-if="icon"
       :icon="icon"
-      class="h-4 w-4"
-      :class="{
-        'h-3 w-3': type === 'subtle-xs',
-        'order-first': iconPosition === 'left',
-      }"
+      :class="[
+        size === 'xxs' ? 'size-3' : 'size-4',
+        {
+          'order-first': iconPosition === 'left',
+        },
+      ]"
     />
   </button>
 </template>

--- a/frontend/src/components/common/Form/ArrayRenderer.vue
+++ b/frontend/src/components/common/Form/ArrayRenderer.vue
@@ -93,7 +93,8 @@ const moveDownClicked = (index: number) => {
         {{ control.label }}
       </div>
       <TButton
-        type="subtle-xs"
+        type="subtle"
+        size="xxs"
         class="mx-4 mb-3 text-xs"
         icon="plus"
         :disabled="!control.enabled || maxItemsReached"

--- a/frontend/src/components/common/Labels/Labels.vue
+++ b/frontend/src/components/common/Labels/Labels.vue
@@ -109,9 +109,7 @@ const removeLabel = async (key: string) => {
       @click.stop
       @blur="addLabel"
     />
-    <TButton v-else-if="!readonly" icon="tag" type="compact" @click.stop="editLabels">
-      new label
-    </TButton>
+    <TButton v-else-if="!readonly" icon="tag" size="sm" @click.stop="editLabels">new label</TButton>
   </div>
 </template>
 

--- a/frontend/src/components/common/LogViewer/LogViewer.vue
+++ b/frontend/src/components/common/LogViewer/LogViewer.vue
@@ -98,7 +98,7 @@ watch(logs, () => {
         <p class="logs-list-heading-name">Message</p>
       </div>
       <div class="flex gap-6">
-        <TButton :icon="copied ? 'check' : 'copy'" type="compact" @click="copyLogs">
+        <TButton :icon="copied ? 'check' : 'copy'" size="sm" @click="copyLogs">
           {{ copied ? 'Copied' : 'Copy' }}
         </TButton>
         <TCheckbox v-model="follow" label="Follow Logs" />

--- a/frontend/src/components/common/UserConsent/UserConsent.vue
+++ b/frontend/src/components/common/UserConsent/UserConsent.vue
@@ -46,7 +46,6 @@ watch(() => currentUser.value, fetchTrackingToken)
             We use cookies to improve our website's interface and onboarding experience. We don't
             use them for ads or share your data with third parties.
             <a
-              type="subtle"
               class="list-item-link cursor-pointer"
               rel="noopener noreferrer"
               href="https://www.siderolabs.com/privacy-policy/"

--- a/frontend/src/views/cluster/Backups/BackupsList.vue
+++ b/frontend/src/views/cluster/Backups/BackupsList.vue
@@ -89,12 +89,12 @@ const openDocs = () => {
       >
         <div class="flex gap-1">
           Check the
-          <TButton type="subtle" @click="openDocs">documentation</TButton>
+          <TButton type="subtle" size="xs" @click="openDocs">documentation</TButton>
           on how to configure s3 backups using CLI.
         </div>
         <div v-if="canManageBackupStore" class="flex gap-1">
           Or
-          <TButton type="subtle" @click="$router.push({ name: 'BackupStorage' })">
+          <TButton type="subtle" size="xs" @click="$router.push({ name: 'BackupStorage' })">
             configure backups in the UI.
           </TButton>
         </div>

--- a/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
@@ -254,6 +254,7 @@ const sectionHeadingId = useId()
         <TButton
           v-if="canUseAll"
           type="subtle"
+          size="xs"
           @click="() => updateMachineCount(MachineSetSpecMachineAllocationType.Unlimited)"
         >
           Use All
@@ -304,7 +305,7 @@ const sectionHeadingId = useId()
       class="col-span-full flex items-center gap-1 border-t border-naturals-n4 p-4 pl-9 text-xs"
     >
       {{ pluralize('machine', hiddenMachinesCount, true) }} are hidden
-      <TButton type="subtle" @click="showMachinesCount = undefined">
+      <TButton type="subtle" size="xs" @click="showMachinesCount = undefined">
         <span class="text-xs">Show all...</span>
       </TButton>
     </div>

--- a/frontend/src/views/omni/Clusters/ClusterEtcdBackupCheckbox.vue
+++ b/frontend/src/views/omni/Clusters/ClusterEtcdBackupCheckbox.vue
@@ -97,7 +97,8 @@ const updateBackupInterval = () => {
     >
       <TButton
         v-if="canManageBackupStore"
-        type="subtle-xs"
+        type="subtle"
+        size="xxs"
         icon="settings"
         icon-position="left"
         class="text-xs"

--- a/frontend/src/views/omni/Clusters/Management/MachineSetConfig.vue
+++ b/frontend/src/views/omni/Clusters/Management/MachineSetConfig.vue
@@ -201,7 +201,7 @@ const openPatchConfig = () => {
       </div>
     </div>
     <div class="flex w-24 items-center justify-end gap-2">
-      <TButton v-if="!noRemove" class="h-6" type="compact" @click="onRemove">Remove</TButton>
+      <TButton v-if="!noRemove" class="h-6" size="sm" @click="onRemove">Remove</TButton>
       <div class="flex justify-center gap-1">
         <IconButton
           v-if="modelValue.role === LabelWorkerRole"

--- a/frontend/src/views/omni/Clusters/Management/MachineSets.vue
+++ b/frontend/src/views/omni/Clusters/Management/MachineSets.vue
@@ -33,9 +33,7 @@ const addWorkers = () => {
 
 <template>
   <div>
-    <TButton icon="plus" class="h-8" type="compact" @click="addWorkers">
-      Add Worker Machine Sets
-    </TButton>
+    <TButton icon="plus" class="h-8" size="sm" @click="addWorkers">Add Worker Machine Sets</TButton>
     <MachineSetConfig
       v-for="(machineSet, index) in state.machineSets"
       :key="machineSet.name"

--- a/frontend/src/views/omni/Home/HomeRecentClusters.vue
+++ b/frontend/src/views/omni/Home/HomeRecentClusters.vue
@@ -37,6 +37,7 @@ const { data } = useWatch<ClusterStatusSpec>({
         icon-position="left"
         icon="clusters"
         type="subtle"
+        size="xs"
         @click="$router.push({ name: 'Clusters' })"
       >
         View All

--- a/frontend/src/views/omni/Home/HomeRecentMachines.vue
+++ b/frontend/src/views/omni/Home/HomeRecentMachines.vue
@@ -35,6 +35,7 @@ const { data } = useWatch<MachineStatusSpec>({
         icon-position="left"
         icon="nodes"
         type="subtle"
+        size="xs"
         @click="$router.push({ name: 'Machines' })"
       >
         View All

--- a/frontend/src/views/omni/ItemLabels/ItemLabels.vue
+++ b/frontend/src/views/omni/ItemLabels/ItemLabels.vue
@@ -168,7 +168,7 @@ const destroyUserLabel = async (key: string) => {
       @click.stop
       @blur="addUserLabel"
     />
-    <TButton v-else-if="addLabelFunc" icon="tag" type="compact" @click.stop="editLabels">
+    <TButton v-else-if="addLabelFunc" icon="tag" size="sm" @click.stop="editLabels">
       new label
     </TButton>
   </div>

--- a/frontend/src/views/omni/Machines/Machines.vue
+++ b/frontend/src/views/omni/Machines/Machines.vue
@@ -170,7 +170,7 @@ function updateSelected(machine: Resource<MachineStatusLinkSpec>, v?: boolean) {
       >
         <div class="flex gap-1">
           Check the
-          <TButton type="subtle" @click="openDocs">documentation</TButton>
+          <TButton type="subtle" size="xs" @click="openDocs">documentation</TButton>
           on how to configure and use infrastructure providers.
         </div>
       </TAlert>
@@ -184,6 +184,7 @@ function updateSelected(machine: Resource<MachineStatusLinkSpec>, v?: boolean) {
           Download and boot the
           <TButton
             type="subtle"
+            size="xs"
             @click="$router.push({ name: 'Home', query: { modal: 'downloadInstallationMedia' } })"
           >
             installation media

--- a/frontend/src/views/omni/Modals/ConfigPatchEdit.vue
+++ b/frontend/src/views/omni/Modals/ConfigPatchEdit.vue
@@ -94,7 +94,7 @@ const openDocs = () => {
     <div class="my-7 flex items-center px-8">
       <div class="heading">Edit Config Patch</div>
       <div class="flex flex-1 justify-end">
-        <TButton icon="question" type="subtle" icon-position="left" @click="openDocs">
+        <TButton icon="question" type="subtle" size="xs" icon-position="left" @click="openDocs">
           Config Reference
         </TButton>
       </div>


### PR DESCRIPTION
Separate the type and size styles in `TButton`.

This gets rid of `compact` and `subtle-xs` as you can replicate them with `type="primary" size="sm"` or `type="subtle" size="xxs"` (had to be `xxs` because `subtle` itself was shrinking itself already, so that is now `type="subtle" size="xs"`)

[📚 Storybook](https://button-seperate-size-type--68d664245076e2bb623d98f3.chromatic.com/?path=/story/components-common-button-tbutton--all-buttons)

<img width="649" height="310" alt="image" src="https://github.com/user-attachments/assets/9692e086-b9d2-428b-b416-f88d549bcd7c" />
