### PR TITLE
fix(installation-media): parse yaml for overlay options before JSON stringifying

### DIFF
--- a/frontend/src/components/common/TextArea/TextArea.stories.ts
+++ b/frontend/src/components/common/TextArea/TextArea.stories.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { fn } from 'storybook/test'
+
+import TextArea from './TextArea.vue'
+
+const meta: Meta<typeof TextArea> = {
+  component: TextArea,
+  args: {
+    title: 'Title',
+    placeholder: 'Placeholder',
+    disabled: false,
+    'onUpdate:modelValue': fn(),
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/components/common/TextArea/TextArea.vue
+++ b/frontend/src/components/common/TextArea/TextArea.vue
@@ -1,0 +1,42 @@
+<!--
+Copyright (c) 2025 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+interface Props {
+  title?: string
+  overheadTitle?: boolean
+  placeholder?: string
+  disabled?: boolean
+}
+
+const { title, placeholder } = defineProps<Props>()
+
+const modelValue = defineModel<string>()
+</script>
+
+<template>
+  <label class="flex flex-col gap-4 text-sm font-medium text-naturals-n14">
+    <span v-if="title && overheadTitle" class="text-sm">
+      {{ title }}
+    </span>
+
+    <div
+      class="flex max-h-full items-center justify-start gap-x-2 gap-y-3 rounded border border-naturals-n8 p-2 transition-colors focus-within:border-naturals-n5 has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:border-naturals-n6 has-disabled:bg-naturals-n3 has-disabled:text-naturals-n9 has-disabled:select-none"
+    >
+      <span v-if="title && !overheadTitle" class="mr-1 min-w-fit text-xs after:content-[':']">
+        {{ title }}
+      </span>
+
+      <textarea
+        ref="input"
+        v-model.trim="modelValue"
+        :disabled="disabled"
+        class="peer min-w-2 flex-1 border-none bg-transparent text-xs text-naturals-n13 placeholder-naturals-n7 outline-hidden transition-colors focus:border-transparent focus:outline-hidden disabled:opacity-0"
+        :placeholder="placeholder"
+      ></textarea>
+    </div>
+  </label>
+</template>

--- a/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
@@ -142,9 +142,7 @@ const schematic = computedAsync(async () => {
       overlay = {
         name: selectedSBC.value.spec.overlay_name,
         image: selectedSBC.value.spec.overlay_image,
-        options: formState.value.overlayOptions
-          ? JSON.stringify(formState.value.overlayOptions)
-          : undefined,
+        options: formState.value.overlayOptions,
       }
     }
 

--- a/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.vue
@@ -14,6 +14,7 @@ import type { SBCConfigSpec } from '@/api/omni/specs/virtual.pb'
 import { SBCConfigType, VirtualNamespace } from '@/api/resources'
 import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
+import TextArea from '@/components/common/TextArea/TextArea.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import { getDocsLink } from '@/methods'
 import { useResourceList } from '@/methods/useResourceList'
@@ -95,7 +96,7 @@ const selectedSBC = computed(() =>
     <p>Skip this step if unsure.</p>
 
     <template v-if="supportsOverlayOptions && selectedSBC">
-      <TInput
+      <TextArea
         v-model="formState.overlayOptions"
         placeholder="configTxtAppend: 'dtoverlay=vc4-fkms-v3d'"
         title="Extra overlay options (advanced)"

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -7,7 +7,6 @@ package grpc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 
@@ -133,8 +132,10 @@ func (s *managementServer) getOverlay(ctx context.Context, req *management.Creat
 	if req.Overlay != nil {
 		options := map[string]any{}
 
-		if err := json.Unmarshal([]byte(req.Overlay.Options), &options); err != nil {
-			return schematic.Overlay{}, err
+		if req.Overlay.Options != "" {
+			if err := yaml.Unmarshal([]byte(req.Overlay.Options), &options); err != nil {
+				return schematic.Overlay{}, err
+			}
 		}
 
 		return schematic.Overlay{


### PR DESCRIPTION
Fix errors when creating SBC images due to incorrect handling of overlay options. Send overlay options as-is from frontend (as a YML string) and convert the input to a text area. In the backend, check first if options are set and then unmarshal as YAML instead of as JSON.