### PR TITLE
test: fix flaky `MachineUpgradeStatusController` test

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
-	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 	"github.com/siderolabs/talos/pkg/machinery/client"
@@ -113,9 +112,9 @@ func (ctrl *StatusController) transform(ctx context.Context, r controller.Reader
 		return nil
 	}
 
-	kernelArgsRes, err := safe.ReaderGetByID[*omni.KernelArgs](ctx, r, ms.Metadata().ID())
+	kernelArgsRes, err := kernelargs.GetUncached(ctx, r, ms.Metadata().ID())
 	if err != nil && !state.IsNotFoundError(err) {
-		return fmt.Errorf("error getting extra kernel args configuration: %w", err)
+		return fmt.Errorf("error getting extra kernel args: %w", err)
 	}
 
 	kernelArgs, kernelArgsOk, err := kernelargs.Calculate(ms, kernelArgsRes)

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
@@ -225,6 +225,11 @@ func TestReconcile(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		// assert that it was observed by the controller
+		rtestutils.AssertResource(ctx, t, st, id, func(res *omni.MachineUpgradeStatus, assertion *assert.Assertions) {
+			assertion.False(res.TypedSpec().Value.IsMaintenance)
+		})
+
 		// update the args to trigger a pending update
 		_, err = safe.StateUpdateWithConflicts(ctx, st, kernelArgs.Metadata(), func(res *omni.KernelArgs) error {
 			res.TypedSpec().Value.Args = []string{"final-arg1", "final-arg2"}


### PR DESCRIPTION
Do the same thing we did in the schematic configuration controller and read the KernelArgs resource uncached.

This logic is in the process of being centralized in #1792, but still, it should help with the test stability at the time being.