### PR TITLE
feat: support kernel args management in cluster templates

### DIFF
--- a/client/pkg/omnictl/cluster/template/export.go
+++ b/client/pkg/omnictl/cluster/template/export.go
@@ -19,9 +19,10 @@ import (
 )
 
 var exportCmdFlags struct {
-	cluster string
-	output  string
-	force   bool
+	cluster           string
+	output            string
+	includeKernelArgs bool
+	force             bool
 }
 
 // exportCmd represents the template export command.
@@ -54,7 +55,7 @@ func export(ctx context.Context, client *client.Client) (err error) {
 		defer func() { err = errors.Join(err, output.Close()) }()
 	}
 
-	_, err = operations.ExportTemplate(ctx, client.Omni().State(), exportCmdFlags.cluster, output)
+	_, err = operations.ExportTemplate(ctx, client.Omni().State(), exportCmdFlags.cluster, exportCmdFlags.includeKernelArgs, output)
 
 	return err
 }
@@ -62,6 +63,8 @@ func export(ctx context.Context, client *client.Client) (err error) {
 func init() {
 	exportCmd.Flags().StringVarP(&exportCmdFlags.cluster, "cluster", "c", "", "cluster name")
 	exportCmd.Flags().StringVarP(&exportCmdFlags.output, "output", "o", "", "output file (default: stdout)")
+	exportCmd.Flags().BoolVarP(&exportCmdFlags.includeKernelArgs, "include-kernel-args", "", false,
+		"include kernel arguments (KernelArgs resources) in the exported template")
 	exportCmd.Flags().BoolVarP(&exportCmdFlags.force, "force", "f", false, "overwrite output file if it exists")
 
 	ensure.NoError(exportCmd.MarkFlagRequired("cluster"))

--- a/client/pkg/template/internal/models/cluster.go
+++ b/client/pkg/template/internal/models/cluster.go
@@ -45,6 +45,9 @@ type Cluster struct { //nolint:govet
 
 	// Cluster-wide patches.
 	Patches PatchList `yaml:"patches,omitempty"`
+
+	// KernelArgs are the additional kernel arguments.
+	KernelArgs KernelArgs `yaml:",inline"`
 }
 
 // Features defines cluster-wide features.

--- a/client/pkg/template/internal/models/kernelargs.go
+++ b/client/pkg/template/internal/models/kernelargs.go
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package models
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+// KernelArgs is a wrapper type for the kernel args, which can be specified at a Cluster, MachineSet, or Machine level in cluster templates.
+//
+// This type needs to be included in the models as an inline YAML, e.g., via `yaml:",inline"`.
+type KernelArgs struct {
+	Value *[]string `yaml:"kernelArgs,omitempty"`
+}
+
+// Get returns the kernel args value and whether they are actually defined.
+func (ka *KernelArgs) Get() (args []string, defined bool) {
+	if ka.Value != nil {
+		return *ka.Value, true
+	}
+
+	return nil, false
+}
+
+// Set sets the kernel args value.
+func (ka *KernelArgs) Set(args []string) {
+	ka.Value = &args
+}
+
+func buildKernelArgsResource(id MachineID, args []string) *omni.KernelArgs {
+	kernelArgsRes := omni.NewKernelArgs(resource.ID(id))
+
+	kernelArgsRes.Metadata().Annotations().Set(omni.ResourceManagedByClusterTemplates, "")
+
+	kernelArgsRes.TypedSpec().Value.Args = args
+
+	return kernelArgsRes
+}

--- a/client/pkg/template/internal/models/models.go
+++ b/client/pkg/template/internal/models/models.go
@@ -25,12 +25,11 @@ type Meta struct {
 
 // TranslateContext is a context for translation.
 type TranslateContext struct {
-	LockedMachines map[MachineID]struct{}
-
-	MachineDescriptors map[MachineID]Descriptors
-
-	// ClusterName is the name of the cluster.
-	ClusterName string
+	LockedMachines            map[MachineID]struct{}
+	MachineDescriptors        map[MachineID]Descriptors
+	MachineSetLevelKernelArgs map[MachineID]KernelArgs
+	ClusterLevelKernelArgs    KernelArgs
+	ClusterName               string
 }
 
 // SystemExtensions is embedded in Cluster, MachineSet and Machine objects.

--- a/client/pkg/template/operations/delete.go
+++ b/client/pkg/template/operations/delete.go
@@ -87,5 +87,5 @@ func deleteTemplate(ctx context.Context, tmpl *template.Template, out io.Writer,
 		syncResult.Destroy = slices.Insert(syncResult.Destroy, 0, extensionsConfigurations.Items, links, allPatches)
 	}
 
-	return syncDelete(ctx, syncResult, out, st, syncOptions)
+	return sync(ctx, syncResult, out, st, syncOptions)
 }

--- a/client/pkg/template/operations/testdata/export/cluster-resources.yaml
+++ b/client/pkg/template/operations/testdata/export/cluster-resources.yaml
@@ -227,6 +227,21 @@ spec: {}
 
 
 
+################################ Kernel Args
+metadata:
+  namespace: default
+  type: KernelArgs.omni.sidero.dev
+  id: 024780fe-b0d6-43e0-a868-b142ba0a67a6
+  annotations:
+    omni.sidero.dev/managed-by-cluster-templates:
+spec:
+  args:
+    - arg-1
+    - arg-2
+---
+
+
+
 ################################ Config Patches - user defined
 metadata:
   namespace: default

--- a/client/pkg/template/operations/testdata/export/cluster-template-with-kernel-args.yaml
+++ b/client/pkg/template/operations/testdata/export/cluster-template-with-kernel-args.yaml
@@ -1,0 +1,150 @@
+kind: Cluster
+systemExtensions:
+  - siderolabs/hello-world-service
+name: export-test
+labels:
+  cluster-label-1: val
+  cluster-label-2: val2
+kubernetes:
+  version: v1.28.2
+talos:
+  version: v1.5.5
+features:
+  diskEncryption: true
+  enableWorkloadProxy: true
+  useEmbeddedDiscoveryService: true
+  backupConfiguration:
+    interval: 2h0m0s
+patches:
+  - idOverride: 499-2e4b9030-aade-47cf-8f7f-3031b7ae49bb
+    annotations:
+      name: User defined patch
+    inline:
+      machine:
+        network:
+          kubespan:
+            enabled: false
+  - idOverride: 500-ae981813-420d-464f-a246-fd7e861402f1
+    annotations:
+      description: Cluster Patch Description
+      name: User defined patch
+    inline:
+      machine:
+        network:
+          kubespan:
+            enabled: false
+            mtu: 1410
+  - idOverride: 600-3fb9b4d2-b13c-48a7-9929-3632e68ff5da
+    annotations:
+      description: Cluster Patch Description 2
+      name: User defined patch
+    inline:
+      machine:
+        network:
+          kubespan:
+            enabled: false
+            mtu: 1234
+---
+kind: ControlPlane
+systemExtensions:
+  - siderolabs/qemu-guest-agent
+bootstrapSpec:
+  clusterUUID: 98d00c6b-fae1-4bf2-afa3-0282ef443f84
+  snapshot: FFFFFFFF9AA169F0.snapshot
+machines:
+  - 3f8b33d2-52b1-42ed-8505-4025ddbc31f1
+patches:
+  - idOverride: 500-2e2a2a64-5085-407a-a205-f75f4c64a060
+    annotations:
+      description: Some Test Description 123
+      name: User defined patch
+    inline:
+      machine:
+        network:
+          kubespan:
+            enabled: false
+            mtu: 1111
+---
+kind: Workers
+systemExtensions:
+  - siderolabs/hello-world-service
+machines:
+  - 024780fe-b0d6-43e0-a868-b142ba0a67a6
+updateStrategy:
+  rolling:
+    maxParallelism: 3
+deleteStrategy:
+  type: Rolling
+  rolling:
+    maxParallelism: 5
+patches:
+  - idOverride: 500-3792b0d9-0fc2-46fb-becf-4d5439bbe5ba
+    annotations:
+      description: Some Test Description ABC
+      name: User defined patch
+    inline:
+      machine:
+        network:
+          kubespan:
+            enabled: false
+            mtu: 1447
+---
+kind: Workers
+name: w07c5e8
+machineClass:
+  name: mc1
+  size: Unlimited
+patches:
+  - idOverride: 500-32fe29d6-221a-4e6e-a55e-6b1700cae09d
+    annotations:
+      description: Some Test Description 987
+      name: User defined patch
+    inline:
+      machine:
+        network:
+          kubespan:
+            enabled: false
+            mtu: 1217
+---
+kind: Workers
+name: w3c03cf
+machineClass:
+  name: mc2
+  size: 1
+patches:
+  - idOverride: 666-4a5ca2e0-4f57-4761-bf61-c1e4cf583170
+    annotations:
+      description: Some Test Description ZXC
+      name: User defined patch
+    inline:
+      machine:
+        network:
+          kubespan:
+            enabled: false
+            mtu: 1298
+---
+kind: Machine
+name: 024780fe-b0d6-43e0-a868-b142ba0a67a6
+locked: true
+patches:
+  - idOverride: 500-1104d832-79fb-4121-a67f-752fa8f763e9
+    annotations:
+      description: Some Test Description ASD
+      name: User defined patch
+    inline:
+      machine:
+        network:
+          kubespan:
+            enabled: false
+            mtu: 1166
+kernelArgs:
+  - arg-1
+  - arg-2
+---
+kind: Machine
+systemExtensions:
+  - something-custom
+name: 3f8b33d2-52b1-42ed-8505-4025ddbc31f1
+install:
+  disk: /dev/sdc
+kernelArgs: []

--- a/client/pkg/template/order.go
+++ b/client/pkg/template/order.go
@@ -21,6 +21,7 @@ var canonicalResourceOrder = map[resource.Type]int{
 	omni.ConfigPatchType:             3,
 	omni.MachineSetType:              4,
 	omni.MachineSetNodeType:          5,
+	omni.KernelArgsType:              6,
 }
 
 func sortResources[T any](s []T, mapper func(T) resource.Metadata) {

--- a/client/pkg/template/testdata/cluster-with-kernel-args-resources.yaml
+++ b/client/pkg/template/testdata/cluster-with-kernel-args-resources.yaml
@@ -1,0 +1,265 @@
+metadata:
+    namespace: default
+    type: Clusters.omni.sidero.dev
+    id: kernel-args-test-cluster
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    annotations:
+        omni.sidero.dev/managed-by-cluster-templates:
+spec:
+    kubernetesversion: 1.34.2
+    talosversion: 1.11.5
+    features:
+        enableworkloadproxy: false
+        diskencryption: false
+        useembeddeddiscoveryservice: false
+    backupconfiguration: null
+---
+metadata:
+    namespace: default
+    type: MachineSets.omni.sidero.dev
+    id: kernel-args-test-cluster-control-planes
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/role-controlplane:
+spec:
+    updatestrategy: 1
+    machineclass: null
+    bootstrapspec: null
+    deletestrategy: 0
+    updatestrategyconfig: null
+    deletestrategyconfig: null
+    machineallocation: null
+---
+metadata:
+    namespace: default
+    type: MachineSetNodes.omni.sidero.dev
+    id: 03595977-1864-4e8a-b917-b40a6080de2f
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/machine-set: kernel-args-test-cluster-control-planes
+        omni.sidero.dev/role-controlplane:
+spec: {}
+---
+metadata:
+    namespace: default
+    type: MachineSetNodes.omni.sidero.dev
+    id: 424c3bbe-1ec2-475e-b804-abf77d6b6c30
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/machine-set: kernel-args-test-cluster-control-planes
+        omni.sidero.dev/role-controlplane:
+spec: {}
+---
+metadata:
+    namespace: default
+    type: KernelArgs.omni.sidero.dev
+    id: 424c3bbe-1ec2-475e-b804-abf77d6b6c30
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    annotations:
+        omni.sidero.dev/managed-by-cluster-templates:
+spec:
+    args:
+        - cp-kernel-arg-1
+        - cp-kernel-arg-2
+---
+metadata:
+    namespace: default
+    type: MachineSetNodes.omni.sidero.dev
+    id: ac5a7d82-3802-488f-8d2e-3e8f925199b8
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/machine-set: kernel-args-test-cluster-control-planes
+        omni.sidero.dev/role-controlplane:
+spec: {}
+---
+metadata:
+    namespace: default
+    type: MachineSets.omni.sidero.dev
+    id: kernel-args-test-cluster-workers
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/role-worker:
+spec:
+    updatestrategy: 1
+    machineclass: null
+    bootstrapspec: null
+    deletestrategy: 0
+    updatestrategyconfig: null
+    deletestrategyconfig: null
+    machineallocation: null
+---
+metadata:
+    namespace: default
+    type: MachineSetNodes.omni.sidero.dev
+    id: b7201377-6194-4796-a831-295e865668e2
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/machine-set: kernel-args-test-cluster-workers
+        omni.sidero.dev/role-worker:
+spec: {}
+---
+metadata:
+    namespace: default
+    type: MachineSetNodes.omni.sidero.dev
+    id: 6d8f28c6-2358-4503-936a-723508112185
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/machine-set: kernel-args-test-cluster-workers
+        omni.sidero.dev/role-worker:
+spec: {}
+---
+metadata:
+    namespace: default
+    type: MachineSets.omni.sidero.dev
+    id: kernel-args-test-cluster-workers-2
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/role-worker:
+spec:
+    updatestrategy: 1
+    machineclass: null
+    bootstrapspec: null
+    deletestrategy: 0
+    updatestrategyconfig: null
+    deletestrategyconfig: null
+    machineallocation: null
+---
+metadata:
+    namespace: default
+    type: MachineSetNodes.omni.sidero.dev
+    id: dba84301-9a87-40f6-b775-0480aa3ce704
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    labels:
+        omni.sidero.dev/cluster: kernel-args-test-cluster
+        omni.sidero.dev/machine-set: kernel-args-test-cluster-workers-2
+        omni.sidero.dev/role-worker:
+spec: {}
+---
+metadata:
+    namespace: default
+    type: KernelArgs.omni.sidero.dev
+    id: 03595977-1864-4e8a-b917-b40a6080de2f
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    annotations:
+        omni.sidero.dev/managed-by-cluster-templates:
+spec:
+    args:
+        - machine-kernel-arg-1
+---
+metadata:
+    namespace: default
+    type: KernelArgs.omni.sidero.dev
+    id: dba84301-9a87-40f6-b775-0480aa3ce704
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    annotations:
+        omni.sidero.dev/managed-by-cluster-templates:
+spec:
+    args:
+        - cluster-kernel-arg-1
+        - cluster-kernel-arg-2
+---
+metadata:
+    namespace: default
+    type: KernelArgs.omni.sidero.dev
+    id: ac5a7d82-3802-488f-8d2e-3e8f925199b8
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    annotations:
+        omni.sidero.dev/managed-by-cluster-templates:
+spec:
+    args:
+        - cp-kernel-arg-1
+        - cp-kernel-arg-2
+---
+metadata:
+    namespace: default
+    type: KernelArgs.omni.sidero.dev
+    id: b7201377-6194-4796-a831-295e865668e2
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    annotations:
+        omni.sidero.dev/managed-by-cluster-templates:
+spec:
+    args: []
+---
+metadata:
+    namespace: default
+    type: KernelArgs.omni.sidero.dev
+    id: 6d8f28c6-2358-4503-936a-723508112185
+    version: undefined
+    owner:
+    phase: running
+    created: 0001-01-01T00:00:00Z
+    updated: 0001-01-01T00:00:00Z
+    annotations:
+        omni.sidero.dev/managed-by-cluster-templates:
+spec:
+    args:
+        - worker-kernel-arg-1
+        - worker-kernel-arg-2

--- a/client/pkg/template/testdata/cluster-with-kernel-args.yaml
+++ b/client/pkg/template/testdata/cluster-with-kernel-args.yaml
@@ -1,0 +1,50 @@
+kind: Cluster
+name: kernel-args-test-cluster
+kubernetes:
+  version: v1.34.2
+talos:
+  version: v1.11.5
+kernelArgs:
+  - cluster-kernel-arg-1
+  - cluster-kernel-arg-2
+---
+kind: ControlPlane
+machines:
+  - 03595977-1864-4e8a-b917-b40a6080de2f # Case: Explicit Override
+  - 424c3bbe-1ec2-475e-b804-abf77d6b6c30 # Case: Implicit Inheritance
+  - ac5a7d82-3802-488f-8d2e-3e8f925199b8 # Case: Explicit Inheritance (No Args Key)
+kernelArgs:
+  - cp-kernel-arg-1
+  - cp-kernel-arg-2
+---
+kind: Workers
+machines:
+  - b7201377-6194-4796-a831-295e865668e2 # Case: Force Empty []
+  - 6d8f28c6-2358-4503-936a-723508112185 # Case: Explicit Null (Should behave like [])
+kernelArgs:
+  - worker-kernel-arg-1
+  - worker-kernel-arg-2
+---
+kind: Workers
+name: workers-2
+machines:
+  - dba84301-9a87-40f6-b775-0480aa3ce704 # Case: Cluster Fallback (Set has no args)
+---
+kind: Machine
+name: 03595977-1864-4e8a-b917-b40a6080de2f
+kernelArgs:
+  - machine-kernel-arg-1
+---
+kind: Machine
+name: dba84301-9a87-40f6-b775-0480aa3ce704
+---
+kind: Machine
+name: ac5a7d82-3802-488f-8d2e-3e8f925199b8
+---
+kind: Machine
+name: b7201377-6194-4796-a831-295e865668e2
+kernelArgs: []
+---
+kind: Machine
+name: 6d8f28c6-2358-4503-936a-723508112185
+kernelArgs: null # same as the key not existing

--- a/frontend/src/views/cluster/Config/PatchEdit.vue
+++ b/frontend/src/views/cluster/Config/PatchEdit.vue
@@ -523,7 +523,7 @@ onMounted(async () => {
   <div class="relative -mx-6 -mb-6 flex flex-1 flex-col overflow-hidden" :style="{ width: 'auto' }">
     <div class="flex flex-1 flex-col overflow-hidden px-6 pb-16">
       <PageHeader :title="title" :subtitle="subtitle" :notes="notes" />
-      <ManagedByTemplatesWarning :cluster="currentCluster" />
+      <ManagedByTemplatesWarning :resource="currentCluster" />
       <div v-if="state === State.NotExists" class="mb-4 flex items-center gap-3">
         <TInput v-model="patchName" title="Name" />
         <TInput v-model="patchDescription" class="flex-1" title="Description" />

--- a/frontend/src/views/cluster/Config/Patches.vue
+++ b/frontend/src/views/cluster/Config/Patches.vue
@@ -269,7 +269,7 @@ onMounted(async () => {
 
 <template>
   <div class="flex flex-col gap-4 overflow-y-auto">
-    <ManagedByTemplatesWarning :cluster="cluster" />
+    <ManagedByTemplatesWarning :resource="cluster" />
     <div class="flex gap-4">
       <TInput v-model="filter" class="flex-1" placeholder="Search..." icon="search" />
       <TButton type="highlighted" :disabled="!canManageConfigPatches" @click="openPatchCreate">

--- a/frontend/src/views/cluster/ManagedByTemplatesWarning.vue
+++ b/frontend/src/views/cluster/ManagedByTemplatesWarning.vue
@@ -5,13 +5,11 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import type { Ref } from 'vue'
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
-import type { ClusterSpec } from '@/api/omni/specs/omni.pb'
 import { ClusterType, DefaultNamespace, ResourceManagedByClusterTemplates } from '@/api/resources'
 import Watch from '@/api/watch'
 import TAlert from '@/components/TAlert.vue'
@@ -19,27 +17,25 @@ import TAlert from '@/components/TAlert.vue'
 export type WarningStyle = 'alert' | 'popup' | 'short'
 
 type Props = {
-  cluster?: Resource<ClusterSpec>
+  resource?: Resource
   warningStyle?: WarningStyle
 }
 
-const props = withDefaults(defineProps<Props>(), {
-  warningStyle: 'alert',
-})
+const { resource, warningStyle = 'alert' } = defineProps<Props>()
 
-const cluster: Ref<Resource<ClusterSpec> | undefined> = ref(props.cluster)
+const routeResource = ref<Resource>()
+const activeResource = computed(() => resource || routeResource.value)
 
-// If the cluster is not passed explicitly, watch it from the route, if cluster exists in the route params.
-if (!props.cluster) {
+// If the resource is not passed explicitly, default to the cluster in the route, if exists.
+if (!resource) {
   const route = useRoute()
-  const clusterWatch = new Watch(cluster)
+  const clusterWatch = new Watch(routeResource)
 
   clusterWatch.setup(
     computed(() => {
       if (!route.params.cluster) {
         return undefined
       }
-
       return {
         resource: {
           type: ClusterType,
@@ -52,20 +48,28 @@ if (!props.cluster) {
   )
 }
 
-const clusterIsManagedByTemplates = computed(() => {
-  return cluster.value?.metadata?.annotations?.[ResourceManagedByClusterTemplates] !== undefined
+const resourceIsManagedByTemplates = computed(() => {
+  return (
+    activeResource.value?.metadata?.annotations?.[ResourceManagedByClusterTemplates] !== undefined
+  )
+})
+
+const resourceWord = computed(() => {
+  return activeResource.value?.metadata?.type === ClusterType ? 'cluster' : 'resource'
 })
 </script>
 
 <template>
-  <template v-if="clusterIsManagedByTemplates">
+  <template v-if="resourceIsManagedByTemplates">
     <div v-if="warningStyle === 'alert'" class="pb-5">
-      <TAlert type="warn" title="This cluster is managed using cluster templates.">
+      <TAlert type="warn" :title="`This ${resourceWord} is managed using cluster templates.`">
         It is recommended to manage it using its template and not through this UI.
       </TAlert>
     </div>
     <div v-else-if="warningStyle === 'popup'" class="pb-5 text-xs">
-      <p class="py-2 text-primary-p3">This cluster is managed using cluster templates.</p>
+      <p class="py-2 text-primary-p3">
+        This {{ resourceWord }} is managed using cluster templates.
+      </p>
       <p class="py-2 font-bold text-primary-p3">
         It is recommended to manage it using its template and not through this UI.
       </p>

--- a/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
@@ -131,7 +131,7 @@ onMounted(async () => {
 <template>
   <div class="flex flex-col gap-3">
     <PageHeader :title="`Add Machines to Cluster ${$route.params.cluster}`" />
-    <ManagedByTemplatesWarning :cluster="currentCluster" />
+    <ManagedByTemplatesWarning :resource="currentCluster" />
     <template v-if="existingResources.length > 0">
       <div class="text-naturals-n13">Machine Sets</div>
       <MachineSets />


### PR DESCRIPTION
Implement kernel args support in cluster templates.

Managing kernel args via templates is opt-in: only and only if the `kernelArgs` YAML key is defined on a `Cluster`, `ControlPlane`, `Worker` or `Machine`, the matching `KernelArgs` resource will be created/updated.

Lower levels override higher levels (Cluster -> MachineSet -> Machine).

Unlike other cluster template managed resources, they will never be destroyed, i.e, when they are removed from a template (removed completely, as in, `kernelArgs` key doesn't exist) or when `omnictl cluster template delete` is run. They instead will get updated to have the annotation `omni.sidero.dev/managed-by-cluster-templates` removed from them.

Add the new flag `--include-kernel-args` to the `omnictl cluster template export` command to optionally include them in the exported template. Note: when this flag is set, `kernelArgs` key is always included at per-machine level, not pulled up even if they are the same for all machines in a machine set or a cluster.

Update the frontend, specifically the kernel args update screen to warn the user if kernel args for that machine is managed by templates, similar to what we do for clusters.

Closes #1940.