### PR TITLE
refactor: do SQLite migrations unconditionally, rework the config flags

### DIFF
--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -8,7 +8,6 @@ package app
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -54,7 +53,7 @@ func PrepareConfig(logger *zap.Logger, params ...*config.Params) (*config.Params
 }
 
 // Run the Omni service.
-func Run(ctx context.Context, state *omni.State, secondaryStorageDB *sql.DB, config *config.Params, logger *zap.Logger) error {
+func Run(ctx context.Context, state *omni.State, config *config.Params, logger *zap.Logger) error {
 	talosClientFactory := talos.NewClientFactory(state.Default(), logger)
 	talosRuntime := talos.New(talosClientFactory, logger)
 
@@ -123,7 +122,7 @@ func Run(ctx context.Context, state *omni.State, secondaryStorageDB *sql.DB, con
 	machineMap := siderolink.NewMachineMap(siderolink.NewStateStorage(state.Default()))
 
 	logHandler, err := siderolink.NewLogHandler(
-		secondaryStorageDB,
+		state.SecondaryStorageDB(),
 		machineMap,
 		state.Default(),
 		&config.Logs.Machine,
@@ -155,7 +154,6 @@ func Run(ctx context.Context, state *omni.State, secondaryStorageDB *sql.DB, con
 		omniRuntime,
 		logHandler,
 		authConfig,
-		secondaryStorageDB,
 		logger,
 	)
 	if err != nil {

--- a/hack/compose/docker-compose.yml
+++ b/hack/compose/docker-compose.yml
@@ -55,6 +55,8 @@ services:
       - VAULT_ADDR=http://127.0.0.1:8200
       - VAULT_TOKEN=dev-o-token
       - SIDEROLINK_DEV_JOIN_TOKEN=w7uVuW3zbVKIYQuzEcyetAHeYMeo5q2L9RvkAVfCfSCD
+    command: >-
+      --sqlite-storage-path=/_out/secondary-storage/sqlite.db
 
   vault-dev:
     container_name: local-vault

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -8,13 +8,40 @@ match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 pre_release = true
 previous = "v1.3.0"
 
-[notes]
-
-[notes.sqlite-storage-migration]
-title = "Migration to SQLite Storage"
+[notes.aaa-urgent-sqlite-migration]
+title = "Urgent Upgrade Notes **(No, really, you MUST read this before you upgrade)**"
 description = """\
-Discovery service state, audit logs, machine logs, and secondary resources have been migrated to use SQLite
-storage.
+This release consolidates **Discovery service state**, **Audit logs**, **Machine logs**, and **Secondary resources** into a single SQLite storage backend.
+
+**1. New Required Flag**
+You **must** set the new `--sqlite-storage-path` (or `.storage.sqlite.path`) flag. There is no default value, and Omni will not start without it.
+
+**2. Audit Logging Changes**
+A new flag `--audit-log-enabled` (or `.logs.audit.enabled`) has been introduced to explicitly enable or disable audit logging.
+* **Default:** `true`.
+* **Change:** Previously, audit logging was implicitly enabled only when the path was set. Now, it is enabled by default.
+
+**3. Automatic Migration**
+Omni will automatically migrate your existing data (BoltDB, file-based logs) to the new SQLite database on the first startup. To ensure this happens correctly, simply add the new SQLite flag and **leave your existing storage flags in place** for the first run.
+
+Once the migration is complete, you are free to remove the deprecated flags listed below. If they remain, they will be ignored and eventually dropped in future versions.
+
+**4. Deprecated Flags (Kept for Migration)**
+The following flags (and config keys) are deprecated and kept solely to facilitate the automatic migration:
+* `--audit-log-dir` (`.logs.audit.path`)
+* `--secondary-storage-path` (`.storage.secondary.path`)
+* `--machine-log-storage-path` (`.logs.machine.storage.path`)
+* `--machine-log-storage-enabled` (`.logs.machine.storage.enabled`)
+* `--embedded-discovery-service-snapshot-path` (`.services.embeddedDiscoveryService.snapshotsPath`)
+* `--machine-log-buffer-capacity` (`.logs.machine.bufferInitialCapacity`)
+* `--machine-log-buffer-max-capacity` (`.logs.machine.bufferMaxCapacity`)
+* `--machine-log-buffer-safe-gap` (`.logs.machine.bufferSafetyGap`)
+* `--machine-log-num-compressed-chunks` (`.logs.machine.storage.numCompressedChunks`)
+
+**5. Removed Flags**
+The following flags have been removed and are no longer supported:
+* `--machine-log-storage-flush-period` (`.logs.machine.storage.flushPeriod`)
+* `--machine-log-storage-flush-jitter` (`.logs.machine.storage.flushJitter`)
 """
 
 [notes.infra-provider-cleanup]

--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -219,6 +219,8 @@ export OMNI_CONFIG="${TEST_OUTPUTS_DIR}/config.yaml"
 mkdir -p omnictl
 cp -p ${ARTIFACTS}/omnictl-* omnictl/
 
+sqlite_path="${TEST_OUTPUTS_DIR}/sqlite.db"
+
 echo "---
 services:
   api:
@@ -261,7 +263,7 @@ storage:
   secondary:
     path: ${ARTIFACTS}/secondary-storage/bolt.db
   sqlite:
-    path: ${ARTIFACTS}/secondary-storage/sqlite.db
+    path: ${sqlite_path}
   default:
     kind: etcd
     etcd:
@@ -613,6 +615,9 @@ SIDEROLINK_DEV_JOIN_TOKEN=${JOIN_TOKEN} \
 if [ "${INTEGRATION_RUN_E2E_TEST:-true}" == "true" ]; then
   # write partial omni config
   echo "---
+  storage:
+    sqlite:
+      path: ${sqlite_path}
   services:
     api:
       endpoint: 0.0.0.0:8099

--- a/internal/backend/discovery/sqlitestore_test.go
+++ b/internal/backend/discovery/sqlitestore_test.go
@@ -18,6 +18,8 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/siderolabs/omni/internal/backend/discovery"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
+	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 func TestMain(m *testing.M) {
@@ -214,16 +216,17 @@ func TestWriteAfterClose(t *testing.T) {
 func setupStore(ctx context.Context, t *testing.T) (*discovery.SQLiteStore, *sql.DB) {
 	t.Helper()
 
-	path := filepath.Join(t.TempDir(), "test.db")
+	conf := config.Default()
+	conf.Storage.SQLite.Path = filepath.Join(t.TempDir(), "test.db")
 
-	db, err := sql.Open("sqlite", path)
+	db, err := sqlite.OpenDB(conf.Storage.SQLite)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		require.NoError(t, db.Close())
 	})
 
-	store, err := discovery.NewSQLiteStore(ctx, db)
+	store, err := discovery.NewSQLiteStore(ctx, db, 0)
 	require.NoError(t, err)
 
 	return store, db

--- a/internal/backend/discovery/store.go
+++ b/internal/backend/discovery/store.go
@@ -20,18 +20,8 @@ import (
 )
 
 // InitSQLiteSnapshotStore initializes a SQLite snapshot store if enabled in the config.
-//
-//nolint:nilnil
 func InitSQLiteSnapshotStore(ctx context.Context, config *config.EmbeddedDiscoveryService, db *sql.DB, logger *zap.Logger) (storage.SnapshotStore, error) {
-	if config == nil {
-		return nil, nil
-	}
-
-	if !config.SQLiteSnapshotsEnabled { // file store is used, return a nil store to preserve the existing behavior
-		return nil, nil
-	}
-
-	store, err := NewSQLiteStore(ctx, db)
+	store, err := NewSQLiteStore(ctx, db, config.SQLiteTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize sqlite snapshot store: %w", err)
 	}

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
-	_ "modernc.org/sqlite"
 
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 )
@@ -72,6 +71,10 @@ type Store struct {
 }
 
 func NewStore(ctx context.Context, db *sql.DB, timeout time.Duration) (*Store, error) {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
 	templateParams := schemaParams{
 		TableName:           tableName,
 		IDColumn:            idColumn,

--- a/internal/backend/runtime/omni/audit/logger_test.go
+++ b/internal/backend/runtime/omni/audit/logger_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -74,11 +75,9 @@ func TestMigrateFromFileToSQLite(t *testing.T) {
 	// 3. Trigger Migration via NewLog
 	// We provide both Path and SQLite enabled, which triggers initLogger -> migrateFromFileToSQLite
 	logConf := config.LogsAudit{
-		Path: dir,
-		SQLite: config.LogsAuditSQLite{
-			Enabled: true,
-			Timeout: 5 * time.Second,
-		},
+		Enabled:       pointer.To(true),
+		Path:          dir,
+		SQLiteTimeout: 5 * time.Second,
 	}
 
 	auditLogger, err := audit.NewLog(ctx, logConf, db, logger)
@@ -140,11 +139,9 @@ func TestMigrateSkipIfHasData(t *testing.T) {
 
 	// 3. Trigger NewLog
 	logConf := config.LogsAudit{
-		Path: dir,
-		SQLite: config.LogsAuditSQLite{
-			Enabled: true,
-			Timeout: 5 * time.Second,
-		},
+		Enabled:       pointer.To(true),
+		Path:          dir,
+		SQLiteTimeout: 5 * time.Second,
 	}
 
 	auditLogger, err := audit.NewLog(ctx, logConf, db, logger)
@@ -202,11 +199,9 @@ THIS_IS_BROKEN_JSON
 
 	// 4. Trigger Migration
 	logConf := config.LogsAudit{
-		Path: dir,
-		SQLite: config.LogsAuditSQLite{
-			Enabled: true,
-			Timeout: 5 * time.Second,
-		},
+		Enabled:       pointer.To(true),
+		Path:          dir,
+		SQLiteTimeout: 5 * time.Second,
 	}
 
 	auditLogger, err := audit.NewLog(ctx, logConf, db, logger)

--- a/internal/backend/runtime/omni/sqlite/sqlite.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 
+	_ "modernc.org/sqlite"
+
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 

--- a/internal/backend/runtime/omni/state_sqlite.go
+++ b/internal/backend/runtime/omni/state_sqlite.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cosi-project/state-sqlite/pkg/state/impl/sqlite"
 	"go.etcd.io/bbolt"
 	"go.uber.org/zap"
-	_ "modernc.org/sqlite"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/go-pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -62,12 +63,24 @@ func TestMergeConfig(t *testing.T) {
 						PrivateKeySource: "vault",
 					},
 				},
+				SQLite: config.SQLite{
+					Path: "/some/path", // set it, as it is required
+				},
+			},
+			Logs: config.Logs{
+				Audit: config.LogsAudit{
+					SQLiteTimeout: 5 * time.Second,
+				},
 			},
 		},
 	)
 
 	require.NoError(t, err)
-	require.True(t, cfg.Services.EmbeddedDiscoveryService.Enabled)
+	assert.True(t, cfg.Services.EmbeddedDiscoveryService.Enabled)
+	assert.Equal(t, 5*time.Second, cfg.Logs.Audit.SQLiteTimeout)
+
+	// assert that the default value of cfg.Logs.Audit.Enabled boolean value is preserved even when the config.LogsAudit struct was partially set as an override
+	assert.True(t, pointer.SafeDeref(cfg.Logs.Audit.Enabled))
 }
 
 func TestValidateStateConfig(t *testing.T) {

--- a/internal/pkg/config/logs.go
+++ b/internal/pkg/config/logs.go
@@ -24,27 +24,19 @@ type Logs struct {
 // LogsMachine configures Talos machine logs handler.
 type LogsMachine struct {
 	// Storage configures the machine logs storage if SQLite storage is not enabled.
-	//
-	// Deprecated: use SQLite storage instead.
 	Storage LogsMachineStorage `yaml:"storage"`
-	SQLite  LogsMachineSQLite  `yaml:"sqlite"`
+
 	// BufferInitialCapacity is the initial capacity of the in-memory buffer for logs.
 	//
-	// It is used only if SQLite storage is not enabled.
-	//
-	// Deprecated: use SQLite storage instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	BufferInitialCapacity int `yaml:"bufferInitialCapacity"`
 	// BufferMaxCapacity is the maximum capacity of the in-memory buffer for logs.
 	//
-	// It is used only if SQLite storage is not enabled.
-	//
-	// Deprecated: use SQLite storage instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	BufferMaxCapacity int `yaml:"bufferMaxCapacity"`
 	// BufferSafetyGap is the safety gap to use when trimming the buffer.
 	//
-	// It is used only if SQLite storage is not enabled.
-	//
-	// Deprecated: use SQLite storage instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	BufferSafetyGap int `yaml:"bufferSafetyGap"`
 }
 
@@ -54,50 +46,46 @@ type LogsMachine struct {
 type LogsMachineStorage struct {
 	// Enabled indicates whether the storage is enabled.
 	//
-	// Deprecated: use SQLite storage instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	Enabled bool `yaml:"enabled"`
+
 	// Path to store the logs in.
 	//
-	// Deprecated: use SQLite storage instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	Path string `yaml:"path"`
+
 	// FlushPeriod is the period to use to flush the logs to disk.
 	//
-	// Deprecated: use SQLite storage instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	FlushPeriod time.Duration `yaml:"flushPeriod"`
+
 	// FlushJitter flush period jitter.
 	//
-	// Deprecated: use SQLite storage instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	FlushJitter float64 `yaml:"flushJitter"`
+
 	// NumCompressedChunks is the count of log chunks to keep in the logs history.
 	//
-	// Deprecated: use SQLite storage instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	NumCompressedChunks int `yaml:"numCompressedChunks"`
-}
 
-type LogsMachineSQLite struct {
-	Enabled          bool          `yaml:"enabled"`
-	Timeout          time.Duration `yaml:"timeout"`
+	SQLiteTimeout    time.Duration `yaml:"sqliteTimeout"`
 	CleanupInterval  time.Duration `yaml:"cleanupInterval"`
 	CleanupOlderThan time.Duration `yaml:"cleanupOlderThan"`
 }
 
 // LogsAudit configures audit logs persistence.
 type LogsAudit struct {
+	// Enabled indicates whether audit logging is enabled.
+	Enabled *bool `yaml:"enabled"`
+
 	// Path to store the audit logs in.
+	//
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	Path string `yaml:"path"`
 
-	SQLite LogsAuditSQLite `yaml:"sqlite"`
-}
-
-// LogsAuditSQLite configures audit logs persistence in SQLite.
-type LogsAuditSQLite struct {
-	// Enabled indicates whether the SQLite storage is enabled.
-	//
-	// If it is enabled, the Path field in the LogsAudit config is ignored, and the logs are stored in the secondary storage SQLite database.
-	Enabled bool `yaml:"enabled"`
-
-	// Timeout is the timeout for SQLite operations.
-	Timeout time.Duration `yaml:"timeout"`
+	// SQLiteTimeout is the timeout for SQLite operations.
+	SQLiteTimeout time.Duration `yaml:"sqliteTimeout"`
 }
 
 // ResourceLoggerConfig is the config for the Omni resource logger.

--- a/internal/pkg/config/services.go
+++ b/internal/pkg/config/services.go
@@ -203,17 +203,16 @@ type EmbeddedDiscoveryService struct {
 	Port    int  `yaml:"port"`
 
 	// SnapshotsEnabled turns on the discovery service persistence.
-	//
-	// Deprecated: use SQLiteSnapshotsEnabled instead.
 	SnapshotsEnabled bool `yaml:"snapshotsEnabled"`
 
-	SQLiteSnapshotsEnabled bool `yaml:"sqliteSnapshotsEnabled"`
 	// SnapshotsPath is the path on disk where to store the discovery service state.
 	//
-	// Deprecated: use SQLiteSnapshotsEnabled instead.
+	// Deprecated: this field is kept for the SQLite migration, and will be removed in future versions.
 	SnapshotsPath     string        `yaml:"snapshotsPath"`
 	SnapshotsInterval time.Duration `yaml:"snapshotsInterval"`
 	LogLevel          string        `yaml:"logLevel"`
+
+	SQLiteTimeout time.Duration `yaml:"sqliteTimeout"`
 }
 
 // LoadBalancerService configures Omni Kubernetes loadbalancer.

--- a/internal/pkg/config/storage.go
+++ b/internal/pkg/config/storage.go
@@ -45,7 +45,7 @@ type BoltDB struct {
 
 // SQLite defines sqlite storage configs.
 type SQLite struct {
-	Path                   string `yaml:"path"`
+	Path                   string `yaml:"path" validate:"required"`
 	ExperimentalBaseParams string `yaml:"experimentalBaseParams"`
 	ExtraParams            string `yaml:"extraParams"`
 }

--- a/internal/pkg/features/features.go
+++ b/internal/pkg/features/features.go
@@ -32,7 +32,7 @@ func UpdateResources(ctx context.Context, st state.State, logger *zap.Logger) er
 			MaxInterval:  durationpb.New(config.Config.EtcdBackup.MaxInterval),
 		}
 
-		res.TypedSpec().Value.AuditLogEnabled = config.Config.Logs.Audit.Path != ""
+		res.TypedSpec().Value.AuditLogEnabled = config.Config.Logs.Audit.Path != "" //nolint:staticcheck
 		res.TypedSpec().Value.ImageFactoryBaseUrl = config.Config.Registries.ImageFactoryBaseURL
 		res.TypedSpec().Value.UserPilotSettings = &specs.UserPilotSettings{
 			AppToken: config.Config.Account.UserPilot.AppToken,

--- a/internal/pkg/siderolink/logstore/circularlog/manager.go
+++ b/internal/pkg/siderolink/logstore/circularlog/manager.go
@@ -40,10 +40,6 @@ func (m *StoreManager) Run(ctx context.Context) error {
 
 // Exists implements the LogStoreManager interface.
 func (m *StoreManager) Exists(_ context.Context, id string) (bool, error) {
-	if !m.config.Storage.Enabled {
-		return false, nil
-	}
-
 	matches, err := m.logFiles(id)
 	if err != nil {
 		return false, fmt.Errorf("failed to list log files for machine %q: %w", id, err)

--- a/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
@@ -516,7 +516,7 @@ func setupDB(ctx context.Context, t *testing.T, logger *zap.Logger) *sqlitelog.S
 		require.NoError(t, db.Close())
 	})
 
-	storeManager, err := sqlitelog.NewStoreManager(ctx, db, config.Default().Logs.Machine.SQLite, logger)
+	storeManager, err := sqlitelog.NewStoreManager(ctx, db, config.Default().Logs.Machine.Storage, logger)
 	require.NoError(t, err)
 
 	return storeManager


### PR DESCRIPTION
Remove the flags for turning on SQLite storage for:
- Discovery service state
- Audit logs
- Machine logs

Instead, migrate them unconditionally to SQLite on the next startup.

Remove many flags which are no longer meaningful. Only keep the ones which are required for the migrations.

Additionally: Make the `--sqlite-storage-path` (or its config counterpart `.storage.sqlite.path`) required with no default value, as a default value does not make sense for it in most of the cases.