### PR TITLE
feat: make namespace implicit in auth.NewPublicKey

### DIFF
--- a/client/pkg/omni/resources/auth/public_key.go
+++ b/client/pkg/omni/resources/auth/public_key.go
@@ -21,9 +21,9 @@ import (
 )
 
 // NewPublicKey creates a new PublicKey resource.
-func NewPublicKey(ns, id string) *PublicKey {
+func NewPublicKey(id string) *PublicKey {
 	return typed.NewResource[PublicKeySpec, PublicKeyExtension](
-		resource.NewMetadata(ns, PublicKeyType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.DefaultNamespace, PublicKeyType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.PublicKeySpec{}),
 	)
 }

--- a/internal/backend/grpc/auth.go
+++ b/internal/backend/grpc/auth.go
@@ -171,7 +171,7 @@ func (s *authServer) RegisterPublicKey(ctx context.Context, request *authpb.Regi
 		}
 	}
 
-	newPubKey := authres.NewPublicKey(resources.DefaultNamespace, pubKey.id)
+	newPubKey := authres.NewPublicKey(pubKey.id)
 
 	_, err = safe.StateGet[*authres.PublicKey](ctx, s.state, newPubKey.Metadata())
 	if state.IsNotFoundError(err) {
@@ -208,7 +208,7 @@ func (s *authServer) AwaitPublicKeyConfirmation(ctx context.Context, request *au
 	ctx, cancel := context.WithTimeout(ctx, awaitPublicKeyConfirmationTimeout)
 	defer cancel()
 
-	pubKey := authres.NewPublicKey(resources.DefaultNamespace, request.GetPublicKeyId())
+	pubKey := authres.NewPublicKey(request.GetPublicKeyId())
 
 	_, err := s.state.WatchFor(ctx, pubKey.Metadata(),
 		state.WithEventTypes(state.Created, state.Updated),
@@ -311,7 +311,7 @@ func (s *authServer) ConfirmPublicKey(ctx context.Context, request *authpb.Confi
 		return nil, err
 	}
 
-	pubKey, err := safe.StateGet[*authres.PublicKey](ctx, s.state, authres.NewPublicKey(resources.DefaultNamespace, request.GetPublicKeyId()).Metadata())
+	pubKey, err := safe.StateGet[*authres.PublicKey](ctx, s.state, authres.NewPublicKey(request.GetPublicKeyId()).Metadata())
 	if err != nil {
 		if state.IsNotFoundError(err) {
 			return nil, status.Error(codes.PermissionDenied, "permission denied")

--- a/internal/backend/grpc/serviceaccount.go
+++ b/internal/backend/grpc/serviceaccount.go
@@ -80,7 +80,7 @@ func (s *managementServer) RenewServiceAccount(ctx context.Context, req *managem
 		return nil, err
 	}
 
-	publicKeyResource := authres.NewPublicKey(resources.DefaultNamespace, key.ID)
+	publicKeyResource := authres.NewPublicKey(key.ID)
 	publicKeyResource.Metadata().Labels().Set(authres.LabelPublicKeyUserID, identity.TypedSpec().Value.UserId)
 
 	publicKeyResource.TypedSpec().Value.PublicKey = key.Data

--- a/internal/backend/runtime/omni/audit/audit_test.go
+++ b/internal/backend/runtime/omni/audit/audit_test.go
@@ -50,7 +50,7 @@ func TestAudit(t *testing.T) {
 
 	hooks.Init(l)
 
-	res := auth.NewPublicKey(resources.DefaultNamespace, "917e47635eb900d0ae66271dd1e06966e048c4f3")
+	res := auth.NewPublicKey("917e47635eb900d0ae66271dd1e06966e048c4f3")
 
 	res.Metadata().Labels().Set(auth.LabelPublicKeyUserID, "002cf196-1767-43fd-8e3d-91241e2ce70c")
 

--- a/internal/backend/runtime/omni/controllers/omni/infra_provider_cleanup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_provider_cleanup_test.go
@@ -42,7 +42,7 @@ func (c infraProviderCleanupTestHelper) prepareProvider(t *testing.T, ctx contex
 	serviceAccount.Metadata().Labels().Set(auth.LabelIdentityTypeServiceAccount, "")
 	serviceAccount.Metadata().Labels().Set(auth.LabelIdentityUserID, userID)
 	serviceAccount.TypedSpec().Value.UserId = userID
-	publicKey := auth.NewPublicKey(resources.DefaultNamespace, "test-public-key")
+	publicKey := auth.NewPublicKey("test-public-key")
 	publicKey.Metadata().Labels().Set(auth.LabelIdentityUserID, userID)
 
 	require.NoError(t, st.Create(ctx, provider))

--- a/internal/backend/runtime/omni/controllers/omni/key_pruner_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/key_pruner_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 )
@@ -49,13 +48,13 @@ func (suite *KeyPrunerSuite) setup() *clock.Mock {
 func (suite *KeyPrunerSuite) TestRemoveExpiredKey() {
 	fakeClock := suite.setup()
 
-	publicKey := authres.NewPublicKey(resources.DefaultNamespace, testID)
+	publicKey := authres.NewPublicKey(testID)
 	publicKey.TypedSpec().Value.Confirmed = true
 	publicKey.TypedSpec().Value.Expiration = timestamppb.New(fakeClock.Now().Add(defaultExpirationTime))
 
 	fakeClock.Add(4 * time.Second)
 
-	publicKey2 := authres.NewPublicKey(resources.DefaultNamespace, "testID2")
+	publicKey2 := authres.NewPublicKey("testID2")
 	publicKey2.TypedSpec().Value.Confirmed = true
 	publicKey2.TypedSpec().Value.Expiration = timestamppb.New(fakeClock.Now().Add(defaultExpirationTime))
 

--- a/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
@@ -52,7 +52,7 @@ func (suite *ClusterServiceAccountStatusSuite) TestReconcile() {
 	user2 := auth.NewUser(resources.DefaultNamespace, infraProviderServiceAccount.TypedSpec().Value.UserId)
 	user2.TypedSpec().Value.Role = string(role.InfraProvider)
 
-	publicKey := auth.NewPublicKey(resources.DefaultNamespace, "asdf")
+	publicKey := auth.NewPublicKey("asdf")
 	publicKey.Metadata().Labels().Set(auth.LabelPublicKeyUserID, user1.Metadata().ID())
 	publicKey.TypedSpec().Value.Identity = &specs.Identity{
 		Email: serviceAccount.Metadata().ID(),

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -193,9 +193,9 @@ func (suite *MigrationSuite) Test_changePublicKeyOwner() {
 	defer cancel()
 
 	keys := []*authres.PublicKey{
-		authres.NewPublicKey(resources.DefaultNamespace, "test1"),
-		authres.NewPublicKey(resources.DefaultNamespace, "test2"),
-		authres.NewPublicKey(resources.DefaultNamespace, "test3"),
+		authres.NewPublicKey("test1"),
+		authres.NewPublicKey("test2"),
+		authres.NewPublicKey("test3"),
 	}
 
 	for _, key := range keys[:2] {
@@ -727,10 +727,10 @@ func (suite *MigrationSuite) TestAddServiceAccountScopesToUsers() {
 	user2 := authres.NewUser(resources.DefaultNamespace, fmt.Sprintf("user2-%s", id))
 	user2.TypedSpec().Value.Scopes = scope.NewScopes(scope.UserAny).Strings()
 
-	publicKey1 := authres.NewPublicKey(resources.DefaultNamespace, fmt.Sprintf("publicKey1-%s", id))
+	publicKey1 := authres.NewPublicKey(fmt.Sprintf("publicKey1-%s", id))
 	publicKey1.TypedSpec().Value.Scopes = scope.NewScopes(scope.ClusterAny).Strings()
 
-	publicKey2 := authres.NewPublicKey(resources.DefaultNamespace, fmt.Sprintf("publicKey2-%s", id))
+	publicKey2 := authres.NewPublicKey(fmt.Sprintf("publicKey2-%s", id))
 
 	suite.Require().NoError(suite.state.Create(ctx, user1))
 	suite.Require().NoError(suite.state.Create(ctx, user2))
@@ -824,19 +824,19 @@ func (suite *MigrationSuite) TestConvertScopesToRoles() {
 	userWithServiceAccountScopes := authres.NewUser(resources.DefaultNamespace, fmt.Sprintf("userWithServiceAccountScopes-%s", uuid.New().String()))
 	userWithServiceAccountScopes.TypedSpec().Value.Scopes = scope.NewScopes(scope.ServiceAccountCreate).Strings()
 
-	pubKeyWithNoScopes := authres.NewPublicKey(resources.DefaultNamespace, fmt.Sprintf("pubKeyWithNoScopes-%s", uuid.New().String()))
+	pubKeyWithNoScopes := authres.NewPublicKey(fmt.Sprintf("pubKeyWithNoScopes-%s", uuid.New().String()))
 	pubKeyWithNoScopes.TypedSpec().Value.Scopes = []string{}
 
-	pubKeyWithReadScopes := authres.NewPublicKey(resources.DefaultNamespace, fmt.Sprintf("pubKeyWithReadScopes-%s", uuid.New().String()))
+	pubKeyWithReadScopes := authres.NewPublicKey(fmt.Sprintf("pubKeyWithReadScopes-%s", uuid.New().String()))
 	pubKeyWithReadScopes.TypedSpec().Value.Scopes = scope.NewScopes(scope.MachineRead, scope.ClusterRead).Strings()
 
-	pubKeyWithModifyScopes := authres.NewPublicKey(resources.DefaultNamespace, fmt.Sprintf("pubKeyWithModifyScopes-%s", uuid.New().String()))
+	pubKeyWithModifyScopes := authres.NewPublicKey(fmt.Sprintf("pubKeyWithModifyScopes-%s", uuid.New().String()))
 	pubKeyWithModifyScopes.TypedSpec().Value.Scopes = scope.NewScopes(scope.ClusterModify).Strings()
 
-	pubKeyWithUserMgmtScopes := authres.NewPublicKey(resources.DefaultNamespace, fmt.Sprintf("pubKeyWithUserMgmtScopes-%s", uuid.New().String()))
+	pubKeyWithUserMgmtScopes := authres.NewPublicKey(fmt.Sprintf("pubKeyWithUserMgmtScopes-%s", uuid.New().String()))
 	pubKeyWithUserMgmtScopes.TypedSpec().Value.Scopes = scope.NewScopes(scope.UserRead).Strings()
 
-	pubKeyWithServiceAccountScopes := authres.NewPublicKey(resources.DefaultNamespace, fmt.Sprintf("pubKeyWithServiceAccountScopes-%s", uuid.New().String()))
+	pubKeyWithServiceAccountScopes := authres.NewPublicKey(fmt.Sprintf("pubKeyWithServiceAccountScopes-%s", uuid.New().String()))
 	pubKeyWithServiceAccountScopes.TypedSpec().Value.Scopes = scope.NewScopes(scope.ServiceAccountCreate).Strings()
 
 	suite.Require().NoError(suite.state.Create(ctx, userWithNoScopes))
@@ -917,12 +917,12 @@ func (suite *MigrationSuite) TestLowercaseEmails() {
 	identityOverwritten := authres.NewIdentity(resources.DefaultNamespace, "c@a.com")
 	identityOverwritten.TypedSpec().Value.UserId = "eee"
 
-	publicKey := authres.NewPublicKey(resources.DefaultNamespace, "1")
+	publicKey := authres.NewPublicKey("1")
 	publicKey.TypedSpec().Value.Identity = &specs.Identity{
 		Email: "USER@a.com",
 	}
 
-	danglingPublicKey := authres.NewPublicKey(resources.DefaultNamespace, "2")
+	danglingPublicKey := authres.NewPublicKey("2")
 
 	suite.Require().NoError(suite.state.Create(ctx, identityUppercase))
 	suite.Require().NoError(suite.state.Create(ctx, identityConflict))

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -521,7 +521,7 @@ func (s *Server) authenticatorFunc() auth.AuthenticatorFunc {
 	return func(ctx context.Context, fingerprint string) (*auth.Authenticator, error) {
 		ctx = actor.MarkContextAsInternalActor(ctx)
 
-		ptr := authres.NewPublicKey(resources.DefaultNamespace, fingerprint).Metadata()
+		ptr := authres.NewPublicKey(fingerprint).Metadata()
 
 		pubKey, err := safe.StateGet[*authres.PublicKey](ctx, s.state.Default(), ptr)
 		if err != nil {

--- a/internal/backend/services/workloadproxy/accessvalidator.go
+++ b/internal/backend/services/workloadproxy/accessvalidator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
-	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
@@ -90,7 +89,7 @@ func (p *SignatureAccessValidator) ValidateAccess(ctx context.Context, publicKey
 
 	ctx = actor.MarkContextAsInternalActor(ctx)
 
-	publicKey, err := safe.StateGet[*authres.PublicKey](ctx, p.state, authres.NewPublicKey(resources.DefaultNamespace, publicKeyID).Metadata())
+	publicKey, err := safe.StateGet[*authres.PublicKey](ctx, p.state, authres.NewPublicKey(publicKeyID).Metadata())
 	if err != nil {
 		return err
 	}

--- a/internal/backend/services/workloadproxy/accessvalidator_test.go
+++ b/internal/backend/services/workloadproxy/accessvalidator_test.go
@@ -54,7 +54,7 @@ func TestAccessValidator(t *testing.T) {
 	key, err := pgp.GenerateKey("test", "", "test@example.com", 8*time.Hour)
 	require.NoError(t, err)
 
-	publicKey := auth.NewPublicKey(resources.DefaultNamespace, "test-public-key-id")
+	publicKey := auth.NewPublicKey("test-public-key-id")
 
 	armored, err := key.ArmorPublic()
 	require.NoError(t, err)

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -1156,7 +1156,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 				resource: system.NewCertRefreshTick(resources.DefaultNamespace, uuid.New().String()),
 			},
 			{
-				resource: authres.NewPublicKey(resources.DefaultNamespace, uuid.New().String()),
+				resource: authres.NewPublicKey(uuid.New().String()),
 			},
 			{
 				resource: omni.NewEtcdAuditResult(resources.DefaultNamespace, uuid.New().String()),

--- a/internal/pkg/auth/serviceaccount/serviceaccount.go
+++ b/internal/pkg/auth/serviceaccount/serviceaccount.go
@@ -79,7 +79,7 @@ func Create(ctx context.Context, st state.State, name, userRole string, useUserR
 
 	newUserID := uuid.NewString()
 
-	publicKeyResource := authres.NewPublicKey(resources.DefaultNamespace, key.ID)
+	publicKeyResource := authres.NewPublicKey(key.ID)
 	publicKeyResource.Metadata().Labels().Set(authres.LabelPublicKeyUserID, newUserID)
 
 	if sa.IsInfraProvider {
@@ -150,7 +150,7 @@ func Destroy(ctx context.Context, st state.State, name string) error {
 
 	pubKeys, err := st.List(
 		ctx,
-		authres.NewPublicKey(resources.DefaultNamespace, "").Metadata(),
+		authres.NewPublicKey("").Metadata(),
 		state.WithLabelQuery(resource.LabelEqual(authres.LabelIdentityUserID, identity.TypedSpec().Value.UserId)),
 	)
 	if err != nil {


### PR DESCRIPTION
Relates to https://github.com/siderolabs/omni/issues/1133
Part of refactoring backend code (specifically making namespace implicit) for `NewPublicKey`
See https://github.com/siderolabs/omni/pull/2060