### PR TITLE
fix: ignore labeled `MachineSetNodes` in the UI same way as for CLI

### DIFF
--- a/frontend/src/methods/cluster.ts
+++ b/frontend/src/methods/cluster.ts
@@ -164,6 +164,11 @@ export const clusterSync = async (resources: Resource[], old?: Resource[]) => {
 
     for (const key in resourcesMap) {
       const md = resourcesMap[key].metadata
+
+      if (md.labels?.[LabelManagedByMachineSetNodeController] !== undefined) {
+        continue
+      }
+
       toDestroy.push({
         id: md.id,
         namespace: md.namespace,


### PR DESCRIPTION
It looks like the UI was affected by the same bug as CLI, see https://github.com/siderolabs/omni/pull/2056