### PR TITLE
feat(frontend): create a generic table component

### DIFF
--- a/frontend/src/components/common/Table/Table.stories.ts
+++ b/frontend/src/components/common/Table/Table.stories.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import TableCell from './TableCell.vue'
+import TableRoot from './TableRoot.vue'
+import TableRow from './TableRow.vue'
+
+const meta: Meta = {
+  component: TableRoot,
+  subcomponents: { TableRow, TableCell },
+  args: {
+    label: 'Label',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => ({
+    components: { TableRoot, TableRow, TableCell },
+    template: `
+      <TableRoot>
+        <template #head>
+          <TableRow>
+            <TableCell th>Cat</TableCell>
+            <TableCell th>Food</TableCell>
+            <TableCell th>Science</TableCell>
+            <TableCell th>Plane</TableCell>
+            <TableCell th>Book</TableCell>
+            <TableCell th>Product</TableCell>
+          </TableRow>
+        </template>
+
+        <template #body>
+          ${faker.helpers
+            .multiple(
+              () => `
+              <TableRow>
+                <TableCell>${faker.animal.cat()}</TableCell>
+                <TableCell>${faker.food.dish()}</TableCell>
+                <TableCell>${faker.science.chemicalElement().name}</TableCell>
+                <TableCell>${faker.airline.airplane().name}</TableCell>
+                <TableCell>${faker.book.title()}</TableCell>
+                <TableCell>${faker.commerce.productName()}</TableCell>
+              </TableRow>
+            `,
+              { count: 100 },
+            )
+            .join('')}
+        </template>
+        </TableRoot>
+    `,
+  }),
+}

--- a/frontend/src/components/common/Table/TableCell.vue
+++ b/frontend/src/components/common/Table/TableCell.vue
@@ -1,0 +1,15 @@
+<!--
+Copyright (c) 2025 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+defineProps<{ th?: boolean }>()
+</script>
+
+<template>
+  <component :is="th ? 'th' : 'td'" class="px-2" :class="th ? 'text-uppercase py-2' : 'py-4'">
+    <slot></slot>
+  </component>
+</template>

--- a/frontend/src/components/common/Table/TableRoot.vue
+++ b/frontend/src/components/common/Table/TableRoot.vue
@@ -1,0 +1,24 @@
+<!--
+Copyright (c) 2025 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+defineSlots<{
+  head(): unknown
+  body(): unknown
+}>()
+</script>
+
+<template>
+  <table class="text-xs text-naturals-n13">
+    <thead v-if="$slots.head" class="bg-naturals-n2 text-left">
+      <slot name="head"></slot>
+    </thead>
+
+    <tbody v-if="$slots.body" class="[&_tr]:not-last-of-type:border-b">
+      <slot name="body"></slot>
+    </tbody>
+  </table>
+</template>

--- a/frontend/src/components/common/Table/TableRow.vue
+++ b/frontend/src/components/common/Table/TableRow.vue
@@ -1,0 +1,13 @@
+<!--
+Copyright (c) 2025 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts"></script>
+
+<template>
+  <tr class="border-naturals-n5 hover:bg-white/5">
+    <slot></slot>
+  </tr>
+</template>

--- a/frontend/src/views/omni/Machines/MachinesPending.vue
+++ b/frontend/src/views/omni/Machines/MachinesPending.vue
@@ -22,6 +22,9 @@ import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TList from '@/components/common/List/TList.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
+import TableCell from '@/components/common/Table/TableCell.vue'
+import TableRoot from '@/components/common/Table/TableRoot.vue'
+import TableRow from '@/components/common/Table/TableRow.vue'
 
 const router = useRouter()
 
@@ -76,19 +79,18 @@ function rejectMachines(...ids: string[]) {
       </template>
 
       <template #default="{ items, searchQuery }">
-        <table class="w-full text-xs text-naturals-n13">
-          <thead class="bg-naturals-n2 text-left">
-            <tr class="[&>th]:p-2">
-              <th>ID</th>
-              <th>Provider</th>
-            </tr>
-          </thead>
+        <TableRoot class="w-full">
+          <template #head>
+            <TableRow>
+              <TableCell th>ID</TableCell>
+              <TableCell th>Provider</TableCell>
+            </TableRow>
+          </template>
 
-          <tbody>
-            <tr
+          <template #body>
+            <TableRow
               v-for="item in items"
               :key="itemID(item)"
-              class="border-b border-naturals-n5 last-of-type:border-none hover:bg-white/5 [&>td]:px-2 [&>td]:py-4"
               role="button"
               :aria-label="item.metadata.id"
               @click="
@@ -98,7 +100,7 @@ function rejectMachines(...ids: string[]) {
                     : selectedMachines.add(item.metadata.id!)
               "
             >
-              <td>
+              <TableCell>
                 <div class="flex items-center gap-2">
                   <TCheckbox
                     :model-value="selectedMachines.has(item.metadata.id!)"
@@ -111,12 +113,12 @@ function rejectMachines(...ids: string[]) {
                     highlight-class="bg-naturals-n14"
                   />
                 </div>
-              </td>
+              </TableCell>
 
-              <td>{{ item.metadata.labels?.[LabelInfraProviderID] }}</td>
-            </tr>
-          </tbody>
-        </table>
+              <TableCell>{{ item.metadata.labels?.[LabelInfraProviderID] }}</TableCell>
+            </TableRow>
+          </template>
+        </TableRoot>
       </template>
     </TList>
   </div>


### PR DESCRIPTION
Create a generic table component to share table styling amongst pages. Currently we only have one instance of this, other pages are using `grid` layouts instead of tables. Will update them case-by-case.

> `table` is preferred over `grid` for tabular data for a11y and easier alignment