### PR TITLE
fix(frontend): fix sidebar children toggle behaviour

### DIFF
--- a/frontend/src/components/common/MenuItem/TMenuItem.stories.ts
+++ b/frontend/src/components/common/MenuItem/TMenuItem.stories.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import TMenuItem from './TMenuItem.vue'
+
+const meta: Meta<typeof TMenuItem> = {
+  component: TMenuItem,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    name: 'Name',
+    icon: 'kubernetes',
+    label: 'Label',
+    tooltip: 'Tooltip',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithSubItems: Story = {
+  args: {
+    name: 'Name',
+    icon: 'kubernetes',
+    label: 'Label',
+    subItems: faker.helpers.multiple(() => ({ name: faker.animal.cat() }), { count: 5 }),
+  },
+}

--- a/frontend/src/components/common/MenuItem/TMenuItem.vue
+++ b/frontend/src/components/common/MenuItem/TMenuItem.vue
@@ -76,7 +76,6 @@ componentAttributes.class = (componentAttributes.class ?? '') + ' item-container
           class="item w-full"
           :class="{ 'sub-item': level > 0, root: level === 0 }"
           :style="{ 'padding-left': `${24 * (level + 1)}px` }"
-          @click="toggleSubmenu"
         >
           <TIcon
             v-if="icon || iconSvgBase64"
@@ -89,7 +88,12 @@ componentAttributes.class = (componentAttributes.class ?? '') + ' item-container
             <span>{{ label }}</span>
           </div>
 
-          <div v-if="subItems?.length" class="expand-button">
+          <div
+            v-if="subItems?.length"
+            class="expand-button"
+            role="button"
+            @click.prevent="toggleSubmenu"
+          >
             <TIcon
               class="transition-color h-6 w-6 transition-transform duration-250 hover:text-naturals-n13"
               :class="{ 'rotate-180': !expanded }"


### PR DESCRIPTION
Fix unintented change in the sidebar that toggled children without specifically clicking the arrow icon. Now clicking the title only navigates and clicking the arrow icon only toggles the sub-menu.