### PR TITLE
fix: move infra provider ID annotations to labels

### DIFF
--- a/client/pkg/siderolink/siderolink.go
+++ b/client/pkg/siderolink/siderolink.go
@@ -70,7 +70,7 @@ func WithMachine(machine *omni.Machine) JoinConfigOption {
 			opts.extraTokenData[omni.LabelMachineRequest] = machineRequest
 		}
 
-		if providerID, ok := machine.Metadata().Annotations().Get(omni.LabelInfraProviderID); ok {
+		if providerID, ok := machine.Metadata().Labels().Get(omni.LabelInfraProviderID); ok {
 			opts.extraTokenData[omni.LabelInfraProviderID] = providerID
 		}
 	}

--- a/client/pkg/siderolink/siderolink_test.go
+++ b/client/pkg/siderolink/siderolink_test.go
@@ -156,7 +156,7 @@ func TestConnectionParamsKernelArgs(t *testing.T) {
 				}
 
 				if tt.machine.providerID != "" {
-					m.Metadata().Annotations().Set(omni.LabelInfraProviderID, tt.machine.providerID)
+					m.Metadata().Labels().Set(omni.LabelInfraProviderID, tt.machine.providerID)
 				}
 
 				options = append(options, siderolink.WithMachine(m))
@@ -362,7 +362,7 @@ certificates: ""
 				}
 
 				if tt.machine.providerID != "" {
-					m.Metadata().Annotations().Set(omni.LabelInfraProviderID, tt.machine.providerID)
+					m.Metadata().Labels().Set(omni.LabelInfraProviderID, tt.machine.providerID)
 				}
 
 				options = append(options, siderolink.WithMachine(m))

--- a/internal/backend/runtime/omni/controllers/omni/bmc_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/bmc_config.go
@@ -44,7 +44,7 @@ func NewBMCConfigController() *BMCConfigController {
 					return err
 				}
 
-				providerID, ok := link.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+				providerID, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
 				if !ok {
 					return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("the link is not created by an infra provider")
 				}

--- a/internal/backend/runtime/omni/controllers/omni/infra_machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine.go
@@ -177,7 +177,7 @@ func (ctrl *InfraMachineController) reconcileRunning(ctx context.Context, r cont
 		return err
 	}
 
-	providerID, ok := link.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+	providerID, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
 	if !ok {
 		return nil // the link is not created by an infra provider
 	}

--- a/internal/backend/runtime/omni/controllers/omni/infra_machine_registration.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine_registration.go
@@ -30,7 +30,7 @@ func NewInfraMachineRegistrationController() *InfraMachineRegistrationController
 		qtransform.Settings[*siderolink.Link, *infra.MachineRegistration]{
 			Name: "InfraMachineRegistrationController",
 			MapMetadataOptionalFunc: func(link *siderolink.Link) optional.Optional[*infra.MachineRegistration] {
-				if _, ok := link.Metadata().Annotations().Get(omni.LabelInfraProviderID); !ok {
+				if _, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID); !ok {
 					return optional.None[*infra.MachineRegistration]()
 				}
 
@@ -40,7 +40,7 @@ func NewInfraMachineRegistrationController() *InfraMachineRegistrationController
 				return siderolink.NewLink(resources.DefaultNamespace, machine.Metadata().ID(), nil)
 			},
 			TransformFunc: func(_ context.Context, _ controller.Reader, _ *zap.Logger, link *siderolink.Link, machine *infra.MachineRegistration) error {
-				providerID, ok := link.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+				providerID, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
 				if !ok {
 					return xerrors.NewTaggedf[qtransform.DestroyOutputTag]("the link doesn't have the provider ID label")
 				}

--- a/internal/backend/runtime/omni/controllers/omni/infra_machine_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine_test.go
@@ -40,7 +40,7 @@ func (suite *InfraMachineControllerSuite) TestReconcile() {
 
 	link := siderolink.NewLink(resources.DefaultNamespace, "machine-1", &specs.SiderolinkSpec{})
 
-	link.Metadata().Annotations().Set(omni.LabelInfraProviderID, "bare-metal")
+	link.Metadata().Labels().Set(omni.LabelInfraProviderID, "bare-metal")
 	suite.Require().NoError(suite.state.Create(suite.ctx, link))
 
 	infraMachine := infra.NewMachine("machine-1")

--- a/internal/backend/runtime/omni/controllers/omni/machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine.go
@@ -91,9 +91,8 @@ func (h *machineControllerHelper) transform(ctx context.Context, r controller.Re
 		return err
 	}
 
-	helpers.CopyLabels(link, machine, omni.LabelMachineRequest, omni.LabelMachineRequestSet)
-
-	helpers.CopyAnnotations(link, machine, omni.LabelInfraProviderID, omni.CreatedWithUniqueToken)
+	helpers.CopyLabels(link, machine, omni.LabelMachineRequest, omni.LabelMachineRequestSet, omni.LabelInfraProviderID)
+	helpers.CopyAnnotations(link, machine, omni.CreatedWithUniqueToken)
 
 	spec := machine.TypedSpec().Value
 
@@ -109,7 +108,7 @@ func (h *machineControllerHelper) transform(ctx context.Context, r controller.Re
 
 // handleInfraProvider checks if the link has an infra provider ID annotation, and if so, runs the infra provider handling logic - static or provisioning (regular).
 func (h *machineControllerHelper) handleInfraProvider(ctx context.Context, r controller.Reader, link *siderolink.Link, machine *omni.Machine) error {
-	infraProviderID, ok := link.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+	infraProviderID, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
 	if !ok { // not created by an infra provider, skip
 		return nil
 	}

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -250,7 +250,7 @@ func (ctrl *MachineStatusController) reconcileRunning(ctx context.Context, r con
 
 		helpers.CopyLabels(machine, m, omni.LabelMachineRequest, omni.LabelMachineRequestSet, omni.LabelNoManualAllocation, omni.LabelIsManagedByStaticInfraProvider)
 
-		infraProvider, ok := machine.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+		infraProvider, ok := machine.Metadata().Labels().Get(omni.LabelInfraProviderID)
 		if ok {
 			m.Metadata().Labels().Set(omni.LabelInfraProviderID, infraProvider)
 		} else {

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -244,6 +244,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: dropExtraInputFinalizers,
 				name:     "dropExtraInputFinalizers",
 			},
+			{
+				callback: moveInfraProviderAnnotationsToLabels,
+				name:     "moveInfraProviderAnnotationsToLabels",
+			},
 		},
 	}
 }

--- a/internal/integration/infra_test.go
+++ b/internal/integration/infra_test.go
@@ -184,7 +184,7 @@ func infraMachinesAcceptHook(t *testing.T, omniState state.State, infraProviderI
 		discoveredLinks := 0
 
 		for link := range links.All() {
-			providerID, ok := link.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+			providerID, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
 			if !ok {
 				continue
 			}
@@ -279,7 +279,7 @@ func infraMachinesAcceptHook(t *testing.T, omniState state.State, infraProviderI
 	rtestutils.AssertResources(ctx, t, omniState, ids, func(res *omni.MachineStatus, assertion *assert.Assertions) {
 		link := linksMap[res.Metadata().ID()]
 
-		infraProviderID, _ := link.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+		infraProviderID, _ := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
 
 		aLabel := fmt.Sprintf(omni.InfraProviderLabelPrefixFormat, infraProviderID) + "a"
 		aVal, _ := res.Metadata().Labels().Get(aLabel)
@@ -304,7 +304,7 @@ func infraMachinesDestroyHook(t *testing.T, omniState state.State, providerID st
 	var deleted int
 
 	for link := range links.All() {
-		pid, ok := link.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+		pid, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
 		if !ok {
 			continue
 		}

--- a/internal/pkg/siderolink/provision.go
+++ b/internal/pkg/siderolink/provision.go
@@ -196,7 +196,7 @@ func newLink[T res](provisionContext *provisionContext,
 
 	if provisionContext.token != nil {
 		if value, ok := provisionContext.token.ExtraData[omni.LabelInfraProviderID]; ok {
-			link.Metadata().Annotations().Set(omni.LabelInfraProviderID, value)
+			link.Metadata().Labels().Set(omni.LabelInfraProviderID, value)
 		}
 
 		if value, ok := provisionContext.token.ExtraData[omni.LabelMachineRequest]; ok {

--- a/internal/pkg/siderolink/provision_test.go
+++ b/internal/pkg/siderolink/provision_test.go
@@ -679,7 +679,7 @@ func TestProvision(t *testing.T) {
 			func(r *siderolinkres.Link, assertion *assert.Assertions) {
 				assertion.Equal(r.TypedSpec().Value.NodePublicKey, request.NodePublicKey)
 
-				providerID, ok := r.Metadata().Annotations().Get(omni.LabelInfraProviderID)
+				providerID, ok := r.Metadata().Labels().Get(omni.LabelInfraProviderID)
 				assertion.True(ok)
 				assertion.Equal("test", providerID)
 			},


### PR DESCRIPTION
This change updates the handling of the infra provider ID by migrating it from annotations to labels in the `Link` and `Machine` resources.

This was done because we have noticed that there was a bug in the `InfraMachineController`, where we mapped them to the primary input using a label query. It was also named as a label and was used as a label in other resource types.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>