### PR TITLE
feat: store machine logs in sqlite

### DIFF
--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -8,6 +8,7 @@ package app
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -53,7 +54,7 @@ func PrepareConfig(logger *zap.Logger, params ...*config.Params) (*config.Params
 }
 
 // Run the Omni service.
-func Run(ctx context.Context, state *omni.State, config *config.Params, logger *zap.Logger) error {
+func Run(ctx context.Context, state *omni.State, secondaryStorageDB *sql.DB, config *config.Params, logger *zap.Logger) error {
 	talosClientFactory := talos.NewClientFactory(state.Default(), logger)
 	talosRuntime := talos.New(talosClientFactory, logger)
 
@@ -122,6 +123,7 @@ func Run(ctx context.Context, state *omni.State, config *config.Params, logger *
 	machineMap := siderolink.NewMachineMap(siderolink.NewStateStorage(state.Default()))
 
 	logHandler, err := siderolink.NewLogHandler(
+		secondaryStorageDB,
 		machineMap,
 		state.Default(),
 		&config.Logs.Machine,

--- a/internal/backend/runtime/omni/state.go
+++ b/internal/backend/runtime/omni/state.go
@@ -7,6 +7,7 @@ package omni
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -105,7 +106,7 @@ func (s *State) HandleErrors(ctx context.Context) error {
 }
 
 // NewState creates a production Omni state.
-func NewState(ctx context.Context, params *config.Params, logger *zap.Logger, metricsRegistry prometheus.Registerer) (*State, error) {
+func NewState(ctx context.Context, params *config.Params, secondaryStorageDB *sql.DB, logger *zap.Logger, metricsRegistry prometheus.Registerer) (*State, error) {
 	var (
 		defaultPersistentState *PersistentState
 		err                    error
@@ -126,8 +127,7 @@ func NewState(ctx context.Context, params *config.Params, logger *zap.Logger, me
 
 	virtualState := virtual.NewState(state.WrapCore(defaultPersistentState.State))
 
-	secondaryPersistentState, err := newSQLitePersistentState(
-		ctx, params.Storage.SQLite, logger)
+	secondaryPersistentState, err := newSQLitePersistentState(ctx, secondaryStorageDB, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SQLite state for secondary storage: %w", err)
 	}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -9,6 +9,7 @@ package integration_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"flag"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -40,6 +42,7 @@ import (
 	_ "github.com/siderolabs/omni/cmd/acompat" // this package should always be imported first for init->set env to work
 	"github.com/siderolabs/omni/cmd/omni/pkg/app"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/clientconfig"
 	"github.com/siderolabs/omni/internal/pkg/config"
@@ -473,7 +476,9 @@ func runOmni(t *testing.T) (string, error) {
 
 	omniCtx := actor.MarkContextAsInternalActor(t.Context())
 
-	state, err := omni.NewState(omniCtx, config, logger, prometheus.DefaultRegisterer)
+	secondaryStorageDB := testDB(t)
+
+	state, err := omni.NewState(omniCtx, config, secondaryStorageDB, logger, prometheus.DefaultRegisterer)
 	if err != nil {
 		return "", err
 	}
@@ -485,7 +490,7 @@ func runOmni(t *testing.T) (string, error) {
 	eg.Go(func() error {
 		defer cancel()
 
-		return app.Run(omniCtx, state, config, logger)
+		return app.Run(omniCtx, state, secondaryStorageDB, config, logger)
 	})
 
 	t.Log("waiting for Omni to start")
@@ -501,4 +506,20 @@ func runOmni(t *testing.T) (string, error) {
 	t.Logf("running integration tests using embedded Omni at %q", omniEndpoint)
 
 	return sa, nil
+}
+
+func testDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	conf := config.Default().Storage.SQLite
+	conf.Path = filepath.Join(t.TempDir(), "integration-test.db")
+
+	db, err := sqlite.OpenDB(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	return db
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -159,11 +159,17 @@ func Default() *Params {
 				BufferMaxCapacity:     131072,
 				BufferSafetyGap:       256,
 				Storage: LogsMachineStorage{
-					Enabled:             true,
+					Enabled:             true, // todo: Keeping this enabled to get the logs migrated to sqlite, drop this after a while, when all logs are supposedly in SQLite.
 					Path:                "_out/logs",
 					FlushPeriod:         10 * time.Minute,
 					FlushJitter:         0.1,
 					NumCompressedChunks: 5,
+				},
+				SQLite: LogsMachineSQLite{
+					Enabled:          true,
+					Timeout:          10 * time.Second,
+					CleanupInterval:  30 * time.Minute,
+					CleanupOlderThan: 24 * 30 * time.Hour,
 				},
 			},
 		},

--- a/internal/pkg/config/logs.go
+++ b/internal/pkg/config/logs.go
@@ -23,27 +23,62 @@ type Logs struct {
 
 // LogsMachine configures Talos machine logs handler.
 type LogsMachine struct {
-	// Storage configures persistent machine log storage of the Omni instance.
+	// Storage configures the machine logs storage if SQLite storage is not enabled.
+	//
+	// Deprecated: use SQLite storage instead.
 	Storage LogsMachineStorage `yaml:"storage"`
-
+	SQLite  LogsMachineSQLite  `yaml:"sqlite"`
+	// BufferInitialCapacity is the initial capacity of the in-memory buffer for logs.
+	//
+	// It is used only if SQLite storage is not enabled.
+	//
+	// Deprecated: use SQLite storage instead.
 	BufferInitialCapacity int `yaml:"bufferInitialCapacity"`
-	BufferMaxCapacity     int `yaml:"bufferMaxCapacity"`
-	BufferSafetyGap       int `yaml:"bufferSafetyGap"`
+	// BufferMaxCapacity is the maximum capacity of the in-memory buffer for logs.
+	//
+	// It is used only if SQLite storage is not enabled.
+	//
+	// Deprecated: use SQLite storage instead.
+	BufferMaxCapacity int `yaml:"bufferMaxCapacity"`
+	// BufferSafetyGap is the safety gap to use when trimming the buffer.
+	//
+	// It is used only if SQLite storage is not enabled.
+	//
+	// Deprecated: use SQLite storage instead.
+	BufferSafetyGap int `yaml:"bufferSafetyGap"`
 }
 
-// LogsMachineStorage configures the machine logs storage.
+// LogsMachineStorage configures the machine logs storage if SQLite storage is not enabled.
 //
 //nolint:govet
 type LogsMachineStorage struct {
+	// Enabled indicates whether the storage is enabled.
+	//
+	// Deprecated: use SQLite storage instead.
 	Enabled bool `yaml:"enabled"`
 	// Path to store the logs in.
+	//
+	// Deprecated: use SQLite storage instead.
 	Path string `yaml:"path"`
 	// FlushPeriod is the period to use to flush the logs to disk.
+	//
+	// Deprecated: use SQLite storage instead.
 	FlushPeriod time.Duration `yaml:"flushPeriod"`
 	// FlushJitter flush period jitter.
+	//
+	// Deprecated: use SQLite storage instead.
 	FlushJitter float64 `yaml:"flushJitter"`
 	// NumCompressedChunks is the count of log chunks to keep in the logs history.
+	//
+	// Deprecated: use SQLite storage instead.
 	NumCompressedChunks int `yaml:"numCompressedChunks"`
+}
+
+type LogsMachineSQLite struct {
+	Enabled          bool          `yaml:"enabled"`
+	Timeout          time.Duration `yaml:"timeout"`
+	CleanupInterval  time.Duration `yaml:"cleanupInterval"`
+	CleanupOlderThan time.Duration `yaml:"cleanupOlderThan"`
 }
 
 // LogsAudit configures audit logs peristence.

--- a/internal/pkg/siderolink/logmigrate.go
+++ b/internal/pkg/siderolink/logmigrate.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package siderolink
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/circularlog"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/sqlitelog"
+)
+
+func migrateLogStoreToSQLite(ctx context.Context, circularStoreManager *circularlog.StoreManager, sqliteStoreManager *sqlitelog.StoreManager, logger *zap.Logger) error {
+	machineIDs, err := circularStoreManager.MachineIDs()
+	if err != nil {
+		return fmt.Errorf("failed to get machine IDs from circular log store manager: %w", err)
+	}
+
+	logger.Info("starting log store migration to sqlite", zap.Int("machine_count", len(machineIDs)))
+
+	for _, id := range machineIDs {
+		logger.Info("migrate log store to sqlite", zap.String("machine_id", id))
+
+		if err = migrateMachineLogs(ctx, circularStoreManager, sqliteStoreManager, id, logger); err != nil {
+			return fmt.Errorf("failed to migrate log store for machine %q: %w", id, err)
+		}
+
+		if err = circularStoreManager.Remove(ctx, id); err != nil {
+			return fmt.Errorf("failed to remove old circular log store for machine %q: %w", id, err)
+		}
+	}
+
+	logger.Info("completed log store migration to sqlite")
+
+	return nil
+}
+
+func migrateMachineLogs(ctx context.Context, circularStoreManager *circularlog.StoreManager, sqliteStoreManager *sqlitelog.StoreManager, id string, logger *zap.Logger) error {
+	hasDataInNewStore, err := sqliteStoreManager.Exists(ctx, id)
+	if err != nil {
+		return fmt.Errorf("failed to check if sqlite log store exists for machine %q: %w", id, err)
+	}
+
+	if hasDataInNewStore {
+		logger.Info("skip migration for machine as sqlite log store already has data (probably already migrated)", zap.String("machine_id", id))
+
+		return nil
+	}
+
+	oldStore, err := circularStoreManager.Create(id)
+	if err != nil {
+		return fmt.Errorf("failed to create circular log store for machine %q: %w", id, err)
+	}
+
+	defer oldStore.Close() //nolint:errcheck
+
+	newStore, err := sqliteStoreManager.Create(id)
+	if err != nil {
+		return fmt.Errorf("failed to create sqlite log store for machine %q: %w", id, err)
+	}
+
+	defer newStore.Close() //nolint:errcheck
+
+	reader, err := oldStore.Reader(ctx, 0, false)
+	if err != nil {
+		return fmt.Errorf("failed to create reader for circular log store for machine %q: %w", id, err)
+	}
+
+	defer reader.Close() //nolint:errcheck
+
+	for {
+		line, readErr := reader.ReadLine(ctx)
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+
+			return fmt.Errorf("failed to read from reader for machine %q: %w", id, readErr)
+		}
+
+		if writeErr := newStore.WriteLine(ctx, line); writeErr != nil {
+			return fmt.Errorf("failed to write line to sqlite log store for machine %q: %w", id, writeErr)
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/siderolink/logstore/circularlog/circularlog.go
+++ b/internal/pkg/siderolink/logstore/circularlog/circularlog.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//nolint:staticcheck // circularlog is deprecated, but it is fine here
+package circularlog
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/siderolabs/go-circular"
+	"github.com/siderolabs/go-tail"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/client/pkg/panichandler"
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+)
+
+// NewStore creates a new Store.
+func NewStore(config *config.LogsMachine, id string, compressor circular.Compressor, logger *zap.Logger) (*Store, error) {
+	bufferOpts := []circular.OptionFunc{
+		circular.WithInitialCapacity(config.BufferInitialCapacity),
+		circular.WithMaxCapacity(config.BufferMaxCapacity),
+		circular.WithSafetyGap(config.BufferSafetyGap),
+		circular.WithNumCompressedChunks(config.Storage.NumCompressedChunks, compressor),
+		circular.WithLogger(logger),
+	}
+
+	if config.Storage.Enabled {
+		bufferOpts = append(bufferOpts, circular.WithPersistence(circular.PersistenceOptions{
+			ChunkPath:     filepath.Join(config.Storage.Path, id+".log"),
+			FlushInterval: config.Storage.FlushPeriod,
+			FlushJitter:   config.Storage.FlushJitter,
+		}))
+	}
+
+	buffer, err := circular.NewBuffer(bufferOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create circular buffer for machine %q: %w", id, err)
+	}
+
+	if config.Storage.Enabled {
+		loadLegacyLogs(config, id, buffer, logger)
+	}
+
+	return &Store{buf: buffer, logger: logger}, nil
+}
+
+// Store implements the logstore.LogStore interface using a circular buffer as the backend.
+type Store struct {
+	buf    *circular.Buffer
+	logger *zap.Logger
+}
+
+// WriteLine implements the logstore.LogStore interface.
+func (s *Store) WriteLine(_ context.Context, message []byte) error {
+	if _, err := s.buf.Write([]byte("\n")); err != nil {
+		return err
+	}
+
+	if _, err := s.buf.Write(message); err != nil {
+		return err
+	}
+
+	if _, err := s.buf.Write([]byte("\n")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close closes the Store.
+func (s *Store) Close() error {
+	return s.buf.Close()
+}
+
+// Reader implements the logstore.LogStore interface.
+func (s *Store) Reader(ctx context.Context, nLines int, follow bool) (logstore.LineReader, error) {
+	var rdr io.ReadSeekCloser
+
+	closeCh := make(chan struct{})
+
+	if follow {
+		rdr = s.buf.GetStreamingReader()
+
+		// Make sure that we close the reader when the context is done
+		panichandler.Go(func() {
+			select {
+			case <-closeCh: // normal close, reader is already closed
+				return
+			case <-ctx.Done(): // context is done, close the reader
+			}
+
+			if err := rdr.Close(); err != nil {
+				s.logger.Error("failed to close circular buffer on context done", zap.Error(err))
+			}
+		}, s.logger)
+	} else {
+		rdr = s.buf.GetReader()
+	}
+
+	if rdr == nil {
+		return nil, fmt.Errorf("buffer reader is not available")
+	}
+
+	if nLines > 0 {
+		// since we are surrounding each message with \n we should increase lines by two times.
+		seekLines := nLines * 2
+
+		if err := tail.SeekLines(rdr, seekLines); err != nil {
+			return nil, fmt.Errorf("failed to seek %d lines: %w", seekLines, err)
+		}
+	}
+
+	return &LineReader{reader: rdr, closeCh: closeCh}, nil
+}
+
+// LineReader is a reader which reads lines surrounded by \n from the underlying reader.
+type LineReader struct {
+	reader    io.ReadCloser
+	buf       *bufio.Reader
+	closeCh   chan struct{}
+	closeOnce sync.Once
+}
+
+// Close closes the LineReader underlying reader.
+func (r *LineReader) Close() error {
+	closeErr := r.reader.Close()
+
+	r.closeOnce.Do(func() {
+		close(r.closeCh)
+	})
+
+	return closeErr
+}
+
+// ReadLine reads a line from the underlying reader.
+func (r *LineReader) ReadLine(context.Context) ([]byte, error) {
+	if r.buf == nil {
+		r.buf = bufio.NewReader(r.reader)
+	}
+
+	for {
+		emptyLine, err := r.buf.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				return nil, io.EOF
+			}
+
+			return nil, fmt.Errorf("failed to read line: %w", err)
+		}
+
+		if len(emptyLine) != 1 {
+			// missed the start of the line, skipping to the next entry
+			continue
+		}
+
+		logLine, err := r.buf.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				return nil, io.EOF
+			}
+
+			return nil, fmt.Errorf("failed to read line: %w", err)
+		}
+
+		return trimNewlines(logLine), nil
+	}
+}
+
+// trimNewlines trims a newline from the start and from end of a byte slice.
+func trimNewlines(data []byte) []byte {
+	if len(data) == 0 {
+		return data
+	}
+
+	if data[0] == '\n' {
+		data = data[1:]
+	}
+
+	if len(data) > 0 && data[len(data)-1] == '\n' {
+		data = data[:len(data)-1]
+	}
+
+	return data
+}
+
+// loadLegacyLogs loads logs stored of the machine with the given id in the old format, if exists, into the given writer.
+// It is used to migrate logs from the old format to the new format.
+// It removes the old log file and its hash file regardless of the result.
+//
+// It is a best-effort function and does not return any error.
+func loadLegacyLogs(config *config.LogsMachine, id string, writer io.Writer, logger *zap.Logger) {
+	filePath := filepath.Join(config.Storage.Path, fmt.Sprintf("%s.log", id))
+	shaSumPath := filePath + ".sha256sum"
+
+	defer func() {
+		if err := os.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logger.Error("failed to remove legacy log file", zap.String("path", filePath), zap.Error(err))
+		}
+
+		if err := os.Remove(shaSumPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logger.Error("failed to remove legacy log hash file", zap.String("path", shaSumPath), zap.Error(err))
+		}
+	}()
+
+	bufferData, err := os.ReadFile(filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+
+		logger.Error("failed to read legacy log buffer file", zap.String("path", filePath), zap.Error(err))
+
+		return
+	}
+
+	hashHexExpectedBytes, err := os.ReadFile(shaSumPath)
+	if err != nil {
+		logger.Error("failed to read legacy log buffer hash file", zap.String("path", shaSumPath), zap.Error(err))
+
+		return
+	}
+
+	hashHexExpected := string(hashHexExpectedBytes)
+
+	// verify the hash
+	hashActual := sha256.Sum256(bufferData)
+	hashHexActual := hex.EncodeToString(hashActual[:])
+
+	if hashHexExpected != hashHexActual {
+		logger.Error("invalid legacy log buffer hash in file", zap.String("expected", hashHexExpected), zap.String("actual", hashHexActual))
+
+		return
+	}
+
+	if _, err = io.Copy(writer, bytes.NewReader(bufferData)); err != nil {
+		logger.Error("failed to write legacy log buffer to writer", zap.Error(err))
+	}
+
+	logger.Info("loaded legacy log buffer", zap.String("path", filePath))
+}

--- a/internal/pkg/siderolink/logstore/circularlog/manager.go
+++ b/internal/pkg/siderolink/logstore/circularlog/manager.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//nolint:staticcheck // circularlog is deprecated, but it is fine here
+package circularlog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/siderolabs/go-circular/zstd"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+)
+
+// StoreManager manages circular log stores for machines.
+type StoreManager struct {
+	config     *config.LogsMachine
+	logger     *zap.Logger
+	compressor *zstd.Compressor
+}
+
+// Run implements the LogStoreManager interface.
+func (m *StoreManager) Run(ctx context.Context) error {
+	// nothing to do, circular log cleanup is handled inside the library
+	<-ctx.Done()
+
+	return nil
+}
+
+// Exists implements the LogStoreManager interface.
+func (m *StoreManager) Exists(_ context.Context, id string) (bool, error) {
+	if !m.config.Storage.Enabled {
+		return false, nil
+	}
+
+	matches, err := m.logFiles(id)
+	if err != nil {
+		return false, fmt.Errorf("failed to list log files for machine %q: %w", id, err)
+	}
+
+	return len(matches) > 0, nil
+}
+
+// Remove implements the LogStoreManager interface.
+func (m *StoreManager) Remove(_ context.Context, id string) error {
+	matches, err := m.logFiles(id)
+	if err != nil {
+		return fmt.Errorf("failed to list log files for machine %q: %w", id, err)
+	}
+
+	var errs error
+
+	for _, match := range matches {
+		if err = os.Remove(match); err != nil && !errors.Is(err, os.ErrNotExist) {
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// MachineIDs returns the list of machine IDs that have persistent log stores.
+func (m *StoreManager) MachineIDs() ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(m.config.Storage.Path, "*.log*"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list log files: %w", err)
+	}
+
+	ids := make([]string, 0, len(matches))
+
+	for _, match := range matches {
+		base := filepath.Base(match)
+		id := strings.SplitN(base, ".log", 2)[0]
+		ids = append(ids, id)
+	}
+
+	slices.Sort(ids)
+
+	return slices.Compact(ids), nil
+}
+
+// logFiles returns all log files for the given machine ID.
+//
+// It probes the file system to check if a log file exists for this machine.
+// Checks both for the old (/path/machine-id.log) and the new (/path/machine-id.log.NUM) format.
+func (m *StoreManager) logFiles(id string) ([]string, error) {
+	return filepath.Glob(filepath.Join(m.config.Storage.Path, id+".log*"))
+}
+
+// Create implements the LogStoreManager interface.
+func (m *StoreManager) Create(id string) (logstore.LogStore, error) {
+	return NewStore(m.config, id, m.compressor, m.logger)
+}
+
+// NewStoreManager returns a new StoreManager.
+func NewStoreManager(config *config.LogsMachine, compressor *zstd.Compressor, logger *zap.Logger) *StoreManager {
+	return &StoreManager{
+		config:     config,
+		compressor: compressor,
+		logger:     logger,
+	}
+}

--- a/internal/pkg/siderolink/logstore/logstore.go
+++ b/internal/pkg/siderolink/logstore/logstore.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package logstore
+
+import (
+	"context"
+	"io"
+)
+
+// LogStore is an interface for writing logs and getting readers to read them.
+type LogStore interface {
+	WriteLine(ctx context.Context, message []byte) error
+
+	// Reader returns a reader starting from N lines before the end.
+	//
+	// If nLines < 0, it reads from the very beginning.
+	//
+	// If follow is true, ReadLine() blocks instead of returning EOF when catching up.
+	Reader(ctx context.Context, nLines int, follow bool) (LineReader, error)
+
+	io.Closer
+}
+
+// LineReader is an interface for reading lines from a log store.
+type LineReader interface {
+	io.Closer
+
+	// ReadLine reads the next message.
+	//
+	// Returns io.EOF if follow=false and end is reached.
+	//
+	// Blocks if follow=true and end is reached, until a new line is available or context is done.
+	ReadLine(ctx context.Context) ([]byte, error)
+}

--- a/internal/pkg/siderolink/logstore/sqlitelog/manager.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/manager.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlitelog
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+)
+
+const (
+	tableName       = "machine_logs"
+	idColumn        = "id"
+	machineIDColumn = "machine_id"
+	createdAtColumn = "created_at"
+	messageColumn   = "message"
+)
+
+// StoreManager manages log stores for machines.
+type StoreManager struct {
+	db     *sql.DB
+	logger *zap.Logger
+	config config.LogsMachineSQLite
+}
+
+// Run implements the LogStoreManager interface.
+func (m *StoreManager) Run(ctx context.Context) error {
+	ticker := time.NewTicker(m.config.CleanupInterval)
+	defer ticker.Stop()
+
+	// Do the initial cleanup immediately
+	if err := m.doCleanup(ctx); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return nil
+			}
+
+			return ctx.Err()
+		case <-ticker.C:
+		}
+
+		if err := m.doCleanup(ctx); err != nil {
+			m.logger.Error("failed to cleanup old logs", zap.Error(err))
+		}
+	}
+}
+
+func (m *StoreManager) doCleanup(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, m.config.Timeout)
+	defer cancel()
+
+	query := fmt.Sprintf("DELETE FROM %s WHERE %s < ?", tableName, createdAtColumn)
+	cutoff := time.Now().Add(-m.config.CleanupOlderThan).Unix()
+
+	result, err := m.db.ExecContext(ctx, query, cutoff)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup old logs: %w", err)
+	}
+
+	numRowsDeleted, err := result.RowsAffected()
+	if err != nil {
+		m.logger.Debug("failed to get number of rows affected during logs cleanup", zap.Error(err))
+	}
+
+	logLevel := zap.DebugLevel
+	if numRowsDeleted > 0 {
+		logLevel = zap.InfoLevel
+	}
+
+	m.logger.Log(logLevel, "completed logs cleanup", zap.Int64("rows_affected", numRowsDeleted))
+
+	return nil
+}
+
+// Exists implements the LogStoreManager interface.
+func (m *StoreManager) Exists(ctx context.Context, id string) (bool, error) {
+	id = truncateMachineID(id)
+
+	ctx, cancel := context.WithTimeout(ctx, m.config.Timeout)
+	defer cancel()
+
+	var dummy int
+
+	query := fmt.Sprintf("SELECT 1 FROM %s WHERE %s=? LIMIT 1", tableName, machineIDColumn)
+	if err := m.db.QueryRowContext(ctx, query, id).Scan(&dummy); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to check existence of logs for machine %q: %w", id, err)
+	}
+
+	return true, nil
+}
+
+// Remove implements the LogStoreManager interface.
+func (m *StoreManager) Remove(ctx context.Context, id string) error {
+	id = truncateMachineID(id)
+
+	ctx, cancel := context.WithTimeout(ctx, m.config.Timeout)
+	defer cancel()
+
+	query := fmt.Sprintf("DELETE FROM %s WHERE %s=?", tableName, machineIDColumn)
+
+	result, err := m.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete logs for machine %q: %w", id, err)
+	}
+
+	numRowsDeleted, err := result.RowsAffected()
+	if err != nil {
+		m.logger.Debug("failed to get number of rows affected when removing logs for machine", zap.String("machine_id", id), zap.Error(err))
+	} else {
+		m.logger.Info("removed logs for machine", zap.String("machine_id", id), zap.Int64("rows_affected", numRowsDeleted))
+	}
+
+	return nil
+}
+
+const schemaTmpl = `
+    CREATE TABLE IF NOT EXISTS {{.TableName}} (
+      {{.IDColumn}}        INTEGER PRIMARY KEY,
+      {{.MachineIDColumn}} TEXT    NOT NULL,
+      {{.MessageColumn}}   BLOB    NOT NULL,
+      {{.CreatedAtColumn}} INTEGER NOT NULL
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS idx_{{.TableName}}_{{.MachineIDColumn}} 
+    ON {{.TableName}}({{.MachineIDColumn}}, {{.IDColumn}});
+`
+
+type schemaParams struct {
+	TableName       string
+	IDColumn        string
+	MachineIDColumn string
+	MessageColumn   string
+	CreatedAtColumn string
+}
+
+// NewStoreManager creates a new StoreManager.
+func NewStoreManager(ctx context.Context, db *sql.DB, config config.LogsMachineSQLite, logger *zap.Logger) (*StoreManager, error) {
+	templateParams := schemaParams{
+		TableName:       tableName,
+		IDColumn:        idColumn,
+		MachineIDColumn: machineIDColumn,
+		MessageColumn:   messageColumn,
+		CreatedAtColumn: createdAtColumn,
+	}
+
+	tmpl, err := template.New("schema").Parse(schemaTmpl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse sqlite log table schema template: %w", err)
+	}
+
+	var sb strings.Builder
+
+	if err = tmpl.Execute(&sb, templateParams); err != nil {
+		return nil, fmt.Errorf("failed to execute sqlite log table schema template: %w", err)
+	}
+
+	schemaSQL := sb.String()
+
+	if _, err = db.ExecContext(ctx, schemaSQL); err != nil {
+		return nil, fmt.Errorf("failed to create sqlite log table schema: %w", err)
+	}
+
+	return &StoreManager{
+		config: config,
+		db:     db,
+		logger: logger,
+	}, nil
+}
+
+// Create implements the LogStoreManager interface.
+func (m *StoreManager) Create(id string) (logstore.LogStore, error) {
+	return NewStore(m.config, m.db, id, m.logger)
+}

--- a/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlitelog
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	_ "modernc.org/sqlite"
+
+	"github.com/siderolabs/omni/client/pkg/panichandler"
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+)
+
+const (
+	// machineIDMaxLength is the maximum length allowed for the machine ID.
+	//
+	// Normally, a machine ID is a UUID, so 36 characters should be enough. However, to be safe, we allow up to 128 characters.
+	//
+	// If the machine ID exceeds this length, it will be truncated.
+	machineIDMaxLength = 128
+
+	// messageMaxLength is the maximum length allowed for a log message.
+	//
+	// If a log message exceeds this length, it will be truncated.
+	messageMaxLength = 16 * 1024 // 16 KB
+)
+
+// NewStore creates a new Store.
+func NewStore(config config.LogsMachineSQLite, db *sql.DB, id string, logger *zap.Logger) (*Store, error) {
+	s := &Store{
+		id:     truncateMachineID(id),
+		config: config,
+		db:     db,
+		logger: logger,
+	}
+
+	return s, nil
+}
+
+// Store implements the logstore.LogStore interface using SQLite as the backend.
+type Store struct {
+	db          *sql.DB
+	logger      *zap.Logger
+	id          string
+	subscribers []chan struct{}
+	config      config.LogsMachineSQLite
+	mu          sync.Mutex
+	closed      bool
+}
+
+// WriteLine implements the logstore.LogStore interface.
+func (s *Store) WriteLine(ctx context.Context, message []byte) error {
+	message = truncateMessage(message)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return errors.New("store is closed")
+	}
+
+	query := fmt.Sprintf(`INSERT INTO %s (%s, %s, %s) VALUES (?, ?, ?)`, tableName, machineIDColumn, messageColumn, createdAtColumn)
+
+	ctx, cancel := context.WithTimeout(ctx, s.config.Timeout)
+	defer cancel()
+
+	if _, err := s.db.ExecContext(ctx, query, s.id, message, time.Now().Unix()); err != nil {
+		return fmt.Errorf("failed to write log message: %w", err)
+	}
+
+	if len(s.subscribers) == 0 {
+		return nil
+	}
+
+	for _, ch := range s.subscribers {
+		select {
+		case ch <- struct{}{}:
+		default:
+			// channel is full, reader is already notified
+		}
+	}
+
+	return nil
+}
+
+// Close implements the logstore.LogStore interface.
+func (s *Store) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.closed = true
+
+	for _, ch := range s.subscribers {
+		close(ch)
+	}
+
+	s.subscribers = nil
+
+	return nil
+}
+
+func (s *Store) subscribe() chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ch := make(chan struct{}, 1)
+
+	s.subscribers = append(s.subscribers, ch)
+
+	return ch
+}
+
+func (s *Store) unsubscribe(ch chan struct{}) {
+	if ch == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.subscribers = slices.DeleteFunc(s.subscribers, func(c chan struct{}) bool {
+		return c == ch
+	})
+}
+
+// Reader implements the logstore.LogStore interface.
+func (s *Store) Reader(ctx context.Context, nLines int, follow bool) (logstore.LineReader, error) {
+	var (
+		closeCh  = make(chan struct{})
+		followCh chan struct{}
+	)
+
+	if follow {
+		followCh = s.subscribe()
+
+		// Make sure that we unsubscribe when the context is done
+		panichandler.Go(func() {
+			select {
+			case <-closeCh: // normal close, reader is already unsubscribed
+				return
+			case <-ctx.Done():
+				s.unsubscribe(followCh)
+			}
+		}, s.logger)
+	}
+
+	// If nLines is 0, we are not reading any history.
+	// However, we need to know the current max ID to start following new logs correctly.
+	// Otherwise, lastLogID defaults to 0, and the first "follow" signal will fetch the entire history.
+	var lastLogID int64
+
+	if nLines == 0 {
+		var err error
+
+		if lastLogID, err = s.currentMaxID(ctx); err != nil {
+			s.unsubscribe(followCh)
+			close(closeCh)
+
+			return nil, fmt.Errorf("failed to get current max id: %w", err)
+		}
+	}
+
+	rows, err := s.readerRows(ctx, nLines) //nolint:rowserrcheck // false positive, we do not iterate the logs here
+	if err != nil {
+		s.unsubscribe(followCh)
+		close(closeCh)
+
+		return nil, fmt.Errorf("failed to build reader rows: %w", err)
+	}
+
+	return &lineReader{
+		store:     s,
+		rows:      rows,
+		followCh:  followCh,
+		closeCh:   closeCh,
+		lastLogID: lastLogID,
+	}, nil
+}
+
+type lineReader struct {
+	store     *Store
+	rows      *sql.Rows
+	followCh  chan struct{}
+	closeCh   chan struct{}
+	lastLogID int64
+	closeOnce sync.Once
+}
+
+// ReadLine implements the logstore.LineReader interface.
+func (r *lineReader) ReadLine(ctx context.Context) ([]byte, error) {
+	for {
+		// If there is a row available in the result set, return that
+		if r.rows.Next() {
+			var message []byte
+
+			if err := r.rows.Scan(&r.lastLogID, &message); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return nil, io.EOF
+				}
+
+				return nil, fmt.Errorf("failed to scan log message: %w", err)
+			}
+
+			return message, nil
+		}
+
+		// Current batch is exhausted; wait for the next batch of logs.
+		if err := r.fetchNextBatch(ctx); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// fetchNextBatch handles the transition between the current exhausted result set
+// and the next batch of logs. It closes the current rows, waits for a notification,
+// and queries the database for new logs.
+func (r *lineReader) fetchNextBatch(ctx context.Context) error {
+	// Check for errors in the exhausted result set
+	if err := r.rows.Err(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return io.EOF
+		}
+
+		return fmt.Errorf("failed to read log message: %w", err)
+	}
+
+	if err := r.rows.Close(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return io.EOF
+		}
+
+		return fmt.Errorf("failed to close rows: %w", err)
+	}
+
+	if r.followCh == nil {
+		return io.EOF
+	}
+
+	// Wait for notification
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return io.EOF
+		}
+
+		return ctx.Err()
+	case _, ok := <-r.followCh:
+		if !ok {
+			return io.EOF
+		}
+	}
+
+	newRows, err := r.store.readerRowsAfter(ctx, r.lastLogID) //nolint:rowserrcheck // false positive, we do not iterate the logs here
+	if err != nil {
+		// If the context was canceled during the query, return EOF
+		// to allow graceful shutdown of the reader loop.
+		if errors.Is(err, context.Canceled) {
+			return io.EOF
+		}
+
+		return fmt.Errorf("failed to query new logs: %w", err)
+	}
+
+	r.rows = newRows
+
+	return nil
+}
+
+// Close implements the logstore.LineReader interface.
+func (r *lineReader) Close() error {
+	var closeErr error
+
+	if r.rows != nil {
+		if err := r.rows.Close(); err != nil {
+			closeErr = fmt.Errorf("failed to close rows: %w", err)
+		}
+	}
+
+	r.closeOnce.Do(func() {
+		r.store.unsubscribe(r.followCh)
+		close(r.closeCh)
+	})
+
+	return closeErr
+}
+
+func (s *Store) readerRows(ctx context.Context, nLines int) (*sql.Rows, error) {
+	if nLines == 0 { // No lines are requested, return an empty result set
+		query := fmt.Sprintf("SELECT %s, %s FROM %s WHERE 1=0", idColumn, messageColumn, tableName)
+
+		return s.db.QueryContext(ctx, query)
+	}
+
+	startID, err := s.readerStartID(ctx, nLines)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine start ID: %w", err)
+	}
+
+	query := fmt.Sprintf("SELECT %s, %s FROM %s WHERE %s = ? AND %s >= ? ORDER BY %s ASC", idColumn, messageColumn, tableName, machineIDColumn, idColumn, idColumn)
+
+	rows, err := s.db.QueryContext(ctx, query, s.id, startID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize rows: %w", err)
+	}
+
+	return rows, nil
+}
+
+func (s *Store) readerRowsAfter(ctx context.Context, lastLogID int64) (*sql.Rows, error) {
+	query := fmt.Sprintf("SELECT %s, %s FROM %s WHERE %s = ? AND %s > ? ORDER BY %s ASC",
+		idColumn, messageColumn, tableName, machineIDColumn, idColumn, idColumn)
+
+	rows, err := s.db.QueryContext(ctx, query, s.id, lastLogID)
+	if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}
+
+func (s *Store) readerStartID(ctx context.Context, nLines int) (int64, error) {
+	if nLines < 0 {
+		return 0, nil
+	}
+
+	// Do COALESCE to return 0 if there are no logs for the machine
+	query := fmt.Sprintf("SELECT COALESCE(MIN(id), 0) FROM (SELECT %s AS id FROM %s WHERE %s = ? ORDER BY %s DESC LIMIT ?)",
+		idColumn, tableName, machineIDColumn, idColumn)
+
+	ctx, cancel := context.WithTimeout(ctx, s.config.Timeout)
+	defer cancel()
+
+	var startID int64
+
+	err := s.db.QueryRowContext(ctx, query, s.id, nLines).Scan(&startID)
+
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("failed to query start log id: %w", err)
+	}
+
+	return startID, nil
+}
+
+func (s *Store) currentMaxID(ctx context.Context) (int64, error) {
+	query := fmt.Sprintf("SELECT COALESCE(MAX(%s), 0) FROM %s WHERE %s = ?", idColumn, tableName, machineIDColumn)
+
+	ctx, cancel := context.WithTimeout(ctx, s.config.Timeout)
+	defer cancel()
+
+	var id int64
+	if err := s.db.QueryRowContext(ctx, query, s.id).Scan(&id); err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+func truncateMessage(message []byte) []byte {
+	if len(message) <= messageMaxLength {
+		return message
+	}
+
+	return message[:messageMaxLength]
+}
+
+func truncateMachineID(id string) string {
+	if len(id) <= machineIDMaxLength {
+		return id
+	}
+
+	return id[:machineIDMaxLength]
+}

--- a/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
@@ -1,0 +1,523 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlitelog_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/siderolabs/go-circular/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
+	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/circularlog"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/sqlitelog"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestReadWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	storeManager := setupDB(ctx, t, logger)
+
+	sqliteStore1, err := storeManager.Create("test-1")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, sqliteStore1.Close())
+	})
+
+	sqliteStore2, err := storeManager.Create("test-2")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, sqliteStore2.Close())
+	})
+
+	t.Cleanup(func() {
+		require.NoError(t, sqliteStore1.Close())
+	})
+
+	defaultConfig := config.Default()
+
+	compressor, err := zstd.NewCompressor()
+	require.NoError(t, err)
+
+	circularStore, err := circularlog.NewStore(&defaultConfig.Logs.Machine, "test-1", compressor, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, circularStore.Close())
+	})
+
+	numLines := 1000
+
+	for i := range numLines {
+		require.NoError(t, sqliteStore1.WriteLine(ctx, fmt.Appendf(nil, "Hello, World %d!", i)))
+		require.NoError(t, sqliteStore2.WriteLine(ctx, fmt.Appendf(nil, "Hello, World %d!", i)))
+		require.NoError(t, circularStore.WriteLine(ctx, fmt.Appendf(nil, "Hello, World %d!", i)))
+	}
+
+	t.Run("read all", func(t *testing.T) {
+		t.Parallel()
+
+		testRead(ctx, t, sqliteStore1, circularStore, numLines, -1)
+	})
+
+	t.Run("tail", func(t *testing.T) {
+		t.Parallel()
+
+		testRead(ctx, t, sqliteStore1, circularStore, 100, 100)
+	})
+}
+
+func TestFollow(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	storeManager := setupDB(ctx, t, logger)
+
+	store, err := storeManager.Create("test-1")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	require.NoError(t, store.WriteLine(ctx, []byte("Hello, World 1!")))
+	require.NoError(t, store.WriteLine(ctx, []byte("Hello, World 2!")))
+
+	rdr, err := store.Reader(ctx, -1, true)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	lineCh := make(chan string)
+
+	wg.Go(func() {
+		readLines(ctx, t, rdr, lineCh)
+	})
+
+	assertLine(ctx, t, lineCh, "Hello, World 1!")
+	assertLine(ctx, t, lineCh, "Hello, World 2!")
+
+	require.NoError(t, store.WriteLine(ctx, []byte("Hello, World 3!")))
+	require.NoError(t, store.WriteLine(ctx, []byte("Hello, World 4!")))
+
+	assertLine(ctx, t, lineCh, "Hello, World 3!")
+	assertLine(ctx, t, lineCh, "Hello, World 4!")
+
+	cancel()
+
+	wg.Wait()
+}
+
+func TestTruncation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	storeManager := setupDB(ctx, t, logger)
+
+	// 1. Setup Long ID and Huge Message
+	longID := "machine-" + string(make([]byte, 200))
+
+	hugeMessage := make([]byte, 20*1024)
+	for i := range hugeMessage {
+		hugeMessage[i] = 'a'
+	}
+
+	store, err := storeManager.Create(longID)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	// 2. Write the huge message immediately.
+	// This populates the DB so Exists() can return true,
+	// and allows us to test message truncation simultaneously.
+	err = store.WriteLine(ctx, hugeMessage)
+	require.NoError(t, err)
+
+	// 3. Test Machine ID Truncation (in Manager)
+	// The manager should find the store even if we pass the original long ID.
+	exists, err := storeManager.Exists(ctx, longID)
+	require.NoError(t, err)
+	assert.True(t, exists, "Manager should find store with truncated ID (requires at least one log line written)")
+
+	// 4. Test Message Truncation (in Store)
+	// Read it back.
+	rdr, err := store.Reader(ctx, -1, false)
+	require.NoError(t, err)
+
+	lines := readAllLines(ctx, t, rdr)
+	require.Len(t, lines, 1)
+
+	// It should be exactly 16KB (16 * 1024).
+	assert.Len(t, lines[0], 16*1024, "Message should be truncated to 16KB")
+}
+
+func TestManagerLifecycle(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	storeManager := setupDB(ctx, t, logger)
+	id := "lifecycle-test"
+
+	// 1. Check Exists before creation.
+	exists, err := storeManager.Exists(ctx, id)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// 2. Create and write.
+	store, err := storeManager.Create(id)
+	require.NoError(t, err)
+	require.NoError(t, store.WriteLine(ctx, []byte("log data")))
+
+	require.NoError(t, store.Close())
+
+	// 3. Check Exists after creation and close.
+	exists, err = storeManager.Exists(ctx, id)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// 4. Remove.
+	err = storeManager.Remove(ctx, id)
+	require.NoError(t, err)
+
+	// 5. Check Exists after removal.
+	exists, err = storeManager.Exists(ctx, id)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// 6. Verify data is actually gone.
+	storeRecreated, err := storeManager.Create(id)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, storeRecreated.Close())
+	})
+
+	rdr, err := storeRecreated.Reader(ctx, -1, false)
+	require.NoError(t, err)
+	lines := readAllLines(ctx, t, rdr)
+	assert.Empty(t, lines)
+}
+
+func TestReaderParameters(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	storeManager := setupDB(ctx, t, logger)
+	store, err := storeManager.Create("reader-params")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	// Write 10 lines.
+	for i := range 10 {
+		require.NoError(t, store.WriteLine(ctx, fmt.Appendf(nil, "line %d", i)))
+	}
+
+	tests := []struct {
+		name      string
+		firstLine string
+		nLines    int
+		wantCount int
+	}{
+		{
+			name:      "Read All (Negative)",
+			nLines:    -1,
+			wantCount: 10,
+			firstLine: "line 0",
+		},
+		{
+			name:      "Read None (Zero)",
+			nLines:    0,
+			wantCount: 0,
+		},
+		{
+			name:      "Read Tail (Small)",
+			nLines:    3,
+			wantCount: 3,
+			firstLine: "line 7",
+		},
+		{
+			name:      "Read Tail (Large)",
+			nLines:    100,
+			wantCount: 10,
+			firstLine: "line 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rdr, err := store.Reader(ctx, tt.nLines, false)
+			require.NoError(t, err)
+
+			lines := readAllLines(ctx, t, rdr)
+			assert.Len(t, lines, tt.wantCount)
+
+			if tt.wantCount > 0 && tt.firstLine != "" {
+				assert.Equal(t, tt.firstLine, lines[0])
+			}
+		})
+	}
+}
+
+func TestFollowNoHistory(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	storeManager := setupDB(ctx, t, logger)
+	store, err := storeManager.Create("follow-no-history")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	// 1. Write historical data.
+	require.NoError(t, store.WriteLine(ctx, []byte("history 1")))
+	require.NoError(t, store.WriteLine(ctx, []byte("history 2")))
+
+	// 2. Request 0 lines, but follow=true.
+	rdr, err := store.Reader(ctx, 0, true)
+	require.NoError(t, err)
+
+	// 3. Write new data.
+	expected := "new 1"
+	require.NoError(t, store.WriteLine(ctx, []byte(expected)))
+
+	// 4. Read the first line.
+	// Logic check: nLines=0 should skip "history 1/2" and stream "new 1" immediately.
+	line, err := rdr.ReadLine(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, string(line), "Reader(0, true) should ignore history and only return new logs")
+}
+
+func TestFollowTail(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	storeManager := setupDB(ctx, t, logger)
+	store, err := storeManager.Create("follow-tail")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	// 1. Write 20 lines of history
+	for i := range 20 {
+		require.NoError(t, store.WriteLine(ctx, fmt.Appendf(nil, "history %d", i)))
+	}
+
+	// 2. Request last 5 lines and follow
+	rdr, err := store.Reader(ctx, 5, true)
+	require.NoError(t, err)
+
+	lineCh := make(chan string)
+
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		readLines(ctx, t, rdr, lineCh)
+	})
+
+	// 3. Verify we get the last 5 lines of history (15-19)
+	for i := 15; i < 20; i++ {
+		assertLine(ctx, t, lineCh, fmt.Sprintf("history %d", i))
+	}
+
+	// 4. Write new data
+	require.NoError(t, store.WriteLine(ctx, []byte("new 1")))
+
+	// 5. Verify we get the new line
+	assertLine(ctx, t, lineCh, "new 1")
+
+	cancel()
+	wg.Wait()
+}
+
+// TestFollowRapidWrites tests that a reader following rapid writes
+// receives all lines without gaps or duplication.
+func TestFollowRapidWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	storeManager := setupDB(ctx, t, logger)
+	store, err := storeManager.Create("rapid-writes")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	// 1. Start reader (following)
+	rdr, err := store.Reader(ctx, 0, true)
+	require.NoError(t, err)
+
+	count := 5000
+
+	var eg errgroup.Group
+
+	eg.Go(func() error {
+		for i := range count {
+			if writeErr := store.WriteLine(ctx, fmt.Appendf(nil, "msg %d", i)); writeErr != nil {
+				return writeErr
+			}
+		}
+
+		return nil
+	})
+
+	// 3. Read and verify no gaps
+	for i := range count {
+		line, readErr := rdr.ReadLine(ctx)
+		require.NoError(t, readErr)
+
+		require.Equal(t, fmt.Sprintf("msg %d", i), string(line))
+	}
+
+	require.NoError(t, eg.Wait())
+}
+
+func testRead(ctx context.Context, t *testing.T, sqliteStore, circularStore logstore.LogStore, expectedLines, tailLines int) {
+	t.Helper()
+
+	sqliteReader, err := sqliteStore.Reader(ctx, tailLines, false)
+	require.NoError(t, err)
+
+	sqliteLines := readAllLines(ctx, t, sqliteReader)
+
+	circularReader, err := circularStore.Reader(ctx, tailLines, false)
+	require.NoError(t, err)
+
+	circularLines := readAllLines(ctx, t, circularReader)
+
+	assert.Len(t, sqliteLines, expectedLines)
+	assert.Equal(t, circularLines, sqliteLines)
+}
+
+func readAllLines(ctx context.Context, t *testing.T, rdr logstore.LineReader) []string {
+	t.Helper()
+
+	var lines []string
+
+	for {
+		line, err := rdr.ReadLine(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return lines
+			}
+
+			require.NoError(t, err)
+		}
+
+		lines = append(lines, string(line))
+	}
+}
+
+func readLines(ctx context.Context, t *testing.T, rdr logstore.LineReader, ch chan<- string) {
+	t.Helper()
+
+	for {
+		line, err := rdr.ReadLine(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+
+			require.NoError(t, err)
+		}
+
+		select {
+		case ch <- string(line):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func assertLine(ctx context.Context, t *testing.T, lineCh <-chan string, expected string) {
+	t.Helper()
+
+	select {
+	case line := <-lineCh:
+		assert.Equal(t, expected, line)
+	case <-ctx.Done():
+		require.NoError(t, ctx.Err())
+	}
+}
+
+// setupDB helper handles the standard SQLite test setup.
+func setupDB(ctx context.Context, t *testing.T, logger *zap.Logger) *sqlitelog.StoreManager {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.db")
+
+	conf := config.Default().Storage.SQLite
+	conf.Path = path
+
+	db, err := sqlite.OpenDB(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	storeManager, err := sqlitelog.NewStoreManager(ctx, db, config.Default().Logs.Machine.SQLite, logger)
+	require.NoError(t, err)
+
+	return storeManager
+}

--- a/internal/pkg/siderolink/machines.go
+++ b/internal/pkg/siderolink/machines.go
@@ -6,15 +6,10 @@
 package siderolink
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
+	"database/sql"
 	"errors"
 	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -22,105 +17,116 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/gen/containers"
-	"github.com/siderolabs/go-circular"
 	"github.com/siderolabs/go-circular/zstd"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/circularlog"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/sqlitelog"
 )
 
-// MachineCache stores a map of machines to their circular log buffers. It also allows to access the buffers
-// using the machine IP.
+// ErrLogStoreNotFound is returned when the log store for a machine is not found.
+var ErrLogStoreNotFound = errors.New("log store not found")
+
+// MachineCache stores a map of machines to their circular log stores. It also allows to access the log stores using the machine IP.
 type MachineCache struct {
-	machineBuffers   containers.LazyMap[MachineID, *circular.Buffer]
-	logger           *zap.Logger
-	logStorageConfig *config.LogsMachine
-	compressor       *zstd.Compressor
-	mx               sync.Mutex
-	inited           bool
+	machineLogStoreManager LogStoreManager
+	machineLogStores       map[MachineID]logstore.LogStore
+	logger                 *zap.Logger
+	logStorageConfig       *config.LogsMachine
+	compressor             *zstd.Compressor
+	secondaryStorageDB     *sql.DB
+	mx                     sync.Mutex
+	inited                 bool
 }
 
 // NewMachineCache returns a new MachineCache.
-func NewMachineCache(logStorageConfig *config.LogsMachine, logger *zap.Logger) (*MachineCache, error) {
+func NewMachineCache(secondaryStorageDB *sql.DB, logStorageConfig *config.LogsMachine, logger *zap.Logger) (*MachineCache, error) {
 	compressor, err := zstd.NewCompressor()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create log compressor: %w", err)
 	}
 
 	return &MachineCache{
-		logStorageConfig: logStorageConfig,
-		compressor:       compressor,
-		logger:           logger,
+		logStorageConfig:   logStorageConfig,
+		compressor:         compressor,
+		secondaryStorageDB: secondaryStorageDB,
+		logger:             logger,
 	}, nil
 }
 
-// WriteMessage writes the message surrounded with '\n' to the circular buffer for the given machine ID.
-func (m *MachineCache) WriteMessage(id MachineID, rawData []byte) error {
-	buffer, err := m.GetWriter(id)
-	if err != nil {
-		return err
+// Run starts the side tasks required by the MachineCache.
+//
+// Currently, it is only the periodic cleanup of old logs in the SQLite log store.
+func (m *MachineCache) Run(ctx context.Context) error {
+	if err := m.initLocked(ctx); err != nil {
+		return fmt.Errorf("failed to initialize machine cache: %w", err)
 	}
 
-	_, err = buffer.Write([]byte("\n"))
-	if err != nil {
-		return err
-	}
-
-	_, err = buffer.Write(rawData)
-	if err != nil {
-		return err
-	}
-
-	_, err = buffer.Write([]byte("\n"))
-	if err != nil {
-		return err
+	if err := m.machineLogStoreManager.Run(ctx); err != nil {
+		return fmt.Errorf("failed to run machine log store manager: %w", err)
 	}
 
 	return nil
 }
 
-// GetBuffer returns the circular buffer for the given machine ID.
-func (m *MachineCache) GetBuffer(id MachineID) (*circular.Buffer, error) {
+// initLocked initializes the cache safely.
+func (m *MachineCache) initLocked(ctx context.Context) error {
 	m.mx.Lock()
 	defer m.mx.Unlock()
 
-	m.init()
+	return m.init(ctx)
+}
 
-	val, ok := m.machineBuffers.Get(id)
+// WriteMessage writes the message surrounded with '\n' to the log store for the given machine ID.
+func (m *MachineCache) WriteMessage(ctx context.Context, id MachineID, rawData []byte) error {
+	logWriter, err := m.initAndGetLogStore(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	return logWriter.WriteLine(ctx, rawData)
+}
+
+// getLogStore returns the log backend for the given machine ID.
+func (m *MachineCache) getLogStore(ctx context.Context, id MachineID) (logstore.LogStore, error) {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
+	if err := m.init(ctx); err != nil {
+		return nil, err
+	}
+
+	val, ok := m.machineLogStores[id]
 	if ok {
 		return val, nil
 	}
 
-	if !m.logStorageConfig.Storage.Enabled {
-		return nil, &BufferNotFoundError{id: id}
-	}
-
-	// Probe the file system to check if a log file exists for this machine.
-	// Check both for the old (/path/machine-id.log) and the new (/path/machine-id.log.NUM) format.
-	glob := filepath.Join(m.logStorageConfig.Storage.Path, string(id)+".log*")
-
-	matches, err := filepath.Glob(glob)
+	exists, err := m.machineLogStoreManager.Exists(ctx, string(id))
 	if err != nil {
-		return nil, fmt.Errorf("failed to list log files for machine %q: %w", id, err)
+		return nil, fmt.Errorf("failed to check if log store exists for machine %q: %w", id, err)
 	}
 
-	if len(matches) == 0 {
-		return nil, &BufferNotFoundError{id: id}
+	if !exists {
+		return nil, fmt.Errorf("%w: %s", ErrLogStoreNotFound, id)
 	}
 
-	return m.machineBuffers.GetOrCreate(id)
+	return m.getOrCreateStore(id)
 }
 
-// GetWriter returns the circular buffer for the given machine ID. Creates buffer if it doesn't exist.
-func (m *MachineCache) GetWriter(id MachineID) (io.Writer, error) {
+// initAndGetLogStore returns the log store for the given machine ID, creating it if it does not exist.
+func (m *MachineCache) initAndGetLogStore(ctx context.Context, id MachineID) (logstore.LogStore, error) {
 	m.mx.Lock()
 	defer m.mx.Unlock()
 
-	m.init()
+	if err := m.init(ctx); err != nil {
+		return nil, err
+	}
 
-	val, err := m.machineBuffers.GetOrCreate(id)
+	val, err := m.getOrCreateStore(id)
 	if err != nil {
 		return nil, err
 	}
@@ -128,9 +134,10 @@ func (m *MachineCache) GetWriter(id MachineID) (io.Writer, error) {
 	return val, nil
 }
 
-// Remove removes the circular buffer for the given machine ID.
-// If storage is enabled, it also removes the logs from the storage i.e., the file system.
-func (m *MachineCache) Remove(id MachineID) error {
+// Remove removes the log store for the given machine ID.
+//
+// If storage is enabled, it also removes the logs from the storage.
+func (m *MachineCache) remove(ctx context.Context, id MachineID) error {
 	m.mx.Lock()
 	defer m.mx.Unlock()
 
@@ -140,86 +147,105 @@ func (m *MachineCache) Remove(id MachineID) error {
 		return nil
 	}
 
-	buf, ok := m.machineBuffers.Get(id)
+	store, ok := m.machineLogStores[id]
 	if !ok {
 		return nil
 	}
 
-	if err := buf.Close(); err != nil {
-		m.logger.Error("failed to close buffer", zap.String("machine_id", string(id)), zap.Error(err))
+	if err := store.Close(); err != nil {
+		m.logger.Error("failed to close store", zap.String("machine_id", string(id)), zap.Error(err))
 	}
 
-	m.machineBuffers.Remove(id)
+	delete(m.machineLogStores, id)
 
-	matches, err := filepath.Glob(filepath.Join(m.logStorageConfig.Storage.Path, string(id)+".log*"))
-	if err != nil {
-		return fmt.Errorf("failed to list log files for machine %q: %w", id, err)
-	}
-
-	var errs error
-
-	for _, match := range matches {
-		if err = os.Remove(match); err != nil && !errors.Is(err, os.ErrNotExist) {
-			errs = multierror.Append(errs, err)
-		}
-	}
-
-	if errs != nil {
-		return fmt.Errorf("failed to remove log files for machine %q: %w", id, errs)
+	if err := m.machineLogStoreManager.Remove(ctx, string(id)); err != nil {
+		return fmt.Errorf("failed to remove logs from storage for machine %q: %w", id, err)
 	}
 
 	return nil
 }
 
-// Close closes all the circular buffers, triggering a flush to the storage for each of them if they have persistence enabled.
+// Close closes all the log stores, triggering a flush to the storage for each of them if they have persistence enabled.
 func (m *MachineCache) Close() error {
+	m.mx.Lock()
+	defer m.mx.Unlock()
+
 	var errs error
 
-	m.machineBuffers.ForEach(func(_ MachineID, buffer *circular.Buffer) {
-		if err := buffer.Close(); err != nil {
+	for _, store := range m.machineLogStores {
+		if err := store.Close(); err != nil {
 			errs = multierror.Append(errs, err)
 		}
-	})
+	}
 
 	return errs
 }
 
-func (m *MachineCache) init() {
+// init initializes the MachineCache.
+//
+// TODO: remove the migration logic and the circular log storage after a few releases, when all machines' logs should have been migrated.
+func (m *MachineCache) init(ctx context.Context) error {
 	if m.inited {
-		return
+		return nil
+	}
+
+	var (
+		circularLogStoreManager *circularlog.StoreManager
+		sqliteLogStoreManager   *sqlitelog.StoreManager
+		err                     error
+	)
+
+	if m.logStorageConfig.Storage.Enabled { //nolint:staticcheck
+		circularLogStoreManager = circularlog.NewStoreManager(m.logStorageConfig, m.compressor, m.logger)
+	}
+
+	if m.logStorageConfig.SQLite.Enabled {
+		if sqliteLogStoreManager, err = sqlitelog.NewStoreManager(ctx, m.secondaryStorageDB, m.logStorageConfig.SQLite, m.logger); err != nil {
+			return fmt.Errorf("failed to create sqlite log store manager: %w", err)
+		}
+	}
+
+	switch {
+	case m.logStorageConfig.Storage.Enabled && m.logStorageConfig.SQLite.Enabled: //nolint:staticcheck
+		m.logger.Info("both sqlite and persistent log storage are enabled, going to migrate from circular log store to sqlite log store")
+
+		if err = migrateLogStoreToSQLite(ctx, circularLogStoreManager, sqliteLogStoreManager, m.logger); err != nil { //nolint:staticcheck
+			return fmt.Errorf("failed to migrate log store from circular to sqlite: %w", err)
+		}
+
+		m.logger.Info("migration completed, using sqlite log store manager for machine logs")
+
+		m.machineLogStoreManager = sqliteLogStoreManager
+	case m.logStorageConfig.SQLite.Enabled:
+		m.logger.Info("using sqlite log store manager for machine logs")
+
+		m.machineLogStoreManager = sqliteLogStoreManager
+	default:
+		m.logger.Info("using circular log store manager for machine logs")
+
+		m.machineLogStoreManager = circularlog.NewStoreManager(m.logStorageConfig, m.compressor, m.logger)
 	}
 
 	m.inited = true
-	m.machineBuffers = containers.LazyMap[MachineID, *circular.Buffer]{
-		Creator: func(id MachineID) (*circular.Buffer, error) {
-			bufferOpts := []circular.OptionFunc{
-				circular.WithInitialCapacity(m.logStorageConfig.BufferInitialCapacity),
-				circular.WithMaxCapacity(m.logStorageConfig.BufferMaxCapacity),
-				circular.WithSafetyGap(m.logStorageConfig.BufferSafetyGap),
-				circular.WithNumCompressedChunks(m.logStorageConfig.Storage.NumCompressedChunks, m.compressor),
-				circular.WithLogger(m.logger),
-			}
+	m.machineLogStores = map[MachineID]logstore.LogStore{}
 
-			if m.logStorageConfig.Storage.Enabled {
-				bufferOpts = append(bufferOpts, circular.WithPersistence(circular.PersistenceOptions{
-					ChunkPath:     filepath.Join(m.logStorageConfig.Storage.Path, string(id)+".log"),
-					FlushInterval: m.logStorageConfig.Storage.FlushPeriod,
-					FlushJitter:   m.logStorageConfig.Storage.FlushJitter,
-				}))
-			}
+	return nil
+}
 
-			buffer, err := circular.NewBuffer(bufferOpts...)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create circular buffer for machine '%s': %w", id, err)
-			}
-
-			if m.logStorageConfig.Storage.Enabled {
-				loadLegacyLogs(m.logStorageConfig, id, buffer, m.logger)
-			}
-
-			return buffer, nil
-		},
+func (m *MachineCache) getOrCreateStore(id MachineID) (logstore.LogStore, error) {
+	store, ok := m.machineLogStores[id]
+	if ok {
+		return store, nil
 	}
+
+	created, err := m.machineLogStoreManager.Create(string(id))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create log store for machine %q: %w", id, err)
+	}
+
+	m.machineLogStores[id] = created
+
+	return created, err
 }
 
 // NewMachineMap returns a new MachineMap.
@@ -305,77 +331,4 @@ func (s *StateStorage) GetMachine(machineIP string) (MachineID, error) {
 	}
 
 	return MachineID(machines.Get(0).Metadata().ID()), nil
-}
-
-// BufferNotFoundError is returned when the machine buffer is not found.
-type BufferNotFoundError struct {
-	id MachineID
-}
-
-// Error returns the error message.
-func (e *BufferNotFoundError) Error() string {
-	return fmt.Sprintf("no buffer found for machine '%s'", e.id)
-}
-
-// IsBufferNotFoundError returns true if the error is of type BufferNotFoundError.
-func IsBufferNotFoundError(err error) bool {
-	var target *BufferNotFoundError
-
-	return errors.As(err, &target)
-}
-
-// loadLegacyLogs loads logs stored of the machine with the given id in the old format, if exists, into the given writer.
-// It is used to migrate logs from the old format to the new format.
-// It removes the old log file and its hash file regardless of the result.
-//
-// It is a best-effort function and does not return any error.
-func loadLegacyLogs(config *config.LogsMachine, id MachineID, writer io.Writer, logger *zap.Logger) {
-	filePath := filepath.Join(config.Storage.Path, fmt.Sprintf("%s.log", id))
-	shaSumPath := filePath + ".sha256sum"
-
-	defer func() {
-		if err := os.Remove(filePath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			logger.Error("failed to remove legacy log file", zap.String("path", filePath), zap.Error(err))
-		}
-
-		if err := os.Remove(shaSumPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			logger.Error("failed to remove legacy log hash file", zap.String("path", shaSumPath), zap.Error(err))
-		}
-	}()
-
-	bufferData, err := os.ReadFile(filePath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return
-		}
-
-		logger.Error("failed to read legacy log buffer file", zap.String("path", filePath), zap.Error(err))
-
-		return
-	}
-
-	hashHexExpectedBytes, err := os.ReadFile(shaSumPath)
-	if err != nil {
-		logger.Error("failed to read legacy log buffer hash file", zap.String("path", shaSumPath), zap.Error(err))
-
-		return
-	}
-
-	hashHexExpected := string(hashHexExpectedBytes)
-
-	// verify the hash
-	hashActual := sha256.Sum256(bufferData)
-	hashHexActual := hex.EncodeToString(hashActual[:])
-
-	if hashHexExpected != hashHexActual {
-		logger.Error("invalid legacy log buffer hash in file", zap.String("expected", hashHexExpected), zap.String("actual", hashHexActual))
-
-		return
-	}
-
-	if _, err = io.Copy(writer, bytes.NewReader(bufferData)); err != nil {
-		logger.Error("failed to write legacy log buffer to writer", zap.Error(err))
-	}
-
-	logger.Info("loaded legacy log buffer", zap.String("path", filePath))
 }


### PR DESCRIPTION
Use SQLite storage to store machine logs.
Use the same SQLite database used for the metrics state.

Refactor machine log storage to define a common interface for circular and sqlite based logs.

Closes #1771.