### PR TITLE
fix: properly check tracking state to show user consent form

### DIFF
--- a/frontend/src/components/common/UserConsent/UserConsent.vue
+++ b/frontend/src/components/common/UserConsent/UserConsent.vue
@@ -36,7 +36,7 @@ watch(() => currentUser.value, fetchTrackingToken)
 </script>
 
 <template>
-  <div v-if="trackingState === undefined && trackerToken">
+  <div v-if="trackingState === null && trackerToken">
     <div class="absolute top-0 left-0 z-50 flex h-screen w-screen flex-col justify-stretch">
       <div class="flex-1 bg-black opacity-25" />
       <div class="border-t border-primary-p3 bg-naturals-n6 p-4">


### PR DESCRIPTION
It was set to `null` by default and it was failing on the check with `=== undefined`.
Make it compare against `null` instead.

Fixes: #1702 