### PR TITLE
fix: keep `ClusterMachineRequestStatus` while `MachineRequest` exists

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_request_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_request_status.go
@@ -129,7 +129,7 @@ func NewClusterMachineRequestStatusController() *ClusterMachineRequestStatusCont
 				return slices.Collect(list.Pointers()), nil
 			},
 		),
-		qtransform.WithIgnoreTeardownUntil(ClusterMachineEncryptionKeyControllerName), // destroy the ClusterMachineRequestStatus after the ClusterMachineEncryptionKey is destroyed
+		qtransform.WithIgnoreTeardownUntil(),
 		qtransform.WithConcurrency(2),
 	)
 }

--- a/internal/pkg/siderolink/siderolink_test.go
+++ b/internal/pkg/siderolink/siderolink_test.go
@@ -307,8 +307,14 @@ func (suite *SiderolinkSuite) TestNodeWithSeveralAdvertisedIPs() {
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{
 		siderolink.DefaultJoinTokenID,
 	}, func(r *siderolink.DefaultJoinToken, assertion *assert.Assertions) {
+		assertion.NotEmpty(r.TypedSpec().Value.TokenId)
+
 		spec = r.TypedSpec().Value
 	})
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{
+		spec.TokenId,
+	}, func(r *siderolink.JoinTokenStatus, assertion *assert.Assertions) {})
 
 	conn := must.Value(grpc.NewClient(suite.address, grpc.WithTransportCredentials(insecure.NewCredentials())))(suite.T())
 	client := pb.NewProvisionServiceClient(conn)


### PR DESCRIPTION
The previous `WithIgnoreTeardownUntil` was wrong, so the resource was removed before `MachineRequest` is destroyed.
That was leading to Omni UI showing incorrect state of the cluster with no machines in `Deprovisioning` state.