### PR TITLE
feat(helm): add oidc auth flags support in omni chart

### DIFF
--- a/deploy/helm/omni/templates/deployment.yaml
+++ b/deploy/helm/omni/templates/deployment.yaml
@@ -91,6 +91,15 @@ spec:
           - --auth-saml-url={{ .Values.auth.saml.url }}
         {{- end }}
         {{- end }}
+        {{- if .Values.auth.oidc.enabled }}
+          - --auth-oidc-enabled=true
+          - --auth-oidc-provider-url={{ .Values.auth.oidc.providerURL }}
+          - --auth-oidc-client-id={{ .Values.auth.oidc.clientId | toString }}
+          - --auth-oidc-client-secret={{ .Values.auth.oidc.clientSecret | toString }}
+          {{- range $s := .Values.auth.oidc.scopes }}
+          - --auth-oidc-scopes={{ $s }}
+          {{- end }}
+        {{- end }}
         {{- if .Values.volumes.tls.secretName }}
           - --cert=/etc/omni/tls/tls.crt
           - --key=/etc/omni/tls/tls.key

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -16,6 +16,15 @@ auth:
   saml:
     enabled: false
     url: "https://www.saml.example"
+  oidc:
+    enabled: false
+    providerURL: ""
+    clientId: ""
+    clientSecret: ""
+    scopes:
+      - openid
+      - email
+      - profile
 includeGenericDevicePlugin: true #
 initialUsers: []
 name: "My Omni instance"


### PR DESCRIPTION
Hi,

I saw OIDC support was recently implemented for 1.2.0 via b70560c1661387c5c34224140789f4e6df2304f9

I am able to use it via extraArgs but thought it would be nice to have it exposed in the Helm chart values like auth0 and saml