### PR TITLE
refactor(frontend): create a docs link generator

### DIFF
--- a/frontend/src/components/THeader/THeader.vue
+++ b/frontend/src/components/THeader/THeader.vue
@@ -8,6 +8,7 @@ included in the LICENSE file.
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import OngoingTasks from '@/components/common/OngoingTasks/OngoingTasks.vue'
+import { useDocsLink } from '@/methods'
 
 interface Props {
   sidebarOpen?: boolean
@@ -15,6 +16,8 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+
+const docsLink = useDocsLink('omni')
 </script>
 
 <template>
@@ -53,7 +56,7 @@ const props = defineProps<Props>()
 
     <div class="flex items-center gap-2 text-naturals-n11">
       <a
-        href="https://omni.siderolabs.com/"
+        :href="docsLink"
         target="_blank"
         rel="noopener noreferrer"
         class="flex gap-1 transition-colors hover:text-naturals-n14"

--- a/frontend/src/methods/index.spec.ts
+++ b/frontend/src/methods/index.spec.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { expect } from '@playwright/test'
+import { parse } from 'semver'
+import { test } from 'vitest'
+import { nextTick, ref } from 'vue'
+
+import { DefaultTalosVersion } from '@/api/resources'
+
+import { useDocsLink } from '.'
+
+const { major, minor } = parse(DefaultTalosVersion, false, true)
+const defaultVersion = `${major}.${minor}`
+
+test.each`
+  type       | path            | options                               | expected
+  ${'talos'} | ${undefined}    | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}`}
+  ${'talos'} | ${'/hello/123'} | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
+  ${'talos'} | ${'hello/123'}  | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
+  ${'talos'} | ${'/hello'}     | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello`}
+  ${'talos'} | ${'123'}        | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/123`}
+  ${'talos'} | ${'/hello/123'} | ${{}}                                 | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
+  ${'talos'} | ${'hello/123'}  | ${{}}                                 | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
+  ${'talos'} | ${'/hello'}     | ${{}}                                 | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello`}
+  ${'talos'} | ${'123'}        | ${{}}                                 | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/123`}
+  ${'talos'} | ${'/hello/123'} | ${{ talosVersion: '1.11.3' }}         | ${'https://docs.siderolabs.com/talos/v1.11/hello/123'}
+  ${'talos'} | ${'hello/123'}  | ${{ talosVersion: '1.10.0' }}         | ${'https://docs.siderolabs.com/talos/v1.10/hello/123'}
+  ${'talos'} | ${'/hello'}     | ${{ talosVersion: '1.9' }}            | ${'https://docs.siderolabs.com/talos/v1.9/hello'}
+  ${'talos'} | ${'123'}        | ${{ talosVersion: '1' }}              | ${'https://docs.siderolabs.com/talos/v1.0/123'}
+  ${'talos'} | ${'/hello/123'} | ${ref({ talosVersion: '1.11.3' })}    | ${'https://docs.siderolabs.com/talos/v1.11/hello/123'}
+  ${'talos'} | ${'hello/123'}  | ${ref({ talosVersion: '1.10.0' })}    | ${'https://docs.siderolabs.com/talos/v1.10/hello/123'}
+  ${'talos'} | ${'/hello'}     | ${ref({ talosVersion: '1.9' })}       | ${'https://docs.siderolabs.com/talos/v1.9/hello'}
+  ${'talos'} | ${'123'}        | ${ref({ talosVersion: '1' })}         | ${'https://docs.siderolabs.com/talos/v1.0/123'}
+  ${'talos'} | ${'/hello/123'} | ${() => ({ talosVersion: '1.11.3' })} | ${'https://docs.siderolabs.com/talos/v1.11/hello/123'}
+  ${'talos'} | ${'hello/123'}  | ${() => ({ talosVersion: '1.10.0' })} | ${'https://docs.siderolabs.com/talos/v1.10/hello/123'}
+  ${'talos'} | ${'/hello'}     | ${() => ({ talosVersion: '1.9' })}    | ${'https://docs.siderolabs.com/talos/v1.9/hello'}
+  ${'talos'} | ${'123'}        | ${() => ({ talosVersion: '1' })}      | ${'https://docs.siderolabs.com/talos/v1.0/123'}
+  ${'omni'}  | ${undefined}    | ${undefined}                          | ${'https://docs.siderolabs.com/omni'}
+  ${'omni'}  | ${'/hello/123'} | ${undefined}                          | ${'https://docs.siderolabs.com/omni/hello/123'}
+  ${'omni'}  | ${'hello/123'}  | ${undefined}                          | ${'https://docs.siderolabs.com/omni/hello/123'}
+  ${'omni'}  | ${'/hello'}     | ${undefined}                          | ${'https://docs.siderolabs.com/omni/hello'}
+  ${'omni'}  | ${'123'}        | ${undefined}                          | ${'https://docs.siderolabs.com/omni/123'}
+  ${'k8s'}   | ${undefined}    | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides'}
+  ${'k8s'}   | ${'/hello/123'} | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides/hello/123'}
+  ${'k8s'}   | ${'hello/123'}  | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides/hello/123'}
+  ${'k8s'}   | ${'/hello'}     | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides/hello'}
+  ${'k8s'}   | ${'123'}        | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides/123'}
+`(
+  'useDocsLink: $type - $path - $options returns $expected',
+  ({ type, path, options, expected }) => {
+    expect(useDocsLink(type, path, options).value).toBe(expected)
+  },
+)
+
+test('useDocsLink supports reactive options', async () => {
+  const talosVersion = ref('1.10')
+  const linkRef = useDocsLink('talos', '/path', () => ({
+    talosVersion: talosVersion.value,
+  }))
+
+  expect(linkRef.value).toBe('https://docs.siderolabs.com/talos/v1.10/path')
+
+  talosVersion.value = '1.11'
+  await nextTick()
+
+  expect(linkRef.value).toBe('https://docs.siderolabs.com/talos/v1.11/path')
+})

--- a/frontend/src/views/cluster/Backups/BackupsList.vue
+++ b/frontend/src/views/cluster/Backups/BackupsList.vue
@@ -26,7 +26,7 @@ import TList from '@/components/common/List/TList.vue'
 import TListItem from '@/components/common/List/TListItem.vue'
 import Watch from '@/components/common/Watch/Watch.vue'
 import TAlert from '@/components/TAlert.vue'
-import { formatBytes } from '@/methods'
+import { formatBytes, useDocsLink } from '@/methods'
 import { canManageBackupStore } from '@/methods/auth'
 import { formatISO } from '@/methods/time'
 
@@ -72,11 +72,8 @@ const watchOpts = computed(() => {
   }
 })
 
-const openDocs = () => {
-  window
-    .open('https://omni.siderolabs.com/how-to-guides/etcd-backups#s3-configuration', '_blank')
-    ?.focus()
-}
+const docsLink = useDocsLink('omni', '/how-to-guides/etcd-backups#s3-configuration')
+const openDocs = () => window.open(docsLink.value, '_blank')?.focus()
 </script>
 
 <template>

--- a/frontend/src/views/omni/Machines/Machines.vue
+++ b/frontend/src/views/omni/Machines/Machines.vue
@@ -34,6 +34,7 @@ import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
 import { useWatch } from '@/components/common/Watch/useWatch'
 import TAlert from '@/components/TAlert.vue'
+import { useDocsLink } from '@/methods'
 import type { Label } from '@/methods/labels'
 import { addLabel, selectors as labelsToSelectors } from '@/methods/labels'
 import { MachineFilterOption } from '@/methods/machine'
@@ -106,9 +107,8 @@ const sortOptions = [
 const filterLabels = ref<Label[]>([])
 const filterValue = ref('')
 
-const openDocs = () => {
-  window.open('https://omni.siderolabs.com/explanation/infrastructure-providers', '_blank')?.focus()
-}
+const docsLink = useDocsLink('omni', '/explanation/infrastructure-providers')
+const openDocs = () => window.open(docsLink.value, '_blank')?.focus()
 
 const { data: machineStatusMetrics } = useWatch<MachineStatusMetricsSpec>({
   resource: {

--- a/frontend/src/views/omni/Modals/UpdateKubernetes.vue
+++ b/frontend/src/views/omni/Modals/UpdateKubernetes.vue
@@ -22,7 +22,6 @@ import { withContext } from '@/api/options'
 import {
   ClusterType,
   DefaultNamespace,
-  DefaultTalosVersion,
   KubernetesUpgradeStatusType,
   KubernetesVersionType,
   TalosVersionType,
@@ -31,6 +30,7 @@ import TButton from '@/components/common/Button/TButton.vue'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import { useWatch } from '@/components/common/Watch/useWatch'
+import { useDocsLink } from '@/methods'
 import { upgradeKubernetes } from '@/methods/cluster'
 import ManagedByTemplatesWarning from '@/views/cluster/ManagedByTemplatesWarning.vue'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
@@ -139,15 +139,9 @@ function isVersionUpgradeable(version: string) {
   return supportedK8sVersions.value.includes(version)
 }
 
-const docsTalosVersion = computed(() => {
-  const { major, minor } = semver.parse(
-    cluster.value?.spec.talos_version || DefaultTalosVersion,
-    {},
-    true,
-  )
-
-  return `v${major}.${minor}`
-})
+const k8sSupportMatrixDocsLink = useDocsLink('talos', '/getting-started/support-matrix', () => ({
+  talosVersion: cluster.value?.spec.talos_version,
+}))
 
 const action = computed(() => {
   if (!status.value) {
@@ -267,14 +261,11 @@ const upgradeClick = async () => {
 
     <p class="text-xs">
       Downgrading minor versions is not supported. You can not skip minor version upgrades. You can
-      only upgrade to versions supported by your talos version. See the
-      <a
-        class="inline-block underline hover:mix-blend-lighten"
-        :href="`https://docs.siderolabs.com/talos/v${docsTalosVersion}/getting-started/support-matrix`"
-      >
+      only upgrade to versions supported by your Talos version. See the
+      <a class="inline-block underline hover:mix-blend-lighten" :href="k8sSupportMatrixDocsLink">
         support matrix
       </a>
-      for which versions are supported by your talos version.
+      for which versions are supported by your Talos version.
     </p>
 
     <p class="text-xs">


### PR DESCRIPTION
Create a docs link generator for omni/talos/k8s-guide docs.

For talos docs, it will default to the [DefaultTalosVersion](https://github.com/siderolabs/omni/blob/084e813a0e869cf9529c3c25443b628b92dbe977/frontend/src/api/resources.ts#L32) if you do not specifically specify a talos version.