### PR TITLE
test: pick UKI and non-UKI machines correctly

### DIFF
--- a/internal/integration/kernelargs_test.go
+++ b/internal/integration/kernelargs_test.go
@@ -43,7 +43,7 @@ func testKernelArgsUpdate(t *testing.T, options *TestOptions) {
 			SkipExtensionCheckOnCreate: options.SkipExtensionsCheckOnCreate,
 
 			// Pick machines which are booted with UKI, as kernel args upgrades are only supported for them.
-			PickFilterFunc: func(ms *omni.MachineStatus) bool {
+			PickFilterFunc: func(ms *omni.MachineStatus, _ []*omni.MachineStatus) bool {
 				return ms.TypedSpec().Value.GetSecurityState().GetBootedWithUki()
 			},
 		}),


### PR DESCRIPTION
Picker can retry if it couldn't pick enough machines, but we set the picked flags only once and never reset them.

Change the approach to take it into account.