### PR TITLE
fix(frontend): fix backup interval clamping

### DIFF
--- a/frontend/src/components/common/TInput/TInput.vue
+++ b/frontend/src/components/common/TInput/TInput.vue
@@ -115,6 +115,7 @@ onMounted(() => focus && inputRef.value?.focus())
         class="peer min-w-2 flex-1 border-none bg-transparent text-xs text-naturals-n13 placeholder-naturals-n7 outline-hidden transition-colors focus:border-transparent focus:outline-hidden disabled:opacity-0"
         :placeholder="placeholder"
         @blur="blurHandler"
+        @keydown.enter="blurHandler"
       />
 
       <TIcon

--- a/frontend/src/components/common/Tooltip/Tooltip.vue
+++ b/frontend/src/components/common/Tooltip/Tooltip.vue
@@ -66,7 +66,7 @@ const align = computed(() => {
 
       <TooltipPortal>
         <TooltipContent
-          class="rounded border border-naturals-n4 bg-naturals-n3 p-4 text-xs text-naturals-n12"
+          class="z-50 rounded border border-naturals-n4 bg-naturals-n3 p-4 text-xs text-naturals-n12"
           :side-offset="offsetDistance"
           :align-offset="offsetSkid"
           :align

--- a/frontend/src/views/omni/Clusters/ClusterEtcdBackupCheckbox.vue
+++ b/frontend/src/views/omni/Clusters/ClusterEtcdBackupCheckbox.vue
@@ -37,7 +37,7 @@ const enabled = computed(() => {
 const interval = computed(() => {
   const value = cluster.value.backup_configuration?.interval
 
-  if (!value) {
+  if (!value || value.trim() === '0') {
     return undefined
   }
 


### PR DESCRIPTION
Fix the input number clamping on the `ClusterEtcdBackupCheckbox` input to also work when hitting enter. Previously numbers were not being clamped when submitting the input with enter. Also fixed an issue of tooltips appearing behind the sidebar.