### PR TITLE
fix: prevent audit logs migration from getting stuck

### DIFF
--- a/internal/backend/runtime/omni/audit/auditlog/auditlogfile/log_file.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogfile/log_file.go
@@ -169,6 +169,7 @@ func (l *logReader) Close() error {
 func (l *logReader) Read() ([]byte, error) {
 	if l.scanner == nil {
 		l.scanner = bufio.NewScanner(l.rdr)
+		l.scanner.Buffer(nil, 16*1024*1024) // 16MB max line size
 	}
 
 	if !l.scanner.Scan() {


### PR DESCRIPTION
Fix the issue where file audit logs would have a very long line, causing the sqlite migration to get stuck due to the bug on reading them via a scanner.

Additionally, increase the buffer size of the scanner to be able to handle lines up to 16MB in size.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>