### PR TITLE
fix: do not clear schematic meta values for non-UKI machines

### DIFF
--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -99,6 +99,7 @@ fi
 KERNEL_ARGS_SCHEMATIC=$(
   cat <<EOF
 customization:
+  meta: [{ key: 42, value: test-1 }, { key: 41, value: test-2 }]
   extraKernelArgs:
     - siderolink.api=grpc://${WIREGUARD_IP}:8090?jointoken=${JOIN_TOKEN}
     - talos.events.sink=[fdae:41e4:649b:9303::1]:8091
@@ -345,6 +346,7 @@ EOF
   schematic=$(
     cat <<EOF
 customization:
+  meta: [{ key: 42, value: test-1 }, { key: 41, value: test-2 }]
   extraKernelArgs:
     - talos.config=http://${WIREGUARD_IP}:$port/config.yaml
     - console=tty0
@@ -365,6 +367,7 @@ function prepare_talos_image() {
   schematic=$(
     cat <<EOF
 customization:
+  meta: [{ key: 42, value: test-1 }, { key: 41, value: test-2 }]
   extraKernelArgs:
     - console=tty0
     - console=ttyS0

--- a/internal/integration/cluster_test.go
+++ b/internal/integration/cluster_test.go
@@ -813,14 +813,14 @@ func getMachineSetNodes(ctx context.Context, t *testing.T, st state.State, clust
 // machineAllocationLock makes sure that only one test allocates machines at a time.
 var machineAllocationLock sync.Mutex
 
-func pickUnallocatedMachines(ctx context.Context, t *testing.T, st state.State, count int, filterFunc func(*omni.MachineStatus) bool, f func([]resource.ID)) {
+func pickUnallocatedMachines(ctx context.Context, t *testing.T, st state.State, count int, filterFunc PickFilterFunc, f func([]resource.ID)) {
 	machineAllocationLock.Lock()
 	defer machineAllocationLock.Unlock()
 
 	result := make([]resource.ID, 0, count)
 
 	if filterFunc == nil {
-		filterFunc = func(_ *omni.MachineStatus) bool { return true }
+		filterFunc = func(*omni.MachineStatus) bool { return true }
 	}
 
 	err := retry.Constant(time.Minute).RetryWithContext(ctx, func(ctx context.Context) error {

--- a/internal/integration/kernelargs_test.go
+++ b/internal/integration/kernelargs_test.go
@@ -42,6 +42,7 @@ func testKernelArgsUpdate(t *testing.T, options *TestOptions) {
 
 			SkipExtensionCheckOnCreate: options.SkipExtensionsCheckOnCreate,
 
+			// Pick machines which are booted with UKI, as kernel args upgrades are only supported for them.
 			PickFilterFunc: func(ms *omni.MachineStatus) bool {
 				return ms.TypedSpec().Value.GetSecurityState().GetBootedWithUki()
 			},


### PR DESCRIPTION
META section updates are no-op for non-UKI machines, but still, the recent changes in the kernel args PR started clearing them (since now we compute schematic ID always), causing the schematic ID to be updated, which caused cluster machines to be upgraded and restarted.

Remove the UKI check and keep meta valus always as-is.

Update the integration tests to:
- Also include META values.
- Make Omni upgrade test pick both UKI and non-UKI machines.