### PR TITLE
refactor(frontend): change RadioGroup to use slots for options

### DIFF
--- a/frontend/src/components/common/Radio/RadioGroup.spec.ts
+++ b/frontend/src/components/common/Radio/RadioGroup.spec.ts
@@ -7,6 +7,7 @@ import { render, screen, waitFor } from '@testing-library/vue'
 import { expect, test } from 'vitest'
 
 import RadioGroup from './RadioGroup.vue'
+import RadioGroupOption from './RadioGroupOption.vue'
 
 const options = Array(5)
   .fill(null)
@@ -22,7 +23,24 @@ test('allows selection', async () => {
   render(RadioGroup, {
     props: {
       label: 'My radio',
-      options,
+    },
+    global: {
+      components: { RadioGroupOption },
+    },
+    slots: {
+      default: options
+        .map(
+          (option) => `
+          <RadioGroupOption value="${option.value}">
+            ${option.label}
+
+            <template #description>
+              ${option.description}
+            </template>
+          </RadioGroupOption>
+        `,
+        )
+        .join(''),
     },
   })
 

--- a/frontend/src/components/common/Radio/RadioGroup.stories.ts
+++ b/frontend/src/components/common/Radio/RadioGroup.stories.ts
@@ -7,20 +7,15 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { fn } from 'storybook/test'
 
 import RadioGroup from './RadioGroup.vue'
+import RadioGroupOption from './RadioGroupOption.vue'
 
 const meta: Meta<typeof RadioGroup> = {
   // https://github.com/storybookjs/storybook/issues/24238
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   component: RadioGroup as any,
+  subcomponents: { RadioGroupOption },
   args: {
     label: faker.company.name(),
-    options: faker.helpers
-      .uniqueArray(() => faker.commerce.isbn(), 10)
-      .map((value) => ({
-        label: faker.commerce.productName(),
-        description: faker.helpers.maybe(() => faker.commerce.productDescription()),
-        value,
-      })),
     'onUpdate:modelValue': fn(),
   },
 }
@@ -28,4 +23,28 @@ const meta: Meta<typeof RadioGroup> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  render: (args) => ({
+    components: { RadioGroup, RadioGroupOption },
+    setup: () => ({ args }),
+    template: `
+      <RadioGroup v-bind="args">
+        ${faker.helpers
+          .uniqueArray(faker.commerce.isbn, 10)
+          .map(
+            (value) => `
+          <RadioGroupOption value="${value}">
+            ${faker.commerce.productName()}
+            ${
+              faker.helpers.maybe(
+                () => `<template #description>${faker.commerce.productDescription()}</template>`,
+              ) || ''
+            }
+          </RadioGroupOption>
+        `,
+          )
+          .join('')}
+      </RadioGroup>
+    `,
+  }),
+}

--- a/frontend/src/components/common/Radio/RadioGroup.vue
+++ b/frontend/src/components/common/Radio/RadioGroup.vue
@@ -4,21 +4,11 @@ Copyright (c) 2025 Sidero Labs, Inc.
 Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
-<script setup lang="ts" generic="T extends string | number | boolean | Record<string, any>">
-import {
-  RadioGroup,
-  RadioGroupDescription,
-  RadioGroupLabel,
-  RadioGroupOption,
-} from '@headlessui/vue'
+<script setup lang="ts" generic="T extends string | number | boolean | Record<string, unknown>">
+import { RadioGroup, RadioGroupLabel } from '@headlessui/vue'
 
 defineProps<{
   label: string
-  options: {
-    label: string
-    description?: string
-    value: T
-  }[]
 }>()
 
 const model = defineModel<T>()
@@ -31,32 +21,7 @@ const model = defineModel<T>()
     </RadioGroupLabel>
 
     <div class="flex flex-col items-start gap-4">
-      <RadioGroupOption
-        v-for="option in options"
-        :key="option.label"
-        v-slot="{ checked }"
-        as="template"
-        :value="option.value"
-      >
-        <div class="flex cursor-pointer items-center gap-2.5 rounded-md">
-          <div
-            class="size-3.5 shrink-0 rounded-full border bg-clip-content p-0.5 transition-colors duration-250"
-            :class="
-              checked ? 'border-primary-p4 bg-primary-p4' : 'border-naturals-n5 bg-transparent'
-            "
-          ></div>
-
-          <div class="text-xs">
-            <RadioGroupLabel as="p" class="font-medium text-naturals-n14">
-              {{ option.label }}
-            </RadioGroupLabel>
-
-            <RadioGroupDescription v-if="option.description" as="span">
-              {{ option.description }}
-            </RadioGroupDescription>
-          </div>
-        </div>
-      </RadioGroupOption>
+      <slot></slot>
     </div>
   </RadioGroup>
 </template>

--- a/frontend/src/components/common/Radio/RadioGroupOption.vue
+++ b/frontend/src/components/common/Radio/RadioGroupOption.vue
@@ -1,0 +1,34 @@
+<!--
+Copyright (c) 2025 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { RadioGroupDescription, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue'
+
+defineProps<{
+  value: string | number | boolean | Record<string, unknown>
+}>()
+</script>
+
+<template>
+  <RadioGroupOption v-slot="{ checked }" as="template" :value>
+    <div class="flex cursor-pointer items-center gap-2.5 rounded-md">
+      <div
+        class="size-3.5 shrink-0 rounded-full border bg-clip-content p-0.5 transition-colors duration-250"
+        :class="checked ? 'border-primary-p4 bg-primary-p4' : 'border-naturals-n5 bg-transparent'"
+      ></div>
+
+      <div class="text-xs">
+        <RadioGroupLabel as="p" class="font-medium text-naturals-n14">
+          <slot></slot>
+        </RadioGroupLabel>
+
+        <RadioGroupDescription v-if="$slots.description" as="span">
+          <slot name="description"></slot>
+        </RadioGroupDescription>
+      </div>
+    </div>
+  </RadioGroupOption>
+</template>

--- a/frontend/src/views/omni/InstallationMedia/Steps/Entry.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Entry.vue
@@ -6,6 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
+import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
@@ -16,30 +17,32 @@ const formState = defineModel<FormState>({ required: true })
   <div class="flex flex-col gap-4">
     <TInput v-model="formState.name" title="Name" overhead-title />
 
-    <RadioGroup
-      v-model="formState.hardwareType"
-      label="Hardware Type"
-      :options="
-        [
-          {
-            label: 'Bare-metal Machine',
-            description:
-              'Suitable for x86-64 and arm64 bare-metal machines, as well as generic virtual machines. If unsure, choose this option.',
-            value: 'metal',
-          },
-          {
-            label: 'Cloud Server',
-            description:
-              'Compatible with AWS, GCP, Azure, VMWare, Equinix Metal, and other platforms, including homelab environments like Proxmox.',
-            value: 'cloud',
-          },
-          {
-            label: 'Single Board Computer',
-            description: 'Supports Raspberry Pi, Pine64, Jetson Nano, and similar devices.',
-            value: 'sbc',
-          },
-        ] satisfies { [key: string]: any; value: typeof formState.hardwareType }[]
-      "
-    />
+    <RadioGroup v-model="formState.hardwareType" label="Hardware Type">
+      <RadioGroupOption value="metal">
+        Bare-metal Machine
+
+        <template #description>
+          Suitable for x86-64 and arm64 bare-metal machines, as well as generic virtual machines. If
+          unsure, choose this option.
+        </template>
+      </RadioGroupOption>
+
+      <RadioGroupOption value="cloud">
+        Cloud Server
+
+        <template #description>
+          Compatible with AWS, GCP, Azure, VMWare, Equinix Metal, and other platforms, including
+          homelab environments like Proxmox.
+        </template>
+      </RadioGroupOption>
+
+      <RadioGroupOption value="sbc">
+        Single Board Computer
+
+        <template #description>
+          Supports Raspberry Pi, Pine64, Jetson Nano, and similar devices.
+        </template>
+      </RadioGroupOption>
+    </RadioGroup>
   </div>
 </template>

--- a/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.vue
@@ -7,6 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
+import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
 import { useDocsLink } from '@/methods'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
@@ -21,25 +22,25 @@ const secureBootDocsLink = useDocsLink(
 
 <template>
   <div class="flex flex-col gap-4">
-    <RadioGroup
-      v-model="formState.machineArch"
-      label="Machine Architecture"
-      :options="
-        [
-          {
-            label: 'amd64',
-            description:
-              'Compatible with Intel and AMD CPUs, also referred to as x86_64. If unsure, select this option.',
-            value: 'amd64',
-          },
-          {
-            label: 'arm64',
-            description: `Suitable for Ampere Computing and other arm64 CPUs. For Single Board Computers, choose the 'SBC' option on the first screen. For AWS and GCP arm64 VMs, use Cloud images.`,
-            value: 'arm64',
-          },
-        ] satisfies { [key: string]: any; value: typeof formState.machineArch }[]
-      "
-    />
+    <RadioGroup v-model="formState.machineArch" label="Machine Architecture">
+      <RadioGroupOption value="amd64">
+        amd64
+
+        <template #description>
+          Compatible with Intel and AMD CPUs, also referred to as x86_64. If unsure, select this
+          option.
+        </template>
+      </RadioGroupOption>
+
+      <RadioGroupOption value="arm64">
+        arm64
+
+        <template #description>
+          Suitable for Ampere Computing and other arm64 CPUs. For Single Board Computers, choose the
+          'SBC' option on the first screen. For AWS and GCP arm64 VMs, use Cloud images.
+        </template>
+      </RadioGroupOption>
+    </RadioGroup>
 
     <TCheckbox v-if="formState.hardwareType !== 'cloud'" v-model="formState.secureBoot">
       <div class="flex flex-col">


### PR DESCRIPTION
Refactor RadioGroup to use slots with RadioGroupOptions instead of options props, to allow for adding extra content like links to the options.

Required for these kinds of options from installation media wizard:
<img width="302" height="72" alt="image" src="https://github.com/user-attachments/assets/a6d18856-d119-48cb-bc67-e823d21397dd" />
