### PR TITLE
feat(frontend): add a radio group component

### DIFF
--- a/frontend/src/components/common/Button/TButtonGroup.stories.ts
+++ b/frontend/src/components/common/Button/TButtonGroup.stories.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { fn } from 'storybook/test'
+
+import TButtonGroup from './TButtonGroup.vue'
+
+const meta: Meta<typeof TButtonGroup> = {
+  component: TButtonGroup,
+  args: {
+    'onUpdate:modelValue': fn(),
+    deselectEnabled: true,
+    options: faker.helpers.multiple(
+      (_, i) => ({
+        label: faker.commerce.productName(),
+        disabled: faker.datatype.boolean(),
+        tooltip: faker.commerce.productDescription(),
+        value: i,
+      }),
+      { count: 5 },
+    ),
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/components/common/Icon/TIcon.stories.ts
+++ b/frontend/src/components/common/Icon/TIcon.stories.ts
@@ -4,6 +4,7 @@
 // included in the LICENSE file.
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
+import Tooltip from '../Tooltip/Tooltip.vue'
 import { icons } from './icons'
 import TIcon from './TIcon.vue'
 
@@ -34,9 +35,15 @@ export const Default: Story = {
 export const AllIcons: Story = {
   decorators: [() => ({ template: '<div class="grid grid-cols-8 gap-2"><story/></div>' })],
   render: () => ({
-    components: { TIcon },
+    components: { TIcon, Tooltip },
     template: iconKeys
-      .map((icon) => `<TIcon icon="${icon}" class="size-6" aria-label="${icon}" />`)
+      .map(
+        (icon) => `
+        <Tooltip description="${icon}">
+          <TIcon icon="${icon}" class="size-6" aria-label="${icon}" />
+        </Tooltip>
+      `,
+      )
       .join(''),
   }),
 }

--- a/frontend/src/components/common/Radio/RadioGroup.spec.ts
+++ b/frontend/src/components/common/Radio/RadioGroup.spec.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { expect, test } from 'vitest'
+
+import RadioGroup from './RadioGroup.vue'
+
+const options = Array(5)
+  .fill(null)
+  .map((_, i) => ({
+    label: `option-${i}-label`,
+    description: `option-${i}-desc`,
+    value: `option-${i}-value`,
+  }))
+
+test('allows selection', async () => {
+  const user = userEvent.setup()
+
+  render(RadioGroup, {
+    props: {
+      label: 'My radio',
+      options,
+    },
+  })
+
+  await waitFor(() => {
+    expect(screen.getByRole('radio', { name: options[0].label })).not.toBeChecked()
+  })
+
+  await user.click(screen.getByRole('radio', { name: options[0].label }))
+
+  expect(screen.getByRole('radio', { name: options[0].label })).toBeChecked()
+})

--- a/frontend/src/components/common/Radio/RadioGroup.stories.ts
+++ b/frontend/src/components/common/Radio/RadioGroup.stories.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { fn } from 'storybook/test'
+
+import RadioGroup from './RadioGroup.vue'
+
+const meta: Meta<typeof RadioGroup> = {
+  // https://github.com/storybookjs/storybook/issues/24238
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: RadioGroup as any,
+  args: {
+    label: faker.company.name(),
+    options: faker.helpers
+      .uniqueArray(() => faker.commerce.isbn(), 10)
+      .map((value) => ({
+        label: faker.commerce.productName(),
+        description: faker.helpers.maybe(() => faker.commerce.productDescription()),
+        value,
+      })),
+    'onUpdate:modelValue': fn(),
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/components/common/Radio/RadioGroup.vue
+++ b/frontend/src/components/common/Radio/RadioGroup.vue
@@ -1,0 +1,62 @@
+<!--
+Copyright (c) 2025 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts" generic="T extends string | number | boolean | Record<string, any>">
+import {
+  RadioGroup,
+  RadioGroupDescription,
+  RadioGroupLabel,
+  RadioGroupOption,
+} from '@headlessui/vue'
+
+defineProps<{
+  label: string
+  options: {
+    label: string
+    description?: string
+    value: T
+  }[]
+}>()
+
+const model = defineModel<T>()
+</script>
+
+<template>
+  <RadioGroup v-model="model">
+    <RadioGroupLabel class="mb-3 block text-sm font-medium text-naturals-n14">
+      {{ label }}
+    </RadioGroupLabel>
+
+    <div class="flex flex-col items-start gap-1">
+      <RadioGroupOption
+        v-for="option in options"
+        :key="option.label"
+        v-slot="{ checked }"
+        as="template"
+        :value="option.value"
+      >
+        <div class="flex cursor-pointer items-center gap-2.5 rounded-md py-2">
+          <div
+            class="size-3.5 rounded-full border bg-clip-content p-0.5 transition-colors duration-250"
+            :class="
+              checked ? 'border-primary-p4 bg-primary-p4' : 'border-naturals-n5 bg-transparent'
+            "
+          ></div>
+
+          <div class="text-xs">
+            <RadioGroupLabel as="p" class="font-medium text-naturals-n14">
+              {{ option.label }}
+            </RadioGroupLabel>
+
+            <RadioGroupDescription v-if="option.description" as="span">
+              {{ option.description }}
+            </RadioGroupDescription>
+          </div>
+        </div>
+      </RadioGroupOption>
+    </div>
+  </RadioGroup>
+</template>


### PR DESCRIPTION
Adds a radio group component for use in the installation media form

<img width="426" height="168" alt="image" src="https://github.com/user-attachments/assets/82cce937-d2ae-4a2f-beb0-8b20d10cdd3b" />
