### PR TITLE
feat(frontend): style all regular links with primary

### DIFF
--- a/frontend/src/AppUnavailable.stories.ts
+++ b/frontend/src/AppUnavailable.stories.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import AppUnavailable from './AppUnavailable.vue'
+
+const meta: Meta<typeof AppUnavailable> = {
+  component: AppUnavailable,
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/AppUnavailable.vue
+++ b/frontend/src/AppUnavailable.vue
@@ -19,9 +19,7 @@ import THeader from '@/components/THeader/THeader.vue'
           <div>It appears we are experiencing some issues.</div>
           <div class="flex">
             Please try later again or&nbsp;
-            <a class="text-naturals-n12 underline" href="https://www.siderolabs.com/contact/">
-              contact us
-            </a>
+            <a class="link-primary" href="https://www.siderolabs.com/contact/">contact us</a>
             .
           </div>
         </div>

--- a/frontend/src/components/SideBar/TSideBar.stories.ts
+++ b/frontend/src/components/SideBar/TSideBar.stories.ts
@@ -400,42 +400,34 @@ export const Default: Story = {
 
           if (type !== ClusterPermissionsType || namespace !== VirtualNamespace) return
 
-          return HttpResponse.json(
-            {
-              body: JSON.stringify({
-                spec: {
-                  can_add_machines: true,
-                  can_remove_machines: true,
-                  can_reboot_machines: true,
-                  can_update_kubernetes: true,
-                  can_download_kubeconfig: true,
-                  can_sync_kubernetes_manifests: true,
-                  can_update_talos: true,
-                  can_download_talosconfig: true,
-                  can_read_config_patches: true,
-                  can_manage_config_patches: true,
-                  can_manage_cluster_features: true,
-                  can_download_support_bundle: true,
-                },
-                metadata: {
-                  created: '2025-10-23T09:34:12Z',
-                  updated: '2025-10-23T09:34:12Z',
-                  namespace: 'virtual',
-                  type: 'ClusterPermissions.omni.sidero.dev',
-                  id: 'talos-default',
-                  owner: '',
-                  phase: 'running',
-                  version: '1',
-                },
-              }),
-            },
-            {
-              headers: {
-                'content-type': 'application/json',
-                'Grpc-metadata-content-type': 'application/grpc',
+          return HttpResponse.json({
+            body: JSON.stringify({
+              spec: {
+                can_add_machines: true,
+                can_remove_machines: true,
+                can_reboot_machines: true,
+                can_update_kubernetes: true,
+                can_download_kubeconfig: true,
+                can_sync_kubernetes_manifests: true,
+                can_update_talos: true,
+                can_download_talosconfig: true,
+                can_read_config_patches: true,
+                can_manage_config_patches: true,
+                can_manage_cluster_features: true,
+                can_download_support_bundle: true,
               },
-            },
-          )
+              metadata: {
+                created: '2025-10-23T09:34:12Z',
+                updated: '2025-10-23T09:34:12Z',
+                namespace: 'virtual',
+                type: 'ClusterPermissions.omni.sidero.dev',
+                id: 'talos-default',
+                owner: '',
+                phase: 'running',
+                version: '1',
+              },
+            }),
+          })
         }),
 
         http.post<never, GetRequest>('/omni.resources.ResourceService/Get', async ({ request }) => {
@@ -443,40 +435,32 @@ export const Default: Story = {
 
           if (type !== ClusterMachineIdentityType || namespace !== DefaultNamespace) return
 
-          return HttpResponse.json(
-            {
-              body: JSON.stringify({
-                spec: {
-                  node_identity: 'xdwlmW302gaDjm7JaSQ4ZF6c67gAciYOZBsTZzkVoVE',
-                  etcd_member_id: '11861357848454170587',
-                  nodename: 'machine-cdecae49-a354-4931-bd7c-e4ca18410f10',
-                  node_ips: ['172.20.0.2'],
-                  discovery_service_endpoint: 'https://discovery.talos.dev:443',
-                },
-                metadata: {
-                  created: '2025-10-23T08:28:43Z',
-                  updated: '2025-10-23T08:29:04Z',
-                  namespace: 'default',
-                  type: 'ClusterMachineIdentities.omni.sidero.dev',
-                  id: 'cdecae49-a354-4931-bd7c-e4ca18410f10',
-                  owner: 'ClusterMachineIdentityController',
-                  phase: 'running',
-                  labels: {
-                    'omni.sidero.dev/cluster': 'talos-default',
-                    'omni.sidero.dev/machine-set': 'talos-default-control-planes',
-                    'omni.sidero.dev/role-controlplane': '',
-                  },
-                  version: 5,
-                },
-              }),
-            },
-            {
-              headers: {
-                'content-type': 'application/json',
-                'Grpc-metadata-content-type': 'application/grpc',
+          return HttpResponse.json({
+            body: JSON.stringify({
+              spec: {
+                node_identity: 'xdwlmW302gaDjm7JaSQ4ZF6c67gAciYOZBsTZzkVoVE',
+                etcd_member_id: '11861357848454170587',
+                nodename: 'machine-cdecae49-a354-4931-bd7c-e4ca18410f10',
+                node_ips: ['172.20.0.2'],
+                discovery_service_endpoint: 'https://discovery.talos.dev:443',
               },
-            },
-          )
+              metadata: {
+                created: '2025-10-23T08:28:43Z',
+                updated: '2025-10-23T08:29:04Z',
+                namespace: 'default',
+                type: 'ClusterMachineIdentities.omni.sidero.dev',
+                id: 'cdecae49-a354-4931-bd7c-e4ca18410f10',
+                owner: 'ClusterMachineIdentityController',
+                phase: 'running',
+                labels: {
+                  'omni.sidero.dev/cluster': 'talos-default',
+                  'omni.sidero.dev/machine-set': 'talos-default-control-planes',
+                  'omni.sidero.dev/role-controlplane': '',
+                },
+                version: 5,
+              },
+            }),
+          })
         }),
       ],
     },

--- a/frontend/src/components/common/UserConsent/UserConsent.stories.ts
+++ b/frontend/src/components/common/UserConsent/UserConsent.stories.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+
+import type { Resource } from '@/api/grpc'
+import type { GetRequest } from '@/api/omni/resources/resources.pb'
+import type { FeaturesConfigSpec } from '@/api/omni/specs/omni.pb'
+import { DefaultNamespace, FeaturesConfigID, FeaturesConfigType } from '@/api/resources'
+import { currentUser } from '@/methods/auth'
+
+import UserConsent from './UserConsent.vue'
+
+/**
+ * Internal UserConsent logic blocks rendering if no currentUser
+ * is set.
+ *
+ * This probably would be better server in a parent component,
+ * and the currentUser probably should be part of a provide/inject
+ * flow for testability and stories.
+ */
+currentUser.value = {
+  spec: {},
+  metadata: {},
+}
+
+const meta: Meta<typeof UserConsent> = {
+  component: UserConsent,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post<never, GetRequest>('/omni.resources.ResourceService/Get', async ({ request }) => {
+          const { type, namespace, id } = await request.clone().json()
+
+          if (
+            type !== FeaturesConfigType ||
+            namespace !== DefaultNamespace ||
+            id !== FeaturesConfigID
+          )
+            return
+
+          const resource: Resource<FeaturesConfigSpec> = {
+            spec: {
+              user_pilot_settings: {
+                app_token: 'token',
+              },
+            },
+            metadata: {},
+          }
+
+          return HttpResponse.json({ body: JSON.stringify(resource) })
+        }),
+      ],
+    },
+  },
+}

--- a/frontend/src/components/common/UserConsent/UserConsent.vue
+++ b/frontend/src/components/common/UserConsent/UserConsent.vue
@@ -5,12 +5,11 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computedAsync } from '@vueuse/core'
 
 import TButton from '@/components/common/Button/TButton.vue'
 import { currentUser } from '@/methods/auth'
-import { getUserPilotToken, initializeUserPilot } from '@/methods/features'
-import { trackingState } from '@/methods/features'
+import { getUserPilotToken, initializeUserPilot, trackingState } from '@/methods/features'
 
 const enableTracking = async () => {
   if (!currentUser.value) {
@@ -22,17 +21,13 @@ const enableTracking = async () => {
   await initializeUserPilot(currentUser.value)
 }
 
-const trackerToken = ref<string | undefined>()
-
-const fetchTrackingToken = async () => {
+const trackerToken = computedAsync(async () => {
   if (!currentUser.value) {
     return
   }
 
-  trackerToken.value = await getUserPilotToken()
-}
-
-watch(() => currentUser.value, fetchTrackingToken)
+  return await getUserPilotToken()
+})
 </script>
 
 <template>
@@ -46,7 +41,7 @@ watch(() => currentUser.value, fetchTrackingToken)
             We use cookies to improve our website's interface and onboarding experience. We don't
             use them for ads or share your data with third parties.
             <a
-              class="list-item-link cursor-pointer"
+              class="link-primary"
               rel="noopener noreferrer"
               href="https://www.siderolabs.com/privacy-policy/"
               target="_blank"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,6 +79,10 @@ included in the LICENSE file.
     @apply z-30 flex w-1/3 flex-col rounded-sm bg-naturals-n3 p-8;
   }
 
+  .link-primary {
+    @apply inline-block text-primary-p3 not-hover:underline visited:text-primary-p1 hover:text-primary-p2 active:text-primary-p5;
+  }
+
   .list-item-link {
     @apply font-bold text-naturals-n14 transition hover:text-naturals-n9;
   }

--- a/frontend/src/views/omni/Clusters/Clusters.stories.ts
+++ b/frontend/src/views/omni/Clusters/Clusters.stories.ts
@@ -258,42 +258,34 @@ export const Data: Story = {
 
           if (type !== ClusterPermissionsType || namespace !== VirtualNamespace) return
 
-          return HttpResponse.json(
-            {
-              body: JSON.stringify({
-                spec: {
-                  can_add_machines: true,
-                  can_remove_machines: true,
-                  can_reboot_machines: true,
-                  can_update_kubernetes: true,
-                  can_download_kubeconfig: true,
-                  can_sync_kubernetes_manifests: true,
-                  can_update_talos: true,
-                  can_download_talosconfig: true,
-                  can_read_config_patches: true,
-                  can_manage_config_patches: true,
-                  can_manage_cluster_features: true,
-                  can_download_support_bundle: true,
-                },
-                metadata: {
-                  created: '2025-10-01T18:42:13Z',
-                  updated: '2025-10-01T18:42:13Z',
-                  namespace: 'virtual',
-                  type: 'ClusterPermissions.omni.sidero.dev',
-                  id: 'talos-test-cluster',
-                  owner: '',
-                  phase: 'running',
-                  version: 1,
-                },
-              }),
-            },
-            {
-              headers: {
-                'content-type': 'application/json',
-                'Grpc-metadata-content-type': 'application/grpc',
+          return HttpResponse.json({
+            body: JSON.stringify({
+              spec: {
+                can_add_machines: true,
+                can_remove_machines: true,
+                can_reboot_machines: true,
+                can_update_kubernetes: true,
+                can_download_kubeconfig: true,
+                can_sync_kubernetes_manifests: true,
+                can_update_talos: true,
+                can_download_talosconfig: true,
+                can_read_config_patches: true,
+                can_manage_config_patches: true,
+                can_manage_cluster_features: true,
+                can_download_support_bundle: true,
               },
-            },
-          )
+              metadata: {
+                created: '2025-10-01T18:42:13Z',
+                updated: '2025-10-01T18:42:13Z',
+                namespace: 'virtual',
+                type: 'ClusterPermissions.omni.sidero.dev',
+                id: 'talos-test-cluster',
+                owner: '',
+                phase: 'running',
+                version: 1,
+              },
+            }),
+          })
         }),
       ],
     },

--- a/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.vue
@@ -135,7 +135,7 @@ const platforms = computed(() =>
 
       <!-- prettier-ignore -->
       <template #description>
-        {{ platform.description }} (<a class="text-primary-p3 underline" :href="platform.documentation" @click.stop>documentation</a>).
+        {{ platform.description }} (<a class="link-primary" :href="platform.documentation" @click.stop>documentation</a>).
       </template>
     </RadioGroupOption>
   </RadioGroup>

--- a/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.vue
@@ -53,7 +53,7 @@ const secureBootDocsLink = computed(() =>
             :href="secureBootDocsLink"
             rel="noopener noreferrer"
             target="_blank"
-            class="inline-block text-primary-p3 underline"
+            class="link-primary"
             @click.stop
           >
             SecureBoot

--- a/frontend/src/views/omni/InstallationMedia/Steps/SBCType.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SBCType.vue
@@ -135,7 +135,7 @@ const SBCs = computed(() =>
 
         <!-- prettier-ignore -->
         <template v-if="sbc.documentation">
-          (<a class="text-primary-p3 underline" :href="sbc.documentation" @click.stop>documentation</a>).
+          (<a class="link-primary" :href="sbc.documentation" @click.stop>documentation</a>).
         </template>
       </template>
     </RadioGroupOption>

--- a/frontend/src/views/omni/InstallationMedia/Steps/SystemExtensions.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SystemExtensions.vue
@@ -57,7 +57,7 @@ function toggleExtension(ref: string, enabled: boolean) {
         href="https://github.com/siderolabs/extensions"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-block text-primary-p3 underline"
+        class="link-primary"
       >
         System Extensions
       </a>

--- a/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.vue
@@ -100,7 +100,12 @@ const k8sSupportMatrixDocsLink = computed(() =>
         aria-labelledby="docs-label-id"
       >
         <li>
-          <a :href="whatsNewDocsLink" rel="noopener noreferrer" target="_blank" class="underline">
+          <a
+            :href="whatsNewDocsLink"
+            rel="noopener noreferrer"
+            target="_blank"
+            class="link-primary"
+          >
             What's New
           </a>
         </li>
@@ -110,7 +115,7 @@ const k8sSupportMatrixDocsLink = computed(() =>
             :href="k8sSupportMatrixDocsLink"
             rel="noopener noreferrer"
             target="_blank"
-            class="underline"
+            class="link-primary"
           >
             Support Matrix
           </a>

--- a/frontend/src/views/omni/Modals/DownloadTalosctl.stories.ts
+++ b/frontend/src/views/omni/Modals/DownloadTalosctl.stories.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+import { compare } from 'semver'
+
+import DownloadTalosctl from './DownloadTalosctl.vue'
+
+const meta: Meta<typeof DownloadTalosctl> = {
+  component: DownloadTalosctl,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const versions = faker.helpers
+  .uniqueArray(faker.system.semver, 10)
+  .sort(compare)
+  .map((v) => `v${v}`)
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/talosctl/downloads', () =>
+          HttpResponse.json({
+            release_data: {
+              available_versions: versions.reduce<Record<string, { name: string; url: string }[]>>(
+                (prev, curr) => ({
+                  ...prev,
+                  [curr]: [
+                    {
+                      name: 'Apple',
+                      url: `https://github.com/siderolabs/talos/releases/download/${curr}/talosctl-darwin-amd64`,
+                    },
+                    {
+                      name: 'Apple Silicon',
+                      url: `https://github.com/siderolabs/talos/releases/download/${curr}/talosctl-darwin-arm64`,
+                    },
+                    {
+                      name: 'Linux',
+                      url: `https://github.com/siderolabs/talos/releases/download/${curr}/talosctl-linux-amd64`,
+                    },
+                    {
+                      name: 'Linux ARM',
+                      url: `https://github.com/siderolabs/talos/releases/download/${curr}/talosctl-linux-armv7`,
+                    },
+                    {
+                      name: 'Linux ARM64',
+                      url: `https://github.com/siderolabs/talos/releases/download/${curr}/talosctl-linux-arm64`,
+                    },
+                    {
+                      name: 'Windows',
+                      url: `https://github.com/siderolabs/talos/releases/download/${curr}/talosctl-windows-amd64.exe`,
+                    },
+                  ],
+                }),
+                {},
+              ),
+              default_version: versions.at(-1),
+            },
+            status: 'ok',
+          }),
+        ),
+      ],
+    },
+  },
+}

--- a/frontend/src/views/omni/Modals/DownloadTalosctl.vue
+++ b/frontend/src/views/omni/Modals/DownloadTalosctl.vue
@@ -143,7 +143,7 @@ interface Asset {
         <a
           target="_blank"
           rel="noopener noreferrer"
-          class="download-link text-xs"
+          class="link-primary"
           href="https://github.com/siderolabs/talos/releases"
         >
           here
@@ -172,9 +172,5 @@ interface Asset {
 
 .heading {
   @apply mb-5 flex items-center justify-between text-xl text-naturals-n14;
-}
-
-.download-link {
-  @apply underline;
 }
 </style>

--- a/frontend/src/views/omni/Modals/UpdateKernelArgs.stories.ts
+++ b/frontend/src/views/omni/Modals/UpdateKernelArgs.stories.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import { createWatchStreamHandler } from '@msw/helpers'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+
+import type { Resource } from '@/api/grpc'
+import type { GetRequest } from '@/api/omni/resources/resources.pb'
+import type { KernelArgsSpec, KernelArgsStatusSpec } from '@/api/omni/specs/omni.pb'
+import { DefaultNamespace, KernelArgsStatusType, KernelArgsType } from '@/api/resources'
+
+import UpdateKernelArgs from './UpdateKernelArgs.vue'
+
+const meta: Meta<typeof UpdateKernelArgs> = {
+  component: UpdateKernelArgs,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Data: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<KernelArgsStatusSpec>({
+          expectedOptions: {
+            type: KernelArgsStatusType,
+            namespace: DefaultNamespace,
+          },
+          initialResources: [
+            {
+              spec: {
+                current_args: faker.helpers.multiple(() =>
+                  faker.helpers.slugify(faker.hacker.phrase()).toLowerCase(),
+                ),
+                current_cmdline: faker.helpers.slugify(faker.hacker.phrase()).toLowerCase(),
+                unmet_conditions: faker.helpers.multiple(() =>
+                  faker.helpers.slugify(faker.hacker.phrase()).toLowerCase(),
+                ),
+              },
+              metadata: {},
+            },
+          ],
+        }).handler,
+
+        http.post<never, GetRequest>('/omni.resources.ResourceService/Get', async ({ request }) => {
+          const { type, namespace } = await request.clone().json()
+
+          if (type !== KernelArgsType || namespace !== DefaultNamespace) return
+
+          const resource: Resource<KernelArgsSpec> = {
+            spec: {
+              args: faker.helpers.multiple(() =>
+                faker.helpers.slugify(faker.hacker.phrase()).toLowerCase(),
+              ),
+            },
+            metadata: {},
+          }
+
+          return HttpResponse.json({ body: JSON.stringify(resource) })
+        }),
+      ],
+    },
+  },
+}
+
+export const NoData: Story = {
+  parameters: {
+    msw: {
+      handlers: [createWatchStreamHandler().handler],
+    },
+  },
+}

--- a/frontend/src/views/omni/Modals/UpdateKubernetes.vue
+++ b/frontend/src/views/omni/Modals/UpdateKubernetes.vue
@@ -264,9 +264,7 @@ const upgradeClick = async () => {
     <p class="text-xs">
       Downgrading minor versions is not supported. You can not skip minor version upgrades. You can
       only upgrade to versions supported by your Talos version. See the
-      <a class="inline-block underline hover:mix-blend-lighten" :href="k8sSupportMatrixDocsLink">
-        support matrix
-      </a>
+      <a class="link-primary" :href="k8sSupportMatrixDocsLink">support matrix</a>
       for which versions are supported by your Talos version.
     </p>
 


### PR DESCRIPTION
Adds a `link-primary` class to style regular links with our branding. Also includes some hover/active/visited feedback.

This is to standardise links to this format:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/76420444-1e7f-40be-bacb-79b8e3e46b0c" />

Stories were added for places where links were updated.