### PR TITLE
feat(auth): make auth0 tokens only be valid for 2 minutes

### DIFF
--- a/frontend/e2e/omnictl_fixtures.ts
+++ b/frontend/e2e/omnictl_fixtures.ts
@@ -7,6 +7,7 @@ import { chmod } from 'node:fs/promises'
 import os from 'node:os'
 
 import { expect, test as base } from '@playwright/test'
+import { milliseconds } from 'date-fns'
 
 interface OmnictlFixtures {
   omnictl(
@@ -62,8 +63,39 @@ const test = base.extend<OmnictlFixtures>({
           if (authURL) {
             await page.goto(authURL)
 
-            await page.getByRole('button', { name: 'Grant Access' }).click()
-            await page.getByText('Successfully logged in').waitFor()
+            await expect
+              .poll(
+                async () => {
+                  async function tryLogin() {
+                    if (!process.env.AUTH_USERNAME) throw new Error('username is not set')
+                    if (!process.env.AUTH_PASSWORD) throw new Error('password is not set')
+
+                    try {
+                      // If we can't use the grant access button, it may be because we need to re-auth
+                      await page
+                        .getByRole('textbox', { name: 'Email address' })
+                        .fill(process.env.AUTH_USERNAME, { timeout: milliseconds({ seconds: 1 }) })
+                      await page
+                        .getByRole('textbox', { name: 'Password' })
+                        .fill(process.env.AUTH_PASSWORD)
+                      await page.getByRole('button', { name: 'Continue', exact: true }).click()
+                    } catch {}
+                  }
+
+                  try {
+                    await page
+                      .getByRole('button', { name: 'Grant Access' })
+                      .click({ timeout: milliseconds({ seconds: 1 }) })
+                    await page.getByText('Successfully logged in').waitFor()
+
+                    return true
+                  } catch {
+                    await tryLogin()
+                  }
+                },
+                { message: 'Wait for CLI authentication', timeout: milliseconds({ seconds: 30 }) },
+              )
+              .toBeTruthy()
           }
         },
       })

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,6 +6,7 @@
 import '@/index.css'
 
 import { createAuth0 } from '@auth0/auth0-vue'
+import { milliseconds, millisecondsToSeconds } from 'date-fns'
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 import yamlWorker from 'monaco-yaml/yaml.worker?worker'
 import { createApp } from 'vue'
@@ -73,6 +74,7 @@ const setupApp = async () => {
         clientId: authConfigSpec!.auth0!.client_id!,
         authorizationParams: {
           redirect_uri: window.location.origin,
+          max_age: millisecondsToSeconds(milliseconds({ minutes: 2 })),
         },
         useFormData: !!authConfigSpec!.auth0?.useFormData,
       }),


### PR DESCRIPTION
Make auth0 auth tokens only be valid for 2 minutes. After this time the user will have to reauthenticate if he does not have any non-expired PGP keys.

Fixes #1716 