### PR TITLE
fix: remove KernelArgs resource when a machine is removed

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_cleanup.go
@@ -26,6 +26,7 @@ func NewMachineCleanupController() *MachineCleanupController {
 				&helpers.SameIDHandler[*omni.Machine, *omni.MachineSetNode]{},
 				&helpers.SameIDHandler[*omni.Machine, *omni.InfraMachineConfig]{},
 				&helpers.SameIDHandler[*omni.Machine, *omni.InfraMachineBMCConfig]{},
+				&helpers.SameIDHandler[*omni.Machine, *omni.KernelArgs]{},
 			),
 		},
 	)

--- a/internal/backend/runtime/omni/controllers/omni/machine_request_set_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_request_set_status_test.go
@@ -261,6 +261,10 @@ func (suite *MachineRequestSetStatusSuite) reconcileLabels(ctx context.Context) 
 				res := system.NewResourceLabels[*omni.MachineStatus](status.TypedSpec().Value.Id)
 
 				err = safe.StateModify(ctx, suite.state, res, func(r *system.ResourceLabels[*omni.MachineStatus]) error {
+					if r.Metadata().Phase() == resource.PhaseTearingDown {
+						return nil
+					}
+
 					res.Metadata().Labels().Set(omni.LabelMachineRequest, status.Metadata().ID())
 
 					helpers.CopyAllLabels(status, r)


### PR DESCRIPTION
Clean it up, so we do not end up with stale KernelArgs resources.