### PR TITLE
Update license link and badge in README

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -30,8 +30,8 @@ See [Contributing](CONTRIBUTING.md) for our guidelines.
 
 ## License
 
-<a href="https://github.com/siderolabs/omni/client/blob/main/LICENSE">
-  <img alt="GitHub" src="https://img.shields.io/github/license/siderolabs/omni/client?style=flat-square">
+<a href="https://github.com/siderolabs/omni/blob/main/client/LICENSE">
+  <img alt="MPL 2.0" src="https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg">
 </a>
 
 Some software we distribute is under the General Public License family


### PR DESCRIPTION
The link went to the wrong place and the image used the Shields.io Github API for a repository and this is for something that is part of the repository, not the overall repository which that API does not do.