### PR TITLE
test: fix install extra kernel args in infra test

### DIFF
--- a/internal/integration/infra_test.go
+++ b/internal/integration/infra_test.go
@@ -163,7 +163,7 @@ func machineDeprovisionHook(t *testing.T, client *client.Client, machineRequestS
 func infraMachinesAcceptHook(t *testing.T, omniState state.State, infraProviderID string, expectedCount int, disableKexec bool) {
 	const disableKexecConfigPatch = `machine:
   install:
-    kernelArgs:
+    extraKernelArgs:
       - kexec_load_disabled=1
   sysctls:
     kernel.kexec_load_disabled: "1"`


### PR DESCRIPTION
The yaml key in the config patch was renamed accidentally while working on the extra kernel args feature, causing the infra provider tests to fail.