### PR TITLE
feat: add min-commit flag for omni

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -5167,6 +5167,7 @@ func (x *UserPilotSettings) GetAppToken() string {
 type StripeSettings struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Enabled       bool                   `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	MinCommit     uint32                 `protobuf:"varint,2,opt,name=min_commit,json=minCommit,proto3" json:"min_commit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5206,6 +5207,13 @@ func (x *StripeSettings) GetEnabled() bool {
 		return x.Enabled
 	}
 	return false
+}
+
+func (x *StripeSettings) GetMinCommit() uint32 {
+	if x != nil {
+		return x.MinCommit
+	}
+	return 0
 }
 
 type EtcdBackupSettings struct {
@@ -9897,9 +9905,11 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x0fstripe_settings\x18\a \x01(\v2\x15.specs.StripeSettingsR\x0estripeSettings\x12J\n" +
 	"\"talos_pre_release_versions_enabled\x18\b \x01(\bR\x1etalosPreReleaseVersionsEnabled\"0\n" +
 	"\x11UserPilotSettings\x12\x1b\n" +
-	"\tapp_token\x18\x01 \x01(\tR\bappToken\"*\n" +
+	"\tapp_token\x18\x01 \x01(\tR\bappToken\"I\n" +
 	"\x0eStripeSettings\x12\x18\n" +
-	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xd6\x01\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1d\n" +
+	"\n" +
+	"min_commit\x18\x02 \x01(\rR\tminCommit\"\xd6\x01\n" +
 	"\x12EtcdBackupSettings\x12>\n" +
 	"\rtick_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\ftickInterval\x12<\n" +
 	"\fmin_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\vminInterval\x12<\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1061,6 +1061,7 @@ message UserPilotSettings {
 
 message StripeSettings {
   bool enabled = 1;
+  uint32 min_commit =2;
 }
 
 message EtcdBackupSettings {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -1781,6 +1781,7 @@ func (m *StripeSettings) CloneVT() *StripeSettings {
 	}
 	r := new(StripeSettings)
 	r.Enabled = m.Enabled
+	r.MinCommit = m.MinCommit
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -5237,6 +5238,9 @@ func (this *StripeSettings) EqualVT(that *StripeSettings) bool {
 		return false
 	}
 	if this.Enabled != that.Enabled {
+		return false
+	}
+	if this.MinCommit != that.MinCommit {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -11489,6 +11493,11 @@ func (m *StripeSettings) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.MinCommit != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MinCommit))
+		i--
+		dAtA[i] = 0x10
+	}
 	if m.Enabled {
 		i--
 		if m.Enabled {
@@ -15945,6 +15954,9 @@ func (m *StripeSettings) SizeVT() (n int) {
 	_ = l
 	if m.Enabled {
 		n += 2
+	}
+	if m.MinCommit != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.MinCommit))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -29299,6 +29311,25 @@ func (m *StripeSettings) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Enabled = bool(v != 0)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MinCommit", wireType)
+			}
+			m.MinCommit = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MinCommit |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -513,6 +513,8 @@ func defineLogsFlags() {
 
 	rootCmd.Flags().BoolVar(&cmdConfig.Logs.Stripe.Enabled, "enable-stripe-reporting", cmdConfig.Logs.Stripe.Enabled, "enable Stripe machine usage reporting")
 
+	rootCmd.Flags().Uint32Var(&cmdConfig.Logs.Stripe.MinCommit, "stripe-minimum-commit", cmdConfig.Logs.Stripe.MinCommit, "Minimum number of machines to report to Stripe for the given account")
+
 	// Deprecated logs flags, kept for backwards-compatibility
 	//
 	//nolint:staticcheck,errcheck

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -277,7 +277,7 @@ func NewRuntime(talosClientFactory *talos.ClientFactory, dnsService *dns.Service
 		}
 
 		controllers = append(controllers,
-			omnictrl.NewStripeMetricsReporterController(stripeAPIKey, subscriptionItemID),
+			omnictrl.NewStripeMetricsReporterController(stripeAPIKey, subscriptionItemID, config.Config.Logs.Stripe.MinCommit),
 		)
 	}
 

--- a/internal/pkg/config/logs.go
+++ b/internal/pkg/config/logs.go
@@ -99,5 +99,6 @@ type ResourceLoggerConfig struct {
 
 // LogsStripe report usage metrics to stripe.
 type LogsStripe struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled   bool   `yaml:"enabled"`
+	MinCommit uint32 `yaml:"minCommit"`
 }

--- a/internal/pkg/features/features.go
+++ b/internal/pkg/features/features.go
@@ -38,7 +38,8 @@ func UpdateResources(ctx context.Context, st state.State, logger *zap.Logger) er
 			AppToken: config.Config.Account.UserPilot.AppToken,
 		}
 		res.TypedSpec().Value.StripeSettings = &specs.StripeSettings{
-			Enabled: config.Config.Logs.Stripe.Enabled,
+			Enabled:   config.Config.Logs.Stripe.Enabled,
+			MinCommit: config.Config.Logs.Stripe.MinCommit,
 		}
 		res.TypedSpec().Value.TalosPreReleaseVersionsEnabled = config.Config.Features.EnableTalosPreReleaseVersions
 


### PR DESCRIPTION
This PR would add a new flag for minimum committed machines. This data would come from stripe and if the user's Omni environment has less that the committed machines, we'd just report the minimum specified.