### PR TITLE
feat: allow force-deletion of machine requests

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/infra_machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine.go
@@ -181,12 +181,12 @@ func (ctrl *InfraMachineController) reconcileTearingDown(ctx context.Context, r 
 }
 
 func (ctrl *InfraMachineController) handleInfraProviderDeletion(ctx context.Context, r controller.QRuntime, link *siderolink.Link) error {
-	infraProviderId, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
+	infraProviderID, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID)
 	if !ok {
 		return nil
 	}
 
-	infraProvider, err := safe.ReaderGetByID[*infra.Provider](ctx, r, infraProviderId)
+	infraProvider, err := safe.ReaderGetByID[*infra.Provider](ctx, r, infraProviderID)
 	if err != nil && !state.IsNotFoundError(err) {
 		return err
 	}

--- a/internal/backend/runtime/omni/controllers/omni/machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine.go
@@ -187,7 +187,7 @@ func (h *machineControllerHelper) handleProvisioningInfraProvider(ctx context.Co
 		return err
 	}
 
-	if machineRequestSet != nil && machineRequestSet.Metadata().Owner() == machineProvisionControllerName {
+	if machineRequestSet != nil && machineRequestSet.Metadata().Owner() == MachineProvisionControllerName {
 		machine.Metadata().Labels().Set(omni.LabelNoManualAllocation, "")
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_provision.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_provision.go
@@ -22,18 +22,19 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/mappers"
 )
 
-// MachineProvisionController turns MachineProvision resources into a MachineRequestSets, scales them automatically on demand.
+// MachineProvisionController turns MachineProvision resources into MachineRequestSets, scales them automatically on demand.
 type MachineProvisionController = qtransform.QController[*omni.MachineSet, *omni.MachineRequestSet]
 
-const machineProvisionControllerName = "MachineProvisionController"
+// MachineProvisionControllerName is the name of the MachineProvisionController.
+const MachineProvisionControllerName = "MachineProvisionController"
 
-// NewMachineProvisionController instanciates the machine controller.
+// NewMachineProvisionController instantiates the machine controller.
 //
 //nolint:gocognit
 func NewMachineProvisionController() *MachineProvisionController {
 	return qtransform.NewQController(
 		qtransform.Settings[*omni.MachineSet, *omni.MachineRequestSet]{
-			Name: machineProvisionControllerName,
+			Name: MachineProvisionControllerName,
 			MapMetadataFunc: func(res *omni.MachineSet) *omni.MachineRequestSet {
 				return omni.NewMachineRequestSet(resources.DefaultNamespace, res.Metadata().ID())
 			},
@@ -135,6 +136,7 @@ func NewMachineProvisionController() *MachineProvisionController {
 				},
 			),
 		),
+		qtransform.WithOutputKind(controller.OutputShared),
 		qtransform.WithConcurrency(4),
 	)
 }

--- a/internal/pkg/siderolink/provision.go
+++ b/internal/pkg/siderolink/provision.go
@@ -399,18 +399,18 @@ func establishLink[T res](ctx context.Context, logger *zap.Logger, st state.Stat
 		}
 	}
 
-	if infraProviderId, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID); ok {
-		logger.Debug("the link is originating from an infra provider", zap.String("infra_provider_id", infraProviderId))
+	if infraProviderID, ok := link.Metadata().Labels().Get(omni.LabelInfraProviderID); ok {
+		logger.Debug("the link is originating from an infra provider", zap.String("infra_provider_id", infraProviderID))
 		// the link is originating from an infra provider, reject the request if the infra provider doesn't exist or being deleted
-		infraProvider, infraErr := safe.ReaderGetByID[*infra.Provider](ctx, st, infraProviderId)
+		infraProvider, infraErr := safe.ReaderGetByID[*infra.Provider](ctx, st, infraProviderID)
 		if infraErr != nil && !state.IsNotFoundError(infraErr) {
-			logger.Warn("failed to fetch infra provider", zap.String("infra_provider_id", infraProviderId), zap.Error(infraErr))
+			logger.Warn("failed to fetch infra provider", zap.String("infra_provider_id", infraProviderID), zap.Error(infraErr))
 
-			return nil, status.Errorf(codes.Internal, "failed to fetch infra provider %s", infraProviderId)
+			return nil, status.Errorf(codes.Internal, "failed to fetch infra provider %s", infraProviderID)
 		}
 
 		if infraProvider == nil || infraProvider.Metadata().Phase() != resource.PhaseRunning {
-			logger.Warn("the infra provider is being deleted or doesn't exist", zap.String("infra_provider_id", infraProviderId))
+			logger.Warn("the infra provider is being deleted or doesn't exist", zap.String("infra_provider_id", infraProviderID))
 
 			return nil, status.Errorf(codes.NotFound, "the infra provider is being deleted or doesn't exist")
 		}


### PR DESCRIPTION
Allow force-deletion of `Machine`s managed by dynamic(provisioning) `InfraProvider`
* Clean up finalizers set by `InfraProvider` on `MachineRequest` resource after InfraProvider is deleted
* Clean up associated `MachineRequestStatus` resources after `InfraProvider` is deleted
* Clean up user owned `MachineSetRequest` resources after `InfraProvider` is deleted

Closes: #1853
