### PR TITLE
feat: make namespace implicit for all resources in auth package

### DIFF
--- a/client/pkg/omni/resources/auth/identity.go
+++ b/client/pkg/omni/resources/auth/identity.go
@@ -15,9 +15,9 @@ import (
 )
 
 // NewIdentity creates a new Identity resource.
-func NewIdentity(ns, id string) *Identity {
+func NewIdentity(id string) *Identity {
 	return typed.NewResource[IdentitySpec, IdentityExtension](
-		resource.NewMetadata(ns, IdentityType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.DefaultNamespace, IdentityType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.IdentitySpec{}),
 	)
 }

--- a/client/pkg/omni/resources/auth/public_key.go
+++ b/client/pkg/omni/resources/auth/public_key.go
@@ -21,9 +21,9 @@ import (
 )
 
 // NewPublicKey creates a new PublicKey resource.
-func NewPublicKey(ns, id string) *PublicKey {
+func NewPublicKey(id string) *PublicKey {
 	return typed.NewResource[PublicKeySpec, PublicKeyExtension](
-		resource.NewMetadata(ns, PublicKeyType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.DefaultNamespace, PublicKeyType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.PublicKeySpec{}),
 	)
 }

--- a/client/pkg/omni/resources/auth/saml_assertion.go
+++ b/client/pkg/omni/resources/auth/saml_assertion.go
@@ -15,9 +15,9 @@ import (
 )
 
 // NewSAMLAssertion creates a new SAMLAssertion resource.
-func NewSAMLAssertion(ns, id string) *SAMLAssertion {
+func NewSAMLAssertion(id string) *SAMLAssertion {
 	return typed.NewResource[SAMLAssertionSpec, SAMLAssertionExtension](
-		resource.NewMetadata(ns, SAMLAssertionType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.DefaultNamespace, SAMLAssertionType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.SAMLAssertionSpec{}),
 	)
 }

--- a/client/pkg/omni/resources/auth/saml_label_rule.go
+++ b/client/pkg/omni/resources/auth/saml_label_rule.go
@@ -15,9 +15,9 @@ import (
 )
 
 // NewSAMLLabelRule creates a new SAMLLabelRule resource.
-func NewSAMLLabelRule(ns, id string) *SAMLLabelRule {
+func NewSAMLLabelRule(id string) *SAMLLabelRule {
 	return typed.NewResource[SAMLLabelRuleSpec, SAMLLabelRuleExtension](
-		resource.NewMetadata(ns, SAMLLabelRuleType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.DefaultNamespace, SAMLLabelRuleType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.SAMLLabelRuleSpec{}),
 	)
 }

--- a/client/pkg/omni/resources/auth/user.go
+++ b/client/pkg/omni/resources/auth/user.go
@@ -15,9 +15,9 @@ import (
 )
 
 // NewUser creates a new User resource.
-func NewUser(ns, id string) *User {
+func NewUser(id string) *User {
 	return typed.NewResource[UserSpec, UserExtension](
-		resource.NewMetadata(ns, UserType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.DefaultNamespace, UserType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.UserSpec{}),
 	)
 }

--- a/client/pkg/omnictl/user/create.go
+++ b/client/pkg/omnictl/user/create.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/omni/client/pkg/client"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omnictl/internal/access"
 )
@@ -37,11 +36,11 @@ var createCmd = &cobra.Command{
 
 func createUser(email string) func(ctx context.Context, client *client.Client) error {
 	return func(ctx context.Context, client *client.Client) error {
-		user := auth.NewUser(resources.DefaultNamespace, uuid.NewString())
+		user := auth.NewUser(uuid.NewString())
 
 		user.TypedSpec().Value.Role = createCmdFlags.role
 
-		identity := auth.NewIdentity(resources.DefaultNamespace, email)
+		identity := auth.NewIdentity(email)
 
 		identity.Metadata().Labels().Set(auth.LabelIdentityUserID, user.Metadata().ID())
 

--- a/client/pkg/omnictl/user/delete.go
+++ b/client/pkg/omnictl/user/delete.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/omni/client/pkg/client"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omnictl/internal/access"
 )
@@ -36,14 +35,14 @@ func deleteUsers(emails ...string) func(ctx context.Context, client *client.Clie
 		toDelete := make([]resource.Pointer, 0, len(emails)*2)
 
 		for _, email := range emails {
-			identity := auth.NewIdentity(resources.DefaultNamespace, email)
+			identity := auth.NewIdentity(email)
 
 			existing, err := safe.ReaderGetByID[*auth.Identity](ctx, client.Omni().State(), email)
 			if err != nil {
 				return err
 			}
 
-			toDelete = append(toDelete, identity.Metadata(), auth.NewUser(resources.DefaultNamespace, existing.TypedSpec().Value.UserId).Metadata())
+			toDelete = append(toDelete, identity.Metadata(), auth.NewUser(existing.TypedSpec().Value.UserId).Metadata())
 		}
 
 		for _, md := range toDelete {

--- a/client/pkg/omnictl/user/set_role.go
+++ b/client/pkg/omnictl/user/set_role.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/omni/client/pkg/client"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omnictl/internal/access"
 )
@@ -40,7 +39,7 @@ func setUserRole(email string) func(ctx context.Context, client *client.Client) 
 		}
 
 		_, err = safe.StateUpdateWithConflicts(ctx, client.Omni().State(),
-			auth.NewUser(resources.DefaultNamespace, identity.TypedSpec().Value.UserId).Metadata(),
+			auth.NewUser(identity.TypedSpec().Value.UserId).Metadata(),
 			func(user *auth.User) error {
 				user.TypedSpec().Value.Role = setRoleCmdFlags.role
 

--- a/internal/backend/grpc/serviceaccount.go
+++ b/internal/backend/grpc/serviceaccount.go
@@ -25,7 +25,6 @@ import (
 	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	pkgaccess "github.com/siderolabs/omni/client/pkg/access"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/grpc/router"
@@ -62,12 +61,12 @@ func (s *managementServer) RenewServiceAccount(ctx context.Context, req *managem
 	sa := pkgaccess.ParseServiceAccountFromName(req.Name)
 	id := sa.FullID()
 
-	identity, err := safe.StateGet[*authres.Identity](ctx, s.omniState, authres.NewIdentity(resources.DefaultNamespace, id).Metadata())
+	identity, err := safe.StateGet[*authres.Identity](ctx, s.omniState, authres.NewIdentity(id).Metadata())
 	if err != nil {
 		return nil, err
 	}
 
-	user, err := safe.StateGet[*authres.User](ctx, s.omniState, authres.NewUser(resources.DefaultNamespace, identity.TypedSpec().Value.UserId).Metadata())
+	user, err := safe.StateGet[*authres.User](ctx, s.omniState, authres.NewUser(identity.TypedSpec().Value.UserId).Metadata())
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +79,7 @@ func (s *managementServer) RenewServiceAccount(ctx context.Context, req *managem
 		return nil, err
 	}
 
-	publicKeyResource := authres.NewPublicKey(resources.DefaultNamespace, key.ID)
+	publicKeyResource := authres.NewPublicKey(key.ID)
 	publicKeyResource.Metadata().Labels().Set(authres.LabelPublicKeyUserID, identity.TypedSpec().Value.UserId)
 
 	publicKeyResource.TypedSpec().Value.PublicKey = key.Data

--- a/internal/backend/oidc/internal/storage/token/storage.go
+++ b/internal/backend/oidc/internal/storage/token/storage.go
@@ -24,7 +24,6 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/op"
 
 	"github.com/siderolabs/omni/client/pkg/constants"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/oidc/external"
@@ -302,12 +301,12 @@ func (s *Storage) getImpersonateGroups(ctx context.Context, cluster, userID stri
 func (s *Storage) impersonateGroupsFromUser(ctx context.Context, userID string) ([]string, error) {
 	ctx = actor.MarkContextAsInternalActor(ctx)
 
-	identity, err := safe.StateGet[*auth.Identity](ctx, s.state, auth.NewIdentity(resources.DefaultNamespace, userID).Metadata())
+	identity, err := safe.StateGet[*auth.Identity](ctx, s.state, auth.NewIdentity(userID).Metadata())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get identity: %w", err)
 	}
 
-	user, err := safe.StateGet[*auth.User](ctx, s.state, auth.NewUser(resources.DefaultNamespace, identity.TypedSpec().Value.GetUserId()).Metadata())
+	user, err := safe.StateGet[*auth.User](ctx, s.state, auth.NewUser(identity.TypedSpec().Value.GetUserId()).Metadata())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
@@ -342,7 +341,7 @@ func (s *Storage) impersonateGroupsFromAccessPolicy(ctx context.Context, cluster
 		return nil, fmt.Errorf("failed to get cluster: %w", err)
 	}
 
-	identityRes, err := safe.StateGet[*auth.Identity](ctx, s.state, auth.NewIdentity(resources.DefaultNamespace, userID).Metadata())
+	identityRes, err := safe.StateGet[*auth.Identity](ctx, s.state, auth.NewIdentity(userID).Metadata())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get identity: %w", err)
 	}

--- a/internal/backend/oidc/internal/storage/token/storage_test.go
+++ b/internal/backend/oidc/internal/storage/token/storage_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/constants"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/oidc/external"
@@ -70,11 +69,11 @@ func TestGetPrivateClaimsFromScopes(t *testing.T) {
 		},
 	}
 
-	identity := auth.NewIdentity(resources.DefaultNamespace, userIdentity)
+	identity := auth.NewIdentity(userIdentity)
 
 	identity.TypedSpec().Value.UserId = userID
 
-	user := auth.NewUser(resources.DefaultNamespace, userID)
+	user := auth.NewUser(userID)
 	user.TypedSpec().Value.Role = string(role.None)
 
 	cluster := omni.NewCluster(clusterID)
@@ -171,11 +170,11 @@ func TestSetUserinfoFromScopes(t *testing.T) {
 		},
 	}
 
-	identity := auth.NewIdentity(resources.DefaultNamespace, userIdentity)
+	identity := auth.NewIdentity(userIdentity)
 
 	identity.TypedSpec().Value.UserId = userID
 
-	user := auth.NewUser(resources.DefaultNamespace, userID)
+	user := auth.NewUser(userID)
 
 	// will bring constants.DefaultAccessGroup scope
 	user.TypedSpec().Value.Role = string(role.Operator)
@@ -223,11 +222,11 @@ func TestTokenIntrospection(t *testing.T) {
 	userIdentity := req.GetSubject()
 	userID := "test-user-id"
 
-	identity := auth.NewIdentity(resources.DefaultNamespace, userIdentity)
+	identity := auth.NewIdentity(userIdentity)
 
 	identity.TypedSpec().Value.UserId = userID
 
-	user := auth.NewUser(resources.DefaultNamespace, userID)
+	user := auth.NewUser(userID)
 
 	// will bring constants.DefaultAccessGroup scope
 	user.TypedSpec().Value.Role = string(role.Operator)

--- a/internal/backend/runtime/omni/audit/audit_test.go
+++ b/internal/backend/runtime/omni/audit/audit_test.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
@@ -50,7 +49,7 @@ func TestAudit(t *testing.T) {
 
 	hooks.Init(l)
 
-	res := auth.NewPublicKey(resources.DefaultNamespace, "917e47635eb900d0ae66271dd1e06966e048c4f3")
+	res := auth.NewPublicKey("917e47635eb900d0ae66271dd1e06966e048c4f3")
 
 	res.Metadata().Labels().Set(auth.LabelPublicKeyUserID, "002cf196-1767-43fd-8e3d-91241e2ce70c")
 

--- a/internal/backend/runtime/omni/controllers/omni/infra_provider_cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_provider_cleanup.go
@@ -17,7 +17,6 @@ import (
 	"github.com/siderolabs/gen/xerrors"
 
 	"github.com/siderolabs/omni/client/pkg/access"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -202,7 +201,7 @@ func deleteServiceAccount(ctx context.Context, r controller.ReaderWriter, name s
 		return false, err
 	}
 
-	userMD := auth.NewUser(resources.DefaultNamespace, identity.TypedSpec().Value.UserId).Metadata()
+	userMD := auth.NewUser(identity.TypedSpec().Value.UserId).Metadata()
 
 	for _, f := range []func() (bool, error){
 		func() (bool, error) {

--- a/internal/backend/runtime/omni/controllers/omni/infra_provider_cleanup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_provider_cleanup_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/omni/client/pkg/access"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -36,13 +35,13 @@ func (c infraProviderCleanupTestHelper) prepareProvider(t *testing.T, ctx contex
 	providerStatus := infra.NewProviderStatus(providerID)
 	providerHealthStatus := infra.NewProviderHealthStatus(providerID)
 
-	user := auth.NewUser(resources.DefaultNamespace, userID)
+	user := auth.NewUser(userID)
 	user.TypedSpec().Value.Role = "Admin"
-	serviceAccount := auth.NewIdentity(resources.DefaultNamespace, providerID+access.InfraProviderServiceAccountNameSuffix)
+	serviceAccount := auth.NewIdentity(providerID + access.InfraProviderServiceAccountNameSuffix)
 	serviceAccount.Metadata().Labels().Set(auth.LabelIdentityTypeServiceAccount, "")
 	serviceAccount.Metadata().Labels().Set(auth.LabelIdentityUserID, userID)
 	serviceAccount.TypedSpec().Value.UserId = userID
-	publicKey := auth.NewPublicKey(resources.DefaultNamespace, "test-public-key")
+	publicKey := auth.NewPublicKey("test-public-key")
 	publicKey.Metadata().Labels().Set(auth.LabelIdentityUserID, userID)
 
 	require.NoError(t, st.Create(ctx, provider))

--- a/internal/backend/runtime/omni/controllers/omni/key_pruner_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/key_pruner_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 )
@@ -49,13 +48,13 @@ func (suite *KeyPrunerSuite) setup() *clock.Mock {
 func (suite *KeyPrunerSuite) TestRemoveExpiredKey() {
 	fakeClock := suite.setup()
 
-	publicKey := authres.NewPublicKey(resources.DefaultNamespace, testID)
+	publicKey := authres.NewPublicKey(testID)
 	publicKey.TypedSpec().Value.Confirmed = true
 	publicKey.TypedSpec().Value.Expiration = timestamppb.New(fakeClock.Now().Add(defaultExpirationTime))
 
 	fakeClock.Add(4 * time.Second)
 
-	publicKey2 := authres.NewPublicKey(resources.DefaultNamespace, "testID2")
+	publicKey2 := authres.NewPublicKey("testID2")
 	publicKey2.TypedSpec().Value.Confirmed = true
 	publicKey2.TypedSpec().Value.Expiration = timestamppb.New(fakeClock.Now().Add(defaultExpirationTime))
 

--- a/internal/backend/runtime/omni/controllers/omni/service_account_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/service_account_status.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/access"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 )
 
@@ -50,7 +49,7 @@ func NewServiceAccountStatusController() *ServiceAccountStatusController {
 				return optional.Some(auth.NewServiceAccountStatus(identity.Metadata().ID()))
 			},
 			UnmapMetadataFunc: func(r *auth.ServiceAccountStatus) *auth.Identity {
-				return auth.NewIdentity(resources.DefaultNamespace, r.Metadata().ID())
+				return auth.NewIdentity(r.Metadata().ID())
 			},
 			TransformExtraOutputFunc: func(ctx context.Context, r controller.ReaderWriter, _ *zap.Logger, identity *auth.Identity, status *auth.ServiceAccountStatus) error {
 				publicKeyList, err := safe.ReaderListAll[*auth.PublicKey](
@@ -138,7 +137,7 @@ func NewServiceAccountStatusController() *ServiceAccountStatusController {
 			qtransform.MapperFuncFromTyped[*auth.PublicKey](
 				func(_ context.Context, _ *zap.Logger, _ controller.QRuntime, key *auth.PublicKey) ([]resource.Pointer, error) {
 					return []resource.Pointer{
-						auth.NewIdentity(resources.DefaultNamespace, key.TypedSpec().Value.Identity.Email).Metadata(),
+						auth.NewIdentity(key.TypedSpec().Value.Identity.Email).Metadata(),
 					}, nil
 				},
 			),

--- a/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/access"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
@@ -35,24 +34,24 @@ func (suite *ClusterServiceAccountStatusSuite) TestReconcile() {
 	suite.startRuntime()
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewServiceAccountStatusController()))
 
-	infraProviderServiceAccount := auth.NewIdentity(resources.DefaultNamespace, "p1"+access.InfraProviderServiceAccountNameSuffix)
+	infraProviderServiceAccount := auth.NewIdentity("p1" + access.InfraProviderServiceAccountNameSuffix)
 	infraProviderServiceAccount.TypedSpec().Value.UserId = "user2"
 	infraProviderServiceAccount.Metadata().Labels().Set(auth.LabelIdentityTypeServiceAccount, "")
 
-	serviceAccount := auth.NewIdentity(resources.DefaultNamespace, "u1"+access.ServiceAccountNameSuffix)
+	serviceAccount := auth.NewIdentity("u1" + access.ServiceAccountNameSuffix)
 	serviceAccount.TypedSpec().Value.UserId = "user1"
 	serviceAccount.Metadata().Labels().Set(auth.LabelIdentityTypeServiceAccount, "")
 
-	userIdentity := auth.NewIdentity(resources.DefaultNamespace, "p1")
+	userIdentity := auth.NewIdentity("p1")
 	userIdentity.TypedSpec().Value.UserId = "user1"
 
-	user1 := auth.NewUser(resources.DefaultNamespace, serviceAccount.TypedSpec().Value.UserId)
+	user1 := auth.NewUser(serviceAccount.TypedSpec().Value.UserId)
 	user1.TypedSpec().Value.Role = string(role.Admin)
 
-	user2 := auth.NewUser(resources.DefaultNamespace, infraProviderServiceAccount.TypedSpec().Value.UserId)
+	user2 := auth.NewUser(infraProviderServiceAccount.TypedSpec().Value.UserId)
 	user2.TypedSpec().Value.Role = string(role.InfraProvider)
 
-	publicKey := auth.NewPublicKey(resources.DefaultNamespace, "asdf")
+	publicKey := auth.NewPublicKey("asdf")
 	publicKey.Metadata().Labels().Set(auth.LabelPublicKeyUserID, user1.Metadata().ID())
 	publicKey.TypedSpec().Value.Identity = &specs.Identity{
 		Email: serviceAccount.Metadata().ID(),

--- a/internal/backend/runtime/omni/state_validation_test.go
+++ b/internal/backend/runtime/omni/state_validation_test.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -1091,7 +1090,7 @@ func TestIdentitySAMLValidation(t *testing.T) {
 		Enabled: true,
 	})...)
 
-	user := auth.NewIdentity(resources.DefaultNamespace, "aaa@example.org")
+	user := auth.NewIdentity("aaa@example.org")
 
 	assert := assert.New(t)
 
@@ -1144,18 +1143,18 @@ func TestCreateIdentityValidation(t *testing.T) {
 
 	assert := assert.New(t)
 
-	err := st.Create(ctx, auth.NewIdentity(resources.DefaultNamespace, "aaA"))
+	err := st.Create(ctx, auth.NewIdentity("aaA"))
 
 	assert.True(validated.IsValidationError(err), "expected validation error")
 	assert.ErrorContains(err, "must be lowercase")
 	assert.ErrorContains(err, "not a valid email address")
 
-	err = st.Create(ctx, auth.NewIdentity(resources.DefaultNamespace, "aaa"))
+	err = st.Create(ctx, auth.NewIdentity("aaa"))
 
 	assert.True(validated.IsValidationError(err), "expected validation error")
 	assert.ErrorContains(err, "not a valid email address")
 
-	assert.NoError(st.Create(ctx, auth.NewIdentity(resources.DefaultNamespace, "aaa@example.org")))
+	assert.NoError(st.Create(ctx, auth.NewIdentity("aaa@example.org")))
 }
 
 func TestExposedServiceAliasValidation(t *testing.T) {
@@ -1292,7 +1291,7 @@ func TestSAMLLabelRuleValidation(t *testing.T) {
 	innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
 	st := validated.NewState(innerSt, omni.SAMLLabelRuleValidationOptions()...)
 
-	labelRule := auth.NewSAMLLabelRule(resources.DefaultNamespace, "test-label-rule")
+	labelRule := auth.NewSAMLLabelRule("test-label-rule")
 	labelRule.TypedSpec().Value.AssignRole = "invalid"
 	labelRule.TypedSpec().Value.MatchLabels = []string{"--invalid--- ===== 5"}
 

--- a/internal/backend/saml/session.go
+++ b/internal/backend/saml/session.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/pkg/cosi/labels"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
@@ -146,7 +145,7 @@ func (sp *SessionProvider) CreateSession(w http.ResponseWriter, r *http.Request,
 		return errors.New("couldn't find user identity in the SAML assertion")
 	}
 
-	samlAssertion := auth.NewSAMLAssertion(resources.DefaultNamespace, session)
+	samlAssertion := auth.NewSAMLAssertion(session)
 
 	samlAssertion.TypedSpec().Value.Data, err = json.Marshal(assertion)
 	if err != nil {
@@ -246,7 +245,7 @@ func (sp *SessionProvider) ReadLabelsFromAssertion(ctx context.Context, assertio
 }
 
 func (sp *SessionProvider) ensureUser(ctx context.Context, email string, samlLabels map[string]string) error {
-	users, err := sp.state.List(ctx, auth.NewUser(resources.DefaultNamespace, "").Metadata())
+	users, err := sp.state.List(ctx, auth.NewUser("").Metadata())
 	if err != nil {
 		return err
 	}
@@ -283,7 +282,7 @@ func (sp *SessionProvider) ensureUser(ctx context.Context, email string, samlLab
 }
 
 func (sp *SessionProvider) updateIdentityLabels(ctx context.Context, identity string, samlLabels map[string]string) error {
-	identityPtr := auth.NewIdentity(resources.DefaultNamespace, identity).Metadata()
+	identityPtr := auth.NewIdentity(identity).Metadata()
 
 	_, err := safe.StateUpdateWithConflicts[*auth.Identity](ctx, sp.state, identityPtr, func(r *auth.Identity) error {
 		var toDelete []string

--- a/internal/backend/saml/session_test.go
+++ b/internal/backend/saml/session_test.go
@@ -21,7 +21,6 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/saml"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
@@ -216,22 +215,22 @@ func TestReadLabelsFromAssertion(t *testing.T) {
 func TestRoleInSAMLLabelRules(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
-	operatorRoleToDeveloper := auth.NewSAMLLabelRule(resources.DefaultNamespace, "assign-operator-to-developer")
+	operatorRoleToDeveloper := auth.NewSAMLLabelRule("assign-operator-to-developer")
 
 	operatorRoleToDeveloper.TypedSpec().Value.MatchLabels = []string{"saml.omni.sidero.dev/role/developer"}
 	operatorRoleToDeveloper.TypedSpec().Value.AssignRole = string(role.Operator)
 
-	readerRoleToDeveloper := auth.NewSAMLLabelRule(resources.DefaultNamespace, "assign-reader-to-developer")
+	readerRoleToDeveloper := auth.NewSAMLLabelRule("assign-reader-to-developer")
 
 	readerRoleToDeveloper.TypedSpec().Value.MatchLabels = []string{"saml.omni.sidero.dev/role/developer"}
 	readerRoleToDeveloper.TypedSpec().Value.AssignRole = string(role.Reader)
 
-	adminRoleToManager := auth.NewSAMLLabelRule(resources.DefaultNamespace, "assign-admin-to-manager")
+	adminRoleToManager := auth.NewSAMLLabelRule("assign-admin-to-manager")
 
 	adminRoleToManager.TypedSpec().Value.MatchLabels = []string{"saml.omni.sidero.dev/role/manager"}
 	adminRoleToManager.TypedSpec().Value.AssignRole = string(role.Admin)
 
-	invalidRoleToFoobar := auth.NewSAMLLabelRule(resources.DefaultNamespace, "assign-invalid-role-to-foobar")
+	invalidRoleToFoobar := auth.NewSAMLLabelRule("assign-invalid-role-to-foobar")
 
 	invalidRoleToFoobar.TypedSpec().Value.MatchLabels = []string{"saml.omni.sidero.dev/role/foobar"}
 	invalidRoleToFoobar.TypedSpec().Value.AssignRole = "invalid-role"

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -521,7 +521,7 @@ func (s *Server) authenticatorFunc() auth.AuthenticatorFunc {
 	return func(ctx context.Context, fingerprint string) (*auth.Authenticator, error) {
 		ctx = actor.MarkContextAsInternalActor(ctx)
 
-		ptr := authres.NewPublicKey(resources.DefaultNamespace, fingerprint).Metadata()
+		ptr := authres.NewPublicKey(fingerprint).Metadata()
 
 		pubKey, err := safe.StateGet[*authres.PublicKey](ctx, s.state.Default(), ptr)
 		if err != nil {

--- a/internal/backend/services/workloadproxy/accessvalidator.go
+++ b/internal/backend/services/workloadproxy/accessvalidator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
@@ -90,7 +89,7 @@ func (p *SignatureAccessValidator) ValidateAccess(ctx context.Context, publicKey
 
 	ctx = actor.MarkContextAsInternalActor(ctx)
 
-	publicKey, err := safe.StateGet[*authres.PublicKey](ctx, p.state, authres.NewPublicKey(resources.DefaultNamespace, publicKeyID).Metadata())
+	publicKey, err := safe.StateGet[*authres.PublicKey](ctx, p.state, authres.NewPublicKey(publicKeyID).Metadata())
 	if err != nil {
 		return err
 	}

--- a/internal/backend/services/workloadproxy/accessvalidator_test.go
+++ b/internal/backend/services/workloadproxy/accessvalidator_test.go
@@ -20,7 +20,6 @@ import (
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
@@ -54,7 +53,7 @@ func TestAccessValidator(t *testing.T) {
 	key, err := pgp.GenerateKey("test", "", "test@example.com", 8*time.Hour)
 	require.NoError(t, err)
 
-	publicKey := auth.NewPublicKey(resources.DefaultNamespace, "test-public-key-id")
+	publicKey := auth.NewPublicKey("test-public-key-id")
 
 	armored, err := key.ArmorPublic()
 	require.NoError(t, err)

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -653,9 +653,9 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 
 		// fully client-managed resources
 
-		identity := authres.NewIdentity(resources.DefaultNamespace, uuid.New().String())
+		identity := authres.NewIdentity(uuid.New().String())
 		accessPolicy := authres.NewAccessPolicy()
-		samlLabelRule := authres.NewSAMLLabelRule(resources.DefaultNamespace, uuid.New().String())
+		samlLabelRule := authres.NewSAMLLabelRule(uuid.New().String())
 		cluster := omni.NewCluster(uuid.New().String())
 		cluster.TypedSpec().Value.TalosVersion = "1.2.2"
 		configPatch := omni.NewConfigPatch(uuid.New().String())
@@ -696,7 +696,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				isAdminOnly:    true,
 			},
 			{
-				resource:       authres.NewUser(resources.DefaultNamespace, uuid.New().String()),
+				resource:       authres.NewUser(uuid.New().String()),
 				allowedVerbSet: allVerbsSet,
 				isAdminOnly:    true,
 			},
@@ -1148,7 +1148,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				resource: system.NewCertRefreshTick(uuid.New().String()),
 			},
 			{
-				resource: authres.NewPublicKey(resources.DefaultNamespace, uuid.New().String()),
+				resource: authres.NewPublicKey(uuid.New().String()),
 			},
 			{
 				resource: omni.NewEtcdAuditResult(uuid.New().String()),
@@ -1169,7 +1169,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				resource: omni.NewClusterSecrets(uuid.New().String()),
 			},
 			{
-				resource: authres.NewSAMLAssertion(resources.DefaultNamespace, uuid.New().String()),
+				resource: authres.NewSAMLAssertion(uuid.New().String()),
 			},
 			{
 				resource: omni.NewClusterMachineEncryptionKey(uuid.New().String()),

--- a/internal/pkg/auth/accesspolicy/accesspolicy.go
+++ b/internal/pkg/auth/accesspolicy/accesspolicy.go
@@ -156,7 +156,7 @@ func Validate(accessPolicy *auth.AccessPolicy) error {
 
 		// evaluate the test
 		clusterMD := omni.NewCluster(clusterName).Metadata()
-		identityMD := auth.NewIdentity(resources.DefaultNamespace, userName).Metadata()
+		identityMD := auth.NewIdentity(userName).Metadata()
 
 		for key, value := range test.GetUser().GetLabels() {
 			identityMD.Labels().Set(key, value)

--- a/internal/pkg/auth/accesspolicy/accesspolicy_test.go
+++ b/internal/pkg/auth/accesspolicy/accesspolicy_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
@@ -35,67 +34,67 @@ func TestCheck(t *testing.T) {
 
 	checkResult, err := accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-1-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "user-group-1-user-1").Metadata())
+		auth.NewIdentity("user-group-1-user-1").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-1", "k8s-group-2"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-1-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "user-group-1-user-2").Metadata())
+		auth.NewIdentity("user-group-1-user-2").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-1", "k8s-group-2"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-1-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "standalone-user-1").Metadata())
+		auth.NewIdentity("standalone-user-1").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-1", "k8s-group-2"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("standalone-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "standalone-user-1").Metadata())
+		auth.NewIdentity("standalone-user-1").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-1", "k8s-group-2"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-1-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "user-group-2-user-1").Metadata())
+		auth.NewIdentity("user-group-2-user-1").Metadata())
 	require.NoError(t, err)
 	assert.Empty(t, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-2-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "user-group-2-user-1").Metadata())
+		auth.NewIdentity("user-group-2-user-1").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-3", "k8s-group-4"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-2-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "user-group-2-user-2").Metadata())
+		auth.NewIdentity("user-group-2-user-2").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-3", "k8s-group-4"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-2-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "user-group-2-user-3").Metadata())
+		auth.NewIdentity("user-group-2-user-3").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-3", "k8s-group-4"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-2-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "standalone-user-2").Metadata())
+		auth.NewIdentity("standalone-user-2").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-3", "k8s-group-4"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("standalone-cluster-2").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "standalone-user-2").Metadata())
+		auth.NewIdentity("standalone-user-2").Metadata())
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"k8s-group-3", "k8s-group-4"}, checkResult.KubernetesImpersonateGroups)
 
 	checkResult, err = accesspolicy.Check(accessPolicy,
 		omni.NewCluster("cluster-group-2-cluster-1").Metadata(),
-		auth.NewIdentity(resources.DefaultNamespace, "user-group-1-user-1").Metadata())
+		auth.NewIdentity("user-group-1-user-1").Metadata())
 	require.NoError(t, err)
 	assert.Empty(t, checkResult.KubernetesImpersonateGroups)
 }

--- a/internal/pkg/auth/accesspolicy/cluster.go
+++ b/internal/pkg/auth/accesspolicy/cluster.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth"
@@ -45,7 +44,7 @@ func RoleForCluster(ctx context.Context, id resource.ID, st state.State) (role.R
 		return userRole, false, nil
 	}
 
-	identity, err := safe.StateGet[*authres.Identity](ctx, st, authres.NewIdentity(resources.DefaultNamespace, identityVal.Identity).Metadata())
+	identity, err := safe.StateGet[*authres.Identity](ctx, st, authres.NewIdentity(identityVal.Identity).Metadata())
 	if err != nil {
 		if state.IsNotFoundError(err) {
 			return userRole, false, nil

--- a/internal/pkg/auth/interceptor/saml.go
+++ b/internal/pkg/auth/interceptor/saml.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 	"github.com/siderolabs/omni/internal/pkg/auth"
@@ -103,7 +102,7 @@ func (i *SAML) intercept(ctx context.Context) (context.Context, error) {
 func (i *SAML) getSession(ctx context.Context, sessionID string) (*authres.SAMLAssertion, error) {
 	ctx = actor.MarkContextAsInternalActor(ctx)
 
-	acs, err := safe.StateGet[*authres.SAMLAssertion](ctx, i.state, authres.NewSAMLAssertion(resources.DefaultNamespace, sessionID).Metadata())
+	acs, err := safe.StateGet[*authres.SAMLAssertion](ctx, i.state, authres.NewSAMLAssertion(sessionID).Metadata())
 	if err != nil {
 		i.logger.Info("invalid session", zap.Error(err))
 

--- a/internal/pkg/auth/user/user.go
+++ b/internal/pkg/auth/user/user.go
@@ -17,14 +17,13 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // EnsureInitialResources creates the auth.User and auth.Identity resources if they are not present.
 func EnsureInitialResources(ctx context.Context, st state.State, logger *zap.Logger, initialUsers []string) error {
-	items, err := st.List(ctx, auth.NewUser(resources.DefaultNamespace, "").Metadata())
+	items, err := st.List(ctx, auth.NewUser("").Metadata())
 	if err != nil {
 		return err
 	}
@@ -50,7 +49,7 @@ func EnsureInitialResources(ctx context.Context, st state.State, logger *zap.Log
 func Ensure(ctx context.Context, st state.State, email string, role role.Role, updateRole bool) error {
 	email = strings.ToLower(email)
 
-	identity, err := safe.StateGet[*auth.Identity](ctx, st, auth.NewIdentity(resources.DefaultNamespace, email).Metadata())
+	identity, err := safe.StateGet[*auth.Identity](ctx, st, auth.NewIdentity(email).Metadata())
 	if err != nil {
 		if !state.IsNotFoundError(err) {
 			return err
@@ -58,7 +57,7 @@ func Ensure(ctx context.Context, st state.State, email string, role role.Role, u
 
 		newUserID := uuid.New().String()
 
-		identity = auth.NewIdentity(resources.DefaultNamespace, email)
+		identity = auth.NewIdentity(email)
 		identity.TypedSpec().Value.UserId = newUserID
 		identity.Metadata().Labels().Set(auth.LabelIdentityUserID, newUserID)
 
@@ -68,7 +67,7 @@ func Ensure(ctx context.Context, st state.State, email string, role role.Role, u
 		}
 	}
 
-	user := auth.NewUser(resources.DefaultNamespace, identity.TypedSpec().Value.UserId)
+	user := auth.NewUser(identity.TypedSpec().Value.UserId)
 
 	user.TypedSpec().Value.Role = string(role)
 


### PR DESCRIPTION
Resolves https://github.com/siderolabs/omni/issues/1133

There are more package resources that follow the same pattern, and similar refactoring could be applied there as well.
Example:
`NewUser(ns, id string)`
`NewPublicKey(ns, id string)`
`NewCluster(ns string, id resource.ID)`

I don’t see any open issues for the other resources, but I can include changes in this PR or raise separate issues if refactoring is required elsewhere.