### PR TITLE
feat: implement sqlite store for machine logs

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -483,21 +483,35 @@ func defineAuthFlags() {
 func defineLogsFlags() {
 	rootCmd.Flags().IntVar(
 		&cmdConfig.Logs.Machine.BufferInitialCapacity, "machine-log-buffer-capacity",
-		cmdConfig.Logs.Machine.BufferInitialCapacity, "initial buffer capacity for machine logs in bytes")
+		cmdConfig.Logs.Machine.BufferInitialCapacity, "initial buffer capacity for machine logs in bytes, no-op if the sqlite storage is enabled")
 	rootCmd.Flags().IntVar(&cmdConfig.Logs.Machine.BufferMaxCapacity, "machine-log-buffer-max-capacity",
-		cmdConfig.Logs.Machine.BufferMaxCapacity, "max buffer capacity for machine logs in bytes")
+		cmdConfig.Logs.Machine.BufferMaxCapacity, "max buffer capacity for machine logs in bytes, no-op if the sqlite storage is enabled")
 	rootCmd.Flags().IntVar(&cmdConfig.Logs.Machine.BufferSafetyGap, "machine-log-buffer-safe-gap",
-		cmdConfig.Logs.Machine.BufferSafetyGap, "safety gap for machine log buffer in bytes")
+		cmdConfig.Logs.Machine.BufferSafetyGap, "safety gap for machine log buffer in bytes, no-op if the sqlite storage is enabled")
 	rootCmd.Flags().IntVar(&cmdConfig.Logs.Machine.Storage.NumCompressedChunks, "machine-log-num-compressed-chunks",
-		cmdConfig.Logs.Machine.Storage.NumCompressedChunks, "number of compressed log chunks to keep")
+		cmdConfig.Logs.Machine.Storage.NumCompressedChunks, "number of compressed log chunks to keep, no-op if the sqlite storage is enabled")
 	rootCmd.Flags().BoolVar(&cmdConfig.Logs.Machine.Storage.Enabled, "machine-log-storage-enabled",
-		cmdConfig.Logs.Machine.Storage.Enabled, "enable machine log storage")
+		cmdConfig.Logs.Machine.Storage.Enabled, "enable machine log storage, no-op if the sqlite storage is enabled")
 	rootCmd.Flags().StringVar(&cmdConfig.Logs.Machine.Storage.Path, "machine-log-storage-path",
-		cmdConfig.Logs.Machine.Storage.Path, "path of the directory for storing machine logs")
+		cmdConfig.Logs.Machine.Storage.Path, "path of the directory for storing machine logs, no-op if the sqlite storage is enabled")
 	rootCmd.Flags().DurationVar(&cmdConfig.Logs.Machine.Storage.FlushPeriod, "machine-log-storage-flush-period",
-		cmdConfig.Logs.Machine.Storage.FlushPeriod, "period for flushing machine logs to disk")
+		cmdConfig.Logs.Machine.Storage.FlushPeriod, "period for flushing machine logs to disk, no-op if the sqlite storage is enabled")
 	rootCmd.Flags().Float64Var(&cmdConfig.Logs.Machine.Storage.FlushJitter, "machine-log-storage-flush-jitter",
-		cmdConfig.Logs.Machine.Storage.FlushJitter, "jitter for the machine log storage flush period")
+		cmdConfig.Logs.Machine.Storage.FlushJitter, "jitter for the machine log storage flush period, no-op if the sqlite storage is enabled")
+
+	// todo: add mutual exclusion between above and sqlite below, and info on migration etc.
+	rootCmd.Flags().BoolVar(&cmdConfig.Logs.Machine.SQLite.Enabled, "machine-log-sqlite-enabled",
+		cmdConfig.Logs.Machine.SQLite.Enabled, "enable machine log storage in sqlite database")
+	rootCmd.Flags().StringVar(&cmdConfig.Logs.Machine.SQLite.Path, "machine-log-sqlite-path",
+		cmdConfig.Logs.Machine.SQLite.Path, "path to sqlite database file for machine logs")
+	rootCmd.Flags().IntVar(&cmdConfig.Logs.Machine.SQLite.CacheSize, "machine-log-sqlite-cache-size",
+		cmdConfig.Logs.Machine.SQLite.CacheSize, "sqlite cache size for machine logs in bytes, before they are flushed to disk")
+	rootCmd.Flags().IntVar(&cmdConfig.Logs.Machine.SQLite.ReadBatchSize, "machine-log-sqlite-read-batch-size",
+		cmdConfig.Logs.Machine.SQLite.ReadBatchSize, "sqlite read batch size (number of records) for machine logs")
+	rootCmd.Flags().DurationVar(&cmdConfig.Logs.Machine.SQLite.Timeout, "machine-log-sqlite-timeout",
+		cmdConfig.Logs.Machine.SQLite.Timeout, "sqlite timeout for machine logs")
+	rootCmd.Flags().DurationVar(&cmdConfig.Logs.Machine.SQLite.FlushInterval, "machine-log-sqlite-flush-interval",
+		cmdConfig.Logs.Machine.SQLite.FlushInterval, "interval for flushing machine logs to sqlite database")
 
 	rootCmd.Flags().StringSliceVar(
 		&cmdConfig.Logs.ResourceLogger.Types,

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -238,9 +238,11 @@ func (s *managementServer) Omniconfig(ctx context.Context, _ *emptypb.Empty) (*m
 	}, nil
 }
 
-func (s *managementServer) MachineLogs(request *management.MachineLogsRequest, response grpc.ServerStreamingServer[common.Data]) error {
+func (s *managementServer) MachineLogs(request *management.MachineLogsRequest, serv grpc.ServerStreamingServer[common.Data]) error {
+	ctx := serv.Context()
+
 	// getting machine logs is equivalent to reading machine resource
-	if _, err := auth.CheckGRPC(response.Context(), auth.WithRole(role.Reader)); err != nil {
+	if _, err := auth.CheckGRPC(ctx, auth.WithRole(role.Reader)); err != nil {
 		return err
 	}
 
@@ -254,7 +256,7 @@ func (s *managementServer) MachineLogs(request *management.MachineLogsRequest, r
 		tailLines = optional.Some(request.TailLines)
 	}
 
-	logReader, err := s.logHandler.GetReader(siderolinkinternal.MachineID(machineID), request.Follow, tailLines)
+	logReader, err := s.logHandler.GetReader(ctx, siderolinkinternal.MachineID(machineID), request.Follow, tailLines)
 	if err != nil {
 		return handleError(err)
 	}
@@ -263,16 +265,16 @@ func (s *managementServer) MachineLogs(request *management.MachineLogsRequest, r
 	defer closeRdr() //nolint:errcheck
 
 	// if connection closed, stop reading
-	stop := xcontext.AfterFuncSync(response.Context(), func() { closeRdr() }) //nolint:errcheck
+	stop := xcontext.AfterFuncSync(ctx, func() { closeRdr() }) //nolint:errcheck
 	defer stop()
 
 	for {
-		line, err := logReader.ReadLine()
+		line, err := logReader.ReadLine(ctx)
 		if err != nil {
 			return handleError(err)
 		}
 
-		if err := response.Send(&common.Data{
+		if err := serv.Send(&common.Data{
 			Bytes: line,
 		}); err != nil {
 			return err
@@ -914,7 +916,7 @@ func handleError(err error) error {
 	switch {
 	case errors.Is(err, io.EOF):
 		return nil
-	case siderolinkinternal.IsBufferNotFoundError(err):
+	case errors.Is(err, siderolinkinternal.ErrLogStoreNotFound):
 		return status.Error(codes.NotFound, err.Error())
 	}
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -159,11 +159,19 @@ func Default() *Params {
 				BufferMaxCapacity:     131072,
 				BufferSafetyGap:       256,
 				Storage: LogsMachineStorage{
-					Enabled:             true,
+					Enabled:             false,
 					Path:                "_out/logs",
 					FlushPeriod:         10 * time.Minute,
 					FlushJitter:         0.1,
 					NumCompressedChunks: 5,
+				},
+				SQLite: LogsMachineSQLite{
+					Enabled:       true,
+					Path:          "_out/machine-logs.sqlite",
+					CacheSize:     64 * 1024, // 64KB
+					ReadBatchSize: 512,       // rows
+					Timeout:       10 * time.Second,
+					FlushInterval: 5 * time.Second,
 				},
 			},
 		},

--- a/internal/pkg/config/logs.go
+++ b/internal/pkg/config/logs.go
@@ -23,15 +23,23 @@ type Logs struct {
 
 // LogsMachine configures Talos machine logs handler.
 type LogsMachine struct {
-	// Storage configures persistent machine log storage of the Omni instance.
-	Storage LogsMachineStorage `yaml:"storage"`
-
-	BufferInitialCapacity int `yaml:"bufferInitialCapacity"`
-	BufferMaxCapacity     int `yaml:"bufferMaxCapacity"`
-	BufferSafetyGap       int `yaml:"bufferSafetyGap"`
+	Storage               LogsMachineStorage `yaml:"storage"`
+	SQLite                LogsMachineSQLite  `yaml:"sqlite"`
+	// BufferInitialCapacity is the initial capacity of the in-memory buffer for logs.
+	//
+	// It is used only if SQLite storage is not enabled.
+	BufferInitialCapacity int                `yaml:"bufferInitialCapacity"`
+	// BufferMaxCapacity is the maximum capacity of the in-memory buffer for logs.
+	//
+	// It is used only if SQLite storage is not enabled.
+	BufferMaxCapacity     int                `yaml:"bufferMaxCapacity"`
+	// BufferSafetyGap is the safety gap to use when trimming the buffer.
+	//
+	// It is used only if SQLite storage is not enabled.
+	BufferSafetyGap       int                `yaml:"bufferSafetyGap"`
 }
 
-// LogsMachineStorage configures the machine logs storage.
+// LogsMachineStorage configures the machine logs storage if SQLite storage is not enabled.
 //
 //nolint:govet
 type LogsMachineStorage struct {
@@ -44,6 +52,15 @@ type LogsMachineStorage struct {
 	FlushJitter float64 `yaml:"flushJitter"`
 	// NumCompressedChunks is the count of log chunks to keep in the logs history.
 	NumCompressedChunks int `yaml:"numCompressedChunks"`
+}
+
+type LogsMachineSQLite struct {
+	Path          string        `yaml:"path"`
+	Enabled       bool          `yaml:"enabled"`
+	CacheSize     int           `yaml:"cacheSize"`
+	ReadBatchSize int           `yaml:"readBatchSize"`
+	Timeout       time.Duration `yaml:"timeout"`
+	FlushInterval time.Duration `yaml:"flushInterval"`
 }
 
 // LogsAudit configures audit logs peristence.

--- a/internal/pkg/siderolink/loghandler.go
+++ b/internal/pkg/siderolink/loghandler.go
@@ -6,20 +6,18 @@
 package siderolink
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"net/netip"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/optional"
-	"github.com/siderolabs/go-tail"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
 )
 
 // NewLogHandler returns a new LogHandler.
@@ -39,7 +37,7 @@ func NewLogHandler(machineMap *MachineMap, omniState state.State, storageConfig 
 	return &handler, nil
 }
 
-// LogHandler stores a map of machines to their circular log buffers.
+// LogHandler stores a map of machines to their log stores.
 type LogHandler struct {
 	OmniState state.State
 	Map       *MachineMap
@@ -81,9 +79,9 @@ func (h *LogHandler) Start(ctx context.Context) error {
 
 				h.Map.RemoveByMachineID(machineID)
 
-				err := h.Cache.Remove(machineID)
+				err := h.Cache.remove(ctx, machineID)
 				if err != nil {
-					h.logger.Error("failed to remove machine buffer", zap.String("machine_id", string(machineID)), zap.Error(err))
+					h.logger.Error("failed to remove machine log store", zap.String("machine_id", string(machineID)), zap.Error(err))
 				}
 			}
 		}
@@ -103,7 +101,7 @@ func (h *LogHandler) HasLink(srcAddress netip.Addr) bool {
 }
 
 // HandleMessage handles a log message.
-func (h *LogHandler) HandleMessage(srcAddress netip.Addr, rawData []byte) {
+func (h *LogHandler) HandleMessage(ctx context.Context, srcAddress netip.Addr, rawData []byte) {
 	currentIP := srcAddress.String()
 	if currentIP == "" {
 		h.logger.Error("empty IP address")
@@ -120,23 +118,23 @@ func (h *LogHandler) HandleMessage(srcAddress netip.Addr, rawData []byte) {
 		return
 	}
 
-	err := h.writeMessage(currentIP, rawData)
+	err := h.writeMessage(ctx, currentIP, rawData)
 	if err != nil {
-		logger.Error("failed to write message to buffer", zap.Error(err))
+		logger.Error("failed to write message to log store", zap.Error(err))
 
 		return
 	}
 }
 
-func (h *LogHandler) writeMessage(ip string, data []byte) error {
+func (h *LogHandler) writeMessage(ctx context.Context, ip string, data []byte) error {
 	id, err := h.Map.GetMachineID(ip)
 	if err != nil {
-		return fmt.Errorf("failed to get machine ID for ip address '%s': %w", ip, err)
+		return fmt.Errorf("failed to get machine ID for ip address %q: %w", ip, err)
 	}
 
-	err = h.Cache.WriteMessage(id, data)
+	err = h.Cache.WriteMessage(ctx, id, data)
 	if err != nil {
-		return fmt.Errorf("failed to write message to buffer for machine '%s': %w", id, err)
+		return fmt.Errorf("failed to write message to log store for machine %q: %w", id, err)
 	}
 
 	return nil
@@ -166,79 +164,20 @@ func (h *LogHandler) HandleError(srcAddress netip.Addr, hErr error) {
 }
 
 // GetReader returns a line reader for the given machine ID.
-func (h *LogHandler) GetReader(machineID MachineID, follow bool, tailLines optional.Optional[int32]) (*LineReader, error) {
-	buf, err := h.Cache.GetBuffer(machineID)
+func (h *LogHandler) GetReader(ctx context.Context, machineID MachineID, follow bool, tailLines optional.Optional[int32]) (logstore.LineReader, error) {
+	logStore, err := h.Cache.getLogStore(ctx, machineID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get buffer for machine '%s': %w", machineID, err)
+		return nil, fmt.Errorf("failed to get log store for machine %q: %w", machineID, err)
 	}
 
-	var r interface {
-		io.ReadCloser
-		io.Seeker
+	nLines := tailLines.ValueOrZero()
+
+	reader, err := logStore.Reader(int(nLines), follow)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reader for machine %q: %w", machineID, err)
 	}
 
-	if follow {
-		r = buf.GetStreamingReader()
-	} else {
-		r = buf.GetReader()
-	}
-
-	if tailLines.IsPresent() {
-		// since we are surrounding each message with \n we should increase lines by two times.
-		lines := int(tailLines.ValueOrZero()) * 2
-
-		err := tail.SeekLines(r, lines)
-		if err != nil {
-			return nil, fmt.Errorf("failed to seek %d lines: %w", lines, err)
-		}
-	}
-
-	return &LineReader{reader: r}, nil
-}
-
-// LineReader is a reader which reads lines surrounded by \n from the underlying reader.
-type LineReader struct {
-	buf    *bufio.Reader
-	reader io.ReadCloser
-}
-
-// Close closes the LineReader underlying reader.
-func (r *LineReader) Close() error {
-	return r.reader.Close()
-}
-
-// ReadLine reads a line from the underlying reader.
-func (r *LineReader) ReadLine() ([]byte, error) {
-	if r.buf == nil {
-		r.buf = bufio.NewReader(r.reader)
-	}
-
-	for {
-		emptyLine, err := r.buf.ReadBytes('\n')
-		if err != nil {
-			if err == io.EOF {
-				return nil, io.EOF
-			}
-
-			return nil, fmt.Errorf("failed to read line: %w", err)
-		}
-
-		if len(emptyLine) != 1 {
-			// missed the start of the line, skipping to the next entry
-			continue
-		}
-
-		logLine, err := r.buf.ReadBytes('\n')
-		if err != nil {
-			if err == io.EOF {
-				return nil, io.EOF
-			}
-
-			return nil, fmt.Errorf("failed to read line: %w", err)
-		}
-
-		return trimNewlines(logLine), nil
-	}
+	return reader, nil
 }
 
 // trimNewlines trims a newline from the start and from end of a byte slice.

--- a/internal/pkg/siderolink/loghandler_test.go
+++ b/internal/pkg/siderolink/loghandler_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/siderolabs/gen/optional"
-	"github.com/siderolabs/gen/xtesting/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -48,13 +47,15 @@ func TestLogHandler_HandleMessage(t *testing.T) {
 
 	t.Run("empty log message", func(t *testing.T) {
 		machineMap := siderolink.NewMachineMap(&siderolink.MapStorage{})
-
 		st := state.WrapCore(namespaced.NewState(inmem.Build))
 
 		handler, err := siderolink.NewLogHandler(machineMap, st, &storageConfig, zaptest.NewLogger(t))
 		require.NoError(t, err)
 
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(""))
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(""))
 	})
 
 	t.Run("non-empty log message", func(t *testing.T) {
@@ -69,75 +70,21 @@ func TestLogHandler_HandleMessage(t *testing.T) {
 		handler, err := siderolink.NewLogHandler(cache, st, &storageConfig, zaptest.NewLogger(t))
 		require.NoError(t, err)
 
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world2"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world3"}`))
-		reader, err := handler.GetReader("machine1", false, optional.None[int32]())
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world"}`))
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world2"}`))
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world3"}`))
+		reader, err := handler.GetReader(ctx, "machine1", false, optional.None[int32]())
 		require.NoError(t, err)
-		line, err := reader.ReadLine()
+		line, err := reader.ReadLine(ctx)
 		require.NoError(t, err)
 		require.Equal(t, `{"hello": "world"}`, string(line))
-		line, err = reader.ReadLine()
+		line, err = reader.ReadLine(ctx)
 		require.NoError(t, err)
 		require.Equal(t, `{"hello": "world2"}`, string(line))
-		line, err = reader.ReadLine()
-		require.NoError(t, err)
-		require.Equal(t, `{"hello": "world3"}`, string(line))
-	})
-
-	t.Run("non-empty log message with invalid data in the beginning", func(t *testing.T) {
-		cache := siderolink.NewMachineMap(&siderolink.MapStorage{
-			IPToMachine: map[string]siderolink.MachineID{
-				"1.2.3.4": "machine1",
-			},
-		})
-
-		st := state.WrapCore(namespaced.NewState(inmem.Build))
-
-		handler, err := siderolink.NewLogHandler(cache, st, &storageConfig, zaptest.NewLogger(t))
-		require.NoError(t, err)
-
-		writeBytes(t, handler, "1.2.3.4", []byte(`{"hello": "first"}`))
-
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world2"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world3"}`))
-		reader, err := handler.GetReader("machine1", false, optional.None[int32]())
-		require.NoError(t, err)
-		line, err := reader.ReadLine()
-		require.NoError(t, err)
-		require.Equal(t, `{"hello": "world2"}`, string(line))
-		line, err = reader.ReadLine()
-		require.NoError(t, err)
-		require.Equal(t, `{"hello": "world3"}`, string(line))
-	})
-
-	t.Run("non-empty log message with invalid message in the beginning", func(t *testing.T) {
-		cache := siderolink.NewMachineMap(&siderolink.MapStorage{
-			IPToMachine: map[string]siderolink.MachineID{
-				"1.2.3.4": "machine1",
-			},
-		})
-
-		st := state.WrapCore(namespaced.NewState(inmem.Build))
-
-		handler, err := siderolink.NewLogHandler(cache, st, &storageConfig, zaptest.NewLogger(t))
-		require.NoError(t, err)
-
-		writeBytes(t, handler, "1.2.3.4", []byte(`{"hello": "first"}`+"\n"))
-
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world2"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world3"}`))
-		reader, err := handler.GetReader("machine1", false, optional.None[int32]())
-		require.NoError(t, err)
-		line, err := reader.ReadLine()
-		require.NoError(t, err)
-		require.Equal(t, `{"hello": "world"}`, string(line))
-		line, err = reader.ReadLine()
-		require.NoError(t, err)
-		require.Equal(t, `{"hello": "world2"}`, string(line))
-		line, err = reader.ReadLine()
+		line, err = reader.ReadLine(ctx)
 		require.NoError(t, err)
 		require.Equal(t, `{"hello": "world3"}`, string(line))
 	})
@@ -154,18 +101,21 @@ func TestLogHandler_HandleMessage(t *testing.T) {
 		handler, err := siderolink.NewLogHandler(cache, st, &storageConfig, zaptest.NewLogger(t))
 		require.NoError(t, err)
 
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world2"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world3"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world4"}`))
-		handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world5"}`))
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
 
-		reader, err := handler.GetReader("machine1", false, optional.Some[int32](2))
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world"}`))
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world2"}`))
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world3"}`))
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world4"}`))
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte(`{"hello": "world5"}`))
+
+		reader, err := handler.GetReader(ctx, "machine1", false, optional.Some[int32](2))
 		require.NoError(t, err)
-		line, err := reader.ReadLine()
+		line, err := reader.ReadLine(ctx)
 		require.NoError(t, err)
 		require.Equal(t, `{"hello": "world4"}`, string(line))
-		line, err = reader.ReadLine()
+		line, err = reader.ReadLine(ctx)
 		require.NoError(t, err)
 		require.Equal(t, `{"hello": "world5"}`, string(line))
 	})
@@ -213,8 +163,8 @@ func TestLogHandlerStorage(t *testing.T) {
 	data, err := io.ReadAll(io.LimitReader(rand.Reader, 120))
 	require.NoError(t, err)
 
-	logHandler.HandleMessage(netip.MustParseAddr("1.2.3.4"), data)
-	logHandler.HandleMessage(netip.MustParseAddr("2.3.4.5"), data)
+	logHandler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), data)
+	logHandler.HandleMessage(ctx, netip.MustParseAddr("2.3.4.5"), data)
 
 	// wait for a log flush to happen
 	time.Sleep(2300 * time.Millisecond)
@@ -227,16 +177,16 @@ func TestLogHandlerStorage(t *testing.T) {
 	// send more logs
 	data = data[:16]
 
-	logHandler.HandleMessage(netip.MustParseAddr("1.2.3.4"), data)
-	logHandler.HandleMessage(netip.MustParseAddr("2.3.4.5"), data)
+	logHandler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), data)
+	logHandler.HandleMessage(ctx, netip.MustParseAddr("2.3.4.5"), data)
 
 	time.Sleep(2300 * time.Millisecond)
 
 	assert.FileExists(t, filepath.Join(tempDir, "machine-1.log.1"))
 	assert.FileExists(t, filepath.Join(tempDir, "machine-2.log.1"))
 
-	logHandler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte("bbbb"))
-	logHandler.HandleMessage(netip.MustParseAddr("2.3.4.5"), []byte("BBBB"))
+	logHandler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte("bbbb"))
+	logHandler.HandleMessage(ctx, netip.MustParseAddr("2.3.4.5"), []byte("BBBB"))
 
 	// destroy machine-2
 	require.NoError(t, st.Destroy(ctx, omni.NewMachine(resources.DefaultNamespace, "machine-2").Metadata()))
@@ -296,7 +246,7 @@ func TestLogHandlerStorageLegacyMigration(t *testing.T) {
 	eg.Go(func() error { return logHandler.Start(ctx) })
 
 	// write a log to trigger migration
-	logHandler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte("foo\n"))
+	logHandler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte("foo\n"))
 
 	// assert that the legacy log files are removed
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -304,12 +254,12 @@ func TestLogHandlerStorageLegacyMigration(t *testing.T) {
 		assert.NoFileExists(collect, legacyLogHashPath)
 	}, 2*time.Second, 50*time.Millisecond)
 
-	reader, err := logHandler.GetReader("machine-1", false, optional.None[int32]())
+	reader, err := logHandler.GetReader(ctx, "machine-1", false, optional.None[int32]())
 	require.NoError(t, err)
 
 	t.Cleanup(func() { require.NoError(t, reader.Close()) })
 
-	line, err := reader.ReadLine()
+	line, err := reader.ReadLine(ctx)
 	require.NoError(t, err)
 
 	assert.Equal(t, "legacy log", string(line))
@@ -350,8 +300,8 @@ func TestLogHandlerStorageDisabled(t *testing.T) {
 
 	time.Sleep(300 * time.Millisecond)
 
-	handler.HandleMessage(netip.MustParseAddr("1.2.3.4"), []byte("aaaa"))
-	handler.HandleMessage(netip.MustParseAddr("2.3.4.5"), []byte("AAAA"))
+	handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), []byte("aaaa"))
+	handler.HandleMessage(ctx, netip.MustParseAddr("2.3.4.5"), []byte("AAAA"))
 
 	ctxCancel()
 
@@ -362,10 +312,4 @@ func TestLogHandlerStorageDisabled(t *testing.T) {
 
 	assert.NoFileExists(t, filepath.Join(tempDir, "machine-2.log"))
 	assert.NoFileExists(t, filepath.Join(tempDir, "machine-2.log.sha256sum"))
-}
-
-func writeBytes(t *testing.T, handler *siderolink.LogHandler, ip string, bytes []byte) {
-	id := must.Value(handler.Map.GetMachineID(ip))(t)
-	writeTo := must.Value(handler.Cache.GetWriter(id))(t)
-	must.Value(writeTo.Write(bytes))(t)
 }

--- a/internal/pkg/siderolink/logstore/circularlog/circularlog.go
+++ b/internal/pkg/siderolink/logstore/circularlog/circularlog.go
@@ -1,0 +1,217 @@
+package circularlog
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/go-circular"
+	"github.com/siderolabs/go-tail"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+)
+
+func NewStore(config *config.LogsMachine, id string, compressor circular.Compressor, logger *zap.Logger) (*Store, error) {
+	bufferOpts := []circular.OptionFunc{
+		circular.WithInitialCapacity(config.BufferInitialCapacity),
+		circular.WithMaxCapacity(config.BufferMaxCapacity),
+		circular.WithSafetyGap(config.BufferSafetyGap),
+		circular.WithNumCompressedChunks(config.Storage.NumCompressedChunks, compressor),
+		circular.WithLogger(logger),
+	}
+
+	if config.Storage.Enabled {
+		bufferOpts = append(bufferOpts, circular.WithPersistence(circular.PersistenceOptions{
+			ChunkPath:     filepath.Join(config.Storage.Path, id+".log"),
+			FlushInterval: config.Storage.FlushPeriod,
+			FlushJitter:   config.Storage.FlushJitter,
+		}))
+	}
+
+	buffer, err := circular.NewBuffer(bufferOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create circular buffer for machine %q: %w", id, err)
+	}
+
+	if config.Storage.Enabled {
+		loadLegacyLogs(config, id, buffer, logger)
+	}
+
+	return &Store{buf: buffer}, nil
+}
+
+type Store struct {
+	buf *circular.Buffer
+}
+
+func (s *Store) WriteLine(_ context.Context, message []byte) error {
+	if _, err := s.buf.Write([]byte("\n")); err != nil {
+		return err
+	}
+
+	if _, err := s.buf.Write(message); err != nil {
+		return err
+	}
+
+	if _, err := s.buf.Write([]byte("\n")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) Close() error {
+	return s.buf.Close()
+}
+
+func (s *Store) Reader(nLines int, follow bool) (logstore.LineReader, error) {
+	var rdr io.ReadSeekCloser
+
+	if follow {
+		rdr = s.buf.GetStreamingReader()
+	} else {
+		rdr = s.buf.GetReader()
+	}
+
+	if rdr == nil {
+		return nil, fmt.Errorf("buffer reader is not available")
+	}
+
+	if nLines > 0 {
+		// since we are surrounding each message with \n we should increase lines by two times.
+		seekLines := nLines * 2
+
+		if err := tail.SeekLines(rdr, seekLines); err != nil {
+			return nil, fmt.Errorf("failed to seek %d lines: %w", seekLines, err)
+		}
+	}
+
+	return &LineReader{reader: rdr}, nil
+}
+
+// LineReader is a reader which reads lines surrounded by \n from the underlying reader.
+type LineReader struct {
+	buf    *bufio.Reader
+	reader io.ReadCloser
+}
+
+// Close closes the LineReader underlying reader.
+func (r *LineReader) Close() error {
+	return r.reader.Close()
+}
+
+// ReadLine reads a line from the underlying reader.
+func (r *LineReader) ReadLine(context.Context) ([]byte, error) {
+	if r.buf == nil {
+		r.buf = bufio.NewReader(r.reader)
+	}
+
+	for {
+		emptyLine, err := r.buf.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				return nil, io.EOF
+			}
+
+			return nil, fmt.Errorf("failed to read line: %w", err)
+		}
+
+		if len(emptyLine) != 1 {
+			// missed the start of the line, skipping to the next entry
+			continue
+		}
+
+		logLine, err := r.buf.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				return nil, io.EOF
+			}
+
+			return nil, fmt.Errorf("failed to read line: %w", err)
+		}
+
+		return trimNewlines(logLine), nil
+	}
+}
+
+// trimNewlines trims a newline from the start and from end of a byte slice.
+func trimNewlines(data []byte) []byte {
+	if len(data) == 0 {
+		return data
+	}
+
+	if data[0] == '\n' {
+		data = data[1:]
+	}
+
+	if len(data) > 0 && data[len(data)-1] == '\n' {
+		data = data[:len(data)-1]
+	}
+
+	return data
+}
+
+// loadLegacyLogs loads logs stored of the machine with the given id in the old format, if exists, into the given writer.
+// It is used to migrate logs from the old format to the new format.
+// It removes the old log file and its hash file regardless of the result.
+//
+// It is a best-effort function and does not return any error.
+func loadLegacyLogs(config *config.LogsMachine, id string, writer io.Writer, logger *zap.Logger) {
+	filePath := filepath.Join(config.Storage.Path, fmt.Sprintf("%s.log", id))
+	shaSumPath := filePath + ".sha256sum"
+
+	defer func() {
+		if err := os.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logger.Error("failed to remove legacy log file", zap.String("path", filePath), zap.Error(err))
+		}
+
+		if err := os.Remove(shaSumPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logger.Error("failed to remove legacy log hash file", zap.String("path", shaSumPath), zap.Error(err))
+		}
+	}()
+
+	bufferData, err := os.ReadFile(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+
+		logger.Error("failed to read legacy log buffer file", zap.String("path", filePath), zap.Error(err))
+
+		return
+	}
+
+	hashHexExpectedBytes, err := os.ReadFile(shaSumPath)
+	if err != nil {
+		logger.Error("failed to read legacy log buffer hash file", zap.String("path", shaSumPath), zap.Error(err))
+
+		return
+	}
+
+	hashHexExpected := string(hashHexExpectedBytes)
+
+	// verify the hash
+	hashActual := sha256.Sum256(bufferData)
+	hashHexActual := hex.EncodeToString(hashActual[:])
+
+	if hashHexExpected != hashHexActual {
+		logger.Error("invalid legacy log buffer hash in file", zap.String("expected", hashHexExpected), zap.String("actual", hashHexActual))
+
+		return
+	}
+
+	if _, err = io.Copy(writer, bytes.NewReader(bufferData)); err != nil {
+		logger.Error("failed to write legacy log buffer to writer", zap.Error(err))
+	}
+
+	logger.Info("loaded legacy log buffer", zap.String("path", filePath))
+}

--- a/internal/pkg/siderolink/logstore/logstore.go
+++ b/internal/pkg/siderolink/logstore/logstore.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package logstore
+
+import (
+	"context"
+	"io"
+)
+
+type LogStore interface {
+	WriteLine(ctx context.Context, p []byte) error
+
+	// Reader returns a reader starting from N lines before the end.
+	// If nLines <= 0, it reads from the very beginning.
+	// If follow is true, ReadLine() blocks instead of returning EOF when catching up.
+	Reader(nLines int, follow bool) (LineReader, error)
+
+	io.Closer
+}
+
+type LineReader interface {
+	// ReadLine reads the next message.
+	//
+	// Returns io.EOF if follow=false and end is reached.
+	//
+	// Blocks if follow=true and end is reached.
+	ReadLine(ctx context.Context) ([]byte, error)
+
+	io.Closer
+}

--- a/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog.go
@@ -1,0 +1,386 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlitelog
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	_ "modernc.org/sqlite"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+)
+
+const (
+	schemaSQL = `
+CREATE TABLE IF NOT EXISTS "%[1]s" (
+  id         INTEGER NOT NULL PRIMARY KEY,
+  created_at INTEGER NOT NULL,
+  message    BLOB    NOT NULL
+) STRICT;
+`
+)
+
+func getTableName(id string) string {
+	return "logs_" + id
+}
+
+// OpenDB opens a SQLite database at the given path with appropriate options for log storage.
+func OpenDB(path string) (*sql.DB, error) {
+	dsn := "file:" + path + "?_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)"
+
+	return sql.Open("sqlite", dsn)
+}
+
+func Exists(ctx context.Context, db *sql.DB, id string, timeout time.Duration) (bool, error) {
+	tableName := getTableName(id)
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var count int
+
+	query := "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?"
+	if err := db.QueryRowContext(ctx, query, tableName).Scan(&count); err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
+func Remove(ctx context.Context, db *sql.DB, id string, timeout time.Duration) error {
+	tableName := getTableName(id)
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	_, err := db.ExecContext(ctx, fmt.Sprintf(`DROP TABLE IF EXISTS %q`, tableName))
+	if err != nil {
+		return fmt.Errorf("failed to drop sqlite log table %q: %w", tableName, err)
+	}
+
+	return nil
+}
+
+func NewStore(ctx context.Context, config config.LogsMachineSQLite, db *sql.DB, id string, logger *zap.Logger) (*Store, error) {
+	ctx, cancel := context.WithTimeout(ctx, config.Timeout)
+	defer cancel()
+
+	tableName := getTableName(id)
+
+	schemaReplaced := fmt.Sprintf(schemaSQL, tableName)
+
+	if _, err := db.ExecContext(ctx, schemaReplaced); err != nil {
+		return nil, fmt.Errorf("applying schema migration: %w", err)
+	}
+
+	// Initialize the ID counter by finding the last ID in the database.
+	// We need this because we are manually assigning IDs to support the Hybrid Reader.
+	var maxID sql.NullInt64
+
+	if err := db.QueryRowContext(ctx, fmt.Sprintf(`SELECT MAX(id) FROM %q`, tableName)).Scan(&maxID); err != nil {
+		return nil, fmt.Errorf("failed to get max id: %w", err)
+	}
+
+	s := &Store{
+		config:              config,
+		tableName:           tableName,
+		db:                  db,
+		logger:              logger,
+		subscriptionManager: NewManager(),
+		lastFlush:           time.Now(),
+		buffer:              make([]bufferedLog, 0, 1024),
+	}
+
+	// Initialize nextID to (MaxID + 1). If MaxID is NULL (empty table), Int64 is 0, so nextID becomes 1.
+	s.nextID.Store(maxID.Int64 + 1)
+
+	return s, nil
+}
+
+type bufferedLog struct {
+	message   []byte
+	id        int64
+	createdAt int64
+}
+
+type Store struct {
+	lastFlush           time.Time
+	db                  *sql.DB
+	logger              *zap.Logger
+	subscriptionManager *Manager
+	tableName           string
+	buffer              []bufferedLog
+	config              config.LogsMachineSQLite
+	bufferSizeBytes     int
+	nextID              atomic.Int64
+	mu                  sync.Mutex
+	closed              atomic.Bool
+}
+
+func (c *Store) WriteLine(ctx context.Context, line []byte) error {
+	if c.closed.Load() {
+		return errors.New("store is closed")
+	}
+
+	// Generate the next ID.
+	id := c.nextID.Add(1) - 1
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.buffer = append(c.buffer, bufferedLog{
+		id:        id,
+		createdAt: time.Now().Unix(),
+		message:   line,
+	})
+	c.bufferSizeBytes += len(line)
+
+	// Notify the subscribers that new data is available.
+	c.subscriptionManager.Notify()
+
+	// Flush to DB if needed.
+	if c.bufferSizeBytes >= c.config.CacheSize || time.Since(c.lastFlush) > c.config.FlushInterval {
+		return c.flush(ctx)
+	}
+
+	return nil
+}
+
+// flush writes all buffered lines to the database in a single transaction.
+//
+// It assumes c.mu is already held.
+func (c *Store) flush(ctx context.Context) error {
+	if len(c.buffer) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.config.Timeout)
+	defer cancel()
+
+	tx, err := c.db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("error starting flush transaction: %w", err)
+	}
+
+	defer tx.Rollback() //nolint:errcheck
+
+	query := fmt.Sprintf(`INSERT INTO "%s" (id, created_at, message) VALUES (?, ?, ?)`, c.tableName)
+
+	stmt, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("error preparing flush statement: %w", err)
+	}
+
+	defer stmt.Close() //nolint:errcheck
+
+	for _, entry := range c.buffer {
+		if _, err = stmt.ExecContext(ctx, entry.id, entry.createdAt, entry.message); err != nil {
+			return fmt.Errorf("failed to insert buffered log: %w", err)
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit flush transaction: %w", err)
+	}
+
+	c.buffer = c.buffer[:0]
+	c.bufferSizeBytes = 0
+	c.lastFlush = time.Now()
+
+	// ensure that readers are notified about the flush
+	c.subscriptionManager.Notify()
+
+	return nil
+}
+
+func (c *Store) Close() error {
+	if c.closed.Swap(true) {
+		return nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Do the final flush on close.
+	flushCtx, cancel := context.WithTimeout(context.Background(), c.config.Timeout)
+	defer cancel()
+
+	if err := c.flush(flushCtx); err != nil {
+		c.logger.Error("failed to flush buffer on close", zap.Error(err))
+	}
+
+	c.subscriptionManager.Notify()
+
+	return nil
+}
+
+func (c *Store) Reader(nLines int, follow bool) (logstore.LineReader, error) {
+	var lastID int64
+
+	if nLines > 0 {
+		currentMax := c.nextID.Load() - 1
+
+		lastID = max(currentMax-int64(nLines), 0)
+	}
+
+	var sub Subscription
+
+	if follow {
+		sub = c.subscriptionManager.Subscribe()
+	}
+
+	return &sqliteLineReader{
+		store:   c,
+		lastID:  lastID,
+		follow:  follow,
+		sub:     sub,
+		closeCh: make(chan struct{}),
+		buffer:  make([][]byte, 0, c.config.ReadBatchSize),
+	}, nil
+}
+
+type sqliteLineReader struct {
+	sub     Subscription
+	store   *Store
+	closeCh chan struct{}
+	buffer  [][]byte
+	lastID  int64
+	once    sync.Once
+	follow  bool
+}
+
+func (r *sqliteLineReader) ReadLine(ctx context.Context) ([]byte, error) {
+	for {
+		// If there is a line in the buffer, read it and set buffer to the remaining lines.
+		if len(r.buffer) > 0 {
+			line := r.buffer[0]
+			r.buffer = r.buffer[1:]
+
+			return line, nil
+		}
+
+		// Buffer is empty, try to refill it.
+		if err := r.refillBuffer(ctx); err != nil {
+			r.Close() //nolint:errcheck
+
+			if errors.Is(err, context.Canceled) {
+				return nil, io.EOF
+			}
+
+			return nil, err
+		}
+
+		// If the buffer is filled, continue the loop to read from it.
+		if len(r.buffer) > 0 {
+			continue
+		}
+
+		// No lines available (neither in DB nor in Memory), we are at the end of the log.
+		//
+		// If the follow was not requested, or if the store is closed, return EOF to signal end of log.
+		//
+		// Otherwise, wait for a notification of new data.
+		if !r.follow || r.store.closed.Load() {
+			return nil, io.EOF
+		}
+
+		// Wait for notification or closure.
+		select {
+		case <-r.sub.NotifyCh():
+			continue
+		case <-r.closeCh:
+			return nil, io.EOF
+		}
+	}
+}
+
+func (r *sqliteLineReader) refillBuffer(ctx context.Context) error {
+	r.buffer = r.buffer[:0]
+
+	ctx, cancel := context.WithTimeout(ctx, r.store.config.Timeout)
+	defer cancel()
+
+	query := fmt.Sprintf(`SELECT id, message FROM "%s" WHERE id > ? ORDER BY id LIMIT %d`, r.store.tableName, r.store.config.ReadBatchSize)
+
+	rows, err := r.store.db.QueryContext(ctx, query, r.lastID)
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close() //nolint:errcheck
+
+	count := 0
+
+	for rows.Next() {
+		var (
+			id  int64
+			msg []byte
+		)
+
+		if err = rows.Scan(&id, &msg); err != nil {
+			return err
+		}
+
+		r.lastID = id
+		r.buffer = append(r.buffer, msg)
+		count++
+	}
+
+	if err = rows.Err(); err != nil {
+		return err
+	}
+
+	// If we haven't filled the batch, check the in-memory Buffer (uncommitted data)
+	if count < r.store.config.ReadBatchSize {
+		r.store.mu.Lock()
+		defer r.store.mu.Unlock()
+
+		for _, entry := range r.store.buffer {
+			if entry.id <= r.lastID {
+				continue // Already consumed this ID
+			}
+
+			// If the id is not the next expected one, we stop reading from memory,
+			// we were too slow and missed some entries that are not yet flushed to the DB.
+			if entry.id != r.lastID+1 {
+				break
+			}
+
+			r.buffer = append(r.buffer, entry.message)
+			r.lastID = entry.id
+
+			count++
+
+			if count >= r.store.config.ReadBatchSize {
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *sqliteLineReader) Close() error {
+	r.once.Do(func() {
+		close(r.closeCh)
+
+		if r.sub != nil {
+			r.sub.Unsubscribe()
+		}
+	})
+
+	return nil
+}

--- a/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
@@ -1,0 +1,335 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlitelog_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/go-circular/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/circularlog"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/sqlitelog"
+)
+
+func TestReadWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	db := setupDB(t)
+
+	logger := zaptest.NewLogger(t)
+
+	sqliteStore, err := sqlitelog.NewStore(ctx, config.Default().Logs.Machine.SQLite, db, "test-1", logger)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, sqliteStore.Close())
+	})
+
+	defaultConfig := config.Default()
+
+	compressor, err := zstd.NewCompressor()
+	require.NoError(t, err)
+
+	circularStore, err := circularlog.NewStore(&defaultConfig.Logs.Machine, "test-1", compressor, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	numLines := 1000
+
+	for i := range numLines {
+		require.NoError(t, sqliteStore.WriteLine(ctx, fmt.Appendf(nil, "Hello, World %d!", i)))
+		require.NoError(t, circularStore.WriteLine(ctx, fmt.Appendf(nil, "Hello, World %d!", i)))
+	}
+
+	t.Run("read all", func(t *testing.T) {
+		t.Parallel()
+
+		testRead(ctx, t, sqliteStore, circularStore, numLines, 0)
+	})
+
+	t.Run("tail", func(t *testing.T) {
+		t.Parallel()
+
+		testRead(ctx, t, sqliteStore, circularStore, 100, 100)
+	})
+}
+
+func testRead(ctx context.Context, t *testing.T, sqliteStore, circularStore logstore.LogStore, expectedLines, tailLines int) {
+	sqliteReader, err := sqliteStore.Reader(tailLines, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, sqliteReader.Close())
+	})
+
+	sqliteLines := readAllLines(ctx, t, sqliteReader)
+
+	circularReader, err := circularStore.Reader(tailLines, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, circularReader.Close())
+	})
+
+	circularLines := readAllLines(ctx, t, circularReader)
+
+	assert.Len(t, sqliteLines, expectedLines)
+	assert.Equal(t, circularLines, sqliteLines)
+}
+
+func readAllLines(ctx context.Context, t *testing.T, rdr logstore.LineReader) []string {
+	var lines []string
+
+	for {
+		line, err := rdr.ReadLine(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return lines
+			}
+
+			require.NoError(t, err)
+		}
+
+		lines = append(lines, string(line))
+	}
+}
+
+func readLines(ctx context.Context, t *testing.T, rdr logstore.LineReader, ch chan<- string) {
+	for {
+		line, err := rdr.ReadLine(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+
+			require.NoError(t, err)
+		}
+
+		select {
+		case ch <- string(line):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func TestFollow(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	db := setupDB(t)
+
+	logger := zaptest.NewLogger(t)
+
+	sqliteStore, err := sqlitelog.NewStore(ctx, config.Default().Logs.Machine.SQLite, db, "test-1", logger)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, sqliteStore.Close())
+	})
+
+	require.NoError(t, sqliteStore.WriteLine(ctx, []byte("Hello, World 1!")))
+	require.NoError(t, sqliteStore.WriteLine(ctx, []byte("Hello, World 2!")))
+
+	rdr, err := sqliteStore.Reader(0, true)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	lineCh := make(chan string)
+
+	wg.Go(func() {
+		readLines(ctx, t, rdr, lineCh)
+	})
+
+	assertLine(ctx, t, lineCh, "Hello, World 1!")
+	assertLine(ctx, t, lineCh, "Hello, World 2!")
+
+	require.NoError(t, sqliteStore.WriteLine(ctx, []byte("Hello, World 3!")))
+	require.NoError(t, sqliteStore.WriteLine(ctx, []byte("Hello, World 4!")))
+
+	assertLine(ctx, t, lineCh, "Hello, World 3!")
+	assertLine(ctx, t, lineCh, "Hello, World 4!")
+
+	cancel()
+
+	wg.Wait()
+}
+
+func assertLine(ctx context.Context, t *testing.T, lineCh <-chan string, expected string) {
+	select {
+	case line := <-lineCh:
+		assert.Equal(t, expected, line)
+	case <-ctx.Done():
+		require.NoError(t, ctx.Err())
+	}
+}
+
+// TestWriteBatchSize verifies buffering behavior by observing side effects on the DB.
+func TestWriteBatchSize(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	db := setupDB(t)
+	logger := zaptest.NewLogger(t)
+
+	id := "batch-test-bb"
+	store, err := sqlitelog.NewStore(ctx, config.Default().Logs.Machine.SQLite, db, id, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	tableName := fmt.Sprintf("logs_%s", id)
+
+	// Write a payload slightly smaller than the batch limit (60KB <= 64KB) - should stay in memory
+	largePayload := strings.Repeat("a", 60*1024)
+	require.NoError(t, store.WriteLine(ctx, []byte(largePayload)))
+
+	// Check DB state - should be empty
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %q", tableName)).Scan(&count))
+	assert.Equal(t, 0, count, "Database should be empty (0 rows) because 60KB < 64KB threshold")
+
+	// 2. Write enough data to tip over the limit (60KB + 5KB > 64KB).
+	smallPayload := strings.Repeat("b", 5*1024)
+	require.NoError(t, store.WriteLine(ctx, []byte(smallPayload)))
+
+	// Check DB state again
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %q", tableName)).Scan(&count))
+	assert.Equal(t, 2, count, "Database should contain 2 rows after exceeding 64KB threshold")
+}
+
+// TestHybridReader verifies that the Reader can fetch data that hasn't been flushed to DB yet.
+func TestHybridReader(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	db := setupDB(t)
+	logger := zaptest.NewLogger(t)
+
+	id := "hybrid-test-bb"
+
+	store, err := sqlitelog.NewStore(ctx, config.Default().Logs.Machine.SQLite, db, id, logger)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	tableName := fmt.Sprintf("logs_%s", id)
+
+	// 1. Write data that is small enough to stay in memory (Buffer).
+	liveMsg := "sitting-in-buffer"
+
+	require.NoError(t, store.WriteLine(ctx, []byte(liveMsg)))
+
+	// Verify it is not in the DB.
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %q", tableName)).Scan(&count))
+	require.Equal(t, 0, count, "Pre-condition: Data must not be in DB for this test to be valid")
+
+	// 2. Create a Reader.
+	// Since the DB is empty, if this returns data, it MUST be coming from the memory buffer.
+	reader, err := store.Reader(0, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+	// 3. Read and Verify.
+	line, err := reader.ReadLine(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, liveMsg, string(line), "Reader should retrieve data from memory buffer")
+
+	// Expect EOF
+	_, err = reader.ReadLine(ctx)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+// TestReaderBatching verifies that the reader fetches data lazily by closing the database connection halfway through.
+func TestReaderBatching(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	db := setupDB(t)
+	logger := zaptest.NewLogger(t)
+
+	store, err := sqlitelog.NewStore(ctx, config.Default().Logs.Machine.SQLite, db, "lazy-load-test", logger)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	// Write more lines than one batch (512)
+	totalLines := 600
+	for i := range totalLines {
+		require.NoError(t, store.WriteLine(ctx, fmt.Appendf(nil, "line-%d", i)))
+	}
+
+	// Force flush to ensure data is in DB and not in the Store's memory buffer.
+	require.NoError(t, store.Close())
+
+	// Re-open the store.
+	store, err = sqlitelog.NewStore(ctx, config.Default().Logs.Machine.SQLite, db, "lazy-load-test", logger)
+	require.NoError(t, err)
+
+	reader, err := store.Reader(0, false)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, reader.Close())
+	})
+
+	// 2. Consume exactly one batch (512 lines).
+	knownBatchSize := 512
+	for i := range knownBatchSize {
+		line, lineErr := reader.ReadLine(ctx)
+		require.NoError(t, lineErr)
+		require.Equal(t, fmt.Sprintf("line-%d", i), string(line))
+	}
+
+	// Close the underlying database connection.
+	require.NoError(t, db.Close())
+
+	// 4. Try to read line 513 - it should fail because reader will try to fetch the next batch from the closed DB.
+	_, err = reader.ReadLine(ctx)
+
+	assert.ErrorContains(t, err, "sql: database is closed")
+}
+
+// setupDB helper handles the standard SQLite test setup.
+func setupDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := sqlitelog.OpenDB(path)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	return db
+}

--- a/internal/pkg/siderolink/logstore/sqlitelog/sub.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sub.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlitelog
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/siderolabs/gen/xslices"
+)
+
+// Manager defines a subscription manager.
+type Manager struct {
+	subscriptions []chan struct{}
+	mu            sync.Mutex
+}
+
+type subscription struct {
+	ch chan struct{}
+	m  *Manager
+}
+
+// Subscription is an active subscription interface.
+type Subscription interface {
+	NotifyCh() <-chan struct{}
+	TriggerNotify()
+	Unsubscribe()
+}
+
+// NewManager creates a new subscription manager.
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+// Subscribe creates a new subscription for the given resource kind.
+func (m *Manager) Subscribe() Subscription {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ch := make(chan struct{}, 1)
+
+	m.subscriptions = append(m.subscriptions, ch)
+
+	return &subscription{
+		ch: ch,
+		m:  m,
+	}
+}
+
+// Notify notifies all subscribers about an event for the given resource kind.
+func (m *Manager) Notify() {
+	m.mu.Lock()
+	subs := slices.Clone(m.subscriptions)
+	m.mu.Unlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// Empty checks whether there are any subscriptions.
+func (m *Manager) Empty() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.subscriptions) == 0
+}
+
+// NotifyCh implements Subscription interface.
+func (s *subscription) NotifyCh() <-chan struct{} {
+	return s.ch
+}
+
+// TriggerNotify implements Subscription interface.
+func (s *subscription) TriggerNotify() {
+	select {
+	case s.ch <- struct{}{}:
+	default:
+	}
+}
+
+// Unsubscribe implements Subscription interface.
+func (s *subscription) Unsubscribe() {
+	s.m.mu.Lock()
+	defer s.m.mu.Unlock()
+
+	s.m.subscriptions = xslices.FilterInPlace(s.m.subscriptions,
+		func(ch chan struct{}) bool {
+			return ch != s.ch
+		},
+	)
+}

--- a/internal/pkg/siderolink/logstoremanager.go
+++ b/internal/pkg/siderolink/logstoremanager.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package siderolink
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/siderolabs/go-circular/zstd"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/circularlog"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/sqlitelog"
+)
+
+type LogStoreManager interface {
+	io.Closer
+	Exists(ctx context.Context, id MachineID) (bool, error)
+	Create(ctx context.Context, id MachineID) (logstore.LogStore, error)
+	Remove(ctx context.Context, id MachineID) error
+}
+
+type sqliteLogStoreManager struct {
+	db     *sql.DB
+	logger *zap.Logger
+	config config.LogsMachineSQLite
+}
+
+func (f *sqliteLogStoreManager) Exists(ctx context.Context, id MachineID) (bool, error) {
+	return sqlitelog.Exists(ctx, f.db, string(id), f.config.Timeout)
+}
+
+func (f *sqliteLogStoreManager) Remove(ctx context.Context, id MachineID) error {
+	return sqlitelog.Remove(ctx, f.db, string(id), f.config.Timeout)
+}
+
+func newSQLiteStoreManager(config config.LogsMachineSQLite, logger *zap.Logger) (*sqliteLogStoreManager, error) {
+	path := config.Path
+	dir := filepath.Dir(path)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create directory for sqlite database %q: %w", dir, err)
+	}
+
+	db, err := sqlitelog.OpenDB(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open sqlite database %q: %w", path, err)
+	}
+
+	return &sqliteLogStoreManager{
+		config: config,
+		db:     db,
+		logger: logger,
+	}, nil
+}
+
+func (f *sqliteLogStoreManager) Close() error {
+	return f.db.Close()
+}
+
+func (f *sqliteLogStoreManager) Create(ctx context.Context, id MachineID) (logstore.LogStore, error) {
+	return sqlitelog.NewStore(ctx, f.config, f.db, string(id), f.logger)
+}
+
+type circularLogStoreManager struct {
+	config     *config.LogsMachine
+	logger     *zap.Logger
+	compressor *zstd.Compressor
+}
+
+func (c *circularLogStoreManager) Exists(_ context.Context, id MachineID) (bool, error) {
+	if !c.config.Storage.Enabled {
+		return false, nil
+	}
+
+	matches, err := c.logFiles(id)
+	if err != nil {
+		return false, fmt.Errorf("failed to list log files for machine %q: %w", id, err)
+	}
+
+	return len(matches) > 0, nil
+}
+
+func (c *circularLogStoreManager) Remove(_ context.Context, id MachineID) error {
+	matches, err := c.logFiles(id)
+	if err != nil {
+		return fmt.Errorf("failed to list log files for machine %q: %w", id, err)
+	}
+
+	var errs error
+
+	for _, match := range matches {
+		if err = os.Remove(match); err != nil && !errors.Is(err, os.ErrNotExist) {
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// logFiles returns all log files for the given machine ID.
+//
+// It probes the file system to check if a log file exists for this machine.
+// Checks both for the old (/path/machine-id.log) and the new (/path/machine-id.log.NUM) format.
+func (c *circularLogStoreManager) logFiles(id MachineID) ([]string, error) {
+	return filepath.Glob(filepath.Join(c.config.Storage.Path, string(id)+".log*"))
+}
+
+func (c *circularLogStoreManager) Create(_ context.Context, id MachineID) (logstore.LogStore, error) {
+	return circularlog.NewStore(c.config, string(id), c.compressor, c.logger)
+}
+
+func newCircularLogStoreManager(config *config.LogsMachine, compressor *zstd.Compressor, logger *zap.Logger) *circularLogStoreManager {
+	return &circularLogStoreManager{
+		config:     config,
+		compressor: compressor,
+		logger:     logger,
+	}
+}
+
+func (c *circularLogStoreManager) Close() error {
+	return nil
+}


### PR DESCRIPTION
Implement sqlite as an alternative storage for machine logs:
- Define a new, line-based LogStore interface for writing/reading logs.
- Refactor the code to make circular buffer a LogStore.
- Add an additional LogStore implementation, which is backed by SQLite.
- Implement the SQLite store to have a write-through cache.
- Refactor various places to pass context.Context down to the LogStore.
- Make the SQLite LogStore the default store.

Not done in this PR:
- Periodic removal of old logs as well as discarding them on loading the initial logs from the disk.
- Migrating the logs from the old store (compressed chunks) to the new store, when both stores are enabled.

Part of siderolabs/omni#1771.