### PR TITLE
fix(installation-media): prevent double schematic creation for sbc flow

### DIFF
--- a/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
@@ -125,6 +125,8 @@ const schematicError = ref<string>()
 const schematic = computedAsync(async () => {
   schematicLoading.value = true
 
+  if (formState.value.hardwareType === 'sbc' && !selectedSBC.value) return
+
   const machineLabels = Object.entries(formState.value.machineUserLabels ?? {}).reduce<
     Record<string, string>
   >(


### PR DESCRIPTION
Prevent creating schematics twice for SBCs in the installation media wizard. This was due to `selectedSBC` not being defined on the first pass, and then the computed function reacts to it being defined and runs again.