### PR TITLE
fix: stop referencing deprecated field on frontend storybook

### DIFF
--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -852,7 +852,6 @@ export type MachineStatusMetricsSpec = {
   connected_machines_count?: number
   allocated_machines_count?: number
   pending_machines_count?: number
-  versions_map?: {[key: string]: number}
   platforms?: {[key: string]: number}
   secure_boot_status?: {[key: string]: number}
   uki_status?: {[key: string]: number}

--- a/frontend/src/components/SideBar/TSideBar.stories.ts
+++ b/frontend/src/components/SideBar/TSideBar.stories.ts
@@ -89,7 +89,6 @@ export const Default: Story = {
                 registered_machines_count: 3,
                 connected_machines_count: 3,
                 allocated_machines_count: 3,
-                versions_map: { 'v1.11.3': 3 },
                 platforms: {
                   akamai: 0,
                   aws: 0,


### PR DESCRIPTION
`versions_map` field from `MachineStatusMetricsSpec` is deprecated. Stop referencing it on frontend storybook.

