### PR TITLE
feat: make namespace implicit in k8s and oidc package NewResource

### DIFF
--- a/client/pkg/omni/resources/k8s/kubernetes_resource.go
+++ b/client/pkg/omni/resources/k8s/kubernetes_resource.go
@@ -13,9 +13,9 @@ import (
 )
 
 // NewKubernetesResource creates new cluster config version resource.
-func NewKubernetesResource(ns string, id resource.ID, spec KubernetesResourceSpec) *KubernetesResource {
+func NewKubernetesResource(id resource.ID, spec KubernetesResourceSpec) *KubernetesResource {
 	return typed.NewResource[KubernetesResourceSpec, KubernetesResourceExtension](
-		resource.NewMetadata(ns, KubernetesResourceType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.DefaultNamespace, KubernetesResourceType, id, resource.VersionUndefined),
 		spec,
 	)
 }

--- a/client/pkg/omni/resources/oidc/jwt_public_key.go
+++ b/client/pkg/omni/resources/oidc/jwt_public_key.go
@@ -14,9 +14,9 @@ import (
 )
 
 // NewJWTPublicKey creates new JWTPublicKey state.
-func NewJWTPublicKey(ns, id string) *JWTPublicKey {
+func NewJWTPublicKey(id string) *JWTPublicKey {
 	return typed.NewResource[JWTPublicKeySpec, JWTPublicKeyExtension](
-		resource.NewMetadata(ns, JWTPublicKeyType, id, resource.VersionUndefined),
+		resource.NewMetadata(NamespaceName, JWTPublicKeyType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.JWTPublicKeySpec{}),
 	)
 }

--- a/internal/backend/oidc/internal/storage/keys/storage.go
+++ b/internal/backend/oidc/internal/storage/keys/storage.go
@@ -199,7 +199,7 @@ func (s *Storage) generateKey() (*rsa.PrivateKey, error) {
 }
 
 func (s *Storage) storeKey(ctx context.Context, keyID string, privateKey *rsa.PrivateKey) error {
-	key := oidc.NewJWTPublicKey(oidc.NamespaceName, keyID)
+	key := oidc.NewJWTPublicKey(keyID)
 	key.TypedSpec().Value.PublicKey = x509.MarshalPKCS1PublicKey(&privateKey.PublicKey)
 
 	maxTokenFiletime := s.MaxTokenLifetime()

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -1139,7 +1139,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 		// no access resources
 		testCases = append(testCases, []resourceAuthzTestCase{
 			{
-				resource: oidc.NewJWTPublicKey(resources.DefaultNamespace, uuid.New().String()),
+				resource: oidc.NewJWTPublicKey(uuid.New().String()),
 			},
 			{
 				resource: system.NewDBVersion(uuid.New().String()),


### PR DESCRIPTION
Ref: https://github.com/siderolabs/omni/issues/1133
Refactored `NewKubernetesResource` and `NewJWTPublicKey` to use implicit namespace.

Did not see a reference/use of `NewKubernetesResource` but from the comment 
`// NewKubernetesResource creates new cluster config version resource.`  Sounds important 