### PR TITLE
fix: do not allow downloading deprecated Talos versions in the UI

### DIFF
--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -154,7 +154,10 @@ const factoryDownloadUrl = computed(() => {
 })
 
 const talosVersions = computed(() =>
-  talosVersionsResources.value?.map((res) => res.metadata.id!).sort(semver.compare),
+  talosVersionsResources.value
+    ?.filter((res) => !res.spec.deprecated)
+    .map((res) => res.metadata.id!)
+    .sort(semver.compare),
 )
 
 const selectedOption = ref('')


### PR DESCRIPTION
Filter them by using `deprecated` flag in the resource.