### PR TITLE
fix: ignore labeled `MachineSetNodes` in the export and sync CLI cmds

### DIFF
--- a/client/pkg/template/operations/export.go
+++ b/client/pkg/template/operations/export.go
@@ -483,8 +483,10 @@ func collectResourceLayers[T meta.ResourceWithRD](ctx context.Context, st state.
 	}
 
 	resources.ForEach(func(item T) {
+		_, programmaticallyCreatedMachineSetNode := item.Metadata().Labels().Get(omni.LabelManagedByMachineSetNodeController)
+
 		// skip the resources with an owner, as they are not user-defined
-		if item.Metadata().Owner() != "" {
+		if item.Metadata().Owner() != "" || programmaticallyCreatedMachineSetNode {
 			return
 		}
 

--- a/client/pkg/template/template.go
+++ b/client/pkg/template/template.go
@@ -174,7 +174,9 @@ func (t *Template) actualResources(ctx context.Context, st state.State) ([]resou
 		actualResources = append(actualResources,
 			xslices.Filter(items.Items,
 				func(r resource.Resource) bool {
-					return r.Metadata().Owner() == ""
+					_, programmaticallyCreatedMachineSetNode := r.Metadata().Labels().Get(omni.LabelManagedByMachineSetNodeController)
+
+					return !programmaticallyCreatedMachineSetNode && r.Metadata().Owner() == ""
 				},
 			)...)
 	}

--- a/internal/integration/suites_test.go
+++ b/internal/integration/suites_test.go
@@ -1213,7 +1213,7 @@ Test flow of cluster creation and scaling using cluster templates.`)
 
 		t.Parallel()
 
-		options.claimMachines(t, 5)
+		options.claimMachines(t, 7)
 
 		t.Run(
 			"TestClusterTemplateFlow",

--- a/internal/integration/testdata/cluster-1.tmpl.yaml
+++ b/internal/integration/testdata/cluster-1.tmpl.yaml
@@ -27,3 +27,9 @@ kind: Workers
 name: additional-workers
 machines:
   - {{ index .W 1 }}
+---
+kind: Workers
+name: {{ .MachineClassBasedMachineSetName }}
+machineClass:
+  name: {{ .MachineClass }}
+  size: 1

--- a/internal/integration/testdata/cluster-2.tmpl.yaml
+++ b/internal/integration/testdata/cluster-2.tmpl.yaml
@@ -35,3 +35,9 @@ patches:
           interfaces:
             - interface: dummy-if
               dummy: true
+---
+kind: Workers
+name: {{ .MachineClassBasedMachineSetName }}
+machineClass:
+  name: {{ .MachineClass }}
+  size: 2


### PR DESCRIPTION
Now as `MachineSetNodes` are no longer ever owned by the `MachineSetNodeController` and marked with
`managed-by-machine-set-node-controller` label instead, CLI tools should properly handle that and ignore such `MachineSetNodes` during export and cluster sync.