### PR TITLE
fix: prevent stale reads of kernel args in schematic id calculation

### DIFF
--- a/internal/backend/kernelargs/kernelargs.go
+++ b/internal/backend/kernelargs/kernelargs.go
@@ -43,14 +43,14 @@ func NewInitializer(state state.State, logger *zap.Logger) (*Initializer, error)
 }
 
 func (initializer *Initializer) Init(ctx context.Context, id resource.ID, args []string) error {
-	if len(args) == 0 {
+	extraArgs := xslices.Filter(args, func(value string) bool { return !isProtected(value) })
+
+	if len(extraArgs) == 0 {
 		return nil
 	}
 
 	kernelArgs := omni.NewKernelArgs(id)
-	kernelArgs.TypedSpec().Value.Args = xslices.Filter(args, func(value string) bool {
-		return !isProtected(value)
-	})
+	kernelArgs.TypedSpec().Value.Args = extraArgs
 
 	if err := initializer.state.Create(ctx, kernelArgs); err != nil && !state.IsConflictError(err) {
 		return fmt.Errorf("error creating extra kernel args configuration: %w", err)


### PR DESCRIPTION
Fix the rare issue which was caught by our upgrade tests: `KernelArgs` resource status might not be up to date after we observed them to be initialized on the machine status resource. This caused an unwanted Talos upgrade in rare cases. We were also able to reproduce this with a unit test. Do an uncached read to circumvent that.

Additionally, do a small fix the initialization of the `KernelArgs` resource: do the "emptiness check" on the extra kernel args after we filter the system ones out, so we won't create unnecessary `KernelArgs` resources (this did not cause any changes in the logic, can be considered an optimization fix).