### PR TITLE
feat: allow passing extra parameters to sqlite conn string

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -629,6 +629,20 @@ func defineStorageFlags() {
 		cmdConfig.Storage.SQLite.Path,
 		"path of the file for sqlite-backed secondary storage for frequently updated data, machine and audit logs.",
 	)
+	rootCmd.Flags().StringVar(
+		&cmdConfig.Storage.SQLite.ExperimentalBaseParams,
+		"sqlite-storage-experimental-base-params",
+		cmdConfig.Storage.SQLite.ExperimentalBaseParams,
+		"base DSN (connection string) parameters for sqlite database connection. they must not start with question mark (?). "+
+			"this flag is experimental and may be removed in future releases.",
+	)
+
+	rootCmd.Flags().StringVar(
+		&cmdConfig.Storage.SQLite.ExtraParams,
+		"sqlite-storage-extra-params",
+		cmdConfig.Storage.SQLite.ExtraParams,
+		"extra DSN (connection string) parameters for sqlite database connection. they will be appended to the base params. they must not start with ampersand (&).",
+	)
 }
 
 func defineRegistriesFlags() {

--- a/internal/backend/runtime/omni/sqlite/sqlite.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+// OpenDB opens a SQLite database with the given configuration.
+func OpenDB(config config.SQLite) (*sql.DB, error) {
+	if err := os.MkdirAll(filepath.Dir(config.Path), 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create directory for sqlite database %q: %w", config.Path, err)
+	}
+
+	allParams := config.ExperimentalBaseParams
+	if config.ExtraParams != "" {
+		allParams += "&" + config.ExtraParams
+	}
+
+	dsn := "file:" + config.Path
+	if allParams != "" {
+		dsn += "?" + allParams
+	}
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open sqlite database %q: %w", dsn, err)
+	}
+
+	return db, nil
+}

--- a/internal/backend/runtime/omni/state.go
+++ b/internal/backend/runtime/omni/state.go
@@ -127,7 +127,7 @@ func NewState(ctx context.Context, params *config.Params, logger *zap.Logger, me
 	virtualState := virtual.NewState(state.WrapCore(defaultPersistentState.State))
 
 	secondaryPersistentState, err := newSQLitePersistentState(
-		ctx, params.Storage.SQLite.Path, logger)
+		ctx, params.Storage.SQLite, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SQLite state for secondary storage: %w", err)
 	}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -172,7 +172,8 @@ func Default() *Params {
 				Path: "_out/secondary-storage/bolt.db",
 			},
 			SQLite: SQLite{
-				Path: "_out/secondary-storage/sqlite.db",
+				Path:                   "_out/secondary-storage/sqlite.db",
+				ExperimentalBaseParams: "_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)",
 			},
 			Default: &StorageDefault{
 				Kind: "etcd",

--- a/internal/pkg/config/storage.go
+++ b/internal/pkg/config/storage.go
@@ -45,7 +45,9 @@ type BoltDB struct {
 
 // SQLite defines sqlite storage configs.
 type SQLite struct {
-	Path string `yaml:"path"`
+	Path                   string `yaml:"path"`
+	ExperimentalBaseParams string `yaml:"experimentalBaseParams"`
+	ExtraParams            string `yaml:"extraParams"`
 }
 
 // EtcdParams defines etcd storage configs.


### PR DESCRIPTION
Do not expose the base parameters, as they are required for COSI to work correctly.

Add a flag for the additional parameters, which can for example be used for configuring the SQLite db to be "suitable" for litestream to be able to make backups of it.

Also, add `_pragma=synchronous(NORMAL)` to the base parameters, as it is recommended for better performance when WAL mode is enabled.