### PR TITLE
feat(installation-media): implement cloud provider + sbc steps

### DIFF
--- a/frontend/src/components/THeader/THeader.vue
+++ b/frontend/src/components/THeader/THeader.vue
@@ -10,7 +10,7 @@ import { computedAsync } from '@vueuse/core'
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import OngoingTasks from '@/components/common/OngoingTasks/OngoingTasks.vue'
-import { useDocsLink } from '@/methods'
+import { getDocsLink } from '@/methods'
 import { hasValidKeys } from '@/methods/key'
 
 interface Props {
@@ -20,7 +20,7 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const docsLink = useDocsLink('omni')
+const docsLink = getDocsLink('omni')
 
 // Used to prevent sub-queries being fired before keys are created
 const authorized = computedAsync(async () => await hasValidKeys())

--- a/frontend/src/methods/index.spec.ts
+++ b/frontend/src/methods/index.spec.ts
@@ -5,65 +5,42 @@
 import { expect } from '@playwright/test'
 import { parse } from 'semver'
 import { test } from 'vitest'
-import { nextTick, ref } from 'vue'
 
 import { DefaultTalosVersion } from '@/api/resources'
 
-import { useDocsLink } from '.'
+import { getDocsLink } from '.'
 
 const { major, minor } = parse(DefaultTalosVersion, false, true)
 const defaultVersion = `${major}.${minor}`
 
 test.each`
-  type       | path            | options                               | expected
-  ${'talos'} | ${undefined}    | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}`}
-  ${'talos'} | ${'/hello/123'} | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
-  ${'talos'} | ${'hello/123'}  | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
-  ${'talos'} | ${'/hello'}     | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello`}
-  ${'talos'} | ${'123'}        | ${undefined}                          | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/123`}
-  ${'talos'} | ${'/hello/123'} | ${{}}                                 | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
-  ${'talos'} | ${'hello/123'}  | ${{}}                                 | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
-  ${'talos'} | ${'/hello'}     | ${{}}                                 | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello`}
-  ${'talos'} | ${'123'}        | ${{}}                                 | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/123`}
-  ${'talos'} | ${'/hello/123'} | ${{ talosVersion: '1.11.3' }}         | ${'https://docs.siderolabs.com/talos/v1.11/hello/123'}
-  ${'talos'} | ${'hello/123'}  | ${{ talosVersion: '1.10.0' }}         | ${'https://docs.siderolabs.com/talos/v1.10/hello/123'}
-  ${'talos'} | ${'/hello'}     | ${{ talosVersion: '1.9' }}            | ${'https://docs.siderolabs.com/talos/v1.9/hello'}
-  ${'talos'} | ${'123'}        | ${{ talosVersion: '1' }}              | ${'https://docs.siderolabs.com/talos/v1.0/123'}
-  ${'talos'} | ${'/hello/123'} | ${ref({ talosVersion: '1.11.3' })}    | ${'https://docs.siderolabs.com/talos/v1.11/hello/123'}
-  ${'talos'} | ${'hello/123'}  | ${ref({ talosVersion: '1.10.0' })}    | ${'https://docs.siderolabs.com/talos/v1.10/hello/123'}
-  ${'talos'} | ${'/hello'}     | ${ref({ talosVersion: '1.9' })}       | ${'https://docs.siderolabs.com/talos/v1.9/hello'}
-  ${'talos'} | ${'123'}        | ${ref({ talosVersion: '1' })}         | ${'https://docs.siderolabs.com/talos/v1.0/123'}
-  ${'talos'} | ${'/hello/123'} | ${() => ({ talosVersion: '1.11.3' })} | ${'https://docs.siderolabs.com/talos/v1.11/hello/123'}
-  ${'talos'} | ${'hello/123'}  | ${() => ({ talosVersion: '1.10.0' })} | ${'https://docs.siderolabs.com/talos/v1.10/hello/123'}
-  ${'talos'} | ${'/hello'}     | ${() => ({ talosVersion: '1.9' })}    | ${'https://docs.siderolabs.com/talos/v1.9/hello'}
-  ${'talos'} | ${'123'}        | ${() => ({ talosVersion: '1' })}      | ${'https://docs.siderolabs.com/talos/v1.0/123'}
-  ${'omni'}  | ${undefined}    | ${undefined}                          | ${'https://docs.siderolabs.com/omni'}
-  ${'omni'}  | ${'/hello/123'} | ${undefined}                          | ${'https://docs.siderolabs.com/omni/hello/123'}
-  ${'omni'}  | ${'hello/123'}  | ${undefined}                          | ${'https://docs.siderolabs.com/omni/hello/123'}
-  ${'omni'}  | ${'/hello'}     | ${undefined}                          | ${'https://docs.siderolabs.com/omni/hello'}
-  ${'omni'}  | ${'123'}        | ${undefined}                          | ${'https://docs.siderolabs.com/omni/123'}
-  ${'k8s'}   | ${undefined}    | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides'}
-  ${'k8s'}   | ${'/hello/123'} | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides/hello/123'}
-  ${'k8s'}   | ${'hello/123'}  | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides/hello/123'}
-  ${'k8s'}   | ${'/hello'}     | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides/hello'}
-  ${'k8s'}   | ${'123'}        | ${undefined}                          | ${'https://docs.siderolabs.com/kubernetes-guides/123'}
+  type       | path            | options                       | expected
+  ${'talos'} | ${undefined}    | ${undefined}                  | ${`https://docs.siderolabs.com/talos/v${defaultVersion}`}
+  ${'talos'} | ${'/hello/123'} | ${undefined}                  | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
+  ${'talos'} | ${'hello/123'}  | ${undefined}                  | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
+  ${'talos'} | ${'/hello'}     | ${undefined}                  | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello`}
+  ${'talos'} | ${'123'}        | ${undefined}                  | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/123`}
+  ${'talos'} | ${'/hello/123'} | ${{}}                         | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
+  ${'talos'} | ${'hello/123'}  | ${{}}                         | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello/123`}
+  ${'talos'} | ${'/hello'}     | ${{}}                         | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/hello`}
+  ${'talos'} | ${'123'}        | ${{}}                         | ${`https://docs.siderolabs.com/talos/v${defaultVersion}/123`}
+  ${'talos'} | ${'/hello/123'} | ${{ talosVersion: '1.11.3' }} | ${'https://docs.siderolabs.com/talos/v1.11/hello/123'}
+  ${'talos'} | ${'hello/123'}  | ${{ talosVersion: '1.10.0' }} | ${'https://docs.siderolabs.com/talos/v1.10/hello/123'}
+  ${'talos'} | ${'/hello'}     | ${{ talosVersion: '1.9' }}    | ${'https://docs.siderolabs.com/talos/v1.9/hello'}
+  ${'talos'} | ${'123'}        | ${{ talosVersion: '1' }}      | ${'https://docs.siderolabs.com/talos/v1.0/123'}
+  ${'omni'}  | ${undefined}    | ${undefined}                  | ${'https://docs.siderolabs.com/omni'}
+  ${'omni'}  | ${'/hello/123'} | ${undefined}                  | ${'https://docs.siderolabs.com/omni/hello/123'}
+  ${'omni'}  | ${'hello/123'}  | ${undefined}                  | ${'https://docs.siderolabs.com/omni/hello/123'}
+  ${'omni'}  | ${'/hello'}     | ${undefined}                  | ${'https://docs.siderolabs.com/omni/hello'}
+  ${'omni'}  | ${'123'}        | ${undefined}                  | ${'https://docs.siderolabs.com/omni/123'}
+  ${'k8s'}   | ${undefined}    | ${undefined}                  | ${'https://docs.siderolabs.com/kubernetes-guides'}
+  ${'k8s'}   | ${'/hello/123'} | ${undefined}                  | ${'https://docs.siderolabs.com/kubernetes-guides/hello/123'}
+  ${'k8s'}   | ${'hello/123'}  | ${undefined}                  | ${'https://docs.siderolabs.com/kubernetes-guides/hello/123'}
+  ${'k8s'}   | ${'/hello'}     | ${undefined}                  | ${'https://docs.siderolabs.com/kubernetes-guides/hello'}
+  ${'k8s'}   | ${'123'}        | ${undefined}                  | ${'https://docs.siderolabs.com/kubernetes-guides/123'}
 `(
-  'useDocsLink: $type - $path - $options returns $expected',
+  'getDocsLink: $type - $path - $options returns $expected',
   ({ type, path, options, expected }) => {
-    expect(useDocsLink(type, path, options).value).toBe(expected)
+    expect(getDocsLink(type, path, options)).toBe(expected)
   },
 )
-
-test('useDocsLink supports reactive options', async () => {
-  const talosVersion = ref('1.10')
-  const linkRef = useDocsLink('talos', '/path', () => ({
-    talosVersion: talosVersion.value,
-  }))
-
-  expect(linkRef.value).toBe('https://docs.siderolabs.com/talos/v1.10/path')
-
-  talosVersion.value = '1.11'
-  await nextTick()
-
-  expect(linkRef.value).toBe('https://docs.siderolabs.com/talos/v1.11/path')
-})

--- a/frontend/src/views/cluster/Backups/BackupsList.vue
+++ b/frontend/src/views/cluster/Backups/BackupsList.vue
@@ -26,7 +26,7 @@ import TList from '@/components/common/List/TList.vue'
 import TListItem from '@/components/common/List/TListItem.vue'
 import Watch from '@/components/common/Watch/Watch.vue'
 import TAlert from '@/components/TAlert.vue'
-import { formatBytes, useDocsLink } from '@/methods'
+import { formatBytes, getDocsLink } from '@/methods'
 import { canManageBackupStore } from '@/methods/auth'
 import { formatISO } from '@/methods/time'
 
@@ -72,8 +72,8 @@ const watchOpts = computed(() => {
   }
 })
 
-const docsLink = useDocsLink('omni', '/how-to-guides/etcd-backups#s3-configuration')
-const openDocs = () => window.open(docsLink.value, '_blank')?.focus()
+const docsLink = getDocsLink('omni', '/how-to-guides/etcd-backups#s3-configuration')
+const openDocs = () => window.open(docsLink, '_blank')?.focus()
 </script>
 
 <template>

--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.vue
@@ -34,6 +34,8 @@ export interface FormState {
   joinToken?: string
   machineArch?: 'amd64' | 'arm64'
   secureBoot?: boolean
+  cloudPlatform?: string
+  sbcType?: string
 }
 </script>
 
@@ -72,16 +74,14 @@ const stepCount = computed(() => currentFlowSteps.value?.length ?? 0)
 
 <template>
   <div class="flex h-full flex-col">
-    <div class="p-6">
+    <div class="grow overflow-auto p-6">
       <h1 class="mb-6 text-xl font-medium text-naturals-n14">Create New Media</h1>
 
       <component :is="currentStepComponent" v-model="formState" />
     </div>
 
-    <div class="shrink grow"></div>
-
     <div
-      class="flex w-full items-center gap-4 border-t border-naturals-n4 bg-naturals-n1 px-4 max-md:flex-col max-md:p-4 md:h-16 md:justify-end"
+      class="flex w-full shrink-0 items-center gap-4 border-t border-naturals-n4 bg-naturals-n1 px-4 max-md:flex-col max-md:p-4 md:h-16 md:justify-end"
     >
       <Stepper
         v-if="currentFlowSteps && formState.currentStep > 0"

--- a/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.stories.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import CloudProvider from './CloudProvider.vue'
+
+const meta: Meta<typeof CloudProvider> = {
+  component: CloudProvider,
+  args: {
+    modelValue: { currentStep: 0 },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.vue
@@ -5,9 +5,138 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { computed } from 'vue'
+
+import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
+import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
+import { getDocsLink } from '@/methods'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
-defineModel<FormState>({ required: true })
+const formState = defineModel<FormState>({ required: true })
+
+const platforms = computed(() =>
+  [
+    {
+      value: 'aws',
+      label: 'Amazon Web Services (AWS)',
+      description: 'Runs on AWS VMs booted from an AMI',
+      documentation: '/platform-specific-installations/cloud-platforms/aws',
+    },
+    {
+      value: 'gcp',
+      label: 'Google Cloud (GCP)',
+      description: 'Runs on Google Cloud VMs booted from a disk image',
+      documentation: '/platform-specific-installations/cloud-platforms/gcp',
+    },
+    {
+      value: 'equinixMetal',
+      label: 'Equinix Metal',
+      description: 'Runs on Equinix Metal bare-metal servers',
+      documentation: '/platform-specific-installations/bare-metal-platforms/equinix-metal',
+    },
+    {
+      value: 'azure',
+      label: 'Microsoft Azure',
+      description: 'Runs on Microsoft Azure Linux Virtual Machines',
+      documentation: '/platform-specific-installations/cloud-platforms/azure',
+    },
+    {
+      value: 'digital-ocean',
+      label: 'Digital Ocean',
+      description: 'Runs on Digital Ocean droplets',
+      documentation: '/platform-specific-installations/cloud-platforms/digitalocean',
+    },
+    {
+      value: 'nocloud',
+      label: 'Nocloud',
+      description:
+        "Runs on various hypervisors supporting 'nocloud' metadata (Proxmox, Oxide Computer, etc.)",
+      documentation: '/platform-specific-installations/cloud-platforms/nocloud',
+    },
+    {
+      value: 'openstack',
+      label: 'OpenStack',
+      description: 'Runs on OpenStack virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/openstack',
+    },
+    {
+      value: 'vmware',
+      label: 'VMWare',
+      description: 'Runs on VMWare ESXi virtual machines',
+      documentation: '/platform-specific-installations/virtualized-platforms/vmware',
+    },
+    {
+      value: 'akamai',
+      label: 'Akamai',
+      description: 'Runs on Akamai Cloud (Linode) virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/akamai',
+    },
+    {
+      value: 'cloudstack',
+      label: 'Apache CloudStack',
+      description: 'Runs on Apache CloudStack virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/cloudstack',
+    },
+    {
+      value: 'hcloud',
+      label: 'Hetzner',
+      description: 'Runs on Hetzner virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/hetzner',
+    },
+    {
+      value: 'oracle',
+      label: 'Oracle Cloud',
+      description: 'Runs on Oracle Cloud virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/oracle',
+    },
+    {
+      value: 'upcloud',
+      label: 'UpCloud',
+      description: 'Runs on UpCloud virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/upcloud',
+    },
+    {
+      value: 'vultr',
+      label: 'Vultr',
+      description: 'Runs on Vultr Cloud Compute virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/vultr',
+    },
+    {
+      value: 'exoscale',
+      label: 'Exoscale',
+      description: 'Runs on Exoscale virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/exoscale',
+    },
+    {
+      value: 'opennebula',
+      label: 'OpenNebula',
+      description: 'Runs on OpenNebula virtual machines',
+      documentation: '/platform-specific-installations/virtualized-platforms/opennebula',
+    },
+    {
+      value: 'scaleway',
+      label: 'Scaleway',
+      description: 'Runs on Scaleway virtual machines',
+      documentation: '/platform-specific-installations/cloud-platforms/scaleway',
+    },
+  ].map((p) => ({
+    ...p,
+    documentation: getDocsLink('talos', p.documentation, {
+      talosVersion: formState.value.talosVersion,
+    }),
+  })),
+)
 </script>
 
-<template>Cloud Provider</template>
+<template>
+  <RadioGroup v-mode="formState.cloudPlatform" label="Cloud">
+    <RadioGroupOption v-for="platform in platforms" :key="platform.value" :value="platform.value">
+      {{ platform.label }}
+
+      <!-- prettier-ignore -->
+      <template #description>
+        {{ platform.description }} (<a class="text-primary-p3 underline" :href="platform.documentation" @click.stop>documentation</a>).
+      </template>
+    </RadioGroupOption>
+  </RadioGroup>
+</template>

--- a/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.vue
@@ -5,18 +5,20 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
-import { useDocsLink } from '@/methods'
+import { getDocsLink } from '@/methods'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
 const formState = defineModel<FormState>({ required: true })
 
-const secureBootDocsLink = useDocsLink(
-  'talos',
-  '/platform-specific-installations/bare-metal-platforms',
-  () => ({ talosVersion: formState.value.talosVersion }),
+const secureBootDocsLink = computed(() =>
+  getDocsLink('talos', '/platform-specific-installations/bare-metal-platforms', {
+    talosVersion: formState.value.talosVersion,
+  }),
 )
 </script>
 

--- a/frontend/src/views/omni/InstallationMedia/Steps/SBCType.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SBCType.stories.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import SBCType from './SBCType.vue'
+
+const meta: Meta<typeof SBCType> = {
+  component: SBCType,
+  args: {
+    modelValue: { currentStep: 0 },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/views/omni/InstallationMedia/Steps/SBCType.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SBCType.vue
@@ -5,9 +5,139 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { computed } from 'vue'
+
+import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
+import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
+import { getDocsLink } from '@/methods'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
-defineModel<FormState>({ required: true })
+const formState = defineModel<FormState>({ required: true })
+
+const SBCs = computed(() =>
+  [
+    {
+      value: 'rpi_generic',
+      label: 'Raspberry Pi Series',
+      documentation: '/platform-specific-installations/single-board-computers/rpi_generic',
+    },
+    {
+      value: 'revpi_generic',
+      label: 'Revolution Pi Series',
+    },
+    {
+      value: 'bananapi_m64',
+      label: 'Banana Pi M64',
+      documentation: '/platform-specific-installations/single-board-computers/bananapi_m64',
+    },
+    {
+      value: 'nanopi_r4s',
+      label: 'Friendlyelec Nano PI R4S',
+      documentation: '/platform-specific-installations/single-board-computers/nanopi_r4s',
+    },
+    {
+      value: 'nanopi_r5s',
+      label: 'Friendlyelec Nano PI R5S',
+    },
+    {
+      value: 'jetson_nano',
+      label: 'Jetson Nano',
+      documentation: '/platform-specific-installations/single-board-computers/jetson_nano',
+    },
+    {
+      value: 'libretech_all_h3_cc_h5',
+      label: 'Libre Computer Board ALL-H3-CC',
+      documentation:
+        '/platform-specific-installations/single-board-computers/libretech_all_h3_cc_h5',
+    },
+    {
+      value: 'orangepi_r1_plus_lts',
+      label: 'Orange Pi R1 Plus LTS',
+      documentation: '/platform-specific-installations/single-board-computers/orangepi_r1_plus_lts',
+    },
+    {
+      value: 'pine64',
+      label: 'Pine64',
+      documentation: '/platform-specific-installations/single-board-computers/pine64',
+    },
+    {
+      value: 'rock64',
+      label: 'Pine64 Rock64',
+      documentation: '/platform-specific-installations/single-board-computers/rock64',
+    },
+    {
+      value: 'rock4cplus',
+      label: 'Radxa ROCK 4C Plus',
+      documentation: '/platform-specific-installations/single-board-computers/rock4cplus',
+    },
+    {
+      value: 'rock4se',
+      label: 'Radxa ROCK 4SE',
+    },
+    {
+      value: 'rock5a',
+      label: 'Radxa ROCK 5A',
+      documentation: '/platform-specific-installations/single-board-computers/rock5b',
+    },
+    {
+      value: 'rock5b',
+      label: 'Radxa ROCK 5B',
+      documentation: '/platform-specific-installations/single-board-computers/rock5b',
+    },
+    {
+      value: 'rockpi_4',
+      label: 'Radxa ROCK PI 4',
+      documentation: '/platform-specific-installations/single-board-computers/rockpi_4',
+    },
+    {
+      value: 'rockpi_4c',
+      label: 'Radxa ROCK PI 4C',
+      documentation: '/platform-specific-installations/single-board-computers/rockpi_4c',
+    },
+    {
+      value: 'helios64',
+      label: 'Kobol Helios64',
+    },
+    {
+      value: 'turingrk1',
+      label: 'Turing RK1',
+      documentation: '/platform-specific-installations/single-board-computers/turing_rk1',
+    },
+    {
+      value: 'orangepi-5',
+      label: 'Orange Pi 5',
+      documentation: '/platform-specific-installations/single-board-computers/orangepi_5',
+    },
+    {
+      value: 'orangepi-5-plus',
+      label: 'Orange Pi 5 Plus',
+    },
+    {
+      value: 'rockpro64',
+      label: 'Pine64 RockPro64',
+    },
+  ].map((sbc) => ({
+    ...sbc,
+    documentation:
+      sbc.documentation &&
+      getDocsLink('talos', sbc.documentation, { talosVersion: formState.value.talosVersion }),
+  })),
+)
 </script>
 
-<template>SBC Type</template>
+<template>
+  <RadioGroup v-mode="formState.sbcType" label="Single Board Computer">
+    <RadioGroupOption v-for="sbc in SBCs" :key="sbc.value" :value="sbc.value">
+      {{ sbc.label }}
+
+      <template #description>
+        <span :class="!sbc.documentation && 'after:content-[\'.\']'">Runs on {{ sbc.label }}</span>
+
+        <!-- prettier-ignore -->
+        <template v-if="sbc.documentation">
+          (<a class="text-primary-p3 underline" :href="sbc.documentation" @click.stop>documentation</a>).
+        </template>
+      </template>
+    </RadioGroupOption>
+  </RadioGroup>
+</template>

--- a/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.vue
@@ -20,7 +20,7 @@ import {
 } from '@/api/resources'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
 import { useWatch } from '@/components/common/Watch/useWatch'
-import { useDocsLink } from '@/methods'
+import { getDocsLink } from '@/methods'
 import { useFeatures } from '@/methods/features'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
@@ -57,12 +57,17 @@ const joinTokens = computed(() => joinTokenList.value.map((t) => t.metadata.id!)
 onBeforeMount(() => (formState.value.talosVersion ??= DefaultTalosVersion))
 watchOnce(joinTokens, (v) => (formState.value.joinToken ??= v[0]))
 
-const whatsNewDocsLink = useDocsLink('talos', "/getting-started/what's-new-in-talos", () => ({
-  talosVersion: formState.value.talosVersion,
-}))
-const k8sSupportMatrixDocsLink = useDocsLink('talos', '/getting-started/support-matrix', () => ({
-  talosVersion: formState.value.talosVersion,
-}))
+const whatsNewDocsLink = computed(() =>
+  getDocsLink('talos', "/getting-started/what's-new-in-talos", {
+    talosVersion: formState.value.talosVersion,
+  }),
+)
+
+const k8sSupportMatrixDocsLink = computed(() =>
+  getDocsLink('talos', '/getting-started/support-matrix', {
+    talosVersion: formState.value.talosVersion,
+  }),
+)
 </script>
 
 <template>

--- a/frontend/src/views/omni/Machines/Machines.vue
+++ b/frontend/src/views/omni/Machines/Machines.vue
@@ -34,7 +34,7 @@ import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
 import { useWatch } from '@/components/common/Watch/useWatch'
 import TAlert from '@/components/TAlert.vue'
-import { useDocsLink } from '@/methods'
+import { getDocsLink } from '@/methods'
 import type { Label } from '@/methods/labels'
 import { addLabel, selectors as labelsToSelectors } from '@/methods/labels'
 import { MachineFilterOption } from '@/methods/machine'
@@ -107,8 +107,8 @@ const sortOptions = [
 const filterLabels = ref<Label[]>([])
 const filterValue = ref('')
 
-const docsLink = useDocsLink('omni', '/explanation/infrastructure-providers')
-const openDocs = () => window.open(docsLink.value, '_blank')?.focus()
+const docsLink = getDocsLink('omni', '/explanation/infrastructure-providers')
+const openDocs = () => window.open(docsLink, '_blank')?.focus()
 
 const { data: machineStatusMetrics } = useWatch<MachineStatusMetricsSpec>({
   resource: {

--- a/frontend/src/views/omni/Modals/UpdateKubernetes.vue
+++ b/frontend/src/views/omni/Modals/UpdateKubernetes.vue
@@ -30,7 +30,7 @@ import TButton from '@/components/common/Button/TButton.vue'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import { useWatch } from '@/components/common/Watch/useWatch'
-import { useDocsLink } from '@/methods'
+import { getDocsLink } from '@/methods'
 import { upgradeKubernetes } from '@/methods/cluster'
 import ManagedByTemplatesWarning from '@/views/cluster/ManagedByTemplatesWarning.vue'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
@@ -139,9 +139,11 @@ function isVersionUpgradeable(version: string) {
   return supportedK8sVersions.value.includes(version)
 }
 
-const k8sSupportMatrixDocsLink = useDocsLink('talos', '/getting-started/support-matrix', () => ({
-  talosVersion: cluster.value?.spec.talos_version,
-}))
+const k8sSupportMatrixDocsLink = computed(() =>
+  getDocsLink('talos', '/getting-started/support-matrix', {
+    talosVersion: cluster.value?.spec.talos_version,
+  }),
+)
 
 const action = computed(() => {
   if (!status.value) {


### PR DESCRIPTION
- Implement cloud provider + SBC steps for installation media wizard
- Fix a scrolling issue on the installation media container page.
- Replace `useDocsLink` composable with a simpler `getDocsLink` function to allow calling in locations outside of the vue lifecycle. Don't need the complexity of a composable for this.