### PR TITLE
fix(frontend): remove double scrollbar on machines list

### DIFF
--- a/frontend/src/components/common/Checkbox/TCheckbox.vue
+++ b/frontend/src/components/common/Checkbox/TCheckbox.vue
@@ -21,7 +21,7 @@ const checked = defineModel<boolean>({ default: false })
 
 <template>
   <label class="inline-flex cursor-pointer items-center gap-2 has-disabled:cursor-not-allowed">
-    <input v-model="checked" type="checkbox" :disabled="disabled" class="peer sr-only" />
+    <input v-model="checked" type="checkbox" :disabled="disabled" class="peer sr-only fixed" />
 
     <div
       class="flex size-3.5 items-center justify-center rounded-xs border border-naturals-n7 peer-checked:border-primary-p6 peer-checked:bg-primary-p6 peer-disabled:border-naturals-n5 peer-disabled:bg-naturals-n4"


### PR DESCRIPTION
Removes the double scrollbar on the machines list caused by sr-only. See https://github.com/tailwindlabs/tailwindcss/discussions/12429 for more info.

Fixes #1755 