### PR TITLE
fix: do not filter out rc releases to from pre-release talos versions

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/versions.go
+++ b/internal/backend/runtime/omni/controllers/omni/versions.go
@@ -120,6 +120,7 @@ func (ctrl *VersionsController) reconcileAllVersions(ctx context.Context, r cont
 var allowedPreVersionStrings = map[string]struct{}{
 	"alpha": {},
 	"beta":  {},
+	"rc":    {},
 }
 
 func (ctrl *VersionsController) fetchVersionsFromRegistry(ctx context.Context, source string) ([]string, error) {


### PR DESCRIPTION
Do not filter out `rc` releases from Talos versions list when `enable-talos-pre-release-versions` flag is set to true when running Omni.

