### PR TITLE
fix(installation-media): correct doc links for sbc & cloud steps

### DIFF
--- a/frontend/src/components/common/CodeEditor/CodeEditor.vue
+++ b/frontend/src/components/common/CodeEditor/CodeEditor.vue
@@ -9,6 +9,7 @@ import * as monaco from 'monaco-editor'
 import { configureMonacoYaml } from 'monaco-yaml'
 import { ref, toRefs, watch } from 'vue'
 
+import { getDocsLink } from '@/methods'
 import configSchema from '@/schemas/config.schema.json'
 
 type Props = {
@@ -46,8 +47,7 @@ if (!window.monacoConfigured) {
           type: 'string',
           title: '$patch',
           enum: ['delete'],
-          description:
-            'Delete the configuration block with a strategic merge delete patch.\nSee https://www.talos.dev/latest/talos-guides/configuration/patching/',
+          description: `Delete the configuration block with a strategic merge delete patch.\nSee ${getDocsLink('talos', '/configure-your-talos-cluster/system-configuration/patching')}`,
         }
       }
     }

--- a/frontend/src/methods/index.spec.ts
+++ b/frontend/src/methods/index.spec.ts
@@ -8,10 +8,29 @@ import { test } from 'vitest'
 
 import { DefaultTalosVersion } from '@/api/resources'
 
-import { getDocsLink } from '.'
+import { getDocsLink, getLegacyDocsLink } from '.'
 
 const { major, minor } = parse(DefaultTalosVersion, false, true)
 const defaultVersion = `${major}.${minor}`
+
+test.each`
+  path            | options                       | expected
+  ${undefined}    | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}`}
+  ${'/hello/123'} | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}/hello/123`}
+  ${'hello/123'}  | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}/hello/123`}
+  ${'/hello'}     | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}/hello`}
+  ${'123'}        | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}/123`}
+  ${'/hello/123'} | ${{}}                         | ${`https://talos.dev/v${defaultVersion}/hello/123`}
+  ${'hello/123'}  | ${{}}                         | ${`https://talos.dev/v${defaultVersion}/hello/123`}
+  ${'/hello'}     | ${{}}                         | ${`https://talos.dev/v${defaultVersion}/hello`}
+  ${'123'}        | ${{}}                         | ${`https://talos.dev/v${defaultVersion}/123`}
+  ${'/hello/123'} | ${{ talosVersion: '1.11.3' }} | ${'https://talos.dev/v1.11/hello/123'}
+  ${'hello/123'}  | ${{ talosVersion: '1.10.0' }} | ${'https://talos.dev/v1.10/hello/123'}
+  ${'/hello'}     | ${{ talosVersion: '1.9' }}    | ${'https://talos.dev/v1.9/hello'}
+  ${'123'}        | ${{ talosVersion: '1' }}      | ${'https://talos.dev/v1.0/123'}
+`('getDocsLink: $type - $path - $options returns $expected', ({ path, options, expected }) => {
+  expect(getLegacyDocsLink(path, options)).toBe(expected)
+})
 
 test.each`
   type       | path            | options                       | expected

--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -247,6 +247,27 @@ export const downloadMachineJoinConfig = async (
 
 type DocsType = 'talos' | 'omni' | 'k8s'
 
+/**
+ * @deprecated Update links to use getDocsLink instead where possible.
+ */
+export function getLegacyDocsLink(path?: string, options?: { talosVersion?: string }) {
+  const parts = ['https://talos.dev']
+
+  const talosVersion = options?.talosVersion || DefaultTalosVersion
+
+  const parsed = coerce(talosVersion)
+  if (!parsed) throw new Error(`Failed to parse talos version "${talosVersion}"`)
+
+  const { major, minor } = parsed
+  parts.push(`v${major}.${minor}`)
+
+  if (path) {
+    parts.push(path.replace(/^\//, ''))
+  }
+
+  return parts.join('/')
+}
+
 export function getDocsLink(
   type: 'talos',
   path?: string,

--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.stories.ts
@@ -5,6 +5,8 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
 import InstallationMediaCreate from './InstallationMediaCreate.vue'
+import * as CloudProviderStories from './Steps/CloudProvider.stories'
+import * as SBCTypeStories from './Steps/SBCType.stories'
 import * as SystemExtensionsStories from './Steps/SystemExtensions.stories'
 import * as TalosVersionStories from './Steps/TalosVersion.stories'
 
@@ -25,8 +27,10 @@ export const Default: Story = {
   parameters: {
     msw: {
       handlers: [
-        ...TalosVersionStories.Default.parameters.msw.handlers,
+        ...CloudProviderStories.Default.parameters.msw.handlers,
+        ...SBCTypeStories.Default.parameters.msw.handlers,
         ...SystemExtensionsStories.Default.parameters.msw.handlers,
+        ...TalosVersionStories.Default.parameters.msw.handlers,
       ],
     },
   },

--- a/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.stories.ts
@@ -2,7 +2,14 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
+import { faker } from '@faker-js/faker'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+
+import type { Resource } from '@/api/grpc'
+import type { ListRequest } from '@/api/omni/resources/resources.pb'
+import type { PlatformConfigSpec } from '@/api/omni/specs/virtual.pb'
+import { CloudPlatformConfigType, VirtualNamespace } from '@/api/resources'
 
 import CloudProvider from './CloudProvider.vue'
 
@@ -16,4 +23,40 @@ const meta: Meta<typeof CloudProvider> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post<never, ListRequest>(
+          '/omni.resources.ResourceService/List',
+          async ({ request }) => {
+            const { type, namespace } = await request.clone().json()
+
+            if (type !== CloudPlatformConfigType || namespace !== VirtualNamespace) return
+
+            const items = faker.helpers.multiple<Resource<PlatformConfigSpec>>(
+              () => ({
+                metadata: {
+                  namespace: VirtualNamespace,
+                  type: CloudPlatformConfigType,
+                  id: faker.string.uuid(),
+                },
+                spec: {
+                  label: faker.commerce.productName(),
+                  description: faker.commerce.productDescription(),
+                  documentation: faker.helpers.maybe(() => faker.system.directoryPath()),
+                },
+              }),
+              { count: 20 },
+            )
+
+            return HttpResponse.json({
+              items: items.map((item) => JSON.stringify(item)),
+              total: items.length,
+            })
+          },
+        ),
+      ],
+    },
+  },
+} satisfies Story

--- a/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.vue
@@ -9,10 +9,11 @@ import { computed } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { PlatformConfigSpec } from '@/api/omni/specs/virtual.pb'
-import { CloudPlatformConfigType, DefaultTalosVersion, VirtualNamespace } from '@/api/resources'
+import { CloudPlatformConfigType, VirtualNamespace } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
+import { getLegacyDocsLink } from '@/methods'
 import { useResourceList } from '@/methods/useResourceList'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
@@ -31,7 +32,7 @@ const platforms = computed(() =>
     ...p,
     spec: {
       ...p.spec,
-      documentation: `https://www.talos.dev/v${DefaultTalosVersion}/${p.spec.documentation}`,
+      documentation: p.spec.documentation && getLegacyDocsLink(p.spec.documentation),
     },
   })),
 )
@@ -46,9 +47,15 @@ const platforms = computed(() =>
     >
       {{ platform.spec.label }}
 
-      <!-- prettier-ignore -->
       <template #description>
-        {{ platform.spec.description }} (<a class="link-primary" :href="platform.spec.documentation" @click.stop>documentation</a>).
+        <span :class="!platform.spec.documentation && 'after:content-[\'.\']'">
+          {{ platform.spec.description }}
+        </span>
+
+        <!-- prettier-ignore -->
+        <template v-if="platform.spec.documentation">
+          (<a class="link-primary" :href="platform.spec.documentation" @click.stop>documentation</a>).
+        </template>
       </template>
     </RadioGroupOption>
   </RadioGroup>

--- a/frontend/src/views/omni/InstallationMedia/Steps/SBCType.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SBCType.vue
@@ -9,10 +9,11 @@ import { computed } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { SBCConfigSpec } from '@/api/omni/specs/virtual.pb'
-import { DefaultTalosVersion, SBCConfigType, VirtualNamespace } from '@/api/resources'
+import { SBCConfigType, VirtualNamespace } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
+import { getLegacyDocsLink } from '@/methods'
 import { useResourceList } from '@/methods/useResourceList'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
@@ -31,9 +32,7 @@ const SBCs = computed(() =>
     ...sbc,
     spec: {
       ...sbc.spec,
-      documentation:
-        sbc.spec.documentation &&
-        `https://www.talos.dev/v${DefaultTalosVersion}/${sbc.spec.documentation}`,
+      documentation: sbc.spec.documentation && getLegacyDocsLink(sbc.spec.documentation),
     },
   })),
 )

--- a/frontend/src/views/omni/Modals/ConfigPatchEdit.vue
+++ b/frontend/src/views/omni/Modals/ConfigPatchEdit.vue
@@ -85,7 +85,7 @@ const saveAndClose = async () => {
 }
 
 const openDocs = () => {
-  window.open('https://www.talos.dev/latest/reference/configuration/', '_blank')
+  window.open('https://docs.siderolabs.com', '_blank')
 }
 </script>
 


### PR DESCRIPTION
Correct the docs links for SBC & Cloud provider steps on installation media. Also update some legacy docs links to the new format. Stories updated to reflec t the change for data being obtained from API.