### PR TITLE
fix: get rid of an exception in the `UserInfo`

### DIFF
--- a/frontend/src/components/common/UserInfo/UserInfo.vue
+++ b/frontend/src/components/common/UserInfo/UserInfo.vue
@@ -32,10 +32,10 @@ const {
 const auth0 = useAuth0()
 
 const identity = computed(
-  () => email || auth0.user.value?.email?.toLowerCase() || identityStorage.value,
+  () => email || auth0?.user?.value?.email?.toLowerCase() || identityStorage.value,
 )
-const picture = computed(() => avatar || auth0.user.value?.picture)
-const name = computed(() => fullname || auth0.user.value?.name)
+const picture = computed(() => avatar || auth0?.user?.value?.picture)
+const name = computed(() => fullname || auth0?.user?.value?.name)
 </script>
 
 <template>


### PR DESCRIPTION
The component breaks if the account doesn't have avatar or fullname set. It tries to fall back to `auth0`, and if it's not Auth0 the object is null and everything crashes.

Fixes #2026 