### PR TITLE
refactor(frontend): refactor tselectlist with reka-ui

### DIFF
--- a/frontend/e2e/omnictl_fixtures.ts
+++ b/frontend/e2e/omnictl_fixtures.ts
@@ -31,7 +31,7 @@ const test = base.extend<OmnictlFixtures>({
 
     await page.getByRole('button', { name: 'Download omnictl' }).click()
 
-    await page.getByRole('button', { name: 'omnictl:' }).click()
+    await page.getByRole('combobox', { name: 'omnictl:' }).click()
     await page.getByRole('option', { name: `omnictl-${getPlatform()}-${getArch()}` }).click()
 
     const [downloadOmnictl] = await Promise.all([

--- a/frontend/src/components/common/Form/EnumRenderer.vue
+++ b/frontend/src/components/common/Form/EnumRenderer.vue
@@ -29,7 +29,6 @@ const values = computed(() => {
     <TSelectList
       :id="control.id + '-input'"
       class="h-6"
-      menu-align="right"
       :default-value="control.data ?? 'unset'"
       :disabled="!control.enabled"
       :values="values"

--- a/frontend/src/components/common/SelectList/TSelectList.spec.ts
+++ b/frontend/src/components/common/SelectList/TSelectList.spec.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import userEvent from '@testing-library/user-event'
+import { render, screen, waitFor } from '@testing-library/vue'
+import { mount } from '@vue/test-utils'
+import { expect, test, vi } from 'vitest'
+
+import TSelectList from './TSelectList.vue'
+
+// Used by reka-ui select, test fails without it
+window.HTMLElement.prototype.hasPointerCapture = vi.fn()
+
+test('is accessible with inline label', () => {
+  render(TSelectList, {
+    props: {
+      title: 'My select',
+      values: ['first option', 'second option'],
+    },
+  })
+
+  expect(screen.getByLabelText('My select')).toBeInTheDocument()
+})
+
+test('is accessible with overhead label', () => {
+  render(TSelectList, {
+    props: {
+      title: 'My select',
+      values: ['first option', 'second option'],
+      overheadTitle: true,
+    },
+  })
+
+  expect(screen.getByLabelText('My select')).toBeInTheDocument()
+})
+
+test('accepts a default value', async () => {
+  const user = userEvent.setup()
+  const updateFn = vi.fn()
+  const checkedFn = vi.fn()
+
+  render(TSelectList, {
+    props: {
+      title: 'My select',
+      values: ['first option', 'second option'],
+      defaultValue: 'first option',
+      'onUpdate:modelValue': updateFn,
+      onCheckedValue: checkedFn,
+    },
+  })
+
+  const trigger = screen.getByLabelText('My select')
+
+  expect(updateFn).toHaveBeenCalledExactlyOnceWith('first option')
+  expect(checkedFn).not.toHaveBeenCalled()
+
+  expect(trigger).toHaveTextContent('first option')
+
+  // Open dropdown
+  await user.click(trigger)
+
+  expect(screen.getByRole('option', { name: 'first option' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  )
+})
+
+test('allows selection', async () => {
+  const user = userEvent.setup()
+  const updateFn = vi.fn()
+  const checkedFn = vi.fn()
+
+  render(TSelectList, {
+    props: {
+      title: 'My select',
+      values: ['first option', 'second option'],
+      'onUpdate:modelValue': updateFn,
+      onCheckedValue: checkedFn,
+    },
+  })
+
+  const trigger = screen.getByLabelText('My select')
+
+  expect(trigger.textContent).toBe('My select') // Exact match to assert no default
+
+  // Open dropdown
+  await user.click(trigger)
+
+  const option = screen.getByRole('option', { name: 'second option' })
+
+  // Select option
+  await user.click(option)
+
+  expect(updateFn).toHaveBeenCalledExactlyOnceWith('second option')
+  expect(checkedFn).toHaveBeenCalledExactlyOnceWith('second option')
+
+  expect(trigger).toHaveTextContent('second option')
+  expect(option).toHaveAttribute('aria-selected', 'true')
+})
+
+test('exposes selectItem', async () => {
+  const updateFn = vi.fn()
+  const checkedFn = vi.fn()
+
+  // Can't test defineExpose with testing-library, using @vue/test-utils instead
+  const wrapper = mount(TSelectList, {
+    props: {
+      title: 'My select',
+      values: ['first option', 'second option'],
+      'onUpdate:modelValue': updateFn,
+      onCheckedValue: checkedFn,
+    },
+  })
+
+  expect(wrapper.text()).not.toContain('second option')
+
+  wrapper.vm.selectItem('second option')
+
+  expect(updateFn).toHaveBeenCalledExactlyOnceWith('second option')
+  expect(checkedFn).toHaveBeenCalledExactlyOnceWith('second option')
+
+  await waitFor(() => {
+    expect(wrapper.text()).toContain('second option')
+  })
+})
+
+test('focuses search on open', async () => {
+  const user = userEvent.setup()
+
+  render(TSelectList, {
+    props: {
+      title: 'My select',
+      values: ['first option', 'second option'],
+      searcheable: true,
+    },
+  })
+
+  const trigger = screen.getByLabelText('My select')
+
+  // Open dropdown
+  await user.click(trigger)
+
+  expect(screen.getByRole('textbox', { name: 'search' })).toHaveFocus()
+})

--- a/frontend/src/components/common/SelectList/TSelectList.stories.ts
+++ b/frontend/src/components/common/SelectList/TSelectList.stories.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { fn } from 'storybook/test'
+
+import TSelectList from './TSelectList.vue'
+
+const values = faker.helpers.uniqueArray(() => faker.animal.cat(), 100).sort()
+
+const meta: Meta<typeof TSelectList> = {
+  // https://github.com/storybookjs/storybook/issues/24238
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: TSelectList as any,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    title: 'Kitty',
+    values,
+    defaultValue: values.at(-Math.round(values.length / 2)),
+    hideSelectedSmallScreens: false,
+    searcheable: true,
+    overheadTitle: false,
+    onCheckedValue: fn(),
+    'onUpdate:modelValue': fn(),
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/components/common/SelectList/TSelectList.vue
+++ b/frontend/src/components/common/SelectList/TSelectList.vue
@@ -4,158 +4,172 @@ Copyright (c) 2025 Sidero Labs, Inc.
 Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
-<script setup lang="ts">
-import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/vue'
-import { computed, ref, toRefs } from 'vue'
+<script setup lang="ts" generic="T extends string | number">
+import { useMounted } from '@vueuse/core'
+import {
+  Label,
+  SelectContent,
+  SelectIcon,
+  SelectItem,
+  SelectItemIndicator,
+  SelectItemText,
+  SelectPortal,
+  SelectRoot,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+} from 'reka-ui'
+import { computed, onBeforeMount, ref, useId } from 'vue'
 import WordHighligher from 'vue-word-highlighter'
 
-import TAnimation from '@/components/common/Animation/TAnimation.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 
-const props = withDefaults(
-  defineProps<{
-    title?: string
-    defaultValue?: string | number
-    values: (string | number)[]
-    searcheable?: boolean
-    menuAlign?: 'left' | 'right'
-    hideSelectedSmallScreens?: boolean
-  }>(),
-  {
-    menuAlign: 'left',
-  },
-)
+const {
+  title = '',
+  defaultValue = undefined,
+  values,
+  searcheable,
+} = defineProps<{
+  title?: string
+  defaultValue?: T
+  values: T[]
+  searcheable?: boolean
+  hideSelectedSmallScreens?: boolean
+  overheadTitle?: boolean
+}>()
 
-const emit = defineEmits(['checkedValue'])
+const emit = defineEmits<{
+  checkedValue: [T]
+}>()
 
-const { values } = toRefs(props)
+const isMounted = useMounted()
 const searchTerm = ref('')
-const selectedItem = ref(props.defaultValue)
+const selectedItem = defineModel<T>({
+  set(v) {
+    if (isMounted.value && v !== selectedItem.value) emit('checkedValue', v)
+
+    return v
+  },
+})
 const focusSearch = ref(false)
+const triggerId = useId()
 
 defineExpose({
-  selectItem: (value: string) => {
+  selectItem: (value: T) => {
     selectedItem.value = value
-    emit('checkedValue', value)
   },
+})
+
+// Passing this as a default option to defineModel doesn't work due to the macro's limitations
+onBeforeMount(() => {
+  if (
+    typeof defaultValue !== 'undefined' &&
+    typeof selectedItem.value === 'undefined' &&
+    selectedItem.value !== defaultValue
+  ) {
+    selectedItem.value = defaultValue
+  }
 })
 
 const filteredValues = computed(() => {
   if (!searchTerm.value) {
-    return values.value
+    return values
   }
 
   const term = searchTerm.value.toLowerCase()
 
-  return values.value.filter((item) => item.toString().toLowerCase().indexOf(term) !== -1)
+  return values.filter((item) => item.toString().toLowerCase().includes(term))
 })
+
+// Focus is handled by reka-ui, using timeout to skip their focusing logic in this case
+const onOpen = async (open: boolean) => {
+  if (!searcheable) return
+
+  setTimeout(() => (focusSearch.value = open))
+}
 </script>
 
 <template>
-  <div class="menu">
-    <Listbox v-model="selectedItem">
-      <ListboxButton class="menu-button flex items-center gap-1">
-        <div class="flex overflow-hidden">
-          <div v-if="title" class="menu-title">{{ title }}:</div>
-          <div class="flex-1 truncate" :class="{ 'max-md:hidden': hideSelectedSmallScreens }">
+  <component :is="title && overheadTitle ? Label : 'div'" class="inline-block">
+    <span
+      v-if="title && overheadTitle"
+      class="mb-4 inline-block text-sm font-medium text-naturals-n14"
+    >
+      {{ title }}
+    </span>
+
+    <SelectRoot v-model="selectedItem" @update:open="onOpen">
+      <SelectTrigger
+        :id="triggerId"
+        class="flex size-full items-center justify-between gap-1 rounded border border-naturals-n7 bg-naturals-n2 px-3 py-2.25 text-xs text-naturals-n14"
+      >
+        <SelectValue class="flex gap-1 truncate select-none">
+          <Label
+            v-if="title && !overheadTitle"
+            :for="triggerId"
+            aria-hidden="true"
+            :class="hideSelectedSmallScreens ? `md:after:content-[':']` : `after:content-[':']`"
+          >
+            {{ title }}
+          </Label>
+          <span :class="{ 'max-md:hidden': hideSelectedSmallScreens }">
             {{ selectedItem }}
-          </div>
-        </div>
-        <TIcon class="menu-arrow" icon="arrow-down" />
-      </ListboxButton>
-      <TAnimation @after-enter="focusSearch = true" @after-leave="focusSearch = false">
-        <ListboxOptions class="menu-items" :class="`${menuAlign}-0`">
+          </span>
+        </SelectValue>
+        <SelectIcon>
+          <TIcon class="size-4 fill-current transition-all duration-300" icon="arrow-down" />
+        </SelectIcon>
+      </SelectTrigger>
+
+      <SelectPortal>
+        <SelectContent
+          class="relative z-50 max-h-[min(--spacing(70),var(--reka-select-content-available-height))] min-w-(--reka-select-trigger-width) translate-y-1 space-y-1 overflow-hidden rounded border border-naturals-n4 bg-naturals-n3 p-1.5 text-xs slide-in-from-top-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          position="popper"
+          side="bottom"
+        >
           <TInput
             v-if="searcheable"
             v-model="searchTerm"
             :focus="focusSearch"
             icon="search"
-            title=""
-            class="search-box"
+            aria-label="search"
             placeholder="Search"
             @keydown.stop="() => {}"
           />
-          <div v-if="filteredValues.length > 0" class="menu-items-wrapper">
-            <div
-              v-for="(item, idx) in filteredValues"
-              :key="idx"
-              @click="$emit('checkedValue', item)"
+
+          <SelectScrollUpButton>
+            <TIcon icon="arrow-up" class="mx-auto size-4" />
+          </SelectScrollUpButton>
+
+          <SelectViewport>
+            <SelectItem
+              v-for="item in filteredValues"
+              :key="item"
+              class="flex cursor-pointer items-center justify-between gap-2 px-3 py-1.5 text-naturals-n9 outline-none hover:text-naturals-n13 focus:text-naturals-n13 data-[state=checked]:text-naturals-n13"
+              :value="item"
             >
-              <ListboxOption v-slot="{ active, selected }" class="menu-item" :value="item">
-                <div class="menu-item-wrapper">
-                  <span class="menu-item-text" :class="{ active: active }">
-                    <WordHighligher
-                      :query="searchTerm"
-                      :text-to-highlight="item.toString()"
-                      highlight-class="text-naturals-n14 font-medium bg-transparent truncate"
-                    />
-                  </span>
-                  <TIcon v-show="selected" icon="check" class="menu-check-icon" />
-                </div>
-              </ListboxOption>
-            </div>
-          </div>
-        </ListboxOptions>
-      </TAnimation>
-    </Listbox>
-  </div>
+              <SelectItemText class="truncate transition-all">
+                <WordHighligher
+                  :query="searchTerm"
+                  :text-to-highlight="item.toString()"
+                  highlight-class="text-naturals-n14 font-medium bg-transparent truncate"
+                />
+              </SelectItemText>
+
+              <SelectItemIndicator>
+                <TIcon icon="check" class="size-3" />
+              </SelectItemIndicator>
+            </SelectItem>
+          </SelectViewport>
+
+          <SelectScrollDownButton>
+            <TIcon icon="arrow-down" class="mx-auto size-4" />
+          </SelectScrollDownButton>
+        </SelectContent>
+      </SelectPortal>
+    </SelectRoot>
+  </component>
 </template>
-
-<style scoped>
-@reference "../../../index.css";
-
-.menu {
-  @apply relative;
-}
-
-.menu-button {
-  @apply flex h-full w-full items-center justify-between rounded border border-naturals-n7 bg-naturals-n2 text-xs text-naturals-n14;
-  padding: 9px 12px;
-}
-
-.menu-title {
-  @apply mr-1 truncate text-xs whitespace-nowrap;
-}
-
-.menu-arrow {
-  @apply fill-current transition-all duration-300;
-  width: 16px;
-  height: 16px;
-}
-
-.menu-items {
-  @apply absolute top-10 z-10 flex min-w-full flex-col gap-1 rounded border border-naturals-n4 bg-naturals-n3 p-1.5;
-  max-height: 280px;
-}
-
-.search-box {
-  @apply h-8 text-xs text-naturals-n9;
-}
-
-.menu-item {
-  @apply cursor-pointer text-xs text-naturals-n9;
-  padding: 6px 12px;
-}
-
-.menu-item-wrapper {
-  @apply flex items-center justify-between;
-}
-
-.menu-item-text {
-  @apply truncate transition-all;
-  margin-right: 8px;
-}
-
-.active {
-  @apply text-naturals-n13;
-}
-
-.menu-items-wrapper {
-  @apply flex flex-col overflow-auto py-2;
-}
-
-.menu-check-icon {
-  @apply h-3 w-3 fill-current text-naturals-n14;
-}
-</style>

--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -8,7 +8,7 @@ included in the LICENSE file.
 import yaml from 'js-yaml'
 import * as semver from 'semver'
 import type { Ref } from 'vue'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -88,7 +88,7 @@ const supportsEncryption = computed(() => {
 
 const router = useRouter()
 
-const kubernetesVersionSelector: Ref<{ selectItem: (s: string) => void } | undefined> = ref()
+const kubernetesVersionSelector = useTemplateRef('kubernetesVersionSelector')
 
 const talosVersionsList: Ref<Resource<TalosVersionSpec>[]> = ref([])
 const talosVersionsWatch = new WatchResource(talosVersionsList)

--- a/frontend/src/views/omni/MachineClasses/MachineTemplate.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineTemplate.vue
@@ -34,6 +34,7 @@ const props = defineProps<{
 
 const defaultTunnelMode = (() => {
   switch (props.grpcTunnel) {
+    default:
     case GrpcTunnelMode.UNSET:
       return GRPCTunnelMode.Default
     case GrpcTunnelMode.DISABLED:
@@ -41,8 +42,6 @@ const defaultTunnelMode = (() => {
     case GrpcTunnelMode.ENABLED:
       return GRPCTunnelMode.Enabled
   }
-
-  return GrpcTunnelMode.UNSET
 })()
 
 const emit = defineEmits([
@@ -114,7 +113,6 @@ const updateGRPCTunnelMode = (value: GRPCTunnelMode) => {
       <div>
         <span>Use gRPC Tunnel</span>
         <TSelectList
-          menu-align="right"
           class="h-6"
           :values="[GRPCTunnelMode.Default, GRPCTunnelMode.Enabled, GRPCTunnelMode.Disabled]"
           :default-value="defaultTunnelMode"


### PR DESCRIPTION
Refactor `TSelectList` from `@headlessui` to `reka-ui` which is more testable out of the box and has collision detection. Also added tests, stories, and the `overheadTitle` variant for the installation media page.