### PR TITLE
fix: trim whitespaces from the intial label keys and values

### DIFF
--- a/frontend/src/components/common/Labels/Labels.vue
+++ b/frontend/src/components/common/Labels/Labels.vue
@@ -53,8 +53,8 @@ const addLabel = async () => {
 
   emit('update:modelValue', {
     ...modelValue.value,
-    [parts[0]]: {
-      value: parts[1] ?? '',
+    [parts[0].trim()]: {
+      value: parts[1].trim() ?? '',
       canRemove: true,
     },
   })

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -75,7 +75,7 @@ func (s *managementServer) CreateSchematic(ctx context.Context, request *managem
 			}
 
 			if labels.LegacyLabels != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "'machineInitialLabels' is deprecated")
+				return nil, status.Errorf(codes.InvalidArgument, "'initialMachineLabels' is deprecated")
 			}
 		}
 	}


### PR DESCRIPTION
The UI shows them trimmed, while submits to the backend as is.

Fixes: https://github.com/siderolabs/omni/issues/1930