### PR TITLE
feat: allow Talos APIs for etcd maintenance

### DIFF
--- a/internal/backend/grpc/router/talos_backend.go
+++ b/internal/backend/grpc/router/talos_backend.go
@@ -29,9 +29,13 @@ import (
 
 // operatorMethodSet is the set of methods that are allowed to be called by the minimum role of os:operator.
 var operatorMethodSet = xslices.ToSet([]string{
-	machine.MachineService_EtcdAlarmList_FullMethodName,
 	machine.MachineService_EtcdAlarmDisarm_FullMethodName,
+	machine.MachineService_EtcdAlarmList_FullMethodName,
 	machine.MachineService_EtcdDefragment_FullMethodName,
+	machine.MachineService_EtcdDowngradeCancel_FullMethodName,
+	machine.MachineService_EtcdDowngradeEnable_FullMethodName,
+	machine.MachineService_EtcdDowngradeValidate_FullMethodName,
+	machine.MachineService_EtcdForfeitLeadership_FullMethodName,
 	machine.MachineService_EtcdStatus_FullMethodName,
 	machine.MachineService_PacketCapture_FullMethodName,
 	machine.MachineService_Reboot_FullMethodName,


### PR DESCRIPTION
Add the following etcd maintenance APIs to the allowed list:
- downgrade validate
- downgrade enable
- downgrade cancel
- forfeit leadership

To allow the process documented in: https://docs.siderolabs.com/talos/v1.11/build-and-extend-talos/cluster-operations-and-maintenance/etcd-maintenance#downgrade-v36-to-v35

Closes siderolabs/omni#1570.