### PR TITLE
fix: honor lock status for machines during kubernetes upgrade

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch.go
@@ -20,14 +20,22 @@ type UpgradeStep struct {
 	Node        string
 	Component   Component
 	Patch       Patcher
+	Blocked     bool
 }
 
 // Less returns true if the patch should be applied before the other one.
 //
-// Order is based on the upgrade order.
+// Order is based on the upgrade order. Blocked steps are handled last.
 func (p UpgradeStep) Less(other UpgradeStep) bool {
 	if p.Component == other.Component {
-		return p.Node < other.Node
+		switch {
+		case p.Blocked && !other.Blocked:
+			return false
+		case !p.Blocked && other.Blocked:
+			return true
+		default:
+			return p.Node < other.Node
+		}
 	}
 
 	return p.Component.Less(other.Component)

--- a/internal/integration/suites_test.go
+++ b/internal/integration/suites_test.go
@@ -933,7 +933,7 @@ Tests upgrading Kubernetes version, including reverting a failed upgrade.`)
 
 		t.Parallel()
 
-		options.claimMachines(t, 4)
+		options.claimMachines(t, 5)
 
 		clusterName := "integration-k8s-upgrade"
 
@@ -942,7 +942,7 @@ Tests upgrading Kubernetes version, including reverting a failed upgrade.`)
 			CreateCluster(t.Context(), options.omniClient, ClusterOptions{
 				Name:          clusterName,
 				ControlPlanes: 3,
-				Workers:       1,
+				Workers:       2,
 
 				MachineOptions: MachineOptions{
 					TalosVersion:      options.MachineOptions.TalosVersion,


### PR DESCRIPTION
Currently we do not check machine lock status while calculating the upgrade path for kubernetes, we do it during the update process. Since order is important for updates, this leads to locked machines being higher up in the upgrade plan then unlocked machines and blocking the update from proceeding.

This PR will move the check for machine lock status to upgrade plan calculation, eliminating locked machines blocking the whole kubernetes update process.

Fixes: #1704 
