### PR TITLE
fix: do not skip creating schematic config in agent mode

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -522,7 +522,7 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 			// if the schematic is invalid or the machine is in agent mode, we reset the initial schematic information
 			if spec.Schematic.Invalid || spec.Schematic.InAgentMode {
 				spec.Schematic.InitialSchematic = ""
-				spec.Schematic.InitialState = nil
+				spec.Schematic.InitialState = &specs.MachineStatusSpec_Schematic_InitialState{} // reset to be empty but leave it initialized
 			}
 
 			_, kernelArgsInitialized := m.Metadata().Annotations().Get(omni.KernelArgsInitialized)

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
@@ -402,7 +402,8 @@ func (suite *MachineStatusSuite) TestMachineSchematic() {
 				},
 			},
 			expected: &specs.MachineStatusSpec_Schematic{
-				Invalid: true,
+				Invalid:      true,
+				InitialState: &specs.MachineStatusSpec_Schematic_InitialState{},
 			},
 		},
 		{
@@ -443,6 +444,7 @@ func (suite *MachineStatusSuite) TestMachineSchematic() {
 				InitialSchematic: "",
 				FullId:           defaultSchematic,
 				InAgentMode:      true,
+				InitialState:     &specs.MachineStatusSpec_Schematic_InitialState{},
 			},
 		},
 	} {

--- a/internal/backend/runtime/omni/controllers/omni/schematic_configuration.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic_configuration.go
@@ -303,7 +303,8 @@ func newMachineCustomization(cluster *omni.Cluster, machineStatus *omni.MachineS
 
 	slices.Sort(mc.extensionsList)
 
-	if !extensionsExplicitlyDefined && len(mc.extensionsList) == 0 { // extensions are not explicitly set, we should revert them to their initial state
+	revertToInitialState := !extensionsExplicitlyDefined && len(mc.extensionsList) == 0 && !machineStatus.TypedSpec().Value.Schematic.GetInAgentMode()
+	if revertToInitialState { // extensions are not explicitly set, we should revert them to their initial state
 		initialState := machineStatus.TypedSpec().Value.Schematic.GetInitialState()
 		if initialState == nil {
 			return mc, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine initial schematic state is not yet set")


### PR DESCRIPTION
A recent change caused a regression in the bare metal provider, causing it to not attempt to power on the machines when they were allocated to a cluster.

The issue was caused by the following change, which resets the initial schematic state when the machine is detected to be in agent mode: https://github.com/siderolabs/omni/commit/15deddde56c560c1501e59ca4d7aa68743c49980#diff-6c417154d54297ede498c23ea4bd82a26982766196dbbb8e60aee26322830bcdR525

This caused the `SchematicConfigurationController` to skip reconciliation for the bare metal machines in agent mode, causing the `SchematicConfiguration` resources to not be created. This caused the `TalosVersion` to not be propagated to the `InfraMachine` resources, which caused the bare metal provider to not detect them as allocated.

Fix this in two places:
- Never reset the initial state to be `nil` in `MachineStatusController`.
- Check for the agent mode in `SchematicConfigurationController` and do not skip reconciliation if the machine is in agent mode. (Normally, this would not be needed, as the above change would be enough, but we have a special case here: `MachineStatus` will never be updated for powered off machines, so we cannot rely on it to bring us to the correct the state).