### PR TITLE
fix(frontend): only show label outline if selected

### DIFF
--- a/frontend/src/views/omni/ItemLabels/LabelsInput.vue
+++ b/frontend/src/views/omni/ItemLabels/LabelsInput.vue
@@ -238,7 +238,8 @@ watch(filterValue, async (val: string, old: string) => {
         <div
           v-for="(label, index) in filterLabels"
           :key="label.key"
-          class="-mx-1 -my-2 rounded-md border border-white p-0.5 transition-all"
+          class="-mx-1 -my-2 rounded-md border p-0.5 transition-all"
+          :class="selectedLabel === index ? 'border-white' : 'border-transparent'"
         >
           <ItemLabel
             :label="{


### PR DESCRIPTION
Only show an outline around labels in frontend when they are marked as selected.

This broke during the [tailwind v4 upgrade](https://github.com/siderolabs/omni/pull/1419), as it relied on `bg-opacity` which was removed from tailwind and got migrated incorrectly here.