### PR TITLE
feat: add new label style to tinput

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,6 +45,7 @@
         "@storybook/vue3-vite": "^9.1.10",
         "@tailwindcss/vite": "^4.1.14",
         "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/user-event": "^14.6.1",
         "@testing-library/vue": "^8.1.0",
         "@tsconfig/node22": "^22.0.2",
         "@types/js-yaml": "^4.0.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "@storybook/vue3-vite": "^9.1.10",
     "@tailwindcss/vite": "^4.1.14",
     "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/user-event": "^14.6.1",
     "@testing-library/vue": "^8.1.0",
     "@tsconfig/node22": "^22.0.2",
     "@types/js-yaml": "^4.0.9",

--- a/frontend/src/components/common/TInput/TInput.spec.ts
+++ b/frontend/src/components/common/TInput/TInput.spec.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { expect, test } from 'vitest'
+
+import TInput from './TInput.vue'
+
+test('is accessible with inline label', () => {
+  render(TInput, {
+    props: {
+      modelValue: '',
+      title: 'My input',
+    },
+  })
+
+  expect(screen.getByLabelText('My input')).toBeInTheDocument()
+})
+
+test('is accessible with overhead label', () => {
+  render(TInput, {
+    props: {
+      modelValue: '',
+      title: 'My input',
+      overheadTitle: true,
+    },
+  })
+
+  expect(screen.getByLabelText('My input')).toBeInTheDocument()
+})
+
+test('allows input', async () => {
+  const user = userEvent.setup()
+
+  render(TInput, {
+    props: {
+      modelValue: 'hello',
+      title: 'My input',
+    },
+  })
+
+  expect(screen.getByLabelText('My input')).toHaveValue('hello')
+
+  await user.type(screen.getByLabelText('My input'), 'potatoes')
+
+  expect(screen.getByLabelText('My input')).toHaveValue('hellopotatoes')
+})
+
+test('is clearable', async () => {
+  const user = userEvent.setup()
+
+  render(TInput, {
+    props: {
+      modelValue: 'hello',
+      title: 'My input',
+    },
+  })
+
+  expect(screen.getByLabelText('My input')).toHaveValue('hello')
+
+  await user.click(screen.getByRole('button', { name: 'clear' }))
+
+  expect(screen.getByLabelText('My input')).toHaveValue('')
+})
+
+test('is focusable', async () => {
+  const { rerender } = render(TInput, {
+    props: {
+      modelValue: '',
+      title: 'My input',
+    },
+  })
+
+  expect(screen.getByLabelText('My input')).not.toHaveFocus()
+
+  // due to jsdom limitations trying to test for component being initially focused fails
+  await rerender({ focus: true })
+
+  expect(screen.getByLabelText('My input')).toHaveFocus()
+})
+
+test('is disableable', async () => {
+  const { rerender } = render(TInput, {
+    props: {
+      modelValue: '',
+      title: 'My input',
+      disabled: true,
+    },
+  })
+
+  expect(screen.getByLabelText('My input')).toBeDisabled()
+
+  await rerender({ disabled: false })
+
+  expect(screen.getByLabelText('My input')).not.toBeDisabled()
+})

--- a/frontend/src/components/common/TInput/TInput.stories.ts
+++ b/frontend/src/components/common/TInput/TInput.stories.ts
@@ -12,7 +12,9 @@ import TInput from './TInput.vue'
 type Props = ComponentProps<typeof TInput>
 
 const meta: Meta<typeof TInput> = {
-  component: TInput,
+  // https://github.com/storybookjs/storybook/issues/24238
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: TInput as any,
   args: {
     title: 'Title',
     placeholder: 'Placeholder',
@@ -22,7 +24,7 @@ const meta: Meta<typeof TInput> = {
     focus: false,
     compact: false,
     onClear: fn(),
-    'onUpdate:model-value': fn(),
+    'onUpdate:modelValue': fn(),
   },
   argTypes: {
     type: {

--- a/frontend/src/components/common/TInput/TInput.vue
+++ b/frontend/src/components/common/TInput/TInput.vue
@@ -4,9 +4,8 @@ Copyright (c) 2025 Sidero Labs, Inc.
 Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
-<script setup lang="ts">
-import { vOnClickOutside } from '@vueuse/components'
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+<script setup lang="ts" generic="T extends string | number">
+import { computed, onMounted, useTemplateRef, watch } from 'vue'
 
 import type { IconType } from '@/components/common/Icon/TIcon.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
@@ -14,7 +13,7 @@ import TIcon from '@/components/common/Icon/TIcon.vue'
 interface Props {
   icon?: IconType
   title?: string
-  modelValue: string | number
+  overheadTitle?: boolean
   placeholder?: string
   focus?: boolean
   secondary?: boolean
@@ -30,7 +29,6 @@ interface Props {
 const {
   icon = undefined,
   title = '',
-  modelValue,
   placeholder = '',
   focus,
   type = 'text',
@@ -40,45 +38,42 @@ const {
   onClear = undefined,
 } = defineProps<Props>()
 
-const emit = defineEmits(['update:model-value', 'blur'])
+defineEmits<{
+  blur: []
+}>()
 
 defineExpose({
   getCaretPosition: () => inputRef.value?.selectionStart,
 })
 
 const numberValue = computed(() =>
-  typeof modelValue === 'number' ? modelValue : parseFloat(modelValue),
+  typeof modelValue.value === 'number' ? modelValue.value : parseFloat(modelValue.value),
 )
 
-const updateValue = (value: string | number) => {
-  if (type !== 'number') {
-    emit('update:model-value', value)
-    return
-  }
+const modelValue = defineModel<T>({
+  required: true,
+  set(value) {
+    if (type !== 'number') return value
+    if (value === '') return
 
-  if (value === undefined || value === '') return
+    const numberValue = Number((typeof value === 'number' ? value : parseFloat(value)).toFixed(1))
 
-  let numberValue = Number((typeof value === 'number' ? value : parseFloat(value)).toFixed(1))
+    if (isNaN(numberValue)) return 0
 
-  if (isNaN(numberValue)) numberValue = 0
+    return Math.max(min ?? numberValue, Math.min(max ?? numberValue, numberValue))
+  },
+})
 
-  emit(
-    'update:model-value',
-    Math.max(min ?? numberValue, Math.min(max ?? numberValue, numberValue)),
-  )
+// This function only exists to handle generic typing issues based on how this component works
+function updateValue(value: unknown) {
+  modelValue.value = value as T
 }
 
-const isFocused = ref(false)
 const inputRef = useTemplateRef('input')
 
 const clearInput = () => {
   updateValue('')
   onClear?.()
-}
-
-const blurHandler = () => {
-  isFocused.value = false
-  emit('blur', '')
 }
 
 watch(
@@ -90,100 +85,72 @@ onMounted(() => focus && inputRef.value?.focus())
 </script>
 
 <template>
-  <label
-    v-on-click-outside="() => (isFocused = false)"
-    class="input-box"
-    :class="[{ focused: isFocused, secondary, primary: !secondary, compact, disabled }]"
-    @click.prevent="
-      () => {
-        isFocused = true
-        inputRef?.focus()
-      }
-    "
-  >
-    <TIcon v-if="icon" class="input-box-icon" :icon="icon" />
-    <slot name="labels" />
-    <span v-if="title" class="mr-1 min-w-fit text-xs">{{ title }}:</span>
-    <input
-      ref="input"
-      :class="{ 'opacity-0': disabled }"
-      :readonly="disabled"
-      :value="modelValue"
-      :type="type"
-      class="input-box-input"
-      :placeholder="placeholder"
-      @input="updateValue(($event.target as HTMLInputElement)?.value.trim())"
-      @focus="isFocused = true"
-      @blur="blurHandler"
-    />
-    <div v-if="type === 'number'" class="-my-1 flex flex-col select-none">
-      <TIcon
-        class="h-2 w-2 rotate-180 text-naturals-n12 hover:text-naturals-n14"
-        icon="arrow-down"
-        @click="updateValue(numberValue + step)"
+  <label class="flex flex-col gap-1 text-sm font-medium text-naturals-n14">
+    <span v-if="title && overheadTitle" class="text-sm">
+      {{ title }}
+    </span>
+
+    <div
+      class="flex items-center justify-start gap-x-2 gap-y-3 rounded border transition-colors focus-within:border-naturals-n5 has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:border-naturals-n6 has-disabled:bg-naturals-n3 has-disabled:text-naturals-n9 has-disabled:select-none"
+      :class="[
+        compact ? 'px-2 py-1' : 'p-2',
+        secondary ? 'border-transparent' : 'border-naturals-n8',
+      ]"
+    >
+      <slot name="labels"></slot>
+      <span v-if="title && !overheadTitle" class="mr-1 min-w-fit text-xs after:content-[':']">
+        {{ title }}
+      </span>
+      <input
+        ref="input"
+        v-model.trim="modelValue"
+        :disabled="disabled"
+        :type="type"
+        class="peer min-w-2 flex-1 border-none bg-transparent text-xs text-naturals-n13 placeholder-naturals-n7 outline-hidden transition-colors focus:border-transparent focus:outline-hidden disabled:opacity-0"
+        :placeholder="placeholder"
+        @blur="$emit('blur')"
       />
+
       <TIcon
-        class="h-2 w-2 text-naturals-n12 hover:text-naturals-n14"
-        icon="arrow-down"
-        @click="updateValue(numberValue - step)"
+        v-if="icon"
+        class="order-first size-4 fill-current text-naturals-n8 transition-colors peer-focus:text-naturals-n14"
+        :icon="icon"
       />
-    </div>
-    <div v-else-if="modelValue !== '' || onClear" @click.prevent="clearInput">
-      <TIcon class="input-box-icon" icon="close" />
+
+      <div v-if="type === 'number'" class="-my-1 flex flex-col select-none">
+        <TIcon
+          class="h-2 w-2 rotate-180 text-naturals-n12 hover:text-naturals-n14"
+          icon="arrow-down"
+          @click="updateValue(numberValue + step)"
+        />
+        <TIcon
+          class="h-2 w-2 text-naturals-n12 hover:text-naturals-n14"
+          icon="arrow-down"
+          @click="updateValue(numberValue - step)"
+        />
+      </div>
+
+      <TIcon
+        v-else-if="modelValue !== '' || onClear"
+        role="button"
+        aria-label="clear"
+        class="size-4 fill-current text-naturals-n8 transition-colors peer-focus:text-naturals-n14"
+        icon="close"
+        @click="clearInput"
+      />
     </div>
   </label>
 </template>
 
 <style scoped>
-@reference "../../../index.css";
-
-.input-box {
-  @apply flex items-center justify-start gap-2 gap-y-3 rounded border border-naturals-n8 p-2 transition-colors;
-}
-
-.compact {
-  @apply p-1 px-2;
-}
-
-.input-box-icon {
-  @apply h-4 w-4 cursor-pointer fill-current text-naturals-n8 transition-colors;
-}
-
-.input-box-input {
-  @apply min-w-2 flex-1 border-none bg-transparent text-xs text-naturals-n13 placeholder-naturals-n7 outline-hidden transition-colors focus:border-transparent focus:outline-hidden;
-}
-
-.input-box-icon-wrapper {
-  @apply min-w-4;
-}
-
-.secondary {
-  @apply border-transparent;
-}
-
-.focused {
-  @apply border border-solid border-naturals-n5;
-}
-
-.focused .input-box-icon {
-  @apply text-naturals-n14;
-}
-
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
-  @apply m-0 appearance-none;
+  margin: 0;
+  appearance: none;
 }
 
 /* Firefox */
 input[type='number'] {
   appearance: textfield;
-}
-
-.disabled {
-  @apply cursor-not-allowed border-naturals-n6 bg-naturals-n3;
-}
-
-.disabled * {
-  @apply pointer-events-none text-naturals-n9 select-none;
 }
 </style>

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -5,8 +5,15 @@
 import '@testing-library/jest-dom/vitest'
 
 import { server } from '@msw/server'
+import { cleanup } from '@testing-library/vue'
 import { afterAll, afterEach, beforeAll } from 'vitest'
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
+
+/**
+ * Required for testing-library cleanup, in place of globals
+ * See: https://testing-library.com/docs/vue-testing-library/setup/#cleanup
+ */
+afterEach(() => cleanup())


### PR DESCRIPTION
Adds a new overhead label style to TInput which moves the label out of the input and above it in a separate line.
Also adds tests for `TInput`.

> This new style is required for the installation media form [see: [💄 Figma](https://www.figma.com/design/4qvWHbfWdFKcDc29wPRn3l/Sidero-UI?node-id=3737-39354&t=w0M6mnGaNuv2jIsC-4)]

<img width="392" height="57" alt="image" src="https://github.com/user-attachments/assets/ff8f1a73-2f3a-472d-acda-d7af18180840" />

<img width="345" height="72" alt="image" src="https://github.com/user-attachments/assets/d094553d-2083-454f-9fe4-c89a0e642d19" />
