### PR TITLE
fix: allow aborting kubernetes upgrades

### DIFF
--- a/frontend/src/views/cluster/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewContent.vue
@@ -5,7 +5,6 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import * as semver from 'semver'
 import type { Ref } from 'vue'
 import { computed, onMounted, ref, toRefs, watch } from 'vue'
 
@@ -174,12 +173,6 @@ const machineLockedForKubernetesUpgrade = computed(() => {
 onMounted(async () => {
   isEmbeddedDiscoveryServiceAvailable.value = await embeddedDiscoveryServiceFeatureAvailable()
 })
-
-const isMinorDowngrade = (fromVersion?: string, toVersion?: string): boolean => {
-  if (!fromVersion || !toVersion) return true
-
-  return semver.minor(fromVersion) > semver.minor(toVersion)
-}
 </script>
 
 <template>
@@ -282,11 +275,7 @@ const isMinorDowngrade = (fromVersion?: string, toVersion?: string): boolean => 
             <TButton
               v-if="
                 kubernetesUpgradeStatus.spec.phase === KubernetesUpgradeStatusSpecPhase.Upgrading &&
-                !clusterLocked &&
-                !isMinorDowngrade(
-                  kubernetesUpgradeStatus.spec.current_upgrade_version,
-                  kubernetesUpgradeStatus.spec.last_upgrade_version,
-                )
+                !clusterLocked
               "
               type="secondary"
               class="place-self-end"

--- a/frontend/src/views/omni/Modals/UpdateKubernetes.vue
+++ b/frontend/src/views/omni/Modals/UpdateKubernetes.vue
@@ -278,8 +278,8 @@ const upgradeClick = async () => {
     </p>
 
     <p class="text-xs">
-      Changing the Kubernetes version can result in control plane downtime. It's only possible to
-      cancel the upgrade if you are changing the patch version.
+      Changing the Kubernetes version can result in control plane downtime. During this change you
+      will be able to cancel the upgrade.
     </p>
     <p class="text-xs">This operation starts immediately.</p>
 


### PR DESCRIPTION
Allow aborting Kubernetes upgrades, even if upgrade is between minor versions.

Reverts: [a4a91a9](https://github.com/siderolabs/omni/commit/a4a91a965ffa407d2b75857070782a528159fed3)
