### PR TITLE
feat(frontend): preselect the correct binary for the user's platform where possible

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "reka-ui": "^2.6.0",
         "semver": "^7.7.3",
         "tailwind-merge": "^3.4.0",
+        "ua-parser-js": "^2.0.6",
         "userpilot": "^1.4.2",
         "uuid": "^13.0.0",
         "vue": "^3.5.24",
@@ -5687,6 +5688,26 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7531,6 +7552,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-string": {
       "version": "1.1.1",
@@ -10922,6 +10963,57 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.6.tgz",
+      "integrity": "sha512-EmaxXfltJaDW75SokrY4/lXMrVyXomE/0FpIIqP2Ctic93gK7rlme55Cwkz8l3YZ6gqf94fCU7AnIkidd/KXPg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/undici-types": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "reka-ui": "^2.6.0",
     "semver": "^7.7.3",
     "tailwind-merge": "^3.4.0",
+    "ua-parser-js": "^2.0.6",
     "userpilot": "^1.4.2",
     "uuid": "^13.0.0",
     "vue": "^3.5.24",

--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -4,6 +4,7 @@
 // included in the LICENSE file.
 import type { Node as V1Node } from 'kubernetes-types/core/v1'
 import { coerce } from 'semver'
+import { UAParser } from 'ua-parser-js'
 import type { ComputedRef, Ref } from 'vue'
 import { computed, ref } from 'vue'
 
@@ -26,6 +27,36 @@ import { showError } from '@/notification'
 
 export function getNonce() {
   return document.querySelector<HTMLMetaElement>("meta[name='csp-nonce']")?.content ?? ''
+}
+
+export async function getPlatform() {
+  try {
+    const result = await new UAParser().getResult().withClientHints()
+
+    const os = (() => {
+      switch (result.os.name?.toLowerCase()) {
+        case 'macos':
+          return 'darwin'
+        case 'windows':
+          return 'windows'
+        default:
+          return 'linux'
+      }
+    })()
+
+    const arch = (() => {
+      switch (result.cpu.architecture?.toLowerCase()) {
+        case 'arm64':
+          return 'arm64'
+        default:
+          return 'amd64'
+      }
+    })()
+
+    return [os, arch] as const
+  } catch {
+    return ['linux', 'amd64'] as const
+  }
 }
 
 export const getStatus = (item: V1Node) => {


### PR DESCRIPTION
Pre-select the correct binary for the current user's platform where possible. ARM detection only works on chrome and edge, so firefox and safari might be suggested x64 instead.

This is due to the fact that the detection depends on [getHighEntropyValues](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues) which is not supported in all browsers yet, though privacy settings might mask that information even if it was.

Closes #1907 