### PR TITLE
fix: update `MachineRequestStatus` resource when we populate UUID

### DIFF
--- a/client/pkg/infra/controllers/provision.go
+++ b/client/pkg/infra/controllers/provision.go
@@ -278,9 +278,15 @@ func (ctrl *ProvisionController[T]) reconcileRunning(ctx context.Context, r cont
 		}
 
 		if machines.Len() == 1 {
-			logger.Info("setting machine request UUID", zap.String("machine", machines.Get(0).Metadata().ID()))
+			if err = safe.WriterModify(ctx, r, machineRequestStatus, func(res *infra.MachineRequestStatus) error {
+				logger.Info("setting machine request UUID", zap.String("machine", machines.Get(0).Metadata().ID()))
 
-			machineRequestStatus.TypedSpec().Value.Id = machines.Get(0).Metadata().ID()
+				res.TypedSpec().Value.Id = machines.Get(0).Metadata().ID()
+
+				return nil
+			}); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously the whole reconcile func was wrapped in the `WriterModify` which is no longer true, so we need explicit `WriterModify` calls in all the places inside the reconsile method.