### PR TITLE
test: improve integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-17T13:27:48Z by kres 46e133d.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -246,10 +246,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-backups
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-cluster-import:
@@ -320,10 +317,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-cluster-import
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-forced-removal:
@@ -393,10 +387,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-forced-removal
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-omni-upgrade:
@@ -467,10 +458,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-omni-upgrade
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-scaling:
@@ -540,10 +528,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-scaling
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-short:
@@ -613,10 +598,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-short
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-short-secureboot:
@@ -687,10 +669,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-short-secureboot
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-templates:
@@ -760,10 +739,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-templates
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-upgrades:
@@ -833,10 +809,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-upgrades
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   e2e-workload-proxy:
@@ -906,10 +879,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-e2e-workload-proxy
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
         continue-on-error: true
   integration-test:
@@ -992,10 +962,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"
       - name: coverage
         uses: codecov/codecov-action@v5

--- a/.github/workflows/e2e-backups-cron.yaml
+++ b/.github/workflows/e2e-backups-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -72,8 +72,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-cluster-import-cron.yaml
+++ b/.github/workflows/e2e-cluster-import-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-10T14:11:15Z by kres 063080a.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -73,8 +73,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-forced-removal-cron.yaml
+++ b/.github/workflows/e2e-forced-removal-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -72,8 +72,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-omni-upgrade-cron.yaml
+++ b/.github/workflows/e2e-omni-upgrade-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -73,8 +73,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-scaling-cron.yaml
+++ b/.github/workflows/e2e-scaling-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -72,8 +72,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-short-cron.yaml
+++ b/.github/workflows/e2e-short-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -72,8 +72,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-short-secureboot-cron.yaml
+++ b/.github/workflows/e2e-short-secureboot-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -73,8 +73,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-templates-cron.yaml
+++ b/.github/workflows/e2e-templates-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -72,8 +72,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-upgrades-cron.yaml
+++ b/.github/workflows/e2e-upgrades-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -72,8 +72,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.github/workflows/e2e-workload-proxy-cron.yaml
+++ b/.github/workflows/e2e-workload-proxy-cron.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-09-26T09:19:58Z by kres fdbc9fc.
+# Generated on 2025-10-27T13:48:49Z by kres 46e133d.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -72,8 +72,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test
-          path: |-
-            ~/.talos/clusters/**/*.log
-            !~/.talos/clusters/**/swtpm.log
-            ${{ github.workspace }}/integration-test
+          path: ${{ github.workspace }}/integration-test
           retention-days: "5"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -206,8 +206,6 @@ spec:
           always: true
           continueOnError: true
           paths:
-            - "~/.talos/clusters/**/*.log"
-            - "!~/.talos/clusters/**/swtpm.log"
             - ${{ github.workspace }}/integration-test
     environment:
       WITH_DEBUG: "true"


### PR DESCRIPTION
- Make sure the console output of QEMU is sent to `console=ttyS0` when non-UKI is used.
- Use the new `cluster create` arg `--skip-injecting-extra-cmdline` to make sure `console=ttyS0` kernel arg is not duplicated.
- Get rid of `SUDO_USER` var.
- Add the missing `--omni.output-dir` flag to make sure the support bundles are collected to proper destinations.
- Gather all artifacts to be collected under `TEST_OUTPUTS_DIR` for better organization in the test artifacts archive.
- Quote some strings.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>