### PR TITLE
feat: check computed schematic ID to avoid unnecessary machine upgrades

### DIFF
--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -95,6 +95,8 @@ if [[ "${CI:-false}" == "true" ]]; then
   WIREGUARD_IP=172.20.0.1
 fi
 
+# TODO: to cover more cases of (unwanted) machine upgrades, populate all schematics in this test with as many different options as possible, e.g., overlays, SecureBootCustomization and so on.
+
 # Prepare schematic with kernel args
 KERNEL_ARGS_SCHEMATIC=$(
   cat <<EOF


### PR DESCRIPTION
If we didn't change anything in a schematic, i.e., picked everything from the `MachineStatus`, but ended up calculating a different schematic ID than what the machine already has, just log it as a warning, but preserve the existing schematic ID.