### PR TITLE
fix: make workload proxy cookies HTTP only

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -530,7 +530,7 @@ spec:
     - source: client/api/omni/oidc/oidc.proto
       subdirectory: omni/oidc
       genGateway: true
-    - source: https://raw.githubusercontent.com/siderolabs/go-api-signature/184f94d36cdd4d8bf8770ef629191f63187d63da/api/auth/auth.proto
+    - source: https://raw.githubusercontent.com/siderolabs/go-api-signature/v0.3.10/api/auth/auth.proto
       subdirectory: omni/auth
       genGateway: true
     - source: client/api/omni/specs/omni.proto

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-17T13:27:48Z by kres 46e133d.
+# Generated on 2025-10-23T09:04:40Z by kres 46e133d.
 
 ARG JS_TOOLCHAIN
 ARG TOOLCHAIN
@@ -57,7 +57,7 @@ ADD client/api/common/omni.proto /frontend/src/api/common/
 ADD client/api/omni/resources/resources.proto /frontend/src/api/omni/resources/
 ADD client/api/omni/management/management.proto /frontend/src/api/omni/management/
 ADD client/api/omni/oidc/oidc.proto /frontend/src/api/omni/oidc/
-ADD https://raw.githubusercontent.com/siderolabs/go-api-signature/184f94d36cdd4d8bf8770ef629191f63187d63da/api/auth/auth.proto /frontend/src/api/omni/auth/
+ADD https://raw.githubusercontent.com/siderolabs/go-api-signature/v0.3.10/api/auth/auth.proto /frontend/src/api/omni/auth/
 ADD client/api/omni/specs/omni.proto /frontend/src/api/omni/specs/
 ADD client/api/omni/specs/siderolink.proto /frontend/src/api/omni/specs/
 ADD client/api/omni/specs/system.proto /frontend/src/api/omni/specs/

--- a/frontend/src/api/omni/auth/auth.pb.ts
+++ b/frontend/src/api/omni/auth/auth.pb.ts
@@ -35,6 +35,10 @@ export type ConfirmPublicKeyRequest = {
   public_key_id?: string
 }
 
+export type RevokePublicKeyRequest = {
+  public_key_id?: string
+}
+
 export class AuthService {
   static RegisterPublicKey(req: RegisterPublicKeyRequest, ...options: fm.fetchOption[]): Promise<RegisterPublicKeyResponse> {
     return fm.fetchReq<RegisterPublicKeyRequest, RegisterPublicKeyResponse>("POST", `/auth.AuthService/RegisterPublicKey`, req, ...options)
@@ -44,5 +48,8 @@ export class AuthService {
   }
   static ConfirmPublicKey(req: ConfirmPublicKeyRequest, ...options: fm.fetchOption[]): Promise<GoogleProtobufEmpty.Empty> {
     return fm.fetchReq<ConfirmPublicKeyRequest, GoogleProtobufEmpty.Empty>("POST", `/auth.AuthService/ConfirmPublicKey`, req, ...options)
+  }
+  static RevokePublicKey(req: RevokePublicKeyRequest, ...options: fm.fetchOption[]): Promise<GoogleProtobufEmpty.Empty> {
+    return fm.fetchReq<RevokePublicKeyRequest, GoogleProtobufEmpty.Empty>("POST", `/auth.AuthService/RevokePublicKey`, req, ...options)
   }
 }

--- a/frontend/src/api/omni/auth/auth.proto
+++ b/frontend/src/api/omni/auth/auth.proto
@@ -38,8 +38,13 @@ message ConfirmPublicKeyRequest {
   string public_key_id = 1;
 }
 
+message RevokePublicKeyRequest {
+  string public_key_id = 1;
+}
+
 service AuthService {
   rpc RegisterPublicKey(RegisterPublicKeyRequest) returns (RegisterPublicKeyResponse);
   rpc AwaitPublicKeyConfirmation(AwaitPublicKeyConfirmationRequest) returns (google.protobuf.Empty);
   rpc ConfirmPublicKey(ConfirmPublicKeyRequest) returns (google.protobuf.Empty);
+  rpc RevokePublicKey(RevokePublicKeyRequest) returns (google.protobuf.Empty);
 }

--- a/frontend/src/components/common/UserInfo/UserInfo.vue
+++ b/frontend/src/components/common/UserInfo/UserInfo.vue
@@ -9,9 +9,7 @@ import { useAuth0 } from '@auth0/auth0-vue'
 import { computed, toRefs } from 'vue'
 
 import TActionsBox from '@/components/common/ActionsBox/TActionsBox.vue'
-import { AuthType, authType } from '@/methods'
-import { currentUser } from '@/methods/auth'
-import { resetKeys } from '@/methods/key'
+import { logout } from '@/methods/auth'
 import { identity as identityStorage } from '@/methods/key'
 
 type Props = {
@@ -51,18 +49,6 @@ const imageSize = computed(() => {
 
   return { 'w-12': true, 'h-12': true }
 })
-
-const doLogout = async () => {
-  await auth0?.logout({ logoutParams: { returnTo: window.location.origin } })
-
-  resetKeys()
-
-  currentUser.value = undefined
-
-  if (authType.value !== AuthType.Auth0) {
-    location.reload()
-  }
-}
 </script>
 
 <template>
@@ -79,7 +65,7 @@ const doLogout = async () => {
       {{ identity }}
     </div>
     <TActionsBox v-if="withLogoutControls" placement="top">
-      <div @click="doLogout">
+      <div @click="() => logout(auth0)">
         <div class="cursor-pointer px-4 py-2 hover:text-naturals-n12">Log Out</div>
       </div>
     </TActionsBox>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -12,12 +12,11 @@ import { AuthFlowQueryParam, RedirectQueryParam } from '@/api/resources'
 import { current } from '@/context'
 import { AuthType, authType } from '@/methods'
 import { loadCurrentUser } from '@/methods/auth'
-import { getAuthCookies, isAuthorized } from '@/methods/key'
+import { isAuthorized } from '@/methods/key'
 import { MachineFilterOption } from '@/methods/machine'
 import { refreshTitle } from '@/methods/title'
 
 export const FrontendAuthFlow = 'frontend'
-const requireCookies = false
 
 export const routes: RouteRecordRaw[] = [
   // Unauthenticated routes
@@ -64,17 +63,10 @@ export const routes: RouteRecordRaw[] = [
       sidebar: () => import('@/components/SideBar/TSideBar.vue'),
     },
     beforeEnter: async (to) => {
-      let authorized = await isAuthorized()
-
-      if (requireCookies && !getAuthCookies()) {
-        authorized = false
-      }
+      const authorized = await isAuthorized()
 
       if (authorized) {
         await loadCurrentUser()
-      }
-
-      if (authorized) {
         await refreshTitle()
 
         return true

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/siderolabs/discovery-client v0.1.13
 	github.com/siderolabs/discovery-service v1.0.11
 	github.com/siderolabs/gen v0.8.5
-	github.com/siderolabs/go-api-signature v0.3.9
+	github.com/siderolabs/go-api-signature v0.3.10
 	github.com/siderolabs/go-circular v0.2.3
 	github.com/siderolabs/go-debug v0.6.1
 	github.com/siderolabs/go-kubernetes v0.2.26

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,8 @@ github.com/siderolabs/discovery-service v1.0.11 h1:+ymDXKhPL2f1c5MIO559wciA38PcQ
 github.com/siderolabs/discovery-service v1.0.11/go.mod h1:pUTOYgtYasO/T02zJNNfw0SCP8hDbIgFIvdm+Fn1UKo=
 github.com/siderolabs/gen v0.8.5 h1:xlWXTynnGD/epaj7uplvKvmAkBH+Fp51bLnw1JC0xME=
 github.com/siderolabs/gen v0.8.5/go.mod h1:CRrktDXQf3yDJI7xKv+cDYhBbKdfd/YE16OpgcHoT9E=
-github.com/siderolabs/go-api-signature v0.3.9 h1:JfXTR0J9LOsvQXT0kIdnSm+F3qe+ustLnBuC65H0qvc=
-github.com/siderolabs/go-api-signature v0.3.9/go.mod h1:VcilCqp2k2bYjFhzsxdc2JPqGIcOkHjeG2bLLm1NGeA=
+github.com/siderolabs/go-api-signature v0.3.10 h1:4E3p577ARO4n/s/uSmPSOuVDosQw048LjxRdQa7vAyg=
+github.com/siderolabs/go-api-signature v0.3.10/go.mod h1:dPLiXohup4qHX7KUgF/wwOE3lRU5uAr3ssEomNxiyxY=
 github.com/siderolabs/go-circular v0.2.3 h1:GKkA1Tw79kEFGtWdl7WTxEUTbwtklITeiRT0V1McHrA=
 github.com/siderolabs/go-circular v0.2.3/go.mod h1:YBN/q9YpQphUYnBtBgPsngauSHj1TEZfgQZWZVjk1WE=
 github.com/siderolabs/go-debug v0.6.1 h1:LAkM2ADz+naL3PA6Mv0SzyXYx7aCxYlKdO2dSiZmhRc=

--- a/internal/backend/grpc/auth.go
+++ b/internal/backend/grpc/auth.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -29,7 +31,9 @@ import (
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
+	"github.com/siderolabs/omni/internal/backend/grpc/cookies"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
@@ -48,8 +52,38 @@ const (
 type authServer struct {
 	authpb.UnimplementedAuthServiceServer
 
-	state  state.State
-	logger *zap.Logger
+	logger                    *zap.Logger
+	loginURL                  *url.URL
+	state                     state.State
+	workloadProxyCookieDomain string
+}
+
+func newAuthServer(state state.State, services config.Services, logger *zap.Logger) (*authServer, error) {
+	advertisedURL, err := url.Parse(services.API.URL())
+	if err != nil {
+		return nil, err
+	}
+
+	var workloadProxyCookieDomain string
+
+	domainParts := strings.Split(advertisedURL.Hostname(), ".")
+	if len(domainParts) < 2 {
+		workloadProxyCookieDomain = domainParts[0]
+	} else {
+		workloadProxyCookieDomain = "." + strings.Join(domainParts[1:], ".")
+	}
+
+	loginURL, err := url.Parse(services.API.URL())
+	if err != nil {
+		return nil, err
+	}
+
+	return &authServer{
+		state:                     state,
+		logger:                    logger,
+		workloadProxyCookieDomain: workloadProxyCookieDomain,
+		loginURL:                  loginURL,
+	}, nil
 }
 
 func (s *authServer) register(server grpc.ServiceRegistrar) {
@@ -72,14 +106,9 @@ func (s *authServer) RegisterPublicKey(ctx context.Context, request *authpb.Regi
 		return nil, err
 	}
 
-	loginURL, err := s.buildLoginURL(pubKey.id)
-	if err != nil {
-		return nil, err
-	}
-
 	result := &authpb.RegisterPublicKeyResponse{
 		PublicKeyId: pubKey.id,
-		LoginUrl:    loginURL,
+		LoginUrl:    s.buildLoginURL(pubKey.id),
 	}
 
 	identity, err := safe.StateGet[*authres.Identity](ctx, s.state, authres.NewIdentity(resources.DefaultNamespace, email).Metadata())
@@ -197,6 +226,67 @@ func (s *authServer) AwaitPublicKeyConfirmation(ctx context.Context, request *au
 	return &emptypb.Empty{}, nil
 }
 
+// RevokePublicKey deletes public key by ID.
+// Only authenticated user keys can be removed.
+func (s *authServer) RevokePublicKey(ctx context.Context, request *authpb.RevokePublicKeyRequest) (*emptypb.Empty, error) {
+	creds, err := auth.CheckGRPC(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if !creds.HasValidSignature {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
+
+	ctx = actor.MarkContextAsInternalActor(ctx)
+
+	pubKey, err := safe.StateGetByID[*authres.PublicKey](ctx, s.state, request.PublicKeyId)
+	if err != nil {
+		return nil, err
+	}
+
+	if pubKey.TypedSpec().Value.Identity == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid argument")
+	}
+
+	if pubKey.TypedSpec().Value.Identity.Email != creds.Identity {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
+
+	// resetting the workload proxy cookies
+	if err = cookies.Set(
+		ctx,
+		&http.Cookie{
+			Name:     workloadproxy.PublicKeyIDCookie,
+			Path:     "/",
+			Expires:  time.Unix(0, 0),
+			HttpOnly: true,
+			Secure:   true,
+			Domain:   s.workloadProxyCookieDomain,
+			SameSite: http.SameSiteStrictMode,
+		},
+		&http.Cookie{
+			Name:     workloadproxy.PublicKeyIDSignatureBase64Cookie,
+			Path:     "/",
+			Expires:  time.Unix(0, 0),
+			HttpOnly: true,
+			Secure:   true,
+			Domain:   s.workloadProxyCookieDomain,
+			SameSite: http.SameSiteStrictMode,
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	if err = s.state.TeardownAndDestroy(ctx, pubKey.Metadata(),
+		state.WithTeardownAndDestroyOwner((&omni.KeyPrunerController{}).Name()),
+	); err != nil {
+		return nil, err
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
 // ConfirmPublicKey confirms the public key with the given ID.
 // It uses the ID token in the request metadata to validate the user identity.
 func (s *authServer) ConfirmPublicKey(ctx context.Context, request *authpb.ConfirmPublicKeyRequest) (*emptypb.Empty, error) {
@@ -252,6 +342,38 @@ func (s *authServer) ConfirmPublicKey(ctx context.Context, request *authpb.Confi
 		zap.String("role", pubKey.TypedSpec().Value.GetRole()),
 	)
 
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		values := md.Get(workloadproxy.PublicKeyIDSignatureBase64Cookie)
+		if len(values) > 0 {
+			if err = cookies.Set(
+				ctx,
+				&http.Cookie{
+					Name:     workloadproxy.PublicKeyIDCookie,
+					Value:    request.PublicKeyId,
+					Path:     "/",
+					Expires:  pubKey.TypedSpec().Value.Expiration.AsTime(),
+					HttpOnly: true,
+					Secure:   true,
+					Domain:   s.workloadProxyCookieDomain,
+					SameSite: http.SameSiteStrictMode,
+				},
+				&http.Cookie{
+					Name:     workloadproxy.PublicKeyIDSignatureBase64Cookie,
+					Value:    values[0],
+					Path:     "/",
+					Expires:  pubKey.TypedSpec().Value.Expiration.AsTime(),
+					HttpOnly: true,
+					Secure:   true,
+					Domain:   s.workloadProxyCookieDomain,
+					SameSite: http.SameSiteStrictMode,
+				},
+			); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return &emptypb.Empty{}, nil
 }
 
@@ -268,11 +390,8 @@ func verifiedEmail(ctx context.Context) (string, error) {
 	return authCheckResult.VerifiedEmail, nil
 }
 
-func (s *authServer) buildLoginURL(pgpKeyID string) (string, error) {
-	loginURL, err := url.Parse(config.Config.Services.API.URL())
-	if err != nil {
-		return "", err
-	}
+func (s *authServer) buildLoginURL(pgpKeyID string) string {
+	loginURL := *s.loginURL
 
 	loginURL.Path = loginPath
 
@@ -282,5 +401,5 @@ func (s *authServer) buildLoginURL(pgpKeyID string) (string, error) {
 
 	loginURL.RawQuery = query.Encode()
 
-	return loginURL.String(), nil
+	return loginURL.String()
 }

--- a/internal/backend/grpc/cookies/cookies.go
+++ b/internal/backend/grpc/cookies/cookies.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package cookies defines tools for adding setting cookies in the gRPC gateway response.
+package cookies
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+)
+
+const cookiesMetaHeader = "grpc-gateway-cookies"
+
+// Set allows setting HTTP cookies from the gRPC services, propagating it to the gRPC gateway through Headers.
+func Set(ctx context.Context, cookies ...*http.Cookie) error {
+	header := metadata.Pairs()
+
+	for _, cookie := range cookies {
+		data, err := json.Marshal(cookie)
+		if err != nil {
+			return err
+		}
+
+		header.Append(cookiesMetaHeader, string(data))
+	}
+
+	return grpc.SendHeader(ctx, header)
+}
+
+// Handler is called from the gRPC gateway to get the cookies from the headers and set them in the HTTP response.
+func Handler(ctx context.Context, w http.ResponseWriter, _ proto.Message) error {
+	md, ok := runtime.ServerMetadataFromContext(ctx)
+	if !ok {
+		return fmt.Errorf("failed to extract ServerMetadata from context")
+	}
+
+	cookies := md.HeaderMD.Get(cookiesMetaHeader)
+	if len(cookies) == 0 {
+		return nil
+	}
+
+	for _, encodedCookie := range cookies {
+		var cookie http.Cookie
+
+		if err := json.Unmarshal([]byte(encodedCookie), &cookie); err != nil {
+			return err
+		}
+
+		http.SetCookie(w, &cookie)
+	}
+
+	return nil
+}

--- a/internal/backend/saml/saml.go
+++ b/internal/backend/saml/saml.go
@@ -73,9 +73,6 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 // RegisterHandlers adds login and logout handlers.
 func RegisterHandlers(saml *samlsp.Middleware, mux *http.ServeMux, logger *zap.Logger) {
 	logger = logger.With(zap.String("handler", "saml"))
-	login := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		saml.HandleStartAuthFlow(w, r)
-	})
 
 	md := http.HandlerFunc(saml.ServeMetadata)
 	promLabel := prometheus.Labels{"handler": "saml"}
@@ -87,11 +84,6 @@ func RegisterHandlers(saml *samlsp.Middleware, mux *http.ServeMux, logger *zap.L
 
 	mux.Handle("/saml/metadata", monitoring.NewHandler(
 		logging.NewHandler(md, logger),
-		promLabel,
-	))
-
-	mux.Handle("/login", monitoring.NewHandler(
-		logging.NewHandler(login, logger),
 		promLabel,
 	))
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -839,14 +839,13 @@ func makeMux(
 		"static",
 	)
 
-	if samlHandler != nil {
-		saml.RegisterHandlers(samlHandler, mux, logger)
-	}
-
-	if oidcProvider != nil {
-		if err := oidc.RegisterHandlers(config.Config.Services.API.AdvertisedURL, config.Config.Auth.OIDC, mux, oidcProvider); err != nil {
-			return nil, err
-		}
+	if err := registerAuthHandlers(
+		mux,
+		samlHandler,
+		oidcProvider,
+		logger,
+	); err != nil {
+		return nil, err
 	}
 
 	muxHandle("/image/", imageHandler, "image")
@@ -884,6 +883,51 @@ func makeMux(
 	muxHandle("/healthz", health.NewHandler(state.Default(), logger), "health")
 
 	return mux, nil
+}
+
+func registerAuthHandlers(mux *http.ServeMux, samlHandler *samlsp.Middleware, oidcProvider *coidc.Provider, logger *zap.Logger) error {
+	var (
+		loginHandler  http.HandlerFunc
+		logoutHandler http.HandlerFunc
+	)
+
+	switch {
+	case samlHandler != nil:
+		saml.RegisterHandlers(samlHandler, mux, logger)
+
+		loginHandler = samlHandler.HandleStartAuthFlow
+		logoutHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, config.Config.Services.API.AdvertisedURL, http.StatusSeeOther)
+		})
+	case oidcProvider != nil:
+		handler, err := oidc.NewOIDCHandler(config.Config.Services.API.AdvertisedURL, config.Config.Auth.OIDC, oidcProvider)
+		if err != nil {
+			return err
+		}
+
+		loginHandler = handler.Login
+		logoutHandler = handler.Logout
+
+		mux.HandleFunc(oidc.RedirectURL, handler.OIDCConsume)
+	}
+
+	promLabel := prometheus.Labels{"handler": "auth"}
+
+	if loginHandler != nil {
+		mux.Handle("/login", monitoring.NewHandler(
+			logging.NewHandler(loginHandler, logger),
+			promLabel,
+		))
+	}
+
+	if logoutHandler != nil {
+		mux.Handle("/logout", monitoring.NewHandler(
+			logging.NewHandler(logoutHandler, logger),
+			promLabel,
+		))
+	}
+
+	return nil
 }
 
 func getOmnictlDownloads(dir string) (http.Handler, error) {


### PR DESCRIPTION
It required moving cookies creation/deletion to the backend. Cookies are now updated on `ConfirmPublicKey` and `RevokePublicKey` calls.

Introduced the `RevokePublicKey` method as `auth0` flow didn't have any backend calls in the end of the logout.

Added a way for propagating cookies from the gRPC service to the gRPC gateway.