### PR TITLE
Update image tag format in compose.yaml

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -2,7 +2,7 @@ name: omni-on-prem
 services:
   omni:
     container_name: omni
-    image: "ghcr.io/siderolabs/omni:${OMNI_IMG_TAG}"
+    image: "ghcr.io/siderolabs/omni:v${OMNI_IMG_TAG}"
     devices:
       - /dev/net/tun
     volumes:


### PR DESCRIPTION
Otherwise `docker compose up ` fails with

```shell
 ✘ omni Error failed to resolve reference "ghcr.io/siderolabs/omni:1.3.4": ghcr.io/siderolabs/omni:1.3.4: not found                                                                   1.3s
```