### PR TITLE
feat(installation-media): add download progress and omni specific filenames to images

### DIFF
--- a/frontend/src/methods/useDownloadImage.ts
+++ b/frontend/src/methods/useDownloadImage.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { onUnmounted, ref } from 'vue'
+
+import { useFeatures } from '@/methods/features'
+
+export function useDownloadImage() {
+  const { data: features } = useFeatures()
+
+  const abortController = ref<AbortController>()
+  const isGenerating = ref(false)
+
+  async function abort() {
+    abortController.value?.abort()
+  }
+
+  async function download(imageUrl: string) {
+    try {
+      abort()
+
+      abortController.value = new AbortController()
+      isGenerating.value = true
+
+      const headUrl = new URL(imageUrl, features.value?.spec.image_factory_base_url)
+
+      const headResponse = await fetch(headUrl, {
+        method: 'HEAD',
+        signal: abortController.value.signal,
+        headers: new Headers({
+          'Cache-Control': 'no-store',
+        }),
+      })
+
+      if (!headResponse.ok) {
+        throw new Error(`request failed: ${headResponse.status} ${headResponse.statusText}`)
+      }
+
+      // URL format is hostname/image/:schematicID/:talosVersion/:image
+      const [, , , talosVersion, imageName] = headUrl.pathname.split('/')
+
+      if (!talosVersion || !imageName) {
+        throw new Error(
+          `invalid image path "${headUrl.pathname}". Got Talos version "${talosVersion}" and image name "${imageName}".`,
+        )
+      }
+
+      const accountName = features.value?.spec.account?.name ?? 'default'
+
+      const downloadUrl = new URL(headUrl)
+      downloadUrl.searchParams.set('filename', `omni-${accountName}-${talosVersion}-${imageName}`)
+
+      downloadFile(downloadUrl)
+    } catch (e) {
+      // Ignore abort errors
+      if (abortController.value?.signal.aborted) return
+
+      throw e
+    } finally {
+      isGenerating.value = false
+    }
+  }
+
+  onUnmounted(() => {
+    abort()
+  })
+
+  return {
+    isGenerating,
+    abort,
+    download,
+  }
+}
+
+async function downloadFile(url: URL | string) {
+  const a = document.createElement('a')
+  a.href = url.toString()
+  a.target = '_blank'
+
+  document.body.appendChild(a)
+
+  a.click()
+  a.remove()
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -62,7 +62,7 @@ export default defineConfig(({ command }) => {
       `script-src 'self' 'nonce-${cspNonce}' https://*.userpilot.io`,
       "media-src 'self' https://js.userpilot.io",
       'img-src * data:',
-      "connect-src 'self' https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io",
+      "connect-src 'self' https://factory.staging.talos.dev https://factory.talos.dev https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io",
       "font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.userpilot.io",
       "style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com",
       'frame-src https://*.auth0.com',

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/jxskiss/base62"
+
+	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 const index = "/index.html"
@@ -133,7 +135,7 @@ func (handler *StaticHandler) serveFile(w http.ResponseWriter, r *http.Request, 
 					fmt.Sprintf(";script-src 'self' 'nonce-%s' https://*.userpilot.io", nonce)+
 					";media-src 'self' https://js.userpilot.io"+
 					";img-src * data:"+
-					";connect-src 'self' https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io"+
+					fmt.Sprintf(";connect-src 'self' %s https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io", config.Config.Registries.GetImageFactoryBaseURL())+
 					";font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.userpilot.io"+
 					// We are forced to use unsafe-inline for style-src due to monaco-editor https://github.com/microsoft/monaco-editor/issues/271
 					";style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com"+


### PR DESCRIPTION
When downloading images in the installation media wizard, we will send the request directly to factory instead of proxying through omni. This will require image-factory enabling CORS. The custom filename will be constructed on the frontend.

Closes #2013

> [!IMPORTANT]
> Requires:
> - siderolabs/image-factory/pull/342

<img width="1633" height="853" alt="image" src="https://github.com/user-attachments/assets/dbe6938a-5f66-45c3-8fb0-5ebdf9301aa6" />



