### PR TITLE
fix: change stripe button to billing

### DIFF
--- a/frontend/src/components/SideBar/TSideBar.vue
+++ b/frontend/src/components/SideBar/TSideBar.vue
@@ -305,7 +305,7 @@ const rootItems = computed(() => {
 
     if (featuresConfig.value?.spec.stripe_settings?.enabled) {
       subItems.push({
-        name: 'Stripe',
+        name: 'Billing',
         route: 'https://billing.stripe.com/p/login/8wMcOC8z51GgdPi144',
         regularLink: true,
         icon: 'dashboard',


### PR DESCRIPTION
Change 'Stripe' button in settings menu to read 'Billing' to make it more fuctional, otheswise only users that know we use Stripe for billing will know what the button is for.