### PR TITLE
feat: prevent downgrading talos minor version below initial version

### DIFF
--- a/internal/backend/runtime/omni/state_access.go
+++ b/internal/backend/runtime/omni/state_access.go
@@ -375,6 +375,7 @@ func filterAccess(ctx context.Context, access state.Access) error {
 	case
 		omni.ClusterType,
 		omni.ClusterBootstrapStatusType,
+		omni.ClusterConfigVersionType,
 		omni.ClusterDestroyStatusType,
 		omni.ClusterEndpointType,
 		omni.ClusterKubernetesNodesType,
@@ -547,6 +548,7 @@ func filterAccessByType(access state.Access) error {
 		return status.Error(codes.PermissionDenied, "only read, update and delete access is permitted")
 	case
 		omni.ClusterBootstrapStatusType,
+		omni.ClusterConfigVersionType,
 		omni.ClusterDestroyStatusType,
 		omni.ClusterEndpointType,
 		omni.ClusterKubernetesNodesType,

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -818,6 +818,10 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				allowedVerbSet: readOnlyVerbSet,
 			},
 			{
+				resource:       omni.NewClusterConfigVersion(resources.DefaultNamespace, uuid.New().String()),
+				allowedVerbSet: readOnlyVerbSet,
+			},
+			{
 				resource:       omni.NewClusterDestroyStatus(resources.DefaultNamespace, uuid.New().String()),
 				allowedVerbSet: readOnlyVerbSet,
 			},
@@ -1132,9 +1136,6 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 
 		// no access resources
 		testCases = append(testCases, []resourceAuthzTestCase{
-			{
-				resource: omni.NewClusterConfigVersion(resources.DefaultNamespace, uuid.New().String()),
-			},
 			{
 				resource: oidc.NewJWTPublicKey(resources.DefaultNamespace, uuid.New().String()),
 			},


### PR DESCRIPTION
Talos might introduce new functionality with each new version that's not supported by previous minor release. Omni saves the initial talos version used to create the cluster and uses that version to calculate all machine configs from that point on. Initiating a downgrade to a version below that initial version might lead to machine configs including unsupported configuration. This PR will prevent downgrade paths that would lead the cluster to a broken state.

Closes: #1945
