### PR TITLE
refactor(auth): extract interceptor from key generation logic

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,6 +62,7 @@
         "@vitest/eslint-plugin": "^1.3.26",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.6.0",
+        "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.8.1",
         "dotenv": "^17.2.3",
         "eslint": "^9.38.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
     "@vitest/eslint-plugin": "^1.3.26",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.6.0",
+    "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.8.1",
     "dotenv": "^17.2.3",
     "eslint": "^9.38.0",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,6 +15,11 @@ import UserConsent from '@/components/common/UserConsent/UserConsent.vue'
 import THeader from '@/components/THeader/THeader.vue'
 import TModal from '@/components/TModal.vue'
 import { suspended } from '@/methods'
+import { useRegisterAPIInterceptor } from '@/methods/interceptor'
+import { useWatchKeyExpiry } from '@/methods/key'
+
+useRegisterAPIInterceptor()
+useWatchKeyExpiry()
 
 const isSidebarOpen = ref(false)
 const router = useRouter()

--- a/frontend/src/components/THeader/THeader.vue
+++ b/frontend/src/components/THeader/THeader.vue
@@ -5,10 +5,13 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { computedAsync } from '@vueuse/core'
+
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import OngoingTasks from '@/components/common/OngoingTasks/OngoingTasks.vue'
 import { useDocsLink } from '@/methods'
+import { hasValidKeys } from '@/methods/key'
 
 interface Props {
   sidebarOpen?: boolean
@@ -18,6 +21,9 @@ interface Props {
 const props = defineProps<Props>()
 
 const docsLink = useDocsLink('omni')
+
+// Used to prevent sub-queries being fired before keys are created
+const authorized = computedAsync(async () => await hasValidKeys())
 </script>
 
 <template>
@@ -75,7 +81,7 @@ const docsLink = useDocsLink('omni')
         <span class="truncate text-xs max-sm:hidden">Report an issue</span>
       </a>
 
-      <OngoingTasks />
+      <OngoingTasks v-if="authorized" />
     </div>
   </header>
 </template>

--- a/frontend/src/components/common/OngoingTasks/OngoingTasks.stories.ts
+++ b/frontend/src/components/common/OngoingTasks/OngoingTasks.stories.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import { createWatchStreamHandler } from '@msw/helpers'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { formatRFC3339 } from 'date-fns'
+
+import type { OngoingTaskSpec } from '@/api/omni/specs/omni.pb'
+import { EphemeralNamespace, OngoingTaskType } from '@/api/resources'
+
+import OngoingTasks from './OngoingTasks.vue'
+
+const meta: Meta<typeof OngoingTasks> = {
+  component: OngoingTasks,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<OngoingTaskSpec>({
+          expectedOptions: {
+            namespace: EphemeralNamespace,
+            type: OngoingTaskType,
+          },
+          initialResources: faker.helpers.multiple(
+            () => ({
+              metadata: {
+                id: faker.string.uuid(),
+                created: formatRFC3339(faker.date.recent()),
+              },
+              spec: {
+                title: faker.animal.cat(),
+                ...faker.helpers.arrayElement([
+                  {
+                    kubernetes_upgrade: {
+                      last_upgrade_version: faker.system.semver(),
+                      current_upgrade_version: faker.system.semver(),
+                    },
+                  },
+                  {
+                    talos_upgrade: {
+                      last_upgrade_version: faker.system.semver(),
+                      current_upgrade_version: faker.system.semver(),
+                    },
+                  },
+                  {
+                    machine_upgrade: {
+                      schematic_id: faker.system.semver(),
+                      current_schematic_id: faker.system.semver(),
+                    },
+                  },
+                  {
+                    destroy: {
+                      phase: 'Destroying',
+                    },
+                  },
+                ]),
+              },
+            }),
+            { count: 10 },
+          ),
+        }).handler,
+      ],
+    },
+  },
+}

--- a/frontend/src/components/common/OngoingTasks/OngoingTasks.vue
+++ b/frontend/src/components/common/OngoingTasks/OngoingTasks.vue
@@ -6,7 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { vOnClickOutside } from '@vueuse/components'
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { type Resource } from '@/api/grpc'
@@ -15,25 +15,19 @@ import { EphemeralNamespace, OngoingTaskType } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import TAnimation from '@/components/common/Animation/TAnimation.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
-import Watch from '@/components/common/Watch/Watch.vue'
+import { useWatch } from '@/components/common/Watch/useWatch'
 import IconHeaderDropdownLoading from '@/components/icons/IconHeaderDropdownLoading.vue'
-import { authorized } from '@/methods/key'
 import { formatISO } from '@/methods/time'
 
-const watchOpts = computed(() => {
-  if (authorized.value) {
-    return { resource: resource, runtime: Runtime.Omni }
-  }
-
-  return undefined
-})
+const { data } = useWatch<OngoingTaskSpec>(() => ({
+  resource: {
+    namespace: EphemeralNamespace,
+    type: OngoingTaskType,
+  },
+  runtime: Runtime.Omni,
+}))
 
 const dropdownOpen = ref(false)
-
-const resource = {
-  namespace: EphemeralNamespace,
-  type: OngoingTaskType,
-}
 
 const getPreviousVersion = (item: Resource<OngoingTaskSpec>) => {
   if (item.spec.kubernetes_upgrade) {
@@ -70,98 +64,87 @@ const onClickOutside = () => {
 
 <template>
   <div v-on-click-outside="onClickOutside" class="relative flex items-center">
-    <Watch v-if="watchOpts" :opts="watchOpts" display-always>
-      <template #default="{ data }">
+    <div
+      class="flex cursor-pointer items-center gap-1 text-naturals-n11 transition-colors hover:text-naturals-n14"
+      @click="() => toggleDropdown()"
+    >
+      <IconHeaderDropdownLoading :active="data.length > 0" />
+      <span class="text-xs font-normal whitespace-nowrap select-none">
+        <span class="contents sm:hidden">Tasks</span>
+        <span class="hidden sm:contents">Ongoing Tasks</span>
+      </span>
+      <TIcon
+        class="flex h-4 w-4 items-center justify-center fill-current transition-transform duration-300"
+        :class="{ '-rotate-180': dropdownOpen }"
+        icon="arrow-down"
+      />
+    </div>
+
+    <TAnimation>
+      <div
+        v-show="dropdownOpen"
+        class="absolute top-7 -right-2 z-30 rounded border border-naturals-n4 bg-naturals-n2"
+      >
         <div
-          class="flex cursor-pointer items-center gap-1 text-naturals-n11 transition-colors hover:text-naturals-n14"
-          @click="() => toggleDropdown()"
+          v-for="item in data"
+          :key="itemID(item)"
+          class="flex flex-col gap-2 p-6 not-last:border-b not-last:border-naturals-n4"
         >
-          <IconHeaderDropdownLoading :active="data.length > 0" />
-          <span class="text-xs font-normal whitespace-nowrap select-none">
-            <span class="contents sm:hidden">Tasks</span>
-            <span class="hidden sm:contents">Ongoing Tasks</span>
-          </span>
-          <TIcon
-            class="flex h-4 w-4 items-center justify-center fill-current transition-transform duration-300"
-            :class="{ '-rotate-180': dropdownOpen }"
-            icon="arrow-down"
-          />
-        </div>
+          <div class="flex items-center justify-between gap-4">
+            <h3 class="w-9/12 text-xs whitespace-nowrap text-naturals-n13">
+              {{ item.spec.title }}
+            </h3>
 
-        <TAnimation>
-          <div
-            v-show="dropdownOpen"
-            class="absolute top-7 -right-2 z-30 rounded border border-naturals-n4 bg-naturals-n2"
-          >
-            <div
-              v-for="item in data"
-              :key="itemID(item)"
-              class="flex flex-col gap-2 p-6 not-last:border-b not-last:border-naturals-n4"
-            >
-              <div class="flex items-center justify-between gap-4">
-                <h3 class="w-9/12 text-xs whitespace-nowrap text-naturals-n13">
-                  {{ item.spec.title }}
-                </h3>
+            <span v-if="item.metadata.created" class="w-3/12 text-right text-xs text-naturals-n9">
+              {{ formatISO(item.metadata.created, 'HH:mm:ss') }}
+            </span>
+          </div>
 
-                <span
-                  v-if="item.metadata.created"
-                  class="w-3/12 text-right text-xs text-naturals-n9"
-                >
-                  {{ formatISO(item.metadata.created, 'HH:mm:ss') }}
+          <div class="truncate text-xs text-naturals-n9">
+            <template v-if="item.spec.destroy">
+              {{ item.spec.destroy.phase }}
+            </template>
+
+            <div v-else class="flex items-center gap-2 text-xs">
+              <template v-if="getCurrentVersion(item)">
+                <span v-if="item.spec.kubernetes_upgrade">Upgrade Kubernetes</span>
+                <span v-else-if="item.spec.machine_upgrade">Upgrade Machine</span>
+                <span v-else>Upgrade Talos</span>
+                <div class="flex-1" />
+                <span class="rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13">
+                  {{ getPreviousVersion(item) }}
                 </span>
-              </div>
+                <span>⇾</span>
+                <span class="rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13">
+                  {{ getCurrentVersion(item) }}
+                </span>
+              </template>
 
-              <div class="truncate text-xs text-naturals-n9">
-                <template v-if="item.spec.destroy">
-                  {{ item.spec.destroy.phase }}
-                </template>
+              <template
+                v-else-if="
+                  (item.spec?.kubernetes_upgrade?.phase ?? item.spec?.talos_upgrade?.phase) ===
+                  KubernetesUpgradeStatusSpecPhase.Reverting
+                "
+              >
+                <span>Reverting back to</span>
+                <div class="flex-1" />
+                <span class="rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13">
+                  {{
+                    (item.spec.kubernetes_upgrade ?? item.spec.talos_upgrade)?.last_upgrade_version
+                  }}
+                </span>
+              </template>
 
-                <div v-else class="flex items-center gap-2 text-xs">
-                  <template v-if="getCurrentVersion(item)">
-                    <span v-if="item.spec.kubernetes_upgrade">Upgrade Kubernetes</span>
-                    <span v-else-if="item.spec.machine_upgrade">Upgrade Machine</span>
-                    <span v-else>Upgrade Talos</span>
-                    <div class="flex-1" />
-                    <span class="rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13">
-                      {{ getPreviousVersion(item) }}
-                    </span>
-                    <span>⇾</span>
-                    <span class="rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13">
-                      {{ getCurrentVersion(item) }}
-                    </span>
-                  </template>
-
-                  <template
-                    v-else-if="
-                      (item.spec?.kubernetes_upgrade?.phase ?? item.spec?.talos_upgrade?.phase) ===
-                      KubernetesUpgradeStatusSpecPhase.Reverting
-                    "
-                  >
-                    <span>Reverting back to</span>
-                    <div class="flex-1" />
-                    <span class="rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13">
-                      {{
-                        (item.spec.kubernetes_upgrade ?? item.spec.talos_upgrade)
-                          .last_upgrade_version
-                      }}
-                    </span>
-                  </template>
-
-                  <span v-else>Updating machine schematics</span>
-                </div>
-              </div>
-            </div>
-
-            <div
-              v-if="!data.length"
-              class="flex w-32 items-center justify-center gap-2 p-4 text-xs"
-            >
-              <TIcon icon="check" class="h-4 w-4" />
-              No tasks
+              <span v-else>Updating machine schematics</span>
             </div>
           </div>
-        </TAnimation>
-      </template>
-    </Watch>
+        </div>
+
+        <div v-if="!data.length" class="flex w-32 items-center justify-center gap-2 p-4 text-xs">
+          <TIcon icon="check" class="h-4 w-4" />
+          No tasks
+        </div>
+      </div>
+    </TAnimation>
   </div>
 </template>

--- a/frontend/src/components/common/SelectList/TSelectList.spec.ts
+++ b/frontend/src/components/common/SelectList/TSelectList.spec.ts
@@ -4,13 +4,15 @@
 // included in the LICENSE file.
 import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor } from '@testing-library/vue'
-import { mount } from '@vue/test-utils'
-import { expect, test, vi } from 'vitest'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { afterEach, expect, test, vi } from 'vitest'
 
 import TSelectList from './TSelectList.vue'
 
 // Used by reka-ui select, test fails without it
 window.HTMLElement.prototype.hasPointerCapture = vi.fn()
+
+enableAutoUnmount(afterEach)
 
 test('is accessible with inline label', () => {
   render(TSelectList, {

--- a/frontend/src/methods/auth.spec.ts
+++ b/frontend/src/methods/auth.spec.ts
@@ -1,0 +1,186 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { useAuth0 } from '@auth0/auth0-vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { Code } from '@/api/google/rpc/code.pb'
+import { AuthService } from '@/api/omni/auth/auth.pb'
+import { AuthType, authType } from '@/methods'
+import { currentUser, useLogout } from '@/methods/auth'
+import { useIdentity } from '@/methods/identity'
+import { useKeys } from '@/methods/key'
+
+vi.mock('openpgp', () => ({}))
+
+vi.mock('@auth0/auth0-vue', () => ({
+  useAuth0: vi.fn(),
+}))
+
+vi.mock('@/methods/identity')
+vi.mock('@/methods/key')
+vi.mock('@/api/omni/auth/auth.pb', () => ({
+  AuthService: {
+    RevokePublicKey: vi.fn(),
+  },
+}))
+
+describe('useLogout', () => {
+  let mockKeys: ReturnType<typeof useKeys>
+  let mockIdentity: ReturnType<typeof useIdentity>
+  let mockAuth0: {
+    logout: ReturnType<typeof vi.fn>
+  }
+  let originalLocation: Location
+  let mockLocation: Location
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockKeys = {
+      publicKeyID: ref('test-key-id'),
+      clear: vi.fn(),
+      privateKey: ref(undefined),
+      privateKeyArmored: ref(undefined),
+      publicKey: ref(undefined),
+      publicKeyArmored: ref(undefined),
+    } as unknown as ReturnType<typeof useKeys>
+    vi.mocked(useKeys).mockReturnValue(mockKeys)
+
+    mockIdentity = {
+      identity: ref('test-identity'),
+      fullname: ref('Test User'),
+      avatar: ref('test-avatar'),
+      clear: vi.fn(),
+    }
+    vi.mocked(useIdentity).mockReturnValue(mockIdentity)
+
+    mockAuth0 = {
+      logout: vi.fn().mockResolvedValue(undefined),
+    }
+    vi.mocked(useAuth0).mockReturnValue(mockAuth0 as unknown as ReturnType<typeof useAuth0>)
+
+    currentUser.value = { metadata: { id: 'test-user' } } as typeof currentUser.value
+
+    originalLocation = window.location
+    mockLocation = {
+      ...originalLocation,
+      href: 'http://localhost:3000',
+      origin: 'http://localhost:3000',
+    } as Location
+    delete (window as { location?: Location }).location
+    Object.defineProperty(window, 'location', {
+      value: mockLocation,
+      writable: true,
+      configurable: true,
+    })
+
+    Object.defineProperty(window, 'top', {
+      value: window,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+    vi.clearAllMocks()
+  })
+
+  test('should revoke public key, clear keys and identity, and set currentUser to undefined when publicKeyID exists', async () => {
+    vi.mocked(AuthService.RevokePublicKey).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof AuthService.RevokePublicKey>>,
+    )
+
+    const logout = useLogout()
+    await logout()
+
+    expect(AuthService.RevokePublicKey).toHaveBeenCalledWith({
+      public_key_id: 'test-key-id',
+    })
+    expect(mockKeys.clear).toHaveBeenCalled()
+    expect(mockIdentity.clear).toHaveBeenCalled()
+    expect(currentUser.value).toBeUndefined()
+  })
+
+  test('should not revoke public key when publicKeyID is falsy', async () => {
+    mockKeys.publicKeyID.value = ''
+
+    const logout = useLogout()
+    await logout()
+
+    expect(AuthService.RevokePublicKey).not.toHaveBeenCalled()
+  })
+
+  test('should not throw when RevokePublicKey fails with UNAUTHENTICATED error', async () => {
+    const error = new Error('Unauthenticated') as Error & { code: Code }
+    error.code = Code.UNAUTHENTICATED
+    vi.mocked(AuthService.RevokePublicKey).mockRejectedValue(error)
+
+    const logout = useLogout()
+    await expect(logout()).resolves.not.toThrow()
+
+    expect(AuthService.RevokePublicKey).toHaveBeenCalled()
+    expect(mockKeys.clear).toHaveBeenCalled()
+    expect(mockIdentity.clear).toHaveBeenCalled()
+    expect(currentUser.value).toBeUndefined()
+  })
+
+  test('should throw when RevokePublicKey fails with non-UNAUTHENTICATED error', async () => {
+    const error = new Error('Server error') as Error & { code: Code }
+    error.code = Code.INTERNAL
+    vi.mocked(AuthService.RevokePublicKey).mockRejectedValue(error)
+
+    const logout = useLogout()
+    await expect(logout()).rejects.toThrow('Server error')
+
+    expect(AuthService.RevokePublicKey).toHaveBeenCalled()
+    expect(mockKeys.clear).not.toHaveBeenCalled()
+    expect(mockIdentity.clear).not.toHaveBeenCalled()
+    expect(currentUser.value).not.toBeUndefined()
+  })
+
+  test('should call auth0.logout when authType is Auth0', async () => {
+    vi.mocked(AuthService.RevokePublicKey).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof AuthService.RevokePublicKey>>,
+    )
+    authType.value = AuthType.Auth0
+
+    const logout = useLogout()
+    await logout()
+
+    expect(mockAuth0.logout).toHaveBeenCalledWith({
+      logoutParams: {
+        returnTo: 'http://localhost:3000',
+      },
+    })
+    expect(mockKeys.clear).toHaveBeenCalled()
+    expect(mockIdentity.clear).toHaveBeenCalled()
+    expect(currentUser.value).toBeUndefined()
+  })
+
+  test.each([AuthType.SAML, AuthType.OIDC, AuthType.None])(
+    'should redirect to logout URL when authType is %s',
+    async (mockAuthType) => {
+      vi.mocked(AuthService.RevokePublicKey).mockResolvedValue(
+        {} as Awaited<ReturnType<typeof AuthService.RevokePublicKey>>,
+      )
+      authType.value = mockAuthType
+
+      const logout = useLogout()
+      await logout()
+
+      expect(mockAuth0.logout).not.toHaveBeenCalled()
+      expect(window.location.href).toBe('/logout?flow=frontend')
+      expect(mockKeys.clear).toHaveBeenCalled()
+      expect(mockIdentity.clear).toHaveBeenCalled()
+      expect(currentUser.value).toBeUndefined()
+    },
+  )
+})

--- a/frontend/src/methods/identity.spec.ts
+++ b/frontend/src/methods/identity.spec.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { describe, expect, test } from 'vitest'
+import { nextTick } from 'vue'
+
+import { useIdentity } from './identity'
+
+describe('useIdentity', () => {
+  test('defaults to null', async () => {
+    const { identity, avatar, fullname } = useIdentity()
+
+    expect(identity.value).toBeNull()
+    expect(avatar.value).toBeNull()
+    expect(fullname.value).toBeNull()
+  })
+
+  test('sets values', async () => {
+    const { identity, avatar, fullname } = useIdentity()
+
+    identity.value = '1'
+    avatar.value = '2'
+    fullname.value = '3'
+
+    expect(identity.value).toBe('1')
+    expect(avatar.value).toBe('2')
+    expect(fullname.value).toBe('3')
+  })
+
+  test('clears values', async () => {
+    const { identity, avatar, fullname, clear } = useIdentity()
+
+    identity.value = '1'
+    avatar.value = '2'
+    fullname.value = '3'
+
+    clear()
+
+    expect(identity.value).toBeNull()
+    expect(avatar.value).toBeNull()
+    expect(fullname.value).toBeNull()
+  })
+
+  test('persists values', async () => {
+    // First pass
+    ;(() => {
+      const { identity, avatar, fullname } = useIdentity()
+
+      identity.value = '1'
+      avatar.value = '2'
+      fullname.value = '3'
+
+      expect(identity.value).toBe('1')
+      expect(avatar.value).toBe('2')
+      expect(fullname.value).toBe('3')
+    })()
+
+    // actual storage is updated on the next tick
+    await nextTick()
+
+    // Second pass
+    ;(() => {
+      const { identity, avatar, fullname } = useIdentity()
+
+      expect(identity.value).toBe('1')
+      expect(avatar.value).toBe('2')
+      expect(fullname.value).toBe('3')
+    })()
+  })
+})

--- a/frontend/src/methods/identity.ts
+++ b/frontend/src/methods/identity.ts
@@ -14,9 +14,9 @@ export function useIdentity() {
     fullname: fullnameRef,
     avatar: avatarRef,
     clear() {
-      identityRef.value = undefined
-      fullnameRef.value = undefined
-      avatarRef.value = undefined
+      identityRef.value = null
+      fullnameRef.value = null
+      avatarRef.value = null
     },
   }
 }

--- a/frontend/src/methods/interceptor.spec.ts
+++ b/frontend/src/methods/interceptor.spec.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { getUnixTime } from 'date-fns'
+import fetchIntercept, { type FetchInterceptor } from 'fetch-intercept'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+import { useRegisterAPIInterceptor } from './interceptor'
+
+vi.mock('openpgp', () => ({}))
+vi.mock('fetch-intercept')
+vi.mock('@/methods/identity', () => ({
+  useIdentity() {
+    return { identity: ref('testuser') }
+  },
+}))
+vi.mock('@/methods/key', () => ({
+  useKeys() {
+    return {
+      publicKey: ref(
+        Promise.resolve({
+          getFingerprint: () => 'secret-fingerprint',
+        }),
+      ),
+    }
+  },
+  useSignDetached() {
+    return () => 'secret-signature'
+  },
+}))
+
+const fetchInterceptMock = vi.mocked(fetchIntercept)
+
+const TestComponent = defineComponent({
+  setup: useRegisterAPIInterceptor,
+  template: '<template />',
+})
+
+describe('useRegisterAPIInterceptor', () => {
+  const now = 1762881349000
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+  })
+
+  enableAutoUnmount(afterEach)
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test.each(['/api', '/api/auth.AuthService/RevokePublicKey'])(
+    'intercepts api route: %s',
+    async (originalUrl) => {
+      let interceptorMock: FetchInterceptor['request']
+
+      fetchInterceptMock.register.mockImplementation(({ request }) => {
+        interceptorMock = request
+
+        return vi.fn()
+      })
+
+      mount(TestComponent)
+
+      expect(fetchInterceptMock.register).toHaveBeenCalledOnce()
+      expectToBeDefined(interceptorMock)
+
+      const [url, config] = await interceptorMock(originalUrl, undefined)
+      const headers = Array.from(config.headers) as [string, string]
+
+      expect(url).toBe(originalUrl)
+      expect(headers).toMatchObject([
+        [
+          'grpc-metadata-x-sidero-payload',
+          JSON.stringify({
+            headers: { 'x-sidero-timestamp': [getUnixTime(now).toString()] },
+            method: originalUrl.replace('/api', ''),
+          }),
+        ],
+        [
+          'grpc-metadata-x-sidero-signature',
+          'siderov1 testuser secret-fingerprint secret-signature',
+        ],
+        ['grpc-metadata-x-sidero-timestamp', getUnixTime(now).toString()],
+      ])
+    },
+  )
+
+  test.each(['/image/', '/image/thing/whatever'])(
+    'intercepts image route: %s',
+    async (originalUrl) => {
+      let interceptorMock: FetchInterceptor['request']
+
+      fetchInterceptMock.register.mockImplementation(({ request }) => {
+        interceptorMock = request
+
+        return vi.fn()
+      })
+
+      mount(TestComponent)
+
+      expect(fetchInterceptMock.register).toHaveBeenCalledOnce()
+      expectToBeDefined(interceptorMock)
+
+      const [url, config] = await interceptorMock(originalUrl, undefined)
+      const headers = Array.from(config.headers) as [string, string]
+
+      expect(url).toBe(originalUrl)
+      expect(headers).toMatchObject([
+        ['x-sidero-signature', 'siderov1 testuser secret-fingerprint secret-signature'],
+        ['x-sidero-timestamp', getUnixTime(now).toString()],
+      ])
+    },
+  )
+
+  test.each(['/fake', '/api/auth.whatever'])(
+    'does not intercept route: %s',
+    async (originalUrl) => {
+      let interceptorMock: FetchInterceptor['request']
+
+      fetchInterceptMock.register.mockImplementation(({ request }) => {
+        interceptorMock = request
+
+        return vi.fn()
+      })
+
+      mount(TestComponent)
+
+      expect(fetchInterceptMock.register).toHaveBeenCalledOnce()
+      expectToBeDefined(interceptorMock)
+
+      const [url, config] = await interceptorMock(originalUrl, undefined)
+
+      expect(url).toBe(originalUrl)
+      expect(config).toBeUndefined()
+    },
+  )
+
+  test('unregisters interceptor on unmount', async () => {
+    const unregisterMock = vi.fn()
+
+    fetchInterceptMock.register.mockImplementation(() => unregisterMock)
+
+    const wrapper = mount(TestComponent)
+
+    expect(unregisterMock).not.toHaveBeenCalled()
+    wrapper.unmount()
+    expect(unregisterMock).toHaveBeenCalledOnce()
+  })
+})
+
+function expectToBeDefined<T>(value: T | undefined): asserts value is T {
+  expect(value).toBeDefined()
+}

--- a/frontend/src/methods/interceptor.ts
+++ b/frontend/src/methods/interceptor.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { getUnixTime } from 'date-fns'
+import fetchIntercept from 'fetch-intercept'
+import { onBeforeMount, onUnmounted, ref } from 'vue'
+
+import {
+  authHeader,
+  PayloadHeaderKey,
+  SignatureHeaderKey,
+  SignatureVersionV1,
+  TimestampHeaderKey,
+} from '@/api/resources'
+import { useIdentity } from '@/methods/identity'
+import { useKeys, useSignDetached } from '@/methods/key'
+
+/**
+ * useRegisterAPIInterceptor registers an interceptor on the global fetch.
+ * This will add the necessary authorization headers for Omni gRPC calls.
+ */
+export function useRegisterAPIInterceptor() {
+  const keys = useKeys()
+  const { identity } = useIdentity()
+  const signDetached = useSignDetached()
+
+  const unregisterInterceptor = ref<() => void>()
+
+  onBeforeMount(() => {
+    unregisterInterceptor.value = fetchIntercept.register({
+      async request(url, config?: { headers?: Headers; method?: string }) {
+        url = encodeURI(url)
+
+        if (
+          !/^\/(api|image)/.test(url) ||
+          (url.startsWith('/api/auth.') && !url.startsWith('/api/auth.AuthService/RevokePublicKey'))
+        ) {
+          return [url, config]
+        }
+
+        config ||= {}
+        config.headers ||= new Headers()
+
+        const ts = getUnixTime(Date.now()).toString()
+
+        if (url.startsWith('/api')) {
+          config.headers.set(`Grpc-Metadata-${TimestampHeaderKey}`, ts)
+
+          const payload = JSON.stringify(buildPayload(url, config))
+          const signature = await generateSignatureHeader(payload)
+
+          config.headers.set(`Grpc-Metadata-${PayloadHeaderKey}`, payload)
+          config.headers.set(`Grpc-Metadata-${SignatureHeaderKey}`, signature)
+        } else if (url.startsWith('/image')) {
+          config.headers.set(TimestampHeaderKey, ts)
+
+          const sha256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' // empty string sha256
+          const payload = [config.method ?? 'GET', url, ts, sha256].join('\n')
+          const signature = await generateSignatureHeader(payload)
+
+          config.headers.set(SignatureHeaderKey, signature)
+        }
+
+        return [url, config]
+      },
+    })
+  })
+
+  async function generateSignatureHeader(payload: string) {
+    const signature = await signDetached(payload)
+    const fingerprint = (await keys.publicKey.value)?.getFingerprint()
+
+    return `${SignatureVersionV1} ${identity.value} ${fingerprint} ${signature}`
+  }
+
+  onUnmounted(() => unregisterInterceptor.value?.())
+}
+
+const includedHeaders = [
+  'nodes',
+  'selectors',
+  'fieldSelectors',
+  'runtime',
+  'context',
+  'cluster',
+  'namespace',
+  'uid',
+  TimestampHeaderKey,
+  authHeader,
+]
+
+function buildPayload(url: string, config: { headers?: Headers }) {
+  const headers: Record<string, string[]> = {}
+
+  if (config.headers) {
+    for (const header of includedHeaders) {
+      const key = `Grpc-Metadata-${header}`
+      const value = config.headers.get(key)
+
+      if (value) {
+        if (!headers[header]) {
+          headers[header] = [value]
+        } else {
+          headers[header].push(value)
+        }
+      }
+    }
+  }
+
+  return {
+    headers,
+    method: url.replace(/^\/api/, ''),
+  }
+}

--- a/frontend/src/methods/key.spec.ts
+++ b/frontend/src/methods/key.spec.ts
@@ -1,0 +1,366 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { server } from '@msw/server'
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
+import { add, milliseconds, sub } from 'date-fns'
+import { http, HttpResponse } from 'msw'
+import {
+  generateKey,
+  type Key,
+  type PartialConfig,
+  type PrivateKey,
+  readKey,
+  readPrivateKey,
+  sign,
+  type WebStream,
+} from 'openpgp/lightweight'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+import { useRouter } from 'vue-router'
+
+import type { RegisterPublicKeyRequest, RegisterPublicKeyResponse } from '@/api/omni/auth/auth.pb'
+
+import { createKeys, hasValidKeys, useKeys, useSignDetached, useWatchKeyExpiry } from './key'
+
+vi.mock('openpgp', () => ({
+  enums: {
+    compression: { zlib: 'zlib' },
+    symmetric: { aes256: 'aes256' },
+    hash: { sha256: 'sha256' },
+  },
+  sign: vi.fn(),
+  createMessage: vi.fn(),
+  generateKey: vi.fn(),
+  readPrivateKey: vi.fn(),
+  readKey: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn().mockReturnValue({ fullPath: 'fullPath' }),
+  useRouter: vi.fn().mockReturnValue({ replace: vi.fn() }),
+}))
+
+describe('useKeys', () => {
+  beforeEach(() => {
+    // vi.mocked doesn't work with overloads unfortunately
+    type ReadPrivateKeyFunc = (options: {
+      armoredKey: string
+      config?: PartialConfig
+    }) => Promise<PrivateKey>
+    type ReadKeyFunc = (options: { armoredKey: string; config?: PartialConfig }) => Promise<Key>
+
+    vi.mocked(readPrivateKey as ReadPrivateKeyFunc).mockImplementation(
+      async (o) => `private-✨${o.armoredKey}✨` as unknown as PrivateKey,
+    )
+    vi.mocked(readKey as ReadKeyFunc).mockImplementation(
+      async (o) => `public-✨${o.armoredKey}✨` as unknown as PrivateKey,
+    )
+  })
+
+  afterEach(() => {
+    useKeys().clear()
+
+    vi.mocked(readPrivateKey).mockReset()
+    vi.mocked(readKey).mockReset()
+  })
+
+  test('defaults to null/undefined', () => {
+    const { privateKey, privateKeyArmored, publicKey, publicKeyArmored, publicKeyID } = useKeys()
+
+    expect(privateKeyArmored.value).toBeNull()
+    expect(privateKey.value).toBeUndefined()
+    expect(publicKeyArmored.value).toBeNull()
+    expect(publicKey.value).toBeUndefined()
+    expect(publicKeyID.value).toBeNull()
+  })
+
+  test('sets values', async () => {
+    const { privateKey, privateKeyArmored, publicKey, publicKeyArmored, publicKeyID } = useKeys()
+
+    privateKeyArmored.value = '1'
+    publicKeyArmored.value = '2'
+    publicKeyID.value = '3'
+
+    expect(privateKeyArmored.value).toBe('1')
+    await expect(privateKey.value).resolves.toBe('private-✨1✨')
+    expect(publicKeyArmored.value).toBe('2')
+    await expect(publicKey.value).resolves.toBe('public-✨2✨')
+    expect(publicKeyID.value).toBe('3')
+  })
+
+  test('clears values', () => {
+    const { privateKey, privateKeyArmored, publicKey, publicKeyArmored, publicKeyID, clear } =
+      useKeys()
+
+    privateKeyArmored.value = '1'
+    publicKeyArmored.value = '2'
+    publicKeyID.value = '3'
+
+    clear()
+
+    expect(privateKeyArmored.value).toBeNull()
+    expect(privateKey.value).toBeUndefined()
+    expect(publicKeyArmored.value).toBeNull()
+    expect(publicKey.value).toBeUndefined()
+    expect(publicKeyID.value).toBeNull()
+  })
+
+  test('persists values', async () => {
+    // First pass
+    await (async () => {
+      const { privateKey, privateKeyArmored, publicKey, publicKeyArmored, publicKeyID } = useKeys()
+
+      privateKeyArmored.value = '1'
+      publicKeyArmored.value = '2'
+      publicKeyID.value = '3'
+
+      expect(privateKeyArmored.value).toBe('1')
+      await expect(privateKey.value).resolves.toBe('private-✨1✨')
+      expect(publicKeyArmored.value).toBe('2')
+      await expect(publicKey.value).resolves.toBe('public-✨2✨')
+      expect(publicKeyID.value).toBe('3')
+    })()
+
+    // actual storage is updated on the next tick
+    await nextTick()
+
+    // Second pass
+    await (async () => {
+      const { privateKey, privateKeyArmored, publicKey, publicKeyArmored, publicKeyID } = useKeys()
+
+      expect(privateKeyArmored.value).toBe('1')
+      await expect(privateKey.value).resolves.toBe('private-✨1✨')
+      expect(publicKeyArmored.value).toBe('2')
+      await expect(publicKey.value).resolves.toBe('public-✨2✨')
+      expect(publicKeyID.value).toBe('3')
+    })()
+  })
+})
+
+describe('useWatchKeyExpiry', () => {
+  const now = 1762881349000
+  const TestComponent = defineComponent({
+    setup: useWatchKeyExpiry,
+    template: '<template />',
+  })
+  const getExpirationTime = vi.fn()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    vi.mocked(readPrivateKey, { partial: true }).mockResolvedValue({ getExpirationTime })
+  })
+
+  enableAutoUnmount(afterEach)
+
+  afterEach(() => {
+    useKeys().clear()
+
+    getExpirationTime.mockReset()
+    vi.mocked(readPrivateKey).mockReset()
+    vi.mocked(useRouter().replace).mockReset()
+
+    vi.useRealTimers()
+  })
+
+  test('does nothing if no privateKey', async () => {
+    mount(TestComponent)
+
+    await flushPromises()
+
+    expect(getExpirationTime).not.toHaveBeenCalled()
+  })
+
+  test('clears keys if invalid expiry', async () => {
+    getExpirationTime.mockResolvedValue(Infinity)
+    useKeys().privateKeyArmored.value = 'whatever'
+
+    mount(TestComponent)
+
+    await flushPromises()
+
+    expect(getExpirationTime).toHaveBeenCalledExactlyOnceWith()
+    expect(useKeys().privateKeyArmored.value).toBeFalsy()
+    expect(useRouter().replace).toHaveBeenCalledExactlyOnceWith({
+      name: 'Authenticate',
+      query: { flow: 'frontend', redirect: 'fullPath' },
+    })
+  })
+
+  test('clears keys on expiry', async () => {
+    getExpirationTime.mockResolvedValue(add(now, { minutes: 1 }))
+    useKeys().privateKeyArmored.value = 'whatever'
+
+    mount(TestComponent)
+
+    await flushPromises()
+
+    expect(getExpirationTime).toHaveBeenCalledExactlyOnceWith()
+    expect(useKeys().privateKeyArmored.value).toBeDefined()
+    expect(useRouter().replace).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(milliseconds({ minutes: 2 }))
+
+    expect(useKeys().privateKeyArmored.value).toBeFalsy()
+    expect(useRouter().replace).toHaveBeenCalledExactlyOnceWith({
+      name: 'Authenticate',
+      query: { flow: 'frontend', redirect: 'fullPath' },
+    })
+  })
+
+  test('cleans up on unmount', async () => {
+    getExpirationTime.mockResolvedValue(add(now, { minutes: 1 }))
+    useKeys().privateKeyArmored.value = 'whatever'
+
+    const wrapper = mount(TestComponent)
+
+    await flushPromises()
+
+    expect(getExpirationTime).toHaveBeenCalledExactlyOnceWith()
+    expect(useKeys().privateKeyArmored.value).toBeDefined()
+    expect(useRouter().replace).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+    vi.advanceTimersByTime(milliseconds({ minutes: 2 }))
+
+    expect(useKeys().privateKeyArmored.value).toBeDefined()
+    expect(useRouter().replace).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSignDetached', () => {
+  beforeEach(() => {
+    // vi.mocked doesn't work with overloads unfortunately
+    type ReadPrivateKeyFunc = (options: {
+      armoredKey: string
+      config?: PartialConfig
+    }) => Promise<PrivateKey>
+
+    vi.mocked(readPrivateKey as ReadPrivateKeyFunc).mockImplementation(
+      async (o) => `private-✨${o.armoredKey}✨` as unknown as PrivateKey,
+    )
+
+    vi.mocked(sign).mockResolvedValue(new Uint8Array([1, 2, 3]) as WebStream<Uint8Array>)
+  })
+
+  afterEach(() => {
+    useKeys().clear()
+
+    vi.mocked(sign).mockReset()
+    vi.mocked(readPrivateKey).mockReset()
+  })
+
+  test('uses key from params if available', async () => {
+    const signDetached = useSignDetached()
+    useKeys().privateKeyArmored.value = 'storage-key'
+
+    const signature = await signDetached('data', 'param-key')
+
+    expect(sign).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        signingKeys: 'private-✨param-key✨',
+      }),
+    )
+
+    expect(signature).toBe('AQID')
+  })
+
+  test('uses key from useKeys if no param', async () => {
+    const signDetached = useSignDetached()
+    useKeys().privateKeyArmored.value = 'storage-key'
+
+    const signature = await signDetached('data')
+
+    expect(sign).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        signingKeys: `private-✨storage-key✨`,
+      }),
+    )
+
+    expect(signature).toBe('AQID')
+  })
+
+  test('throws an error if no signing key is found', async () => {
+    const signDetached = useSignDetached()
+
+    await expect(signDetached('data')).rejects.toThrowError()
+  })
+})
+
+describe('hasValidKeys', () => {
+  const getExpirationTime = vi.fn()
+
+  beforeEach(() => {
+    vi.mocked(readPrivateKey, { partial: true }).mockResolvedValue({ getExpirationTime })
+  })
+
+  afterEach(() => {
+    useKeys().clear()
+
+    getExpirationTime.mockReset()
+    vi.mocked(readPrivateKey).mockReset()
+  })
+
+  test('false if no privateKey', async () => {
+    await expect(hasValidKeys()).resolves.toBeFalsy()
+  })
+
+  test('false if no expiration time', async () => {
+    useKeys().privateKeyArmored.value = 'whatever'
+    getExpirationTime.mockResolvedValue(Infinity)
+
+    await expect(hasValidKeys()).resolves.toBeFalsy()
+  })
+
+  test('false if expired', async () => {
+    useKeys().privateKeyArmored.value = 'whatever'
+    getExpirationTime.mockResolvedValue(sub(Date.now(), { seconds: 10 }))
+
+    await expect(hasValidKeys()).resolves.toBeFalsy()
+  })
+
+  test('true if has valid expiration in the future', async () => {
+    useKeys().privateKeyArmored.value = 'whatever'
+    getExpirationTime.mockResolvedValue(add(Date.now(), { seconds: 10 }))
+
+    await expect(hasValidKeys()).resolves.toBeTruthy()
+  })
+})
+
+describe('createKeys', () => {
+  test('creates & registers keys with the api', async () => {
+    vi.mocked(generateKey, { partial: true }).mockResolvedValue({
+      privateKey: 'privateKey' as unknown as PrivateKey,
+      publicKey: 'publicKey' as unknown as Key,
+    })
+
+    server.use(
+      http.post<never, RegisterPublicKeyRequest>('/auth.AuthService/RegisterPublicKey', () => {
+        return HttpResponse.json<RegisterPublicKeyResponse>(
+          { public_key_id: 'public_key_id' },
+          {
+            headers: {
+              'content-type': 'application/json',
+              'Grpc-metadata-content-type': 'application/grpc',
+            },
+          },
+        )
+      }),
+    )
+
+    const { privateKey, publicKey, publicKeyId } = await createKeys('myFANCY@email.COM')
+
+    expect(generateKey).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        userIDs: [{ email: 'myfancy@email.com' }],
+      }),
+    )
+
+    expect(privateKey).toBe('privateKey')
+    expect(publicKey).toBe('publicKey')
+    expect(publicKeyId).toBe('public_key_id')
+  })
+})

--- a/frontend/src/methods/key.ts
+++ b/frontend/src/methods/key.ts
@@ -2,10 +2,8 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
-
 import { useLocalStorage } from '@vueuse/core'
-import * as fetchIntercept from 'fetch-intercept'
-import type { Key, PrivateKey } from 'openpgp/lightweight'
+import { differenceInMilliseconds, isAfter, milliseconds, millisecondsToSeconds } from 'date-fns'
 import {
   createMessage,
   enums,
@@ -14,186 +12,126 @@ import {
   readPrivateKey,
   sign,
 } from 'openpgp/lightweight'
-import { ref } from 'vue'
+import { computed, watchEffect } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 
 import { b64Encode } from '@/api/fetch.pb'
 import { AuthService } from '@/api/omni/auth/auth.pb'
-import {
-  authHeader,
-  PayloadHeaderKey,
-  SignatureHeaderKey,
-  SignatureVersionV1,
-  TimestampHeaderKey,
-} from '@/api/resources'
-import { useIdentity } from '@/methods/identity'
-
-let interceptorsRegistered = false
-let keysReloadTimeout: number
+import { AuthFlowQueryParam, FrontendAuthFlow, RedirectQueryParam } from '@/api/resources'
 
 const privateKeyArmored = useLocalStorage<string>('privateKey', null)
 const publicKeyArmored = useLocalStorage<string>('publicKey', null)
 const publicKeyID = useLocalStorage<string>('publicKeyID', null)
 
-let keys: {
-  privateKey: PrivateKey
-  publicKey: Key
-} | null
+const privateKey = computed(() => {
+  if (!privateKeyArmored.value) return
 
-class KeysInvalidError extends Error {
-  constructor(msg: string) {
-    super(msg)
+  return readPrivateKey({ armoredKey: privateKeyArmored.value })
+})
 
-    // Set the prototype explicitly.
-    Object.setPrototypeOf(this, KeysInvalidError.prototype)
-  }
-}
+const publicKey = computed(() => {
+  if (!publicKeyArmored.value) return
 
-export const authorized = ref(false)
+  return readKey({ armoredKey: publicKeyArmored.value })
+})
 
-export const isAuthorized = async (): Promise<boolean> => {
-  if (!keys) {
-    try {
-      await loadKeys()
-    } catch {
-      return false
-    }
-  }
-
-  const keyExpirationTime = await keys?.privateKey.getExpirationTime()
-
-  if (!keyExpirationTime || new Date() > keyExpirationTime) {
-    return false
-  }
-
-  return true
-}
-
-const loadKeys = async (): Promise<{ privateKey: PrivateKey; publicKey: Key }> => {
-  if (!keys) {
-    if (!privateKeyArmored.value || !publicKeyArmored.value) {
-      throw new KeysInvalidError(`failed to load keys: keys not initialized`)
-    }
-
-    keys = {
-      privateKey: await readPrivateKey({ armoredKey: privateKeyArmored.value }),
-      publicKey: await readKey({ armoredKey: publicKeyArmored.value }),
-    }
-  }
-
-  const now = new Date()
-
-  const keyExpirationTime = await keys.privateKey.getExpirationTime()
-
-  if (!keyExpirationTime || now > keyExpirationTime) {
-    throw new KeysInvalidError(`failed to load keys: the key is expired`)
-  }
-
-  registerInterceptors()
-
-  clearTimeout(keysReloadTimeout)
-  keysReloadTimeout = window.setTimeout(
-    () => {
-      location.reload()
+export function useKeys() {
+  return {
+    privateKey,
+    privateKeyArmored,
+    publicKey,
+    publicKeyArmored,
+    publicKeyID,
+    clear() {
+      privateKeyArmored.value = null
+      publicKeyArmored.value = null
+      publicKeyID.value = null
     },
-    (keyExpirationTime as Date).getTime() - now.getTime() + 1000,
-  )
-
-  authorized.value = true
-
-  return keys
+  }
 }
 
-export const createKeys = async (
-  email: string,
-): Promise<{ privateKey: string; publicKey: string; publicKeyId: string }> => {
+/**
+ * We register this hook to watch the state of our keys
+ * and to automatically send the user to the authentication page
+ * when keys are expire.
+ */
+export function useWatchKeyExpiry() {
+  const router = useRouter()
+  const route = useRoute()
+  const keys = useKeys()
+
+  watchEffect(async (onCleanup) => {
+    if (!keys.privateKey.value) return
+
+    const key = await keys.privateKey.value
+    const keyExpirationTime = await key.getExpirationTime()
+
+    if (!(keyExpirationTime instanceof Date) || isAfter(Date.now(), keyExpirationTime)) {
+      return clearKeysAndRedirect()
+    }
+
+    const keysReloadTimeout = window.setTimeout(
+      clearKeysAndRedirect,
+      differenceInMilliseconds(keyExpirationTime, Date.now()) + 1000,
+    )
+
+    onCleanup(() => clearTimeout(keysReloadTimeout))
+
+    function clearKeysAndRedirect() {
+      keys.clear()
+
+      router.replace({
+        name: 'Authenticate',
+        query: { [AuthFlowQueryParam]: FrontendAuthFlow, [RedirectQueryParam]: route.fullPath },
+      })
+    }
+  })
+}
+
+export function useSignDetached() {
+  const keys = useKeys()
+
+  return async function (data: string, privateKey?: string) {
+    const signingKeys = privateKey
+      ? await readPrivateKey({ armoredKey: privateKey })
+      : await keys.privateKey.value
+
+    if (!signingKeys) {
+      throw new Error('failed to load keys: keys not initialized')
+    }
+
+    const stream = await sign({
+      message: await createMessage({ text: data }),
+      detached: true,
+      signingKeys,
+      format: 'binary',
+    })
+
+    const array = stream as Uint8Array
+
+    return b64Encode(array, 0, array.length)
+  }
+}
+
+export async function hasValidKeys() {
+  if (!privateKey.value) return false
+
+  const key = await privateKey.value
+  const keyExpirationTime = await key.getExpirationTime()
+
+  if (!keyExpirationTime) return false
+
+  return isAfter(keyExpirationTime, Date.now())
+}
+
+export async function createKeys(email: string) {
   email = email.toLowerCase()
 
-  const res = await genKey(email)
-
-  const enc = new TextEncoder()
-
-  const response = await AuthService.RegisterPublicKey({
-    public_key: {
-      pgp_data: enc.encode(res.publicKey),
-    },
-    identity: {
-      email: email,
-    },
-  })
-
-  return {
-    publicKeyId: response.public_key_id!,
-    ...res,
-  }
-}
-
-export const revokePublicKey = async () => {
-  if (!publicKeyID.value) {
-    return
-  }
-
-  await AuthService.RevokePublicKey({
-    public_key_id: publicKeyID.value,
-  })
-}
-
-export const signDetached = async (data: string, privateKey?: string): Promise<string> => {
-  let keys: {
-    privateKey: PrivateKey
-  }
-
-  if (privateKey) {
-    keys = {
-      privateKey: await readPrivateKey({ armoredKey: privateKey }),
-    }
-  } else {
-    keys = await loadKeys()
-  }
-
-  const stream = await sign({
-    message: await createMessage({ text: data }),
-    detached: true,
-    signingKeys: keys.privateKey,
-    format: 'binary',
-  })
-
-  const array = stream as Uint8Array
-
-  return b64Encode(array, 0, array.length)
-}
-
-export const saveKeys = async (privateKey: string, publicKey: string, publicKeyId: string) => {
-  keys = null
-
-  publicKeyArmored.value = publicKey
-  privateKeyArmored.value = privateKey
-  publicKeyID.value = publicKeyId
-
-  const loadedKeys = await loadKeys()
-
-  const expirationTime = await loadedKeys.privateKey.getExpirationTime()
-
-  if (!(expirationTime instanceof Date)) {
-    throw new KeysInvalidError('failed to save keys: invalid expiration time')
-  }
-}
-
-export const resetKeys = () => {
-  keys = null
-
-  publicKeyArmored.value = undefined
-  privateKeyArmored.value = undefined
-  publicKeyID.value = undefined
-
-  authorized.value = false
-}
-
-const genKey = async (email: string): Promise<{ publicKey: string; privateKey: string }> => {
   const { privateKey, publicKey } = await generateKey({
     type: 'ecc',
     curve: 'ed25519Legacy',
-    userIDs: [{ email: email.toLowerCase() }],
-    keyExpirationTime: 7 * 60 * 60 + 50 * 60, // 7 hours 50 minutes
+    userIDs: [{ email }],
+    keyExpirationTime: millisecondsToSeconds(milliseconds({ hours: 7, minutes: 50 })),
     config: {
       preferredCompressionAlgorithm: enums.compression.zlib,
       preferredSymmetricAlgorithm: enums.symmetric.aes256,
@@ -201,127 +139,18 @@ const genKey = async (email: string): Promise<{ publicKey: string; privateKey: s
     },
   })
 
-  return {
-    publicKey: publicKey,
-    privateKey: privateKey,
-  }
-}
+  const enc = new TextEncoder()
 
-const includedHeaders = [
-  'nodes',
-  'selectors',
-  'fieldSelectors',
-  'runtime',
-  'context',
-  'cluster',
-  'namespace',
-  'uid',
-  TimestampHeaderKey,
-  authHeader,
-]
-
-const buildPayload = (
-  url: string,
-  config: { headers?: Headers },
-): { headers: Record<string, string[]>; method: string } => {
-  const headers: Record<string, string[]> = {}
-
-  if (config.headers) {
-    for (const header of includedHeaders) {
-      const key = `Grpc-Metadata-${header}`
-      const value = config.headers.get(key)
-
-      if (value) {
-        if (!headers[header]) {
-          headers[header] = [value]
-        } else {
-          headers[header].push(value)
-        }
-      }
-    }
-  }
-
-  return {
-    headers: headers,
-    method: url.replace(/^\/api/, ''),
-  }
-}
-
-const registerInterceptors = () => {
-  if (interceptorsRegistered) {
-    return
-  }
-
-  const { identity } = useIdentity()
-
-  fetchIntercept.register({
-    request: async (url, config?: { headers?: Headers; method?: string }) => {
-      url = encodeURI(url)
-
-      if (
-        !/^\/(api|image)/.test(url) ||
-        (url.startsWith('/api/auth.') && !url.startsWith('/api/auth.AuthService/RevokePublicKey'))
-      ) {
-        return [url, config]
-      }
-
-      if (!config) {
-        config = {}
-      }
-
-      if (!config.headers) {
-        config.headers = new Headers()
-      }
-
-      const ts = (new Date().getTime() / 1000).toFixed(0)
-
-      try {
-        if (url.indexOf('/api') === 0) {
-          config.headers.set(`Grpc-Metadata-${TimestampHeaderKey}`, ts)
-
-          const payload = JSON.stringify(buildPayload(url, config))
-          const signature = await signDetached(payload)
-          const fingerprint = keys?.publicKey.getFingerprint()
-
-          config.headers.set(`Grpc-Metadata-${PayloadHeaderKey}`, payload)
-          config.headers.set(
-            `Grpc-Metadata-${SignatureHeaderKey}`,
-            `${SignatureVersionV1} ${identity.value} ${fingerprint} ${signature}`,
-          )
-        } else if (url.indexOf('/image/') === 0) {
-          config.headers.set(TimestampHeaderKey, ts)
-
-          const sha256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' // empty string sha256
-          const payload = [config.method ?? 'GET', url, ts, sha256].join('\n')
-          const signature = await signDetached(payload)
-          const fingerprint = keys?.publicKey.getFingerprint()
-
-          config.headers.set(
-            SignatureHeaderKey,
-            `${SignatureVersionV1} ${identity.value} ${fingerprint} ${signature}`,
-          )
-        }
-      } catch {
-        // reload the page to make the key Authenticator regenerate the key
-        location.reload()
-      }
-
-      return [url, config]
+  const response = await AuthService.RegisterPublicKey({
+    public_key: {
+      pgp_data: enc.encode(publicKey),
     },
+    identity: { email },
   })
 
-  interceptorsRegistered = true
-}
-
-export const getParentDomain = () => {
-  const domainParts = window.location.hostname.split('.')
-  if (domainParts.length < 2) {
-    console.error(
-      'there is no parent domain for the current hostname, returning the current hostname',
-    )
-
-    return window.location.hostname
+  return {
+    privateKey,
+    publicKey,
+    publicKeyId: response.public_key_id!,
   }
-
-  return domainParts.slice(1).join('.')
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -12,7 +12,7 @@ import { AuthFlowQueryParam, FrontendAuthFlow, RedirectQueryParam } from '@/api/
 import { current } from '@/context'
 import { AuthType, authType } from '@/methods'
 import { loadCurrentUser } from '@/methods/auth'
-import { isAuthorized } from '@/methods/key'
+import { hasValidKeys } from '@/methods/key'
 import { MachineFilterOption } from '@/methods/machine'
 import { refreshTitle } from '@/methods/title'
 
@@ -34,7 +34,9 @@ export const routes: RouteRecordRaw[] = [
     name: 'OIDC Login',
     component: () => import('@/views/omni/Auth/OIDC.vue'),
     beforeEnter: async (to) => {
-      if (await isAuthorized()) {
+      const authorized = await hasValidKeys()
+
+      if (authorized) {
         return true
       }
 
@@ -61,7 +63,7 @@ export const routes: RouteRecordRaw[] = [
       sidebar: () => import('@/components/SideBar/TSideBar.vue'),
     },
     beforeEnter: async (to) => {
-      const authorized = await isAuthorized()
+      const authorized = await hasValidKeys()
 
       if (authorized) {
         await loadCurrentUser()

--- a/frontend/src/views/omni/Auth/Authenticate.vue
+++ b/frontend/src/views/omni/Auth/Authenticate.vue
@@ -35,7 +35,7 @@ import UserInfo from '@/components/common/UserInfo/UserInfo.vue'
 import { AuthType, authType } from '@/methods'
 import { useLogout } from '@/methods/auth'
 import { useIdentity } from '@/methods/identity'
-import { createKeys, saveKeys, signDetached } from '@/methods/key'
+import { createKeys, useKeys, useSignDetached } from '@/methods/key'
 import { showError } from '@/notification'
 
 const user = ref<User | undefined>(undefined)
@@ -136,6 +136,7 @@ const confirmed = ref(false)
 let redirect: string = route.query[RedirectQueryParam] as string
 
 const logout = useLogout()
+const keys = useKeys()
 const identityStorage = useIdentity()
 
 const generatePublicKey = async () => {
@@ -153,13 +154,9 @@ const generatePublicKey = async () => {
     return
   }
 
-  try {
-    await saveKeys(res.privateKey, res.publicKey, publicKeyId)
-  } catch (e) {
-    showError('Failed to save the key', e.message)
-
-    return
-  }
+  keys.privateKeyArmored.value = res.privateKey
+  keys.publicKeyArmored.value = res.publicKey
+  keys.publicKeyID.value = publicKeyId
 
   identityStorage.identity.value = identity.value.toLowerCase()
   identityStorage.fullname.value = name.value ?? ''
@@ -183,6 +180,7 @@ const generatePublicKey = async () => {
 }
 
 let renewIdToken = false
+const signDetached = useSignDetached()
 
 const confirmPublicKey = async (privateKey?: string) => {
   try {
@@ -279,7 +277,7 @@ const Auth = {
             <div>The keys are going to be issued for the user:</div>
             <UserInfo
               user="user"
-              class="user-info"
+              class="rounded-md bg-naturals-n6 px-6 py-2"
               :email="identity"
               :avatar="picture"
               :fullname="name"
@@ -311,11 +309,3 @@ const Auth = {
     </div>
   </div>
 </template>
-
-<style scoped>
-@reference "../../../index.css";
-
-.user-info {
-  @apply rounded-md bg-naturals-n6 px-6 py-2;
-}
-</style>


### PR DESCRIPTION
Extract interceptor code from the key generation logic in the frontend, simplified the remaining key logic, and wrote tests for all the things I touched.