### PR TITLE
refactor(frontend): create composables for resource list & get

### DIFF
--- a/frontend/src/components/SideBar/TSideBar.vue
+++ b/frontend/src/components/SideBar/TSideBar.vue
@@ -32,7 +32,6 @@ import {
   TalosServiceType,
 } from '@/api/resources'
 import UserInfo from '@/components/common/UserInfo/UserInfo.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import type { SideBarItem } from '@/components/SideBar/TSideBarList.vue'
 import TSidebarList from '@/components/SideBar/TSideBarList.vue'
 import { getContext } from '@/context'
@@ -46,6 +45,7 @@ import {
 } from '@/methods/auth'
 import { useFeatures, useInstallationMediaEnabled } from '@/methods/features'
 import { useIdentity } from '@/methods/identity'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import ExposedServiceSideBar from '@/views/cluster/ExposedService/ExposedServiceSideBar.vue'
 
 const route = useRoute()
@@ -60,7 +60,7 @@ const { canSyncKubernetesManifests, canManageClusterFeatures } = setupClusterPer
   computed(() => route.params.cluster as string),
 )
 
-const { data: machineMetrics } = useWatch<MachineStatusMetricsSpec>({
+const { data: machineMetrics } = useResourceWatch<MachineStatusMetricsSpec>({
   resource: {
     namespace: EphemeralNamespace,
     type: MachineStatusMetricsType,
@@ -69,7 +69,7 @@ const { data: machineMetrics } = useWatch<MachineStatusMetricsSpec>({
   runtime: Runtime.Omni,
 })
 
-const { data: infraProviderStatuses } = useWatch<InfraProviderStatusSpec>(() => ({
+const { data: infraProviderStatuses } = useResourceWatch<InfraProviderStatusSpec>(() => ({
   skip: !canReadMachines.value,
   resource: {
     namespace: InfraProviderNamespace,
@@ -78,8 +78,8 @@ const { data: infraProviderStatuses } = useWatch<InfraProviderStatusSpec>(() => 
   runtime: Runtime.Omni,
 }))
 
-const { data: kubernetesUpgradeManifestStatus } = useWatch<KubernetesUpgradeManifestStatusSpec>(
-  () => ({
+const { data: kubernetesUpgradeManifestStatus } =
+  useResourceWatch<KubernetesUpgradeManifestStatusSpec>(() => ({
     skip: !route.params.cluster,
     runtime: Runtime.Omni,
     resource: {
@@ -87,10 +87,9 @@ const { data: kubernetesUpgradeManifestStatus } = useWatch<KubernetesUpgradeMani
       type: KubernetesUpgradeManifestStatusType,
       id: route.params.cluster as string,
     },
-  }),
-)
+  }))
 
-const { data: cluster } = useWatch<ClusterSpec>(() => ({
+const { data: cluster } = useResourceWatch<ClusterSpec>(() => ({
   skip: !route.params.cluster,
   runtime: Runtime.Omni,
   resource: {
@@ -100,7 +99,7 @@ const { data: cluster } = useWatch<ClusterSpec>(() => ({
   },
 }))
 
-const { data: services } = useWatch(() => ({
+const { data: services } = useResourceWatch(() => ({
   skip: !route.params.machine,
   resource: {
     type: TalosServiceType,

--- a/frontend/src/components/common/OngoingTasks/OngoingTasks.vue
+++ b/frontend/src/components/common/OngoingTasks/OngoingTasks.vue
@@ -14,11 +14,11 @@ import { KubernetesUpgradeStatusSpecPhase, type OngoingTaskSpec } from '@/api/om
 import { EphemeralNamespace, OngoingTaskType } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import TIcon from '@/components/common/Icon/TIcon.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import IconHeaderDropdownLoading from '@/components/icons/IconHeaderDropdownLoading.vue'
 import { formatISO } from '@/methods/time'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
-const { data } = useWatch<OngoingTaskSpec>(() => ({
+const { data } = useResourceWatch<OngoingTaskSpec>(() => ({
   resource: {
     namespace: EphemeralNamespace,
     type: OngoingTaskType,

--- a/frontend/src/components/common/Watch/Watch.vue
+++ b/frontend/src/components/common/Watch/Watch.vue
@@ -18,8 +18,8 @@ import { computed } from 'vue'
 import type { Resource } from '@/api/grpc'
 import type { WatchJoinOptions, WatchOptions, WatchOptionsSingle } from '@/api/watch'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import TAlert from '@/components/TAlert.vue'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 type Props = {
   opts: TOptions
@@ -41,7 +41,7 @@ defineSlots<{
   }): unknown
 }>()
 
-const { data, err, loading } = useWatch<TSpec, TStatus>(() => props.opts)
+const { data, err, loading } = useResourceWatch<TSpec, TStatus>(() => props.opts)
 
 const hasData = computed(() => (Array.isArray(data.value) ? !!data.value.length : !!data.value))
 </script>

--- a/frontend/src/methods/features.ts
+++ b/frontend/src/methods/features.ts
@@ -11,7 +11,7 @@ import { ResourceService } from '@/api/grpc'
 import type { FeaturesConfigSpec } from '@/api/omni/specs/omni.pb'
 import { withRuntime } from '@/api/options'
 import { DefaultNamespace, FeaturesConfigID, FeaturesConfigType } from '@/api/resources'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const resource = {
   type: FeaturesConfigType,
@@ -20,7 +20,7 @@ const resource = {
 }
 
 export function useFeatures() {
-  return useWatch<FeaturesConfigSpec>({
+  return useResourceWatch<FeaturesConfigSpec>({
     resource,
     runtime: Runtime.Omni,
   })

--- a/frontend/src/methods/useResourceGet.spec.ts
+++ b/frontend/src/methods/useResourceGet.spec.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { server } from '@msw/server'
+import { waitFor } from '@testing-library/vue'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+
+import { useResourceGet } from './useResourceGet'
+
+describe('useResourceGet', () => {
+  test('loads a resource and updates state', async () => {
+    const resource = {
+      metadata: { id: 'res-1', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+      spec: { foo: 'bar' },
+    }
+
+    server.use(
+      http.post('/omni.resources.ResourceService/Get', async ({ request }) => {
+        const body = await request.json()
+        expect(body).toEqual({
+          namespace: 'default',
+          type: 'custom.sidero.dev/Resource',
+          id: 'res-1',
+        })
+
+        return HttpResponse.json({ body: JSON.stringify(resource) })
+      }),
+    )
+
+    const { data, loading, error } = useResourceGet({
+      runtime: Runtime.Omni,
+      resource: { namespace: 'default', type: 'custom.sidero.dev/Resource', id: 'res-1' },
+    })
+
+    await waitFor(() => expect(data.value).toEqual(resource))
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeUndefined()
+  })
+
+  test('respects skip and only fetches when loadData is invoked', async () => {
+    const resource = {
+      metadata: { id: 'res-2', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+      spec: { foo: 'baz' },
+    }
+
+    const handler = vi.fn(() => HttpResponse.json({ body: JSON.stringify(resource) }))
+
+    server.use(http.post('/omni.resources.ResourceService/Get', handler))
+
+    const { data, loading, loadData } = useResourceGet({
+      runtime: Runtime.Omni,
+      resource: { namespace: 'default', type: 'custom.sidero.dev/Resource', id: 'res-2' },
+      skip: true,
+    })
+
+    await nextTick()
+    expect(handler).not.toHaveBeenCalled()
+
+    const response = await loadData()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(response).toEqual(resource)
+    expect(data.value).toEqual(resource)
+    expect(loading.value).toBe(false)
+  })
+})

--- a/frontend/src/methods/useResourceGet.ts
+++ b/frontend/src/methods/useResourceGet.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { type MaybeRefOrGetter, ref, toValue, watchEffect } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import type { fetchOption } from '@/api/fetch.pb'
+import { type Resource, ResourceService } from '@/api/grpc'
+import type { GetRequest } from '@/api/omni/resources/resources.pb'
+import { withAbortController, withContext, withRuntime, withSelectors } from '@/api/options'
+import type { WatchContext } from '@/api/watch'
+
+export interface GetOptions {
+  resource: GetRequest
+  runtime: Runtime
+  context?: WatchContext
+  selectors?: string[]
+  skip?: boolean
+}
+
+export function useResourceGet<TSpec = unknown, TStatus = unknown>(
+  opts: MaybeRefOrGetter<GetOptions>,
+) {
+  const data = ref<Resource<TSpec, TStatus>>()
+  const loading = ref(true)
+  const error = ref<Error>()
+
+  watchEffect(async () => {
+    const options = toValue(opts)
+
+    if (options.skip) {
+      loading.value = false
+      return
+    }
+
+    await loadData()
+  })
+
+  return { data, loading, error, loadData }
+
+  async function loadData(abortController?: AbortController) {
+    const options = toValue(opts)
+
+    loading.value = true
+    error.value = undefined
+
+    const fetchOptions: fetchOption[] = []
+
+    if (options.runtime) {
+      fetchOptions.push(withRuntime(options.runtime))
+    }
+
+    if (options.selectors) {
+      fetchOptions.push(withSelectors(options.selectors))
+    }
+
+    if (options.context) {
+      fetchOptions.push(withContext(options.context))
+    }
+
+    if (abortController) {
+      fetchOptions.push(withAbortController(abortController))
+    }
+
+    try {
+      data.value = await ResourceService.Get<Resource<TSpec, TStatus>>(
+        options.resource,
+        ...fetchOptions,
+      )
+    } catch (e) {
+      error.value = e instanceof Error ? e : new Error(JSON.stringify(e))
+    } finally {
+      loading.value = false
+    }
+
+    return data.value
+  }
+}

--- a/frontend/src/methods/useResourceList.spec.ts
+++ b/frontend/src/methods/useResourceList.spec.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { server } from '@msw/server'
+import { waitFor } from '@testing-library/vue'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+
+import { useResourceList } from './useResourceList'
+
+describe('useResourceList', () => {
+  test('loads resources and updates state', async () => {
+    const resources = [
+      {
+        metadata: { id: 'res-1', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+        spec: { foo: 'bar' },
+      },
+      {
+        metadata: { id: 'res-2', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+        spec: { foo: 'baz' },
+      },
+    ]
+
+    server.use(
+      http.post('/omni.resources.ResourceService/List', async ({ request }) => {
+        const body = await request.json()
+        expect(body).toEqual({
+          namespace: 'default',
+          type: 'custom.sidero.dev/Resource',
+        })
+
+        return HttpResponse.json({
+          items: resources.map((resource) => JSON.stringify(resource)),
+          total: resources.length,
+        })
+      }),
+    )
+
+    const { data, loading, error } = useResourceList({
+      runtime: Runtime.Omni,
+      resource: { namespace: 'default', type: 'custom.sidero.dev/Resource' },
+    })
+
+    await waitFor(() => expect(data.value).toEqual(resources))
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeUndefined()
+  })
+
+  test('respects skip and fetches on demand', async () => {
+    const resources = [
+      {
+        metadata: { id: 'res-3', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+        spec: { foo: 'qux' },
+      },
+    ]
+
+    const handler = vi.fn(() =>
+      HttpResponse.json({
+        items: resources.map((resource) => JSON.stringify(resource)),
+        total: resources.length,
+      }),
+    )
+
+    server.use(http.post('/omni.resources.ResourceService/List', handler))
+
+    const { data, loading, loadData } = useResourceList({
+      runtime: Runtime.Omni,
+      resource: { namespace: 'default', type: 'custom.sidero.dev/Resource' },
+      skip: true,
+    })
+
+    await nextTick()
+    expect(handler).not.toHaveBeenCalled()
+
+    const response = await loadData()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(response).toEqual(resources)
+    expect(data.value).toEqual(resources)
+    expect(loading.value).toBe(false)
+  })
+})

--- a/frontend/src/methods/useResourceList.ts
+++ b/frontend/src/methods/useResourceList.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { type MaybeRefOrGetter, ref, toValue, watchEffect } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import type { fetchOption } from '@/api/fetch.pb'
+import { type Resource, ResourceService } from '@/api/grpc'
+import type { ListRequest } from '@/api/omni/resources/resources.pb'
+import { withAbortController, withContext, withRuntime, withSelectors } from '@/api/options'
+import type { WatchContext } from '@/api/watch'
+
+export interface ListOptions {
+  resource: ListRequest
+  runtime: Runtime
+  context?: WatchContext
+  selectors?: string[]
+  skip?: boolean
+}
+
+export function useResourceList<TSpec = unknown, TStatus = unknown>(
+  opts: MaybeRefOrGetter<ListOptions>,
+) {
+  const data = ref<Resource<TSpec, TStatus>[]>()
+  const loading = ref(true)
+  const error = ref<Error>()
+
+  watchEffect(async () => {
+    const options = toValue(opts)
+
+    if (options.skip) {
+      loading.value = false
+      return
+    }
+
+    await loadData()
+  })
+
+  return { data, loading, error, loadData }
+
+  async function loadData(abortController?: AbortController) {
+    const options = toValue(opts)
+
+    loading.value = true
+    error.value = undefined
+
+    const fetchOptions: fetchOption[] = []
+
+    if (options.runtime) {
+      fetchOptions.push(withRuntime(options.runtime))
+    }
+
+    if (options.selectors) {
+      fetchOptions.push(withSelectors(options.selectors))
+    }
+
+    if (options.context) {
+      fetchOptions.push(withContext(options.context))
+    }
+
+    if (abortController) {
+      fetchOptions.push(withAbortController(abortController))
+    }
+
+    try {
+      data.value = await ResourceService.List<Resource<TSpec, TStatus>>(
+        options.resource,
+        ...fetchOptions,
+      )
+    } catch (e) {
+      error.value = e instanceof Error ? e : new Error(JSON.stringify(e))
+    } finally {
+      loading.value = false
+    }
+
+    return data.value
+  }
+}

--- a/frontend/src/methods/useResourceWatch.spec.ts
+++ b/frontend/src/methods/useResourceWatch.spec.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { createBootstrapEvent, createCreatedEvent } from '@msw/helpers'
+import { createWatchStreamMock } from '@msw/server'
+import { render, waitFor } from '@testing-library/vue'
+import { describe, expect, test } from 'vitest'
+import { defineComponent, nextTick, ref } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+
+import { useResourceWatch } from './useResourceWatch'
+
+function renderComposable<T>(factory: () => T) {
+  let composableResult: T
+
+  const TestComponent = defineComponent({
+    setup() {
+      composableResult = factory()
+    },
+    template: '<template />',
+  })
+
+  render(TestComponent)
+
+  return composableResult!
+}
+
+describe('useResourceWatch', () => {
+  test('updates single resource data after watch events', async () => {
+    const { pushEvents } = createWatchStreamMock({ skipBootstrap: true })
+
+    const { data, loading, err } = renderComposable(() =>
+      useResourceWatch({
+        runtime: Runtime.Omni,
+        resource: { namespace: 'default', type: 'custom.sidero.dev/Resource', id: 'res-1' },
+      }),
+    )
+
+    await pushEvents(
+      createCreatedEvent({
+        metadata: { id: 'res-1', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+        spec: { ready: true },
+      }),
+      createBootstrapEvent(),
+    )
+
+    await waitFor(() => {
+      expect(data.value?.metadata.id).toBe('res-1')
+      expect(loading.value).toBe(false)
+      expect(err.value).toBeNull()
+    })
+  })
+
+  test('maintains a list of resources for multi watch', async () => {
+    const { pushEvents } = createWatchStreamMock({ skipBootstrap: true })
+
+    const { data, loading } = renderComposable(() =>
+      useResourceWatch({
+        runtime: Runtime.Omni,
+        resource: { namespace: 'default', type: 'custom.sidero.dev/Resource' },
+      }),
+    )
+
+    await pushEvents(
+      createCreatedEvent({
+        metadata: { id: 'res-1', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+        spec: { ready: true },
+      }),
+      createCreatedEvent({
+        metadata: { id: 'res-2', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+        spec: { ready: false },
+      }),
+      createBootstrapEvent(),
+    )
+
+    await waitFor(() => {
+      expect(data.value).toHaveLength(2)
+      expect(data.value?.map((item) => item.metadata.id).sort()).toEqual(['res-1', 'res-2'])
+      expect(loading.value).toBe(false)
+    })
+  })
+
+  test('respects skip until enabled', async () => {
+    const { pushEvents } = createWatchStreamMock({ skipBootstrap: true })
+
+    const options = ref({
+      runtime: Runtime.Omni,
+      resource: { namespace: 'default', type: 'custom.sidero.dev/Resource' },
+      skip: true,
+    })
+
+    const { data, loading } = renderComposable(() => useResourceWatch(options))
+
+    await nextTick()
+    expect(loading.value).toBe(false)
+
+    options.value = { ...options.value, skip: false }
+
+    await waitFor(() => expect(loading.value).toBe(true))
+
+    await pushEvents(
+      createCreatedEvent({
+        metadata: { id: 'res-3', namespace: 'default', type: 'custom.sidero.dev/Resource' },
+        spec: { ready: true },
+      }),
+      createBootstrapEvent(),
+    )
+
+    await waitFor(() => {
+      expect(data.value).toHaveLength(1)
+      expect(data.value?.[0].metadata.id).toBe('res-3')
+      expect(loading.value).toBe(false)
+    })
+  })
+})

--- a/frontend/src/methods/useResourceWatch.ts
+++ b/frontend/src/methods/useResourceWatch.ts
@@ -26,23 +26,23 @@ interface WatchMulti<TSpec, TStatus> extends WatchBase {
   data: Ref<Resource<TSpec, TStatus>[]>
 }
 
-export function useWatch<TSpec = unknown, TStatus = unknown>(
+export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsSingle>,
 ): WatchSingle<TSpec, TStatus>
 
-export function useWatch<TSpec = unknown, TStatus = unknown>(
+export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsMulti>,
 ): WatchMulti<TSpec, TStatus>
 
-export function useWatch<TSpec = unknown, TStatus = unknown>(
+export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchJoinOptions[]>,
 ): WatchMulti<TSpec, TStatus>
 
-export function useWatch<TSpec = unknown, TStatus = unknown>(
+export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptions | WatchJoinOptions[]>,
 ): WatchSingle<TSpec, TStatus> | WatchMulti<TSpec, TStatus>
 
-export function useWatch<TSpec, TStatus>(
+export function useResourceWatch<TSpec, TStatus>(
   opts: MaybeRefOrGetter<WatchOptions | WatchJoinOptions[]>,
 ) {
   if (isWatchJoinOptions(opts)) return useWatchJoin<TSpec, TStatus>(opts)

--- a/frontend/src/views/cluster/ClusterMachines/ClusterMachines.vue
+++ b/frontend/src/views/cluster/ClusterMachines/ClusterMachines.vue
@@ -17,9 +17,9 @@ import {
   MachineSetType,
 } from '@/api/resources'
 import { itemID } from '@/api/watch'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import Watch from '@/components/common/Watch/Watch.vue'
 import { sortMachineSetIds } from '@/methods/machineset'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 import MachineSet from './MachineSet.vue'
 
@@ -28,7 +28,7 @@ const { clusterID } = defineProps<{
   isSubgrid?: boolean
 }>()
 
-const { data: machineSets } = useWatch<MachineSetSpec>(() => ({
+const { data: machineSets } = useResourceWatch<MachineSetSpec>(() => ({
   resource: {
     type: MachineSetType,
     namespace: DefaultNamespace,
@@ -37,7 +37,7 @@ const { data: machineSets } = useWatch<MachineSetSpec>(() => ({
   selectors: [`${LabelCluster}=${clusterID}`],
 }))
 
-const { data: clusterDiagnostics } = useWatch<ClusterDiagnosticsSpec>(() => ({
+const { data: clusterDiagnostics } = useResourceWatch<ClusterDiagnosticsSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,

--- a/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
@@ -38,7 +38,6 @@ import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import { setupClusterPermissions } from '@/methods/auth'
 import {
   controlPlaneMachineSetId,
@@ -46,6 +45,7 @@ import {
   machineSetTitle,
   scaleMachineSet,
 } from '@/methods/machineset'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError } from '@/notification'
 
 import ClusterMachine from './ClusterMachine.vue'
@@ -95,7 +95,7 @@ const hiddenMachinesCount = computed(() => {
   return Math.max(0, (machineSet.value.spec.machines?.total || 0) - showMachinesCount.value)
 })
 
-const { data: machines } = useWatch<ClusterMachineStatusSpec>(() => ({
+const { data: machines } = useResourceWatch<ClusterMachineStatusSpec>(() => ({
   resource: {
     namespace: DefaultNamespace,
     type: ClusterMachineStatusType,
@@ -108,7 +108,7 @@ const { data: machines } = useWatch<ClusterMachineStatusSpec>(() => ({
   limit: showMachinesCount.value,
 }))
 
-const { data: requests } = useWatch<ClusterMachineRequestStatusSpec>(() => ({
+const { data: requests } = useResourceWatch<ClusterMachineRequestStatusSpec>(() => ({
   skip: !machineSet.value.spec.machine_allocation,
   resource: {
     namespace: DefaultNamespace,

--- a/frontend/src/views/cluster/ExposedService/ExposedServiceSideBar.vue
+++ b/frontend/src/views/cluster/ExposedService/ExposedServiceSideBar.vue
@@ -17,11 +17,11 @@ import IconButton from '@/components/common/Button/IconButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TMenuItem from '@/components/common/MenuItem/TMenuItem.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const route = useRoute()
 
-const { data: exposedServices } = useWatch<ExposedServiceSpec>(() => ({
+const { data: exposedServices } = useResourceWatch<ExposedServiceSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,

--- a/frontend/src/views/cluster/Pods/TPods.vue
+++ b/frontend/src/views/cluster/Pods/TPods.vue
@@ -15,10 +15,10 @@ import TPagination from '@/components/common/Pagination/TPagination.vue'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import TAlert from '@/components/TAlert.vue'
 import { TPodsViewFilterOptions } from '@/constants'
 import { getContext } from '@/context'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import TPodsItem from '@/views/cluster/Pods/components/TPodsItem.vue'
 
 const context = getContext()
@@ -31,7 +31,7 @@ const {
   data: items,
   loading,
   err,
-} = useWatch<V1PodSpec, V1PodStatus>({
+} = useResourceWatch<V1PodSpec, V1PodStatus>({
   resource: { type: kubernetes.pod },
   runtime: Runtime.Kubernetes,
   context,

--- a/frontend/src/views/omni/Clusters/Clusters.vue
+++ b/frontend/src/views/omni/Clusters/Clusters.vue
@@ -25,10 +25,10 @@ import TButton from '@/components/common/Button/TButton.vue'
 import TList from '@/components/common/List/TList.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import { canCreateClusters } from '@/methods/auth'
 import type { Label } from '@/methods/labels'
 import { addLabel, selectors } from '@/methods/labels'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import ClusterItem from '@/views/omni/Clusters/ClusterItem.vue'
 
 import LabelsInput from '../ItemLabels/LabelsInput.vue'
@@ -47,7 +47,7 @@ const watchOpts = computed<WatchOptions>(() => {
   }
 })
 
-const { data } = useWatch<ClusterStatusMetricsSpec>({
+const { data } = useResourceWatch<ClusterStatusMetricsSpec>({
   resource: {
     type: ClusterStatusMetricsType,
     id: ClusterStatusMetricsID,

--- a/frontend/src/views/omni/Extensions/ExtensionsPicker.vue
+++ b/frontend/src/views/omni/Extensions/ExtensionsPicker.vue
@@ -14,7 +14,7 @@ import { DefaultNamespace, TalosExtensionsType } from '@/api/resources'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const { talosVersion, immutableExtensions = {} } = defineProps<{
   talosVersion: string
@@ -26,7 +26,7 @@ const { talosVersion, immutableExtensions = {} } = defineProps<{
 const modelValue = defineModel<Record<string, boolean>>({ required: true })
 const filterExtensions = ref('')
 
-const { data } = useWatch<TalosExtensionsSpec>(() => ({
+const { data } = useResourceWatch<TalosExtensionsSpec>(() => ({
   skip: !talosVersion,
   resource: {
     id: talosVersion,

--- a/frontend/src/views/omni/Home/HomeClustersChart.vue
+++ b/frontend/src/views/omni/Home/HomeClustersChart.vue
@@ -16,9 +16,9 @@ import {
 } from '@/api/resources'
 import Card from '@/components/common/Card/Card.vue'
 import RadialBar from '@/components/common/Charts/RadialBar.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
-const { data } = useWatch<ClusterStatusMetricsSpec>({
+const { data } = useResourceWatch<ClusterStatusMetricsSpec>({
   resource: {
     namespace: EphemeralNamespace,
     type: ClusterStatusMetricsType,

--- a/frontend/src/views/omni/Home/HomeGeneralInformation.vue
+++ b/frontend/src/views/omni/Home/HomeGeneralInformation.vue
@@ -24,7 +24,6 @@ import {
 import TButton from '@/components/common/Button/TButton.vue'
 import Card from '@/components/common/Card/Card.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import TAlert from '@/components/TAlert.vue'
 import {
   downloadAuditLog,
@@ -35,6 +34,7 @@ import {
 } from '@/methods'
 import { canReadAuditLog } from '@/methods/auth'
 import { auditLogEnabled, useInstallationMediaEnabled } from '@/methods/features'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import HomeGeneralInformationCopyable from '@/views/omni/Home/HomeGeneralInformationCopyable.vue'
 
 const auditLogAvailable = ref(false)
@@ -49,7 +49,7 @@ async function copyKernelArgs() {
   copy(await getKernelArgs())
 }
 
-const { data: sysData } = useWatch<SysVersionSpec>({
+const { data: sysData } = useResourceWatch<SysVersionSpec>({
   resource: {
     type: SysVersionType,
     namespace: EphemeralNamespace,
@@ -58,7 +58,7 @@ const { data: sysData } = useWatch<SysVersionSpec>({
   runtime: Runtime.Omni,
 })
 
-const { data: joinTokenData } = useWatch<DefaultJoinTokenSpec>({
+const { data: joinTokenData } = useResourceWatch<DefaultJoinTokenSpec>({
   resource: {
     type: DefaultJoinTokenType,
     namespace: DefaultNamespace,
@@ -71,7 +71,7 @@ const {
   data: apiConfigData,
   err: apiConfigErr,
   loading: apiConfigLoading,
-} = useWatch<SiderolinkAPIConfigSpec>({
+} = useResourceWatch<SiderolinkAPIConfigSpec>({
   resource: {
     type: APIConfigType,
     namespace: DefaultNamespace,

--- a/frontend/src/views/omni/Home/HomeMachinesChart.vue
+++ b/frontend/src/views/omni/Home/HomeMachinesChart.vue
@@ -16,9 +16,9 @@ import {
 } from '@/api/resources'
 import Card from '@/components/common/Card/Card.vue'
 import RadialBar from '@/components/common/Charts/RadialBar.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
-const { data } = useWatch<MachineStatusMetricsSpec>({
+const { data } = useResourceWatch<MachineStatusMetricsSpec>({
   resource: {
     namespace: EphemeralNamespace,
     type: MachineStatusMetricsType,

--- a/frontend/src/views/omni/Home/HomeRecentClusters.vue
+++ b/frontend/src/views/omni/Home/HomeRecentClusters.vue
@@ -14,10 +14,10 @@ import { itemID } from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
 import Card from '@/components/common/Card/Card.vue'
 import CopyButton from '@/components/common/CopyButton/CopyButton.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import ClusterStatus from '@/views/omni/Clusters/ClusterStatus.vue'
 
-const { data } = useWatch<ClusterStatusSpec>({
+const { data } = useResourceWatch<ClusterStatusSpec>({
   resource: {
     namespace: DefaultNamespace,
     type: ClusterStatusType,

--- a/frontend/src/views/omni/Home/HomeRecentMachines.vue
+++ b/frontend/src/views/omni/Home/HomeRecentMachines.vue
@@ -13,9 +13,9 @@ import TButton from '@/components/common/Button/TButton.vue'
 import Card from '@/components/common/Card/Card.vue'
 import CopyButton from '@/components/common/CopyButton/CopyButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
-const { data } = useWatch<MachineStatusSpec>({
+const { data } = useResourceWatch<MachineStatusSpec>({
   resource: {
     namespace: DefaultNamespace,
     type: MachineStatusType,

--- a/frontend/src/views/omni/InstallationMedia/Steps/SystemExtensions.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SystemExtensions.vue
@@ -12,13 +12,13 @@ import type { TalosExtensionsSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, TalosExtensionsType } from '@/api/resources'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
 const formState = defineModel<FormState>({ required: true })
 const filterExtensions = ref('')
 
-const { data } = useWatch<TalosExtensionsSpec>(() => ({
+const { data } = useResourceWatch<TalosExtensionsSpec>(() => ({
   resource: {
     id: formState.value.talosVersion!,
     type: TalosExtensionsType,

--- a/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.vue
@@ -19,24 +19,25 @@ import {
   TalosVersionType,
 } from '@/api/resources'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import { getDocsLink } from '@/methods'
 import { useFeatures } from '@/methods/features'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
 const formState = defineModel<FormState>({ required: true })
 
 const { data: features } = useFeatures()
 
-const { data: talosVersionList, loading: talosVersionsLoading } = useWatch<TalosVersionSpec>({
-  runtime: Runtime.Omni,
-  resource: {
-    type: TalosVersionType,
-    namespace: DefaultNamespace,
-  },
-})
+const { data: talosVersionList, loading: talosVersionsLoading } =
+  useResourceWatch<TalosVersionSpec>({
+    runtime: Runtime.Omni,
+    resource: {
+      type: TalosVersionType,
+      namespace: DefaultNamespace,
+    },
+  })
 
-const { data: joinTokenList, loading: joinTokensLoading } = useWatch<JoinTokenStatusSpec>({
+const { data: joinTokenList, loading: joinTokensLoading } = useResourceWatch<JoinTokenStatusSpec>({
   runtime: Runtime.Omni,
   resource: {
     type: JoinTokenStatusType,

--- a/frontend/src/views/omni/Machines/Machines.vue
+++ b/frontend/src/views/omni/Machines/Machines.vue
@@ -32,12 +32,12 @@ import TButton from '@/components/common/Button/TButton.vue'
 import TList from '@/components/common/List/TList.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import TAlert from '@/components/TAlert.vue'
 import { getDocsLink } from '@/methods'
 import type { Label } from '@/methods/labels'
 import { addLabel, selectors as labelsToSelectors } from '@/methods/labels'
 import { MachineFilterOption } from '@/methods/machine'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import LabelsInput from '@/views/omni/ItemLabels/LabelsInput.vue'
 import MachineDetailsPanel from '@/views/omni/Machines/MachineDetailsPanel.vue'
 import MachineItem from '@/views/omni/Machines/MachineItem.vue'
@@ -49,7 +49,7 @@ const { filter = undefined } = defineProps<{
 const route = useRoute()
 const router = useRouter()
 
-const { data: infraProviderStatuses } = useWatch<InfraProviderStatusSpec>({
+const { data: infraProviderStatuses } = useResourceWatch<InfraProviderStatusSpec>({
   resource: {
     type: InfraProviderStatusType,
     namespace: InfraProviderNamespace,
@@ -110,7 +110,7 @@ const filterValue = ref('')
 const docsLink = getDocsLink('omni', '/explanation/infrastructure-providers')
 const openDocs = () => window.open(docsLink, '_blank')?.focus()
 
-const { data: machineStatusMetrics } = useWatch<MachineStatusMetricsSpec>({
+const { data: machineStatusMetrics } = useResourceWatch<MachineStatusMetricsSpec>({
   resource: {
     type: MachineStatusMetricsType,
     id: MachineStatusMetricsID,

--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -49,9 +49,9 @@ import TSelectList from '@/components/common/SelectList/TSelectList.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import { formatBytes } from '@/methods'
 import { useFeatures } from '@/methods/features'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showSuccess } from '@/notification'
 import ExtensionsPicker from '@/views/omni/Extensions/ExtensionsPicker.vue'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
@@ -105,7 +105,7 @@ const options = ref(new Map<string, Resource<InstallationMediaSpec>>())
 
 const defaultValue = ref('')
 
-const { data: watchOptions } = useWatch<InstallationMediaSpec>({
+const { data: watchOptions } = useResourceWatch<InstallationMediaSpec>({
   runtime: Runtime.Omni,
   resource: {
     type: InstallationMediaType,
@@ -113,7 +113,7 @@ const { data: watchOptions } = useWatch<InstallationMediaSpec>({
   },
 })
 
-const { data: talosVersionsResources } = useWatch<TalosVersionSpec>({
+const { data: talosVersionsResources } = useResourceWatch<TalosVersionSpec>({
   runtime: Runtime.Omni,
   resource: {
     type: TalosVersionType,
@@ -121,7 +121,7 @@ const { data: talosVersionsResources } = useWatch<TalosVersionSpec>({
   },
 })
 
-const { data: joinTokens } = useWatch<JoinTokenStatusSpec>({
+const { data: joinTokens } = useResourceWatch<JoinTokenStatusSpec>({
   runtime: Runtime.Omni,
   resource: {
     type: JoinTokenStatusType,

--- a/frontend/src/views/omni/Modals/MaintenanceUpdate.vue
+++ b/frontend/src/views/omni/Modals/MaintenanceUpdate.vue
@@ -17,7 +17,7 @@ import { DefaultNamespace, MachineStatusType, TalosVersionType } from '@/api/res
 import TButton from '@/components/common/Button/TButton.vue'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showSuccess } from '@/notification'
 import ManagedByTemplatesWarning from '@/views/cluster/ManagedByTemplatesWarning.vue'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
@@ -27,7 +27,7 @@ const route = useRoute()
 
 const selectedVersion = ref('')
 
-const { data: versions, loading } = useWatch<TalosVersionSpec>({
+const { data: versions, loading } = useResourceWatch<TalosVersionSpec>({
   resource: {
     type: TalosVersionType,
     namespace: DefaultNamespace,
@@ -35,7 +35,7 @@ const { data: versions, loading } = useWatch<TalosVersionSpec>({
   runtime: Runtime.Omni,
 })
 
-const { data: machine } = useWatch<MachineStatusSpec>({
+const { data: machine } = useResourceWatch<MachineStatusSpec>({
   resource: {
     type: MachineStatusType,
     namespace: DefaultNamespace,

--- a/frontend/src/views/omni/Modals/RoleEdit.vue
+++ b/frontend/src/views/omni/Modals/RoleEdit.vue
@@ -24,9 +24,9 @@ import {
 } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import { canManageUsers } from '@/methods/auth'
 import { updateRole } from '@/methods/user'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showSuccess } from '@/notification'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
 
@@ -41,7 +41,7 @@ const object = route.query.serviceAccount ? 'Service Account' : 'User'
 const id = route.query.identity ?? route.query.serviceAccount
 const userID = ref(route.query.user as string)
 
-const { data: user } = useWatch<UserSpec>(() => ({
+const { data: user } = useResourceWatch<UserSpec>(() => ({
   resource: {
     id: userID.value,
     namespace: DefaultNamespace,

--- a/frontend/src/views/omni/Modals/UpdateKernelArgs.vue
+++ b/frontend/src/views/omni/Modals/UpdateKernelArgs.vue
@@ -17,7 +17,7 @@ import { DefaultNamespace, KernelArgsStatusType, KernelArgsType } from '@/api/re
 import IconButton from '@/components/common/Button/IconButton.vue'
 import TButton from '@/components/common/Button/TButton.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showSuccess } from '@/notification'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
 
@@ -25,7 +25,7 @@ const args = ref('')
 const route = useRoute()
 const router = useRouter()
 
-const { data: status } = useWatch<KernelArgsStatusSpec>({
+const { data: status } = useResourceWatch<KernelArgsStatusSpec>({
   runtime: Runtime.Omni,
   resource: {
     id: route.query.machine as string,

--- a/frontend/src/views/omni/Modals/UpdateKubernetes.vue
+++ b/frontend/src/views/omni/Modals/UpdateKubernetes.vue
@@ -29,9 +29,9 @@ import {
 import TButton from '@/components/common/Button/TButton.vue'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import { getDocsLink } from '@/methods'
 import { upgradeKubernetes } from '@/methods/cluster'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import ManagedByTemplatesWarning from '@/views/cluster/ManagedByTemplatesWarning.vue'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
 
@@ -44,7 +44,7 @@ const selectedVersion = ref('')
 
 const clusterName = route.params.cluster as string
 
-const { data: cluster } = useWatch<ClusterSpec>({
+const { data: cluster } = useResourceWatch<ClusterSpec>({
   resource: {
     type: ClusterType,
     namespace: DefaultNamespace,
@@ -53,7 +53,7 @@ const { data: cluster } = useWatch<ClusterSpec>({
   runtime: Runtime.Omni,
 })
 
-const { data: status } = useWatch<KubernetesUpgradeStatusSpec>({
+const { data: status } = useResourceWatch<KubernetesUpgradeStatusSpec>({
   resource: {
     namespace: DefaultNamespace,
     type: KubernetesUpgradeStatusType,
@@ -62,7 +62,7 @@ const { data: status } = useWatch<KubernetesUpgradeStatusSpec>({
   runtime: Runtime.Omni,
 })
 
-const { data: allK8sVersions } = useWatch<KubernetesVersionSpec>({
+const { data: allK8sVersions } = useResourceWatch<KubernetesVersionSpec>({
   resource: {
     namespace: DefaultNamespace,
     type: KubernetesVersionType,
@@ -70,7 +70,7 @@ const { data: allK8sVersions } = useWatch<KubernetesVersionSpec>({
   runtime: Runtime.Omni,
 })
 
-const { data: allTalosVersionsUnsorted } = useWatch<TalosVersionSpec>({
+const { data: allTalosVersionsUnsorted } = useResourceWatch<TalosVersionSpec>({
   resource: {
     type: TalosVersionType,
     namespace: DefaultNamespace,

--- a/frontend/src/views/omni/Modals/UpdateTalos.vue
+++ b/frontend/src/views/omni/Modals/UpdateTalos.vue
@@ -16,8 +16,8 @@ import { DefaultNamespace, TalosUpgradeStatusType } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
-import { useWatch } from '@/components/common/Watch/useWatch'
 import { updateTalos } from '@/methods/cluster'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import ManagedByTemplatesWarning from '@/views/cluster/ManagedByTemplatesWarning.vue'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
 
@@ -28,7 +28,7 @@ const selectedVersion = ref('')
 
 const clusterName = route.params.cluster as string
 
-const { data: status } = useWatch<TalosUpgradeStatusSpec>({
+const { data: status } = useResourceWatch<TalosUpgradeStatusSpec>({
   resource: {
     namespace: DefaultNamespace,
     type: TalosUpgradeStatusType,


### PR DESCRIPTION
Create `useResourceList` and `useResourceGet` composables to get a `useWatch` (now useResourceWatch) like API for get/list tasks (i.e. `ResourceService.Get` / `ResourceService.List`)

Related to #1471 

Will allow you do to things like this:
```ts
const { data, error, loading } = useResourceList<PlatformConfigSpec>({
  runtime: Runtime.Omni,
  resource: {
    namespace: VirtualNamespace,
    type: CloudPlatformConfigType,
  },
})
```

If you need fine grained control to run the query lazily or with abortion, you can add `skip: true` and use the supplied lazy function:
```ts
// Get the loadData function from the composable
const { data, error, loading, loadData } = useResourceList<PlatformConfigSpec>({
  skip: true, // prevents eager loading (like in `useResourceWatch`)
  runtime: Runtime.Omni,
  resource: {
    namespace: VirtualNamespace,
    type: CloudPlatformConfigType,
  },
})

async function onManualAction() {
  const abort = new AbortController()

  // newData will be the same data returned from the composable.
  // In here you will also have access to that data imperatively if useful.
  // Error / loading from composable will still be updated when calling lazily.
  // If an error was thrown newData will be undefined here.
  const newData = await loadData(abort)
}
```

---

<details>

<summary>Example refactor</summary>


Before:
```ts
const node = ref<string>()

watch(
  () => route.params.machine as string,
  async (machineId) => {
    if (!machineId) {
      node.value = undefined
      return
    }

    const nodename = await ResourceService.Get<Resource<ClusterMachineIdentitySpec>>(
      {
        type: ClusterMachineIdentityType,
        id: machineId,
        namespace: DefaultNamespace,
      },
      withRuntime(Runtime.Omni),
    )

    node.value = nodename.spec.nodename
  },
  { immediate: true },
)
```

After:
```ts
const { data } = useResourceGet<ClusterMachineIdentitySpec>(() => ({
  skip: !route.params.machine,
  runtime: Runtime.Omni,
  resource: {
    type: ClusterMachineIdentityType,
    id: route.params.machine as string,
    namespace: DefaultNamespace,
  },
}))

const node = computed(() => data.value?.spec.nodename)
```

</details>