### PR TITLE
feat: store discovery service state in SQLite

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -344,18 +344,33 @@ func defineServiceFlags() {
 		cmdConfig.Services.EmbeddedDiscoveryService.Port,
 		"embedded discovery service port to listen on",
 	)
+
+	//nolint:staticcheck
 	rootCmd.Flags().BoolVar(
 		&cmdConfig.Services.EmbeddedDiscoveryService.SnapshotsEnabled,
 		"embedded-discovery-service-snapshots-enabled",
 		cmdConfig.Services.EmbeddedDiscoveryService.SnapshotsEnabled,
 		"enable snapshots for the embedded discovery service",
 	)
+
+	//nolint:staticcheck
 	rootCmd.Flags().StringVar(
 		&cmdConfig.Services.EmbeddedDiscoveryService.SnapshotsPath,
 		"embedded-discovery-service-snapshot-path",
 		cmdConfig.Services.EmbeddedDiscoveryService.SnapshotsPath,
 		"path to the file for storing the embedded discovery service state",
 	)
+
+	rootCmd.Flags().MarkDeprecated("embedded-discovery-service-snapshots-enabled", "use --embedded-discovery-service-sqlite-snapshots-enabled") //nolint:errcheck
+	rootCmd.Flags().MarkDeprecated("embedded-discovery-service-snapshot-path", "use --embedded-discovery-service-sqlite-snapshots-enabled")     //nolint:errcheck
+
+	rootCmd.Flags().BoolVar(
+		&cmdConfig.Services.EmbeddedDiscoveryService.SQLiteSnapshotsEnabled,
+		"embedded-discovery-service-sqlite-snapshots-enabled",
+		cmdConfig.Services.EmbeddedDiscoveryService.SQLiteSnapshotsEnabled,
+		"store embedded discovery service snapshots in the configured SQLite database, this will be the default behavior in the future",
+	)
+
 	rootCmd.Flags().DurationVar(
 		&cmdConfig.Services.EmbeddedDiscoveryService.SnapshotsInterval,
 		"embedded-discovery-service-snapshot-interval",

--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -153,9 +153,9 @@ func Run(ctx context.Context, state *omni.State, secondaryStorageDB *sql.DB, con
 		siderolinkEventsCh,
 		installEventCh,
 		omniRuntime,
-		talosRuntime,
 		logHandler,
 		authConfig,
+		secondaryStorageDB,
 		logger,
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.4
 replace (
 	// forked saml library that has the fix for Fusion Auth ACS parsing
 	github.com/crewjam/saml => github.com/unix4ever/saml v0.0.0-20250630213700-66b137182abe
+
 	// use nested module
 	github.com/siderolabs/omni/client => ./client
 )
@@ -64,7 +65,7 @@ require (
 	github.com/siderolabs/crypto v0.6.4
 	github.com/siderolabs/discovery-api v0.1.6
 	github.com/siderolabs/discovery-client v0.1.13
-	github.com/siderolabs/discovery-service v1.0.11
+	github.com/siderolabs/discovery-service v1.0.13
 	github.com/siderolabs/gen v0.8.6
 	github.com/siderolabs/go-api-signature v0.3.12
 	github.com/siderolabs/go-circular v0.2.3
@@ -80,7 +81,7 @@ require (
 	github.com/siderolabs/image-factory v0.8.4
 	github.com/siderolabs/kms-client v0.1.0
 	github.com/siderolabs/omni/client v1.3.4
-	github.com/siderolabs/proto-codec v0.1.2
+	github.com/siderolabs/proto-codec v0.1.3
 	github.com/siderolabs/siderolink v0.3.15
 	github.com/siderolabs/talos/pkg/machinery v1.12.0-beta.1
 	github.com/siderolabs/tcpproxy v0.1.0 // indirect
@@ -221,7 +222,7 @@ require (
 	github.com/petermattis/goid v0.0.0-20251121121749-a11dd1a45f9a // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/planetscale/vtprotobuf v0.6.1-0.20241121165744-79df5c4772f2 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/planetscale/vtprotobuf v0.6.1-0.20241121165744-79df5c4772f2 h1:1sLMdKq4gNANTj0dUibycTLzpIEKVnLnbaEkxws78nw=
-github.com/planetscale/vtprotobuf v0.6.1-0.20241121165744-79df5c4772f2/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
+github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 h1:S1hI5JiKP7883xBzZAr1ydcxrKNSVNm7+3+JwjxZEsg=
+github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25/go.mod h1:ZQntvDG8TkPgljxtA0R9frDoND4QORU1VXz015N5Ks4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -430,8 +430,8 @@ github.com/siderolabs/discovery-api v0.1.6 h1:/LhsF1ytqFEfWwV0UKfUgn90k9fk5+rhYM
 github.com/siderolabs/discovery-api v0.1.6/go.mod h1:s5CnTyRMGid/vJNSJs8Jw9I4tnKHu/2SGqP2ytTaePQ=
 github.com/siderolabs/discovery-client v0.1.13 h1:s0iK2ixopCFFgQ5zZmzsQ8xf8Hd+SygrUdlhE+um6iQ=
 github.com/siderolabs/discovery-client v0.1.13/go.mod h1:kojlX4Kk0o9wsbJU1XOy4BH0W6RMg2I2d8WJ4ciK3qU=
-github.com/siderolabs/discovery-service v1.0.11 h1:+ymDXKhPL2f1c5MIO559wciA38PcQDMejHcadf2jmPY=
-github.com/siderolabs/discovery-service v1.0.11/go.mod h1:pUTOYgtYasO/T02zJNNfw0SCP8hDbIgFIvdm+Fn1UKo=
+github.com/siderolabs/discovery-service v1.0.13 h1:vSgO2OLvDiTAvKWp9L6z3stgv9IKr5EHGDI8TKh68eQ=
+github.com/siderolabs/discovery-service v1.0.13/go.mod h1:57g7vyTRiosUBXWdDo6mmldctxABD6G86yYVLXTwZ+c=
 github.com/siderolabs/gen v0.8.6 h1:pE6shuqov3L+5rEcAUJ/kY6iJofimljQw5G95P8a5c4=
 github.com/siderolabs/gen v0.8.6/go.mod h1:J9IbusbES2W6QWjtSHpDV9iPGZHc978h1+KJ4oQRspQ=
 github.com/siderolabs/go-api-signature v0.3.12 h1:i1X+kPh9fzo+lEjtEplZSbtq1p21vKv4FCWJcB/ozvk=
@@ -464,8 +464,8 @@ github.com/siderolabs/kms-client v0.1.0 h1:rCDWzcDDsNlp6zdyLngOuuhchVILn+vwUQy3t
 github.com/siderolabs/kms-client v0.1.0/go.mod h1:4UQkRhuEh3kaK7VhJxez4YyJLv6lPEff7g3Pa6Y9okg=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=
 github.com/siderolabs/net v0.4.0/go.mod h1:/ibG+Hm9HU27agp5r9Q3eZicEfjquzNzQNux5uEk0kM=
-github.com/siderolabs/proto-codec v0.1.2 h1:KYrRiCk5wdA2ilZZoW4bWtICCF4y3r28FhmunPa50HE=
-github.com/siderolabs/proto-codec v0.1.2/go.mod h1:TCsjpw732TWuOx4Vd4gYhivPOttEhdPvczLfMQ6Y9Dc=
+github.com/siderolabs/proto-codec v0.1.3 h1:tRzt2Rlc84Uv+Lx6vV2VmFpgHSV1fUNq/7nTXU892dM=
+github.com/siderolabs/proto-codec v0.1.3/go.mod h1:k6Sn8r+0473+xHL4t1rxD51lWm05rDqFpXecSUg3UE8=
 github.com/siderolabs/protoenc v0.2.4 h1:D3Fpn2nQSQOhl8ZlAxijZAf7K6F8CM1uZq0afIGsr8Q=
 github.com/siderolabs/protoenc v0.2.4/go.mod h1:i5XLHjfv5vyi7LhQrSEo19HCA+lYtDd7CWxsoWp9XE8=
 github.com/siderolabs/siderolink v0.3.15 h1:WSsgKQGJY/ObIKjTcYYGEaGfRMyox+r/Ft+9lIgJqOI=

--- a/internal/backend/discovery/sqlitestore.go
+++ b/internal/backend/discovery/sqlitestore.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package discovery
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+const (
+	tableName  = "discovery_service_state"
+	idColumn   = "id"
+	dataColumn = "data"
+
+	id = "state"
+
+	queryTimeout = 30 * time.Second
+)
+
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+func (s *SQLiteStore) Reader(ctx context.Context) (io.ReadCloser, error) {
+	return &reader{
+		db:  s.db,
+		ctx: ctx,
+	}, nil
+}
+
+func (s *SQLiteStore) Writer(ctx context.Context) (io.WriteCloser, error) {
+	return &writer{
+		db:  s.db,
+		ctx: ctx,
+	}, nil
+}
+
+func NewSQLiteStore(ctx context.Context, db *sql.DB) (*SQLiteStore, error) {
+	schema := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+      %s TEXT PRIMARY KEY,
+      %s BLOB
+    ) STRICT;`, tableName, idColumn, dataColumn)
+
+	if _, err := db.ExecContext(ctx, schema); err != nil {
+		return nil, fmt.Errorf("failed to create discovery service state table: %w", err)
+	}
+
+	return &SQLiteStore{db: db}, nil
+}
+
+type writer struct {
+	db *sql.DB
+
+	ctx context.Context //nolint:containedctx
+
+	buf bytes.Buffer
+
+	closed bool
+}
+
+func (w *writer) Write(p []byte) (n int, err error) {
+	if w.closed {
+		return 0, errors.New("write to closed writer")
+	}
+
+	return w.buf.Write(p)
+}
+
+func (w *writer) Close() error {
+	if w.closed {
+		return nil
+	}
+
+	query := fmt.Sprintf("INSERT INTO %s (%s, %s) VALUES (?, ?) ON CONFLICT(%s) DO UPDATE SET %s=excluded.%s", tableName, idColumn, dataColumn, idColumn, dataColumn, dataColumn)
+
+	ctx, cancel := context.WithTimeout(w.ctx, queryTimeout)
+	defer cancel()
+
+	if _, err := w.db.ExecContext(ctx, query, id, w.buf.Bytes()); err != nil {
+		return fmt.Errorf("failed to write snapshot to sqlite: %w", err)
+	}
+
+	w.closed = true
+
+	return nil
+}
+
+type reader struct {
+	db  *sql.DB
+	ctx context.Context //nolint:containedctx
+
+	reader *bytes.Reader
+
+	closed bool
+}
+
+func (r *reader) Read(p []byte) (n int, err error) {
+	if r.closed {
+		return 0, errors.New("read from closed reader")
+	}
+
+	if r.reader == nil {
+		query := fmt.Sprintf("SELECT %s FROM %s WHERE %s = ?", dataColumn, tableName, idColumn)
+
+		ctx, cancel := context.WithTimeout(r.ctx, queryTimeout)
+		defer cancel()
+
+		row := r.db.QueryRowContext(ctx, query, id)
+
+		var data []byte
+
+		if err = row.Scan(&data); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				r.reader = bytes.NewReader(nil)
+
+				return 0, io.EOF
+			}
+
+			return 0, fmt.Errorf("failed to read snapshot from sqlite: %w", err)
+		}
+
+		r.reader = bytes.NewReader(data)
+	}
+
+	return r.reader.Read(p)
+}
+
+func (r *reader) Close() error {
+	r.closed = true
+
+	return nil
+}

--- a/internal/backend/discovery/sqlitestore_test.go
+++ b/internal/backend/discovery/sqlitestore_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package discovery_test
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/siderolabs/omni/internal/backend/discovery"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestReadWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t)
+
+	expectedData := []byte(`SOME_DATA`)
+
+	wd, err := store.Writer(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, wd.Close()) })
+
+	n, err := wd.Write(expectedData)
+	require.NoError(t, err)
+	assert.Equal(t, len(expectedData), n)
+
+	// Explicit close is required to flush the buffer to the DB
+	require.NoError(t, wd.Close())
+
+	rdr, err := store.Reader(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, rdr.Close())
+	})
+
+	data, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Equal(t, expectedData, data)
+}
+
+func TestOverwrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t)
+
+	data1 := []byte("v1-data")
+	data2 := []byte("v2-data-updated")
+
+	// 1. Write Initial Data
+	wd1, err := store.Writer(ctx)
+	require.NoError(t, err)
+	_, err = wd1.Write(data1)
+	require.NoError(t, err)
+	require.NoError(t, wd1.Close())
+
+	// 2. Overwrite Data (UPSERT logic)
+	wd2, err := store.Writer(ctx)
+	require.NoError(t, err)
+	_, err = wd2.Write(data2)
+	require.NoError(t, err)
+	require.NoError(t, wd2.Close())
+
+	// 3. Verify Last Write Wins
+	rdr, err := store.Reader(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rdr.Close()) })
+
+	readData, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Equal(t, data2, readData)
+}
+
+func TestChunkedWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, db := setupStore(ctx, t)
+
+	part1 := []byte("Hello, ")
+	part2 := []byte("World!")
+
+	wd, err := store.Writer(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, wd.Close()) })
+
+	// 1. Write Part 1
+	_, err = wd.Write(part1)
+	require.NoError(t, err)
+
+	// 2. Verify nothing is in DB yet (Writer buffers until Close)
+	// We query directly to verify the buffering behavior
+	var count int
+
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM discovery_service_state").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "Database should be empty before Writer.Close() is called")
+
+	// 3. Write Part 2
+	_, err = wd.Write(part2)
+	require.NoError(t, err)
+
+	// 4. Close/Flush
+	require.NoError(t, wd.Close())
+
+	// 5. Verify Full Data
+	rdr, err := store.Reader(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rdr.Close()) })
+
+	fullData, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!", string(fullData))
+}
+
+func TestEmptyReader(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t)
+
+	// 1. Create Reader without writing anything
+	rdr, err := store.Reader(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rdr.Close()) })
+
+	// 2. Should return EOF immediately (simulating empty file)
+	// The implementation handles sql.ErrNoRows by returning EOF
+	data, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Empty(t, data)
+}
+
+func TestReaderCaching(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, db := setupStore(ctx, t)
+	payload := []byte("cached-data-payload")
+
+	// 1. Write Data
+	wd, err := store.Writer(ctx)
+	require.NoError(t, err)
+	_, err = wd.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, wd.Close())
+
+	// 2. Open Reader
+	rdr, err := store.Reader(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rdr.Close()) })
+
+	// 3. Partial Read (triggers DB query and loads full blob into memory)
+	// We read just the first 6 bytes ("cached")
+	buf := make([]byte, 6)
+	n, err := rdr.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 6, n)
+	assert.Equal(t, "cached", string(buf))
+
+	// 4. Manually corrupt DB
+	_, err = db.ExecContext(ctx, "DELETE FROM discovery_service_state")
+	require.NoError(t, err)
+
+	// 5. Finish Reading
+	remaining, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Equal(t, "-data-payload", string(remaining))
+}
+
+func TestWriteAfterClose(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	store, _ := setupStore(ctx, t)
+
+	wd, err := store.Writer(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, wd.Close())
+
+	_, err = wd.Write([]byte("oops"))
+	assert.Error(t, err, "writing to a closed writer should error")
+}
+
+func setupStore(ctx context.Context, t *testing.T) (*discovery.SQLiteStore, *sql.DB) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	store, err := discovery.NewSQLiteStore(ctx, db)
+	require.NoError(t, err)
+
+	return store, db
+}

--- a/internal/backend/discovery/store.go
+++ b/internal/backend/discovery/store.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package discovery
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/siderolabs/discovery-service/pkg/storage"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+// InitSQLiteSnapshotStore initializes a SQLite snapshot store if enabled in the config.
+//
+//nolint:nilnil
+func InitSQLiteSnapshotStore(ctx context.Context, config *config.EmbeddedDiscoveryService, db *sql.DB, logger *zap.Logger) (storage.SnapshotStore, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	if !config.SQLiteSnapshotsEnabled { // file store is used, return a nil store to preserve the existing behavior
+		return nil, nil
+	}
+
+	store, err := NewSQLiteStore(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize sqlite snapshot store: %w", err)
+	}
+
+	if config.SnapshotsPath != "" { //nolint:staticcheck
+		if err = migrate(ctx, config.SnapshotsPath, store, logger); err != nil { //nolint:staticcheck
+			logger.Error("failed to migrate discovery service state to sqlite store", zap.Error(err))
+		}
+	}
+
+	return store, nil
+}
+
+func migrate(ctx context.Context, path string, sqliteStore *SQLiteStore, logger *zap.Logger) error {
+	rdr, err := sqliteStore.Reader(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get reader for sqlite store: %w", err)
+	}
+
+	defer rdr.Close() //nolint:errcheck
+
+	checkBuf := make([]byte, 1)
+
+	n, err := rdr.Read(checkBuf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("failed to read existing discovery service state from sqlite store: %w", err)
+	}
+
+	if n > 0 {
+		logger.Info("skip discovery service state migration: data already exists in SQLite store")
+
+		return nil
+	}
+
+	fileData, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Debug("skip discovery service state migration: no such file or directory")
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to read discovery service state from file: %w", err)
+	}
+
+	wd, err := sqliteStore.Writer(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get writer for sqlite store: %w", err)
+	}
+
+	defer wd.Close() //nolint:errcheck
+
+	if _, err = wd.Write(fileData); err != nil {
+		return fmt.Errorf("failed to write discovery service state to sqlite store: %w", err)
+	}
+
+	if err = wd.Close(); err != nil {
+		return fmt.Errorf("failed to close (flush) sqlite store writer: %w", err)
+	}
+
+	logger.Info("discovery service state migrated to sqlite store successfully")
+
+	if err = os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to remove old discovery service state file: %w", err)
+	}
+
+	logger.Info("old discovery service state file removed successfully")
+
+	return nil
+}

--- a/internal/backend/discovery/store_test.go
+++ b/internal/backend/discovery/store_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+package discovery_test
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	// Ensure SQLite driver is loaded.
+	_ "modernc.org/sqlite"
+
+	"github.com/siderolabs/omni/internal/backend/discovery"
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+func TestInitSQLiteSnapshotStore_MigrateSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	// 1. Setup Legacy File State
+	// Create a temporary directory for the snapshot file
+	tmpDir := t.TempDir()
+	snapshotPath := filepath.Join(tmpDir, "snapshot.bin")
+	expectedData := []byte("legacy-snapshot-data")
+
+	require.NoError(t, os.WriteFile(snapshotPath, expectedData, 0o644))
+
+	// 2. Trigger Init with Migration Enabled
+	conf := &config.EmbeddedDiscoveryService{
+		SQLiteSnapshotsEnabled: true,
+		SnapshotsPath:          snapshotPath, //nolint:staticcheck
+	}
+
+	store, err := discovery.InitSQLiteSnapshotStore(ctx, conf, db, logger)
+	require.NoError(t, err)
+
+	// 3. Verify Data moved to SQLite
+	rdr, err := store.Reader(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, rdr.Close())
+	})
+
+	data, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Equal(t, expectedData, data, "sqlite store should contain data from legacy file")
+
+	// 4. Verify File is Removed
+	_, err = os.Stat(snapshotPath)
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err), "legacy file should be removed after successful migration")
+}
+
+func TestInitSQLiteSnapshotStore_SkipIfDataExists(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	// 1. Setup Pre-existing SQLite Data
+	// We manually initialize a store to write data before testing Init
+	preStore, err := discovery.NewSQLiteStore(ctx, db)
+	require.NoError(t, err)
+
+	dbData := []byte("existing-db-data")
+	wd, err := preStore.Writer(ctx)
+	require.NoError(t, err)
+	_, err = wd.Write(dbData)
+	require.NoError(t, err)
+	require.NoError(t, wd.Close())
+
+	// 2. Setup Legacy File (Simulate a stale file)
+	tmpDir := t.TempDir()
+	snapshotPath := filepath.Join(tmpDir, "snapshot.bin")
+	fileData := []byte("stale-file-data")
+
+	require.NoError(t, os.WriteFile(snapshotPath, fileData, 0o644))
+
+	// 3. Trigger Init
+	conf := &config.EmbeddedDiscoveryService{
+		SQLiteSnapshotsEnabled: true,
+		SnapshotsPath:          snapshotPath, //nolint:staticcheck
+	}
+
+	store, err := discovery.InitSQLiteSnapshotStore(ctx, conf, db, logger)
+	require.NoError(t, err)
+
+	// 4. Verify SQLite Data Preserved (Migration Skipped)
+	rdr, err := store.Reader(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rdr.Close()) })
+
+	actualData, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Equal(t, dbData, actualData, "should preserve existing sqlite data")
+	assert.NotEqual(t, fileData, actualData, "should not overwrite with file data")
+
+	// 5. Verify File Still Exists
+	_, err = os.Stat(snapshotPath)
+	require.NoError(t, err, "legacy file should NOT be removed if migration was skipped")
+}
+
+func TestInitSQLiteSnapshotStore_NoFile(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	// 1. Setup Path to non-existent file
+	tmpDir := t.TempDir()
+	snapshotPath := filepath.Join(tmpDir, "does-not-exist.bin")
+
+	// 2. Trigger Init
+	conf := &config.EmbeddedDiscoveryService{
+		SQLiteSnapshotsEnabled: true,
+		SnapshotsPath:          snapshotPath,
+	}
+
+	store, err := discovery.InitSQLiteSnapshotStore(ctx, conf, db, logger)
+	require.NoError(t, err)
+
+	// 3. Verify SQLite is empty (no error)
+	rdr, err := store.Reader(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rdr.Close()) })
+
+	data, err := io.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Empty(t, data)
+}
+
+func TestInitSQLiteSnapshotStore_Disabled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	tests := []struct {
+		conf *config.EmbeddedDiscoveryService
+		name string
+	}{
+		{
+			name: "Nil Config",
+			conf: nil,
+		},
+		{
+			name: "Disabled Flag",
+			conf: &config.EmbeddedDiscoveryService{
+				SQLiteSnapshotsEnabled: false,
+				SnapshotsPath:          "/some/path", //nolint:staticcheck
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := discovery.InitSQLiteSnapshotStore(ctx, tt.conf, db, logger)
+			require.NoError(t, err)
+			assert.Nil(t, store, "store should be nil when disabled or config is nil")
+		})
+	}
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -116,12 +116,13 @@ func Default() *Params {
 				Port:    8081,
 			},
 			EmbeddedDiscoveryService: &EmbeddedDiscoveryService{
-				Enabled:           true,
-				Port:              8093,
-				SnapshotsEnabled:  true,
-				SnapshotsPath:     "_out/secondary-storage/discovery-service-state.binpb",
-				SnapshotsInterval: 10 * time.Minute,
-				LogLevel:          zapcore.WarnLevel.String(),
+				Enabled:                true,
+				Port:                   8093,
+				SnapshotsEnabled:       true,
+				SnapshotsPath:          "_out/secondary-storage/discovery-service-state.binpb", // todo: Keeping this enabled to get it migrated to SQLite.
+				SQLiteSnapshotsEnabled: true,
+				SnapshotsInterval:      10 * time.Minute,
+				LogLevel:               zapcore.WarnLevel.String(),
 			},
 			WorkloadProxy: &WorkloadProxy{
 				Subdomain:    "proxy-us",

--- a/internal/pkg/config/services.go
+++ b/internal/pkg/config/services.go
@@ -203,8 +203,14 @@ type EmbeddedDiscoveryService struct {
 	Port    int  `yaml:"port"`
 
 	// SnapshotsEnabled turns on the discovery service persistence.
+	//
+	// Deprecated: use SQLiteSnapshotsEnabled instead.
 	SnapshotsEnabled bool `yaml:"snapshotsEnabled"`
+
+	SQLiteSnapshotsEnabled bool `yaml:"sqliteSnapshotsEnabled"`
 	// SnapshotsPath is the path on disk where to store the discovery service state.
+	//
+	// Deprecated: use SQLiteSnapshotsEnabled instead.
 	SnapshotsPath     string        `yaml:"snapshotsPath"`
 	SnapshotsInterval time.Duration `yaml:"snapshotsInterval"`
 	LogLevel          string        `yaml:"logLevel"`


### PR DESCRIPTION
Use SQLite storage to store the discovery service state. Use the same SQLite database used for the metrics state.

Closes #1970.