### PR TITLE
refactor(frontend): wait for signing keys instead of throwing

### DIFF
--- a/frontend/src/components/THeader/THeader.vue
+++ b/frontend/src/components/THeader/THeader.vue
@@ -5,13 +5,10 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computedAsync } from '@vueuse/core'
-
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import OngoingTasks from '@/components/common/OngoingTasks/OngoingTasks.vue'
 import { getDocsLink } from '@/methods'
-import { hasValidKeys } from '@/methods/key'
 
 interface Props {
   sidebarOpen?: boolean
@@ -21,9 +18,6 @@ interface Props {
 const props = defineProps<Props>()
 
 const docsLink = getDocsLink('omni')
-
-// Used to prevent sub-queries being fired before keys are created
-const authorized = computedAsync(async () => await hasValidKeys())
 </script>
 
 <template>
@@ -81,7 +75,7 @@ const authorized = computedAsync(async () => await hasValidKeys())
         <span class="truncate text-xs max-sm:hidden">Report an issue</span>
       </a>
 
-      <OngoingTasks v-if="authorized" />
+      <OngoingTasks />
     </div>
   </header>
 </template>

--- a/frontend/src/methods/key.spec.ts
+++ b/frontend/src/methods/key.spec.ts
@@ -12,7 +12,7 @@ import { useRouter } from 'vue-router'
 
 import type { RegisterPublicKeyRequest, RegisterPublicKeyResponse } from '@/api/omni/auth/auth.pb'
 
-import { createKeys, hasValidKeys, useKeys, useSignDetached, useWatchKeyExpiry } from './key'
+import { createKeys, hasValidKeys, signDetached, useKeys, useWatchKeyExpiry } from './key'
 
 vi.mock('vue-router', () => ({
   useRoute: vi.fn().mockReturnValue({ fullPath: 'fullPath' }),
@@ -178,14 +178,8 @@ describe('useWatchKeyExpiry', () => {
   })
 })
 
-describe('useSignDetached', () => {
-  afterEach(() => {
-    useKeys().clear()
-  })
-
-  test('uses key from params if available', async () => {
-    const signDetached = useSignDetached()
-
+describe('signDetached', () => {
+  test('signs data', async () => {
     const signature = await signDetached('data', mockKey)
 
     await expect(
@@ -196,28 +190,6 @@ describe('useSignDetached', () => {
         new TextEncoder().encode('data'),
       ),
     ).resolves.toBeTruthy()
-  })
-
-  test('uses key from useKeys if no param', async () => {
-    useKeys().keyPair.value = mockKey
-    const signDetached = useSignDetached()
-
-    const signature = await signDetached('data', undefined)
-
-    await expect(
-      crypto.subtle.verify(
-        { name: 'ECDSA', hash: 'SHA-256' },
-        mockKey.publicKey,
-        signature,
-        new TextEncoder().encode('data'),
-      ),
-    ).resolves.toBeTruthy()
-  })
-
-  test('throws an error if no signing key is found', async () => {
-    const signDetached = useSignDetached()
-
-    await expect(signDetached('data')).rejects.toThrowError()
   })
 })
 

--- a/frontend/src/methods/key.ts
+++ b/frontend/src/methods/key.ts
@@ -67,20 +67,12 @@ export function useWatchKeyExpiry() {
   })
 }
 
-export function useSignDetached() {
-  const keys = useKeys()
-
-  return async function (data: string, keyPair = keys.keyPair.value) {
-    if (!keyPair) {
-      throw new Error('failed to load keys: keys not initialized')
-    }
-
-    return await crypto.subtle.sign(
-      { name: 'ECDSA', hash: 'SHA-256' },
-      keyPair.privateKey,
-      new TextEncoder().encode(data),
-    )
-  }
+export async function signDetached(data: string, keyPair: CryptoKeyPair) {
+  return await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    keyPair.privateKey,
+    new TextEncoder().encode(data),
+  )
 }
 
 export async function hasValidKeys() {

--- a/frontend/src/views/omni/Auth/Authenticate.vue
+++ b/frontend/src/views/omni/Auth/Authenticate.vue
@@ -35,7 +35,7 @@ import UserInfo from '@/components/common/UserInfo/UserInfo.vue'
 import { AuthType, authType } from '@/methods'
 import { useLogout } from '@/methods/auth'
 import { useIdentity } from '@/methods/identity'
-import { createKeys, useKeys, useSignDetached } from '@/methods/key'
+import { createKeys, signDetached, useKeys } from '@/methods/key'
 import { showError } from '@/notification'
 
 const user = ref<User | undefined>(undefined)
@@ -180,7 +180,6 @@ const generatePublicKey = async () => {
 }
 
 let renewIdToken = false
-const signDetached = useSignDetached()
 
 const confirmPublicKey = async (keyPair?: CryptoKeyPair) => {
   try {

--- a/frontend/tsconfig.vitest.json
+++ b/frontend/tsconfig.vitest.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
 
-    "lib": [],
+    "lib": ["ES2022"],
     "types": ["node", "jsdom", "@testing-library/jest-dom"],
 
     "paths": {


### PR DESCRIPTION
Instead of throwing an error when we try to make requests before signing keys are ready, we enter a loop to wait for keys to exist. This prevents errors and the need to handle them, as well as making requests fire immediately when keys are eventually ready.