### PR TITLE
feat: support dynamically updating SAML label roles

### DIFF
--- a/client/api/omni/specs/auth.pb.go
+++ b/client/api/omni/specs/auth.pb.go
@@ -759,9 +759,15 @@ type SAMLLabelRuleSpec struct {
 	// MatchLabels is the list of labels to match the user's Identity against this rule.
 	MatchLabels []string `protobuf:"bytes,1,rep,name=match_labels,json=matchLabels,proto3" json:"match_labels,omitempty"`
 	// AssignRoleOnRegistration is the role to be assigned to the user if this rule matches.
+	//
+	// Deprecated: use AssignRole instead.
 	AssignRoleOnRegistration string `protobuf:"bytes,2,opt,name=assign_role_on_registration,json=assignRoleOnRegistration,proto3" json:"assign_role_on_registration,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	// AssignRole to the user matched by this rule.
+	AssignRole string `protobuf:"bytes,3,opt,name=assign_role,json=assignRole,proto3" json:"assign_role,omitempty"`
+	// UpdateOnEachLogin makes the rule to be applied every time user logs in.
+	UpdateOnEachLogin bool `protobuf:"varint,4,opt,name=update_on_each_login,json=updateOnEachLogin,proto3" json:"update_on_each_login,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SAMLLabelRuleSpec) Reset() {
@@ -806,6 +812,20 @@ func (x *SAMLLabelRuleSpec) GetAssignRoleOnRegistration() string {
 		return x.AssignRoleOnRegistration
 	}
 	return ""
+}
+
+func (x *SAMLLabelRuleSpec) GetAssignRole() string {
+	if x != nil {
+		return x.AssignRole
+	}
+	return ""
+}
+
+func (x *SAMLLabelRuleSpec) GetUpdateOnEachLogin() bool {
+	if x != nil {
+		return x.UpdateOnEachLogin
+	}
+	return false
 }
 
 type ServiceAccountStatusSpec struct {
@@ -1762,10 +1782,13 @@ const file_omni_specs_auth_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\v2\x1c.specs.AccessPolicyUserGroupR\x05value:\x028\x01\x1aa\n" +
 	"\x12ClusterGroupsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x125\n" +
-	"\x05value\x18\x02 \x01(\v2\x1f.specs.AccessPolicyClusterGroupR\x05value:\x028\x01\"u\n" +
+	"\x05value\x18\x02 \x01(\v2\x1f.specs.AccessPolicyClusterGroupR\x05value:\x028\x01\"\xc7\x01\n" +
 	"\x11SAMLLabelRuleSpec\x12!\n" +
 	"\fmatch_labels\x18\x01 \x03(\tR\vmatchLabels\x12=\n" +
-	"\x1bassign_role_on_registration\x18\x02 \x01(\tR\x18assignRoleOnRegistration\"\xf3\x01\n" +
+	"\x1bassign_role_on_registration\x18\x02 \x01(\tR\x18assignRoleOnRegistration\x12\x1f\n" +
+	"\vassign_role\x18\x03 \x01(\tR\n" +
+	"assignRole\x12/\n" +
+	"\x14update_on_each_login\x18\x04 \x01(\bR\x11updateOnEachLogin\"\xf3\x01\n" +
 	"\x18ServiceAccountStatusSpec\x12\x12\n" +
 	"\x04role\x18\x01 \x01(\tR\x04role\x12M\n" +
 	"\vpublic_keys\x18\x02 \x03(\v2,.specs.ServiceAccountStatusSpec.PgpPublicKeyR\n" +

--- a/client/api/omni/specs/auth.proto
+++ b/client/api/omni/specs/auth.proto
@@ -182,7 +182,15 @@ message SAMLLabelRuleSpec {
   repeated string match_labels = 1;
 
   // AssignRoleOnRegistration is the role to be assigned to the user if this rule matches.
+  //
+  // Deprecated: use AssignRole instead.
   string assign_role_on_registration = 2;
+
+  // AssignRole to the user matched by this rule.
+  string assign_role = 3;
+
+  // UpdateOnEachLogin makes the rule to be applied every time user logs in.
+  bool update_on_each_login = 4;
 }
 
 message ServiceAccountStatusSpec {

--- a/client/api/omni/specs/auth_vtproto.pb.go
+++ b/client/api/omni/specs/auth_vtproto.pb.go
@@ -570,6 +570,8 @@ func (m *SAMLLabelRuleSpec) CloneVT() *SAMLLabelRuleSpec {
 	}
 	r := new(SAMLLabelRuleSpec)
 	r.AssignRoleOnRegistration = m.AssignRoleOnRegistration
+	r.AssignRole = m.AssignRole
+	r.UpdateOnEachLogin = m.UpdateOnEachLogin
 	if rhs := m.MatchLabels; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -1386,6 +1388,12 @@ func (this *SAMLLabelRuleSpec) EqualVT(that *SAMLLabelRuleSpec) bool {
 		}
 	}
 	if this.AssignRoleOnRegistration != that.AssignRoleOnRegistration {
+		return false
+	}
+	if this.AssignRole != that.AssignRole {
+		return false
+	}
+	if this.UpdateOnEachLogin != that.UpdateOnEachLogin {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2895,6 +2903,23 @@ func (m *SAMLLabelRuleSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.UpdateOnEachLogin {
+		i--
+		if m.UpdateOnEachLogin {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
+	if len(m.AssignRole) > 0 {
+		i -= len(m.AssignRole)
+		copy(dAtA[i:], m.AssignRole)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.AssignRole)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.AssignRoleOnRegistration) > 0 {
 		i -= len(m.AssignRoleOnRegistration)
 		copy(dAtA[i:], m.AssignRoleOnRegistration)
@@ -3578,6 +3603,13 @@ func (m *SAMLLabelRuleSpec) SizeVT() (n int) {
 	l = len(m.AssignRoleOnRegistration)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.AssignRole)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.UpdateOnEachLogin {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -7412,6 +7444,58 @@ func (m *SAMLLabelRuleSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.AssignRoleOnRegistration = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AssignRole", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AssignRole = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UpdateOnEachLogin", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.UpdateOnEachLogin = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/frontend/src/api/omni/specs/auth.pb.ts
+++ b/frontend/src/api/omni/specs/auth.pb.ts
@@ -151,6 +151,8 @@ export type AccessPolicySpec = {
 export type SAMLLabelRuleSpec = {
   match_labels?: string[]
   assign_role_on_registration?: string
+  assign_role?: string
+  update_on_each_login?: boolean
 }
 
 export type ServiceAccountStatusSpecPgpPublicKey = {

--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -1068,7 +1068,11 @@ func samlLabelRuleValidationOptions() []validated.StateOption {
 	validate := func(res *authres.SAMLLabelRule) error {
 		var multiErr error
 
-		if _, err := role.Parse(res.TypedSpec().Value.GetAssignRoleOnRegistration()); err != nil {
+		if res.TypedSpec().Value.AssignRoleOnRegistration != "" { //nolint:staticcheck
+			return fmt.Errorf("assignroleonregistration is deprecated, please use assignrole instead")
+		}
+
+		if _, err := role.Parse(res.TypedSpec().Value.AssignRole); err != nil {
 			multiErr = multierror.Append(multiErr, err)
 		}
 

--- a/internal/backend/runtime/omni/state_validation_test.go
+++ b/internal/backend/runtime/omni/state_validation_test.go
@@ -1267,14 +1267,14 @@ func TestSAMLLabelRuleValidation(t *testing.T) {
 	st := validated.NewState(innerSt, omni.SAMLLabelRuleValidationOptions()...)
 
 	labelRule := auth.NewSAMLLabelRule(resources.DefaultNamespace, "test-label-rule")
-	labelRule.TypedSpec().Value.AssignRoleOnRegistration = "invalid"
+	labelRule.TypedSpec().Value.AssignRole = "invalid"
 	labelRule.TypedSpec().Value.MatchLabels = []string{"--invalid--- ===== 5"}
 
 	err := st.Create(ctx, labelRule)
 	assert.ErrorContains(t, err, "unknown role")
 	assert.ErrorContains(t, err, "invalid match labels")
 
-	labelRule.TypedSpec().Value.AssignRoleOnRegistration = string(role.Operator)
+	labelRule.TypedSpec().Value.AssignRole = string(role.Operator)
 
 	err = st.Create(ctx, labelRule)
 	assert.ErrorContains(t, err, "invalid match labels")

--- a/internal/pkg/auth/role/role.go
+++ b/internal/pkg/auth/role/role.go
@@ -95,6 +95,28 @@ func (r Role) Previous() (Role, error) {
 	return roles[index-1], nil
 }
 
+// Compare the roles.
+func (r Role) Compare(another Role) int {
+	r1Index, ok := indexes[r]
+	if !ok {
+		panic(fmt.Sprintf("unknown role %s", r))
+	}
+
+	r2Index, ok := indexes[another]
+	if !ok {
+		panic(fmt.Sprintf("unknown role %s", another))
+	}
+
+	switch {
+	case r1Index < r2Index:
+		return -1
+	case r1Index > r2Index:
+		return 1
+	}
+
+	return 0
+}
+
 // Min returns the least capable role from the given roles.
 func Min(first Role, role ...Role) (Role, error) {
 	result := first


### PR DESCRIPTION
Added new `update_on_each_login` field to the `SAMLLabelRule` spec. Also renamed `assign_role_on_registration` to `assign_role` as it's no longer reflecting the actual meaning.

The old field is kept there for the backward compatibility.

Fixes: https://github.com/siderolabs/omni/issues/1201