### PR TITLE
feat(frontend): truncate items inside ongoing tasks list

### DIFF
--- a/frontend/src/components/common/ActionsBox/TActionsBox.vue
+++ b/frontend/src/components/common/ActionsBox/TActionsBox.vue
@@ -26,7 +26,7 @@ const toggleState = ref(false)
 
     <DropdownMenuPortal>
       <DropdownMenuContent
-        class="bg-popover text-popover-foreground z-50 max-h-(--reka-dropdown-menu-content-available-height) origin-(--reka-dropdown-menu-content-transform-origin) rounded border border-naturals-n4 bg-naturals-n3 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+        class="z-50 max-h-(--reka-dropdown-menu-content-available-height) origin-(--reka-dropdown-menu-content-transform-origin) rounded border border-naturals-n4 bg-naturals-n3 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
         align="end"
         side="bottom"
       >

--- a/frontend/src/components/common/OngoingTasks/OngoingTasks.stories.ts
+++ b/frontend/src/components/common/OngoingTasks/OngoingTasks.stories.ts
@@ -7,7 +7,11 @@ import { createWatchStreamHandler } from '@msw/helpers'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { formatRFC3339 } from 'date-fns'
 
-import type { OngoingTaskSpec } from '@/api/omni/specs/omni.pb'
+import {
+  KubernetesUpgradeStatusSpecPhase,
+  type OngoingTaskSpec,
+  TalosUpgradeStatusSpecPhase,
+} from '@/api/omni/specs/omni.pb'
 import { EphemeralNamespace, OngoingTaskType } from '@/api/resources'
 
 import OngoingTasks from './OngoingTasks.vue'
@@ -35,29 +39,45 @@ export const Default: Story = {
                 created: formatRFC3339(faker.date.recent()),
               },
               spec: {
-                title: faker.animal.cat(),
+                title: faker.string.uuid(),
                 ...faker.helpers.arrayElement([
                   {
                     kubernetes_upgrade: {
                       last_upgrade_version: faker.system.semver(),
                       current_upgrade_version: faker.system.semver(),
+                      phase: KubernetesUpgradeStatusSpecPhase.Upgrading,
                     },
                   },
                   {
                     talos_upgrade: {
                       last_upgrade_version: faker.system.semver(),
                       current_upgrade_version: faker.system.semver(),
+                      phase: TalosUpgradeStatusSpecPhase.Upgrading,
+                    },
+                  },
+                  {
+                    talos_upgrade: {
+                      last_upgrade_version: faker.system.semver(),
+                      phase: TalosUpgradeStatusSpecPhase.Reverting,
                     },
                   },
                   {
                     machine_upgrade: {
-                      schematic_id: faker.system.semver(),
-                      current_schematic_id: faker.system.semver(),
+                      schematic_id: faker.string.hexadecimal({
+                        prefix: '',
+                        casing: 'lower',
+                        length: 64,
+                      }),
+                      current_schematic_id: faker.string.hexadecimal({
+                        prefix: '',
+                        casing: 'lower',
+                        length: 64,
+                      }),
                     },
                   },
                   {
                     destroy: {
-                      phase: 'Destroying',
+                      phase: 'Destroying: 2 machine sets, 3 machines',
                     },
                   },
                 ]),


### PR DESCRIPTION
Restrict the size of the ongoing items menu to 320px, and truncate text inside of it to fit. Also refactor to Popover and constrain everything to the viewport accordingly.

Fixes #1882 


https://github.com/user-attachments/assets/a3c013cd-fba8-46aa-b8f0-a87eab744e7c

