### PR TITLE
chore: bump API version to 2 as old CLI is no longer 100% compatible

### DIFF
--- a/internal/version/api.go
+++ b/internal/version/api.go
@@ -8,4 +8,4 @@ package version
 // API represents the current API version of the backend, and is checked by the clients for compatibility.
 //
 // When the backend API changes in a breaking way, this needs to be bumped.
-const API uint32 = 1
+const API uint32 = 2


### PR DESCRIPTION
As `omnictl cluster template sync` on the old `omnictl` might cause undesired changes on the cluster we bump the API version to render older clients not usable on the new Omni versions.