### PR TITLE
feat(frontend): hide descriptions in json schema behind tooltip

### DIFF
--- a/frontend/src/components/common/Form/ContentWrapper.vue
+++ b/frontend/src/components/common/Form/ContentWrapper.vue
@@ -5,28 +5,25 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed } from 'vue'
-
 import TIcon from '../Icon/TIcon.vue'
 import Tooltip from '../Tooltip/Tooltip.vue'
 
-const props = defineProps<{
+defineProps<{
   control: {
     label: string
     errors: string
     description?: string
   }
 }>()
-
-const description = computed(() => {
-  return props.control.description ? ` (${props.control.description})` : ''
-})
 </script>
 
 <template>
   <div v-if="control.label" class="flex items-center justify-between gap-2 px-3 py-3">
     <div class="flex items-center gap-2 text-xs text-naturals-n11">
-      {{ control.label }}{{ description }}
+      {{ control.label }}
+      <Tooltip v-if="control.description" :description="control.description">
+        <TIcon icon="question" class="h-4 w-4" />
+      </Tooltip>
       <Tooltip v-if="control.errors" :description="control.errors">
         <TIcon icon="warning" class="h-4 w-4 text-yellow-y1" />
       </Tooltip>


### PR DESCRIPTION
Hide descriptions for JSON schema fields behind a tooltip in the UI.

Closes #1934