### PR TITLE
chore: add new fields to the `CreateSchematic` Omni API

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -1029,6 +1029,7 @@ type CreateSchematicRequest struct {
 	SecureBoot               bool                                            `protobuf:"varint,6,opt,name=secure_boot,json=secureBoot,proto3" json:"secure_boot,omitempty"`
 	SiderolinkGrpcTunnelMode CreateSchematicRequest_SiderolinkGRPCTunnelMode `protobuf:"varint,7,opt,name=siderolink_grpc_tunnel_mode,json=siderolinkGrpcTunnelMode,proto3,enum=management.CreateSchematicRequest_SiderolinkGRPCTunnelMode" json:"siderolink_grpc_tunnel_mode,omitempty"`
 	JoinToken                string                                          `protobuf:"bytes,8,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
+	Overlay                  *CreateSchematicRequest_Overlay                 `protobuf:"bytes,9,opt,name=overlay,proto3" json:"overlay,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -1117,6 +1118,13 @@ func (x *CreateSchematicRequest) GetJoinToken() string {
 		return x.JoinToken
 	}
 	return ""
+}
+
+func (x *CreateSchematicRequest) GetOverlay() *CreateSchematicRequest_Overlay {
+	if x != nil {
+		return x.Overlay
+	}
+	return nil
 }
 
 type CreateSchematicResponse struct {
@@ -1928,6 +1936,66 @@ func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) GetExpiration(
 	return nil
 }
 
+type CreateSchematicRequest_Overlay struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Image         string                 `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Options       string                 `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateSchematicRequest_Overlay) Reset() {
+	*x = CreateSchematicRequest_Overlay{}
+	mi := &file_omni_management_management_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSchematicRequest_Overlay) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSchematicRequest_Overlay) ProtoMessage() {}
+
+func (x *CreateSchematicRequest_Overlay) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSchematicRequest_Overlay.ProtoReflect.Descriptor instead.
+func (*CreateSchematicRequest_Overlay) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{17, 0}
+}
+
+func (x *CreateSchematicRequest_Overlay) GetImage() string {
+	if x != nil {
+		return x.Image
+	}
+	return ""
+}
+
+func (x *CreateSchematicRequest_Overlay) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CreateSchematicRequest_Overlay) GetOptions() string {
+	if x != nil {
+		return x.Options
+	}
+	return ""
+}
+
 type GetSupportBundleResponse_Progress struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Source        string                 `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
@@ -1941,7 +2009,7 @@ type GetSupportBundleResponse_Progress struct {
 
 func (x *GetSupportBundleResponse_Progress) Reset() {
 	*x = GetSupportBundleResponse_Progress{}
-	mi := &file_omni_management_management_proto_msgTypes[35]
+	mi := &file_omni_management_management_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1953,7 +2021,7 @@ func (x *GetSupportBundleResponse_Progress) String() string {
 func (*GetSupportBundleResponse_Progress) ProtoMessage() {}
 
 func (x *GetSupportBundleResponse_Progress) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[35]
+	mi := &file_omni_management_management_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2016,7 +2084,7 @@ type ValidateJsonSchemaResponse_Error struct {
 
 func (x *ValidateJsonSchemaResponse_Error) Reset() {
 	*x = ValidateJsonSchemaResponse_Error{}
-	mi := &file_omni_management_management_proto_msgTypes[36]
+	mi := &file_omni_management_management_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2028,7 +2096,7 @@ func (x *ValidateJsonSchemaResponse_Error) String() string {
 func (*ValidateJsonSchemaResponse_Error) ProtoMessage() {}
 
 func (x *ValidateJsonSchemaResponse_Error) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[36]
+	mi := &file_omni_management_management_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2152,7 +2220,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\fResponseType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\f\n" +
 	"\bMANIFEST\x10\x01\x12\v\n" +
-	"\aROLLOUT\x10\x02\"\xb5\x04\n" +
+	"\aROLLOUT\x10\x02\"\xca\x05\n" +
 	"\x16CreateSchematicRequest\x12\x1e\n" +
 	"\n" +
 	"extensions\x18\x01 \x03(\tR\n" +
@@ -2166,7 +2234,12 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"secureBoot\x12z\n" +
 	"\x1bsiderolink_grpc_tunnel_mode\x18\a \x01(\x0e2;.management.CreateSchematicRequest.SiderolinkGRPCTunnelModeR\x18siderolinkGrpcTunnelMode\x12\x1d\n" +
 	"\n" +
-	"join_token\x18\b \x01(\tR\tjoinToken\x1a=\n" +
+	"join_token\x18\b \x01(\tR\tjoinToken\x12D\n" +
+	"\aoverlay\x18\t \x01(\v2*.management.CreateSchematicRequest.OverlayR\aoverlay\x1aM\n" +
+	"\aOverlay\x12\x14\n" +
+	"\x05image\x18\x01 \x01(\tR\x05image\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
+	"\aoptions\x18\x03 \x01(\tR\aoptions\x1a=\n" +
 	"\x0fMetaValuesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\rR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"?\n" +
@@ -2263,7 +2336,7 @@ func file_omni_management_management_proto_rawDescGZIP() []byte {
 }
 
 var file_omni_management_management_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_omni_management_management_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_omni_management_management_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_omni_management_management_proto_goTypes = []any{
 	(KubernetesSyncManifestResponse_ResponseType)(0),                // 0: management.KubernetesSyncManifestResponse.ResponseType
 	(CreateSchematicRequest_SiderolinkGRPCTunnelMode)(0),            // 1: management.CreateSchematicRequest.SiderolinkGRPCTunnelMode
@@ -2301,67 +2374,69 @@ var file_omni_management_management_proto_goTypes = []any{
 	(*CreateJoinTokenResponse)(nil),                                 // 33: management.CreateJoinTokenResponse
 	(*ListServiceAccountsResponse_ServiceAccount)(nil),              // 34: management.ListServiceAccountsResponse.ServiceAccount
 	(*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey)(nil), // 35: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	nil, // 36: management.CreateSchematicRequest.MetaValuesEntry
-	(*GetSupportBundleResponse_Progress)(nil), // 37: management.GetSupportBundleResponse.Progress
-	(*ValidateJsonSchemaResponse_Error)(nil),  // 38: management.ValidateJsonSchemaResponse.Error
-	(*durationpb.Duration)(nil),               // 39: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),             // 40: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                     // 41: google.protobuf.Empty
-	(*common.Data)(nil),                       // 42: common.Data
+	(*CreateSchematicRequest_Overlay)(nil),                          // 36: management.CreateSchematicRequest.Overlay
+	nil,                                                             // 37: management.CreateSchematicRequest.MetaValuesEntry
+	(*GetSupportBundleResponse_Progress)(nil),                       // 38: management.GetSupportBundleResponse.Progress
+	(*ValidateJsonSchemaResponse_Error)(nil),                        // 39: management.ValidateJsonSchemaResponse.Error
+	(*durationpb.Duration)(nil),                                     // 40: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                                   // 41: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                                           // 42: google.protobuf.Empty
+	(*common.Data)(nil),                                             // 43: common.Data
 }
 var file_omni_management_management_proto_depIdxs = []int32{
 	34, // 0: management.ListServiceAccountsResponse.service_accounts:type_name -> management.ListServiceAccountsResponse.ServiceAccount
-	39, // 1: management.KubeconfigRequest.service_account_ttl:type_name -> google.protobuf.Duration
+	40, // 1: management.KubeconfigRequest.service_account_ttl:type_name -> google.protobuf.Duration
 	0,  // 2: management.KubernetesSyncManifestResponse.response_type:type_name -> management.KubernetesSyncManifestResponse.ResponseType
-	36, // 3: management.CreateSchematicRequest.meta_values:type_name -> management.CreateSchematicRequest.MetaValuesEntry
+	37, // 3: management.CreateSchematicRequest.meta_values:type_name -> management.CreateSchematicRequest.MetaValuesEntry
 	1,  // 4: management.CreateSchematicRequest.siderolink_grpc_tunnel_mode:type_name -> management.CreateSchematicRequest.SiderolinkGRPCTunnelMode
-	37, // 5: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
-	38, // 6: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	40, // 7: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
-	35, // 8: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	40, // 9: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
-	38, // 10: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	14, // 11: management.ManagementService.Kubeconfig:input_type -> management.KubeconfigRequest
-	7,  // 12: management.ManagementService.Talosconfig:input_type -> management.TalosconfigRequest
-	41, // 13: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
-	5,  // 14: management.ManagementService.MachineLogs:input_type -> management.MachineLogsRequest
-	6,  // 15: management.ManagementService.ValidateConfig:input_type -> management.ValidateConfigRequest
-	25, // 16: management.ManagementService.ValidateJSONSchema:input_type -> management.ValidateJsonSchemaRequest
-	8,  // 17: management.ManagementService.CreateServiceAccount:input_type -> management.CreateServiceAccountRequest
-	10, // 18: management.ManagementService.RenewServiceAccount:input_type -> management.RenewServiceAccountRequest
-	41, // 19: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
-	12, // 20: management.ManagementService.DestroyServiceAccount:input_type -> management.DestroyServiceAccountRequest
-	15, // 21: management.ManagementService.KubernetesUpgradePreChecks:input_type -> management.KubernetesUpgradePreChecksRequest
-	17, // 22: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
-	19, // 23: management.ManagementService.CreateSchematic:input_type -> management.CreateSchematicRequest
-	21, // 24: management.ManagementService.GetSupportBundle:input_type -> management.GetSupportBundleRequest
-	23, // 25: management.ManagementService.ReadAuditLog:input_type -> management.ReadAuditLogRequest
-	27, // 26: management.ManagementService.MaintenanceUpgrade:input_type -> management.MaintenanceUpgradeRequest
-	29, // 27: management.ManagementService.GetMachineJoinConfig:input_type -> management.GetMachineJoinConfigRequest
-	32, // 28: management.ManagementService.CreateJoinToken:input_type -> management.CreateJoinTokenRequest
-	2,  // 29: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
-	3,  // 30: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
-	4,  // 31: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
-	42, // 32: management.ManagementService.MachineLogs:output_type -> common.Data
-	41, // 33: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
-	26, // 34: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
-	9,  // 35: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
-	11, // 36: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
-	13, // 37: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
-	41, // 38: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
-	16, // 39: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
-	18, // 40: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
-	20, // 41: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
-	22, // 42: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
-	24, // 43: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
-	28, // 44: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
-	30, // 45: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
-	33, // 46: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
-	29, // [29:47] is the sub-list for method output_type
-	11, // [11:29] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	36, // 5: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
+	38, // 6: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
+	39, // 7: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	41, // 8: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
+	35, // 9: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
+	41, // 10: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
+	39, // 11: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	14, // 12: management.ManagementService.Kubeconfig:input_type -> management.KubeconfigRequest
+	7,  // 13: management.ManagementService.Talosconfig:input_type -> management.TalosconfigRequest
+	42, // 14: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
+	5,  // 15: management.ManagementService.MachineLogs:input_type -> management.MachineLogsRequest
+	6,  // 16: management.ManagementService.ValidateConfig:input_type -> management.ValidateConfigRequest
+	25, // 17: management.ManagementService.ValidateJSONSchema:input_type -> management.ValidateJsonSchemaRequest
+	8,  // 18: management.ManagementService.CreateServiceAccount:input_type -> management.CreateServiceAccountRequest
+	10, // 19: management.ManagementService.RenewServiceAccount:input_type -> management.RenewServiceAccountRequest
+	42, // 20: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
+	12, // 21: management.ManagementService.DestroyServiceAccount:input_type -> management.DestroyServiceAccountRequest
+	15, // 22: management.ManagementService.KubernetesUpgradePreChecks:input_type -> management.KubernetesUpgradePreChecksRequest
+	17, // 23: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
+	19, // 24: management.ManagementService.CreateSchematic:input_type -> management.CreateSchematicRequest
+	21, // 25: management.ManagementService.GetSupportBundle:input_type -> management.GetSupportBundleRequest
+	23, // 26: management.ManagementService.ReadAuditLog:input_type -> management.ReadAuditLogRequest
+	27, // 27: management.ManagementService.MaintenanceUpgrade:input_type -> management.MaintenanceUpgradeRequest
+	29, // 28: management.ManagementService.GetMachineJoinConfig:input_type -> management.GetMachineJoinConfigRequest
+	32, // 29: management.ManagementService.CreateJoinToken:input_type -> management.CreateJoinTokenRequest
+	2,  // 30: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
+	3,  // 31: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
+	4,  // 32: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
+	43, // 33: management.ManagementService.MachineLogs:output_type -> common.Data
+	42, // 34: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
+	26, // 35: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
+	9,  // 36: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
+	11, // 37: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
+	13, // 38: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
+	42, // 39: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
+	16, // 40: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
+	18, // 41: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
+	20, // 42: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
+	22, // 43: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
+	24, // 44: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
+	28, // 45: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
+	30, // 46: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
+	33, // 47: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
+	30, // [30:48] is the sub-list for method output_type
+	12, // [12:30] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_omni_management_management_proto_init() }
@@ -2375,7 +2450,7 @@ func file_omni_management_management_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_omni_management_management_proto_rawDesc), len(file_omni_management_management_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   37,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -125,6 +125,12 @@ message KubernetesSyncManifestResponse {
 }
 
 message CreateSchematicRequest {
+  message Overlay {
+    string image = 1;
+    string name = 2;
+    string options = 3;
+  }
+
   enum SiderolinkGRPCTunnelMode {
     AUTO = 0;
     DISABLED = 1;
@@ -139,6 +145,7 @@ message CreateSchematicRequest {
   bool secure_boot = 6;
   SiderolinkGRPCTunnelMode siderolink_grpc_tunnel_mode = 7;
   string join_token = 8;
+  Overlay overlay = 9;
 }
 
 message CreateSchematicResponse {

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -400,6 +400,25 @@ func (m *KubernetesSyncManifestResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *CreateSchematicRequest_Overlay) CloneVT() *CreateSchematicRequest_Overlay {
+	if m == nil {
+		return (*CreateSchematicRequest_Overlay)(nil)
+	}
+	r := new(CreateSchematicRequest_Overlay)
+	r.Image = m.Image
+	r.Name = m.Name
+	r.Options = m.Options
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateSchematicRequest_Overlay) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *CreateSchematicRequest) CloneVT() *CreateSchematicRequest {
 	if m == nil {
 		return (*CreateSchematicRequest)(nil)
@@ -410,6 +429,7 @@ func (m *CreateSchematicRequest) CloneVT() *CreateSchematicRequest {
 	r.SecureBoot = m.SecureBoot
 	r.SiderolinkGrpcTunnelMode = m.SiderolinkGrpcTunnelMode
 	r.JoinToken = m.JoinToken
+	r.Overlay = m.Overlay.CloneVT()
 	if rhs := m.Extensions; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -1208,6 +1228,31 @@ func (this *KubernetesSyncManifestResponse) EqualMessageVT(thatMsg proto.Message
 	}
 	return this.EqualVT(that)
 }
+func (this *CreateSchematicRequest_Overlay) EqualVT(that *CreateSchematicRequest_Overlay) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Image != that.Image {
+		return false
+	}
+	if this.Name != that.Name {
+		return false
+	}
+	if this.Options != that.Options {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateSchematicRequest_Overlay) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateSchematicRequest_Overlay)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *CreateSchematicRequest) EqualVT(that *CreateSchematicRequest) bool {
 	if this == that {
 		return true
@@ -1257,6 +1302,9 @@ func (this *CreateSchematicRequest) EqualVT(that *CreateSchematicRequest) bool {
 		return false
 	}
 	if this.JoinToken != that.JoinToken {
+		return false
+	}
+	if !this.Overlay.EqualVT(that.Overlay) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2603,6 +2651,60 @@ func (m *KubernetesSyncManifestResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 
+func (m *CreateSchematicRequest_Overlay) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateSchematicRequest_Overlay) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateSchematicRequest_Overlay) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Options) > 0 {
+		i -= len(m.Options)
+		copy(dAtA[i:], m.Options)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Options)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Image) > 0 {
+		i -= len(m.Image)
+		copy(dAtA[i:], m.Image)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Image)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *CreateSchematicRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2632,6 +2734,16 @@ func (m *CreateSchematicRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Overlay != nil {
+		size, err := m.Overlay.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x4a
 	}
 	if len(m.JoinToken) > 0 {
 		i -= len(m.JoinToken)
@@ -3824,6 +3936,28 @@ func (m *KubernetesSyncManifestResponse) SizeVT() (n int) {
 	return n
 }
 
+func (m *CreateSchematicRequest_Overlay) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Image)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Options)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *CreateSchematicRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -3866,6 +4000,10 @@ func (m *CreateSchematicRequest) SizeVT() (n int) {
 	}
 	l = len(m.JoinToken)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Overlay != nil {
+		l = m.Overlay.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -6297,6 +6435,153 @@ func (m *KubernetesSyncManifestResponse) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *CreateSchematicRequest_Overlay) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateSchematicRequest_Overlay: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateSchematicRequest_Overlay: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Image", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Image = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Options", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Options = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *CreateSchematicRequest) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6637,6 +6922,42 @@ func (m *CreateSchematicRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.JoinToken = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Overlay", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Overlay == nil {
+				m.Overlay = &CreateSchematicRequest_Overlay{}
+			}
+			if err := m.Overlay.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -5030,8 +5030,10 @@ type FeaturesConfigSpec struct {
 	StripeSettings *StripeSettings `protobuf:"bytes,7,opt,name=stripe_settings,json=stripeSettings,proto3" json:"stripe_settings,omitempty"`
 	// TalosPreReleaseVersionsEnabled is true when --enable-talos-pre-release-versions is set.
 	TalosPreReleaseVersionsEnabled bool `protobuf:"varint,8,opt,name=talos_pre_release_versions_enabled,json=talosPreReleaseVersionsEnabled,proto3" json:"talos_pre_release_versions_enabled,omitempty"`
-	unknownFields                  protoimpl.UnknownFields
-	sizeCache                      protoimpl.SizeCache
+	// ImageFactoryPxeBaseUrl is the base URL of the image factory PXE server.
+	ImageFactoryPxeBaseUrl string `protobuf:"bytes,9,opt,name=image_factory_pxe_base_url,json=imageFactoryPxeBaseUrl,proto3" json:"image_factory_pxe_base_url,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *FeaturesConfigSpec) Reset() {
@@ -5118,6 +5120,13 @@ func (x *FeaturesConfigSpec) GetTalosPreReleaseVersionsEnabled() bool {
 		return x.TalosPreReleaseVersionsEnabled
 	}
 	return false
+}
+
+func (x *FeaturesConfigSpec) GetImageFactoryPxeBaseUrl() string {
+	if x != nil {
+		return x.ImageFactoryPxeBaseUrl
+	}
+	return ""
 }
 
 type UserPilotSettings struct {
@@ -9894,7 +9903,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x05error\x18\x05 \x01(\tR\x05error\x12,\n" +
 	"\x12has_explicit_alias\x18\x06 \x01(\bR\x10hasExplicitAlias\"R\n" +
 	"\x1eClusterWorkloadProxyStatusSpec\x120\n" +
-	"\x14num_exposed_services\x18\x01 \x01(\rR\x12numExposedServices\"\x90\x04\n" +
+	"\x14num_exposed_services\x18\x01 \x01(\rR\x12numExposedServices\"\xcc\x04\n" +
 	"\x12FeaturesConfigSpec\x128\n" +
 	"\x18enable_workload_proxying\x18\x01 \x01(\bR\x16enableWorkloadProxying\x12K\n" +
 	"\x14etcd_backup_settings\x18\x02 \x01(\v2\x19.specs.EtcdBackupSettingsR\x12etcdBackupSettings\x12<\n" +
@@ -9903,7 +9912,8 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x16image_factory_base_url\x18\x05 \x01(\tR\x13imageFactoryBaseUrl\x12H\n" +
 	"\x13user_pilot_settings\x18\x06 \x01(\v2\x18.specs.UserPilotSettingsR\x11userPilotSettings\x12>\n" +
 	"\x0fstripe_settings\x18\a \x01(\v2\x15.specs.StripeSettingsR\x0estripeSettings\x12J\n" +
-	"\"talos_pre_release_versions_enabled\x18\b \x01(\bR\x1etalosPreReleaseVersionsEnabled\"0\n" +
+	"\"talos_pre_release_versions_enabled\x18\b \x01(\bR\x1etalosPreReleaseVersionsEnabled\x12:\n" +
+	"\x1aimage_factory_pxe_base_url\x18\t \x01(\tR\x16imageFactoryPxeBaseUrl\"0\n" +
 	"\x11UserPilotSettings\x12\x1b\n" +
 	"\tapp_token\x18\x01 \x01(\tR\bappToken\"I\n" +
 	"\x0eStripeSettings\x12\x18\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1053,6 +1053,9 @@ message FeaturesConfigSpec {
 
   // TalosPreReleaseVersionsEnabled is true when --enable-talos-pre-release-versions is set.
   bool talos_pre_release_versions_enabled = 8;
+
+  // ImageFactoryPxeBaseUrl is the base URL of the image factory PXE server.
+  string image_factory_pxe_base_url = 9;
 }
 
 message UserPilotSettings {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -1747,6 +1747,7 @@ func (m *FeaturesConfigSpec) CloneVT() *FeaturesConfigSpec {
 	r.UserPilotSettings = m.UserPilotSettings.CloneVT()
 	r.StripeSettings = m.StripeSettings.CloneVT()
 	r.TalosPreReleaseVersionsEnabled = m.TalosPreReleaseVersionsEnabled
+	r.ImageFactoryPxeBaseUrl = m.ImageFactoryPxeBaseUrl
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -5200,6 +5201,9 @@ func (this *FeaturesConfigSpec) EqualVT(that *FeaturesConfigSpec) bool {
 		return false
 	}
 	if this.TalosPreReleaseVersionsEnabled != that.TalosPreReleaseVersionsEnabled {
+		return false
+	}
+	if this.ImageFactoryPxeBaseUrl != that.ImageFactoryPxeBaseUrl {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -11343,6 +11347,13 @@ func (m *FeaturesConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ImageFactoryPxeBaseUrl) > 0 {
+		i -= len(m.ImageFactoryPxeBaseUrl)
+		copy(dAtA[i:], m.ImageFactoryPxeBaseUrl)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ImageFactoryPxeBaseUrl)))
+		i--
+		dAtA[i] = 0x4a
+	}
 	if m.TalosPreReleaseVersionsEnabled {
 		i--
 		if m.TalosPreReleaseVersionsEnabled {
@@ -15927,6 +15938,10 @@ func (m *FeaturesConfigSpec) SizeVT() (n int) {
 	}
 	if m.TalosPreReleaseVersionsEnabled {
 		n += 2
+	}
+	l = len(m.ImageFactoryPxeBaseUrl)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -29157,6 +29172,38 @@ func (m *FeaturesConfigSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.TalosPreReleaseVersionsEnabled = bool(v != 0)
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ImageFactoryPxeBaseUrl", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ImageFactoryPxeBaseUrl = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -119,6 +119,12 @@ export type KubernetesSyncManifestResponse = {
   skipped?: boolean
 }
 
+export type CreateSchematicRequestOverlay = {
+  image?: string
+  name?: string
+  options?: string
+}
+
 export type CreateSchematicRequest = {
   extensions?: string[]
   extra_kernel_args?: string[]
@@ -128,6 +134,7 @@ export type CreateSchematicRequest = {
   secure_boot?: boolean
   siderolink_grpc_tunnel_mode?: CreateSchematicRequestSiderolinkGRPCTunnelMode
   join_token?: string
+  overlay?: CreateSchematicRequestOverlay
 }
 
 export type CreateSchematicResponse = {

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -691,6 +691,7 @@ export type FeaturesConfigSpec = {
   user_pilot_settings?: UserPilotSettings
   stripe_settings?: StripeSettings
   talos_pre_release_versions_enabled?: boolean
+  image_factory_pxe_base_url?: string
 }
 
 export type UserPilotSettings = {

--- a/frontend/src/components/common/Labels/Labels.vue
+++ b/frontend/src/components/common/Labels/Labels.vue
@@ -53,7 +53,7 @@ const addLabel = async () => {
   modelValue.value = {
     ...modelValue.value,
     [key.trim()]: {
-      value: value.trim() ?? '',
+      value: value?.trim() ?? '',
       canRemove: true,
     },
   }

--- a/internal/pkg/features/features.go
+++ b/internal/pkg/features/features.go
@@ -34,6 +34,13 @@ func UpdateResources(ctx context.Context, st state.State, logger *zap.Logger) er
 
 		res.TypedSpec().Value.AuditLogEnabled = config.Config.Logs.Audit.Path != "" //nolint:staticcheck
 		res.TypedSpec().Value.ImageFactoryBaseUrl = config.Config.Registries.ImageFactoryBaseURL
+
+		imageFactoryPXEBaseURL, err := config.Config.GetImageFactoryPXEBaseURL()
+		if err != nil {
+			return err
+		}
+
+		res.TypedSpec().Value.ImageFactoryPxeBaseUrl = imageFactoryPXEBaseURL.String()
 		res.TypedSpec().Value.UserPilotSettings = &specs.UserPilotSettings{
 			AppToken: config.Config.Account.UserPilot.AppToken,
 		}


### PR DESCRIPTION
Now it's possible to pass the `overlay` ID directly to the request. `MediaId` is also still supported, but is there only for the backward compatibility.
`InstallationMedia` resources will be used only in the `omnictl download`.

Updated the Wizard UI to no longer use `InstallationMedia` resources. Dropped `pxe_url` from the `CreateSchematic` response, as all required arguments are now on the client side (if not using `InstallationMedia` resources).

Closes #2014 