### PR TITLE
fix(frontend): keep use_embedded_discovery_service state when scaling

### DIFF
--- a/frontend/src/states/cluster-management.ts
+++ b/frontend/src/states/cluster-management.ts
@@ -318,21 +318,21 @@ export class State {
     if (this.cluster.features.enableWorkloadProxy) {
       cluster.spec.features = {
         ...cluster.spec.features,
-        enable_workload_proxy: this.cluster.features?.enableWorkloadProxy,
+        enable_workload_proxy: this.cluster.features.enableWorkloadProxy,
       }
     }
 
     if (this.cluster.features.useEmbeddedDiscoveryService) {
       cluster.spec.features = {
         ...cluster.spec.features,
-        use_embedded_discovery_service: this.cluster.features?.useEmbeddedDiscoveryService,
+        use_embedded_discovery_service: this.cluster.features.useEmbeddedDiscoveryService,
       }
     }
 
     if (this.cluster.features.encryptDisks) {
       cluster.spec.features = {
         ...cluster.spec.features,
-        disk_encryption: this.cluster.features?.encryptDisks,
+        disk_encryption: this.cluster.features.encryptDisks,
       }
     }
 
@@ -706,6 +706,7 @@ export const populateExisting = async (clusterName: string) => {
     features: {
       enableWorkloadProxy: cluster.spec.features?.enable_workload_proxy,
       encryptDisks: cluster.spec.features?.disk_encryption,
+      useEmbeddedDiscoveryService: cluster.spec.features?.use_embedded_discovery_service,
     },
     etcdBackupConfig: {
       enabled: cluster.spec.backup_configuration?.enabled,


### PR DESCRIPTION
Remember the previous value of `use_embedded_discovery_service` during cluster scaling.

It seems that the flow is for `ClusterScale->onMounted` to call the `populateExisting` method which has a side effect of initialising a `state` variable, but it did not initialise `use_embedded_discovery_service`. Later this state variable is used to determine what resources to create/update, and it updated it to a version without this feature being enabled.

Fixes #1849 