### PR TITLE
fix(frontend): prevent an error when downloading support bundle

### DIFF
--- a/frontend/src/views/cluster/Nodes/NodeOverview.vue
+++ b/frontend/src/views/cluster/Nodes/NodeOverview.vue
@@ -56,8 +56,8 @@ import ItemLabels from '@/views/omni/ItemLabels/ItemLabels.vue'
 
 const services = ref<
   {
-    name: string
-    state: string
+    name?: string
+    state?: string
     status: TCommonStatuses
     events?: ServiceEvent[]
   }[]
@@ -85,20 +85,20 @@ const fetchServices = async () => {
 
   services.value = []
 
-  for (const message of res.messages!) {
-    for (const service of message.services!) {
+  res.messages?.forEach((message) =>
+    message.services?.forEach((service) =>
       services.value.push({
-        name: service.id!,
-        state: service.state!,
+        name: service.id,
+        state: service.state,
         status: service.health?.unknown
           ? TCommonStatuses.HEALTH_UNKNOWN
           : service.health?.healthy
             ? TCommonStatuses.HEALTHY
             : TCommonStatuses.UNHEALTHY,
         events: service.events?.events,
-      })
-    }
-  }
+      }),
+    ),
+  )
 }
 
 fetchServices()


### PR DESCRIPTION
Prevent a potential error when downloading a support bundle if MachineService.ServiceList does not return messages with services.

Context: https://talossystems.slack.com/archives/C05348STLHY/p1765276566032969?thread_ts=1765276423.005629&cid=C05348STLHY