### PR TITLE
chore: move image package to client

### DIFF
--- a/client/pkg/clusterimport/clusterimport.go
+++ b/client/pkg/clusterimport/clusterimport.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	xmaps "github.com/siderolabs/gen/maps"
 	"github.com/siderolabs/image-factory/pkg/schematic"
-	"github.com/siderolabs/omni/internal/pkg/image"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/config/configdiff"
@@ -38,6 +37,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/siderolabs/omni/client/pkg/constants"
+	"github.com/siderolabs/omni/client/pkg/image"
 	"github.com/siderolabs/omni/client/pkg/machineconfig"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"

--- a/client/pkg/image/image.go
+++ b/client/pkg/image/image.go
@@ -1,7 +1,6 @@
-// Copyright (c) 2025 Sidero Labs, Inc.
-//
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Package image contains the container image helpers.
 package image

--- a/client/pkg/image/image_test.go
+++ b/client/pkg/image/image_test.go
@@ -1,7 +1,6 @@
-// Copyright (c) 2025 Sidero Labs, Inc.
-//
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 package image_test
 
@@ -11,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/siderolabs/omni/internal/pkg/image"
+	"github.com/siderolabs/omni/client/pkg/image"
 )
 
 func TestGetTag(t *testing.T) {

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/kubernetes_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/kubernetes_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/siderolabs/omni/client/pkg/image"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/kubernetes"
-	"github.com/siderolabs/omni/internal/pkg/image"
 )
 
 func TestComponentLess(t *testing.T) {

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	cosihelpers "github.com/siderolabs/omni/client/pkg/cosi/helpers"
+	"github.com/siderolabs/omni/client/pkg/image"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/panichandler"
@@ -38,7 +39,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/exposedservice"
 	"github.com/siderolabs/omni/internal/pkg/config"
-	"github.com/siderolabs/omni/internal/pkg/image"
 )
 
 // KubernetesStatusController manages KubernetesStatus resource lifecycle.

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/image"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
@@ -36,7 +37,6 @@ import (
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/auth/scope"
-	"github.com/siderolabs/omni/internal/pkg/image"
 )
 
 const (


### PR DESCRIPTION
Move image package to client because it's now used both omni and omni/client
