### PR TITLE
fix: restore monaco-editor styles by enabling unsafe-inline

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -52,12 +52,9 @@ export default defineConfig(({ command }) => {
   if (command === 'serve') {
     const cspNonce = faker.string.alphanumeric(14)
 
-    // Dev only, required for vue dev tools
-    const devToolsHash = 'sha256-skqujXORqzxt1aE0NNXxujEanPTX6raoqSscTV/Ww/Y='
-
     // Inject CSP for dev server for testing.
     // Actual CSP in production is set in ../internal/frontend/handler.go
-    // Ideally these sources should match (except for devToolsHash).
+    // Ideally these sources should match.
     config.server ||= {}
     config.server.headers ||= {}
     config.server.headers['content-security-policy'] = [
@@ -66,7 +63,7 @@ export default defineConfig(({ command }) => {
       'img-src * data:',
       "connect-src 'self' https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io",
       "font-src 'self' data:",
-      `style-src 'self' 'nonce-${cspNonce}' '${devToolsHash}' data: https://fonts.googleapis.com https://fonts.gstatic.com`,
+      `style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com https://fonts.gstatic.com`,
       'frame-src https://*.auth0.com',
     ].join(';')
 

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -133,7 +133,8 @@ func (handler *StaticHandler) serveFile(w http.ResponseWriter, r *http.Request, 
 					";img-src * data:"+
 					";connect-src 'self' https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io"+
 					";font-src 'self' data:"+
-					fmt.Sprintf(";style-src 'self' 'nonce-%s' data: https://fonts.googleapis.com https://fonts.gstatic.com", nonce)+
+					// We are forced to use unsafe-inline for style-src due to monaco-editor https://github.com/microsoft/monaco-editor/issues/271
+					";style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com https://fonts.gstatic.com"+
 					";frame-src https://*.auth0.com",
 			)
 


### PR DESCRIPTION
Fix monaco-editor styling by enabling `'unsafe-inline'` for `style-src` in CSP. There is an issue on their github for this, but there does not seem to be any interest in fixing it at the moment.

- https://github.com/microsoft/monaco-editor/issues/271