### PR TITLE
fix: reduce usage of cached state to avoid stale reads

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
@@ -171,6 +171,7 @@ func TestReconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.MachineUpgradeStatus, assertion *assert.Assertions) {
+			assertion.True(res.TypedSpec().Value.IsMaintenance)
 			assertion.Equal(specs.MachineUpgradeStatusSpec_Upgrading, res.TypedSpec().Value.Phase)
 			assertion.Equal("Talos upgrade initiated", res.TypedSpec().Value.Status)
 			assertion.Empty(res.TypedSpec().Value.Error)


### PR DESCRIPTION
Cached state usage should be very limited, as it has weaker consistency guarantees compared to the underlying state. Revert the usage of cached state in the validations and in various components, which we introduced a while ago.

The COSI resource server still uses the cached state.

Fix another cache-related stale read behavior in the `MachineUpgradeStatus` controller (same as 3e90bc6c94205d5b150766290558993d0ed208a6) and fix its test to not be flaky.