### PR TITLE
fix(frontend): correctly set the size of the lock icon for clusters

### DIFF
--- a/frontend/src/components/icons/IconLockClosedToggle.vue
+++ b/frontend/src/components/icons/IconLockClosedToggle.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <template>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="size-6">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" width="24" height="24">
     <mask id="toggle">
       <rect id="cover" x="-5%" y="-5%" width="110%" height="110%" fill="white" />
       <circle cx="18" cy="3" r="5" fill="black" />

--- a/frontend/src/components/icons/IconLocked.vue
+++ b/frontend/src/components/icons/IconLocked.vue
@@ -11,7 +11,8 @@ included in the LICENSE file.
     viewBox="0 0 24 24"
     stroke-width="1.5"
     stroke="currentColor"
-    class="size-6"
+    width="24"
+    height="24"
   >
     <path
       stroke-linecap="round"

--- a/frontend/src/components/icons/IconUnlocked.vue
+++ b/frontend/src/components/icons/IconUnlocked.vue
@@ -11,7 +11,8 @@ included in the LICENSE file.
     viewBox="0 0 24 24"
     stroke-width="1.5"
     stroke="currentColor"
-    class="size-6"
+    width="24"
+    height="24"
   >
     <path
       stroke-linecap="round"

--- a/frontend/src/views/omni/Clusters/ClusterItem.vue
+++ b/frontend/src/views/omni/Clusters/ClusterItem.vue
@@ -91,7 +91,7 @@ const { height } = useElementSize(slider)
           />
         </RouterLink>
 
-        <TIcon v-if="locked" class="size-3.5" icon="locked" aria-label="locked" />
+        <TIcon v-if="locked" class="size-3.5 shrink-0" icon="locked" aria-label="locked" />
       </div>
 
       <div id="machine-count">


### PR DESCRIPTION
Correctly set the size of the lock icon for clusters by using overridable width & height properties on the SVG instead of a class