### PR TITLE
fix(frontend): correct the icon colors on tstatus

### DIFF
--- a/frontend/src/components/common/Status/TStatus.vue
+++ b/frontend/src/components/common/Status/TStatus.vue
@@ -130,7 +130,7 @@ const iconData = computed((): { iconColor?: string; iconTypeValue?: IconType } =
       case TCommonStatuses.HEALTHY:
         return {
           iconTypeValue: 'check-in-circle-classic',
-          iconColor: 'var(--color--green-g1)',
+          iconColor: 'var(--color-green-g1)',
         }
       case TCommonStatuses.UNHEALTHY:
         return {
@@ -141,7 +141,7 @@ const iconData = computed((): { iconColor?: string; iconTypeValue?: IconType } =
       case TCommonStatuses.ON:
         return {
           iconTypeValue: 'dot',
-          iconColor: 'var(--color--green-g1)',
+          iconColor: 'var(--color-green-g1)',
         }
       case TCommonStatuses.DISABLED:
       case TCommonStatuses.OFF:
@@ -162,7 +162,7 @@ const iconData = computed((): { iconColor?: string; iconTypeValue?: IconType } =
       case TCommonStatuses.UP_TO_DATE:
         return {
           iconTypeValue: 'check-in-circle-classic',
-          iconColor: 'var(--color--green-g1)',
+          iconColor: 'var(--color-green-g1)',
         }
       case TCommonStatuses.OUTDATED:
         return {
@@ -172,12 +172,12 @@ const iconData = computed((): { iconColor?: string; iconTypeValue?: IconType } =
       case TCommonStatuses.APPLIED:
         return {
           iconTypeValue: 'check-in-circle-classic',
-          iconColor: 'var(--color--green-g1)',
+          iconColor: 'var(--color-green-g1)',
         }
       case TCommonStatuses.PENDING:
         return {
           iconTypeValue: 'time',
-          iconColor: 'var(--color--yellow-y1)',
+          iconColor: 'var(--color-yellow-y1)',
         }
       case TCommonStatuses.AWAITING_CONNECTION:
         return {
@@ -199,9 +199,9 @@ const iconColor = computed(() => {
   if (iconType.value) {
     switch (iconType.value) {
       case 'check-in-circle-classic':
-        return { color: 'var(--color--green-g1)' }
+        return { color: 'var(--color-green-g1)' }
       case 'loading':
-        return { color: 'var(--color--yellow-y1)' }
+        return { color: 'var(--color-yellow-y1)' }
       case 'time':
         return { color: 'var(--color-naturals-n9)' }
       case 'refresh':

--- a/frontend/src/views/omni/Settings/InfraProviders.stories.ts
+++ b/frontend/src/views/omni/Settings/InfraProviders.stories.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import { createWatchStreamHandler } from '@msw/helpers'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { Resource } from '@/api/grpc'
+import type { InfraProviderCombinedStatusSpec } from '@/api/omni/specs/omni.pb'
+import { EphemeralNamespace, InfraProviderCombinedStatusType } from '@/api/resources'
+
+import InfraProviders from './InfraProviders.vue'
+
+const meta: Meta<typeof InfraProviders> = {
+  component: InfraProviders,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<InfraProviderCombinedStatusSpec>({
+          expectedOptions: {
+            namespace: EphemeralNamespace,
+            type: InfraProviderCombinedStatusType,
+          },
+          initialResources: faker.helpers.multiple<Resource<InfraProviderCombinedStatusSpec>>(
+            () => ({
+              metadata: { id: faker.string.uuid() },
+              spec: {
+                name: faker.animal.cat(),
+                icon: faker.image
+                  .dataUri({ type: 'svg-base64' })
+                  .replace('data:image/svg+xml;base64,', ''),
+                description: faker.hacker.phrase(),
+                health: {
+                  connected: faker.datatype.boolean(),
+                  error: faker.helpers.maybe(() => faker.hacker.phrase()),
+                  initialized: faker.datatype.boolean(),
+                },
+              },
+            }),
+            { count: 10 },
+          ),
+        }).handler,
+      ],
+    },
+  },
+}


### PR DESCRIPTION
Correct the icon colors in TStatus which mad mistyped color variables. Also add stories for InfraProviders page.

<img width="1304" height="946" alt="image" src="https://github.com/user-attachments/assets/dcf32cb5-6422-4121-bf37-d78dbd28b574" />
