### PR TITLE
feat: centralize Schematic ID computation

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -5752,9 +5752,11 @@ func (x *TalosExtensionsSpec) GetItems() []*TalosExtensionsSpec_Info {
 
 // SchematicConfigurationSpec is the desired Image Factory schematic for a machine, machine set or a cluster.
 type SchematicConfigurationSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SchematicId   string                 `protobuf:"bytes,1,opt,name=schematic_id,json=schematicId,proto3" json:"schematic_id,omitempty"`
-	TalosVersion  string                 `protobuf:"bytes,2,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	SchematicId  string                 `protobuf:"bytes,1,opt,name=schematic_id,json=schematicId,proto3" json:"schematic_id,omitempty"`
+	TalosVersion string                 `protobuf:"bytes,2,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
+	// KernelArgs are the kernel args which were used to compute the SchematicId.
+	KernelArgs    []string `protobuf:"bytes,3,rep,name=kernel_args,json=kernelArgs,proto3" json:"kernel_args,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5801,6 +5803,13 @@ func (x *SchematicConfigurationSpec) GetTalosVersion() string {
 		return x.TalosVersion
 	}
 	return ""
+}
+
+func (x *SchematicConfigurationSpec) GetKernelArgs() []string {
+	if x != nil {
+		return x.KernelArgs
+	}
+	return nil
 }
 
 // ExtensionsConfigurationSpec is the desired list of extensions to be installed on the machine or the set of machines.
@@ -9954,10 +9963,12 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12\x10\n" +
 	"\x03ref\x18\x05 \x01(\tR\x03ref\x12\x16\n" +
-	"\x06digest\x18\x06 \x01(\tR\x06digest\"d\n" +
+	"\x06digest\x18\x06 \x01(\tR\x06digest\"\x85\x01\n" +
 	"\x1aSchematicConfigurationSpec\x12!\n" +
 	"\fschematic_id\x18\x01 \x01(\tR\vschematicId\x12#\n" +
-	"\rtalos_version\x18\x02 \x01(\tR\ftalosVersion\"=\n" +
+	"\rtalos_version\x18\x02 \x01(\tR\ftalosVersion\x12\x1f\n" +
+	"\vkernel_args\x18\x03 \x03(\tR\n" +
+	"kernelArgs\"=\n" +
 	"\x1bExtensionsConfigurationSpec\x12\x1e\n" +
 	"\n" +
 	"extensions\x18\x01 \x03(\tR\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1200,6 +1200,9 @@ message TalosExtensionsSpec {
 message SchematicConfigurationSpec {
   string schematic_id = 1;
   string talos_version = 2;
+
+  // KernelArgs are the kernel args which were used to compute the SchematicId.
+  repeated string kernel_args = 3;
 }
 
 // ExtensionsConfigurationSpec is the desired list of extensions to be installed on the machine or the set of machines.

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -2137,6 +2137,11 @@ func (m *SchematicConfigurationSpec) CloneVT() *SchematicConfigurationSpec {
 	r := new(SchematicConfigurationSpec)
 	r.SchematicId = m.SchematicId
 	r.TalosVersion = m.TalosVersion
+	if rhs := m.KernelArgs; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.KernelArgs = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -5715,6 +5720,15 @@ func (this *SchematicConfigurationSpec) EqualVT(that *SchematicConfigurationSpec
 	}
 	if this.TalosVersion != that.TalosVersion {
 		return false
+	}
+	if len(this.KernelArgs) != len(that.KernelArgs) {
+		return false
+	}
+	for i, vx := range this.KernelArgs {
+		vy := that.KernelArgs[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -12423,6 +12437,15 @@ func (m *SchematicConfigurationSpec) MarshalToSizedBufferVT(dAtA []byte) (int, e
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.KernelArgs) > 0 {
+		for iNdEx := len(m.KernelArgs) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.KernelArgs[iNdEx])
+			copy(dAtA[i:], m.KernelArgs[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.KernelArgs[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
 	if len(m.TalosVersion) > 0 {
 		i -= len(m.TalosVersion)
 		copy(dAtA[i:], m.TalosVersion)
@@ -16304,6 +16327,12 @@ func (m *SchematicConfigurationSpec) SizeVT() (n int) {
 	l = len(m.TalosVersion)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.KernelArgs) > 0 {
+		for _, s := range m.KernelArgs {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -31587,6 +31616,38 @@ func (m *SchematicConfigurationSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.TalosVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KernelArgs", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.KernelArgs = append(m.KernelArgs, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/client/pkg/omni/resources/omni/cluster.go
+++ b/client/pkg/omni/resources/omni/cluster.go
@@ -50,7 +50,16 @@ func (ClusterExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 		Type:             ClusterType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: resources.DefaultNamespace,
-		PrintColumns:     []meta.PrintColumn{},
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Talos Version",
+				JSONPath: "{.talosversion}",
+			},
+			{
+				Name:     "Kubernetes Version",
+				JSONPath: "{.kubernetesversion}",
+			},
+		},
 	}
 }
 

--- a/client/pkg/omni/resources/omni/schematic_configuration.go
+++ b/client/pkg/omni/resources/omni/schematic_configuration.go
@@ -43,6 +43,15 @@ func (SchematicConfigurationExtension) ResourceDefinition() meta.ResourceDefinit
 		Type:             SchematicConfigurationType,
 		Aliases:          []resource.Type{},
 		DefaultNamespace: resources.DefaultNamespace,
-		PrintColumns:     []meta.PrintColumn{},
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Schematic ID",
+				JSONPath: "{.schematicid}",
+			},
+			{
+				Name:     "Talos Version",
+				JSONPath: "{.talosversion}",
+			},
+		},
 	}
 }

--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -367,7 +367,7 @@ func defineServiceFlags() {
 		&cmdConfig.Services.DevServerProxy.BindEndpoint,
 		"frontend-bind",
 		cmdConfig.Services.DevServerProxy.BindEndpoint,
-		"proxy server which will redirect all non API requests to the definied frontend server.")
+		"proxy server which will redirect all non API requests to the defined frontend server.")
 }
 
 func defineAuthFlags() {
@@ -558,6 +558,12 @@ func defineStorageFlags() {
 		"etcd-embedded-unsafe-fsync",
 		cmdConfig.Storage.Default.Etcd.EmbeddedUnsafeFsync,
 		"disable fsync in the embedded etcd server (dangerous).",
+	)
+	rootCmd.Flags().StringVar(
+		&cmdConfig.Storage.Default.Etcd.EmbeddedDBPath,
+		"etcd-embedded-db-path",
+		cmdConfig.Storage.Default.Etcd.EmbeddedDBPath,
+		"path to the embedded etcd database.",
 	)
 
 	ensure.NoError(rootCmd.Flags().MarkHidden("etcd-embedded-unsafe-fsync"))

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -796,6 +796,7 @@ export type TalosExtensionsSpec = {
 export type SchematicConfigurationSpec = {
   schematic_id?: string
   talos_version?: string
+  kernel_args?: string[]
 }
 
 export type ExtensionsConfigurationSpec = {

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/clients.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/clients.go
@@ -11,11 +11,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/siderolabs/image-factory/pkg/schematic"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 
-	"github.com/siderolabs/omni/internal/backend/imagefactory"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 )
 
@@ -27,12 +25,6 @@ type TalosClientFactory interface {
 type TalosClient interface {
 	io.Closer
 	UpgradeWithOptions(ctx context.Context, opts ...client.UpgradeOption) (*machineapi.UpgradeResponse, error)
-}
-
-// ImageFactoryClient ensures that the given schematic exists in the image factory.
-type ImageFactoryClient interface {
-	EnsureSchematic(ctx context.Context, inputSchematic schematic.Schematic) (imagefactory.EnsuredSchematic, error)
-	Host() string
 }
 
 type talosCliFactory struct{}

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -248,6 +248,14 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: moveInfraProviderAnnotationsToLabels,
 				name:     "moveInfraProviderAnnotationsToLabels",
 			},
+			{
+				callback: dropSchematicConfigFinalizerFromClusterMachines,
+				name:     "dropSchematicConfigFinalizerFromClusterMachines",
+			},
+			{
+				callback: dropTalosUpgradeStatusFinalizersFromSchematicConfigs,
+				name:     "dropTalosUpgradeStatusFinalizersFromSchematicConfigs",
+			},
 		},
 	}
 }

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -248,7 +248,7 @@ func NewRuntime(talosClientFactory *talos.ClientFactory, dnsService *dns.Service
 		omnictrl.NewConnectionParamsController(),
 		omnictrl.NewJoinTokenStatusController(),
 		omnictrl.NewNodeUniqueTokenCleanupController(time.Minute),
-		machineupgrade.NewStatusController(imageFactoryClient, nil),
+		machineupgrade.NewStatusController(imageFactoryHost, nil),
 		kernelargsctrl.NewStatusController(),
 	}
 


### PR DESCRIPTION
We compute the schematic id for a machine in two different places: in the `SchematicConfigurationController` for allocated machines, and in `MachineUpgradeStatusController` for maintenance mode machines.

Centralize this computation to be done only in `SchematicConfigurationController`.

Change the lifecycle of the `SchematicConfiguration` resource to be bound to a machine, not to a cluster.