### PR TITLE
fix(frontend): align cluster machines properly when mixing with classes

### DIFF
--- a/frontend/src/components/SideBar/TSideBar.stories.ts
+++ b/frontend/src/components/SideBar/TSideBar.stories.ts
@@ -8,6 +8,7 @@ import { http, HttpResponse } from 'msw'
 import { vueRouter } from 'storybook-vue3-router'
 import { RouterView } from 'vue-router'
 
+import type { Resource } from '@/api/grpc'
 import type { GetRequest } from '@/api/omni/resources/resources.pb'
 import type { InfraProviderStatusSpec } from '@/api/omni/specs/infra.pb'
 import type {
@@ -17,6 +18,7 @@ import type {
   KubernetesUpgradeManifestStatusSpec,
   MachineStatusMetricsSpec,
 } from '@/api/omni/specs/omni.pb'
+import type { ClusterPermissionsSpec } from '@/api/omni/specs/virtual.pb'
 import {
   ClusterMachineIdentityType,
   ClusterPermissionsType,
@@ -416,16 +418,11 @@ export const Default: Story = {
                 can_download_support_bundle: true,
               },
               metadata: {
-                created: '2025-10-23T09:34:12Z',
-                updated: '2025-10-23T09:34:12Z',
-                namespace: 'virtual',
-                type: 'ClusterPermissions.omni.sidero.dev',
+                namespace: VirtualNamespace,
+                type: ClusterPermissionsType,
                 id: 'talos-default',
-                owner: '',
-                phase: 'running',
-                version: '1',
               },
-            }),
+            } as Resource<ClusterPermissionsSpec>),
           })
         }),
 

--- a/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
@@ -266,11 +266,13 @@ const sectionHeadingId = useId()
         }})
       </div>
 
-      <TActionsBox v-if="canRemoveMachineSet" class="self-center justify-self-end">
-        <TActionsBoxItem icon="delete" danger @select="() => openMachineSetDestroy(machineSet)">
-          Destroy Machine Set
-        </TActionsBoxItem>
-      </TActionsBox>
+      <div class="flex items-center justify-end">
+        <TActionsBox v-if="canRemoveMachineSet">
+          <TActionsBoxItem icon="delete" danger @select="() => openMachineSetDestroy(machineSet)">
+            Destroy Machine Set
+          </TActionsBoxItem>
+        </TActionsBox>
+      </div>
     </div>
 
     <ClusterMachine

--- a/frontend/src/views/omni/Clusters/Clusters.stories.ts
+++ b/frontend/src/views/omni/Clusters/Clusters.stories.ts
@@ -24,6 +24,7 @@ import {
   MachineSetSpecMachineAllocationType,
   type MachineSetStatusSpec,
 } from '@/api/omni/specs/omni.pb'
+import type { ClusterPermissionsSpec } from '@/api/omni/specs/virtual.pb'
 import {
   ClusterDiagnosticsType,
   ClusterLocked,
@@ -275,16 +276,11 @@ export const Data: Story = {
                 can_download_support_bundle: true,
               },
               metadata: {
-                created: '2025-10-01T18:42:13Z',
-                updated: '2025-10-01T18:42:13Z',
-                namespace: 'virtual',
-                type: 'ClusterPermissions.omni.sidero.dev',
+                namespace: VirtualNamespace,
+                type: ClusterPermissionsType,
                 id: 'talos-test-cluster',
-                owner: '',
-                phase: 'running',
-                version: 1,
               },
-            }),
+            } as Resource<ClusterPermissionsSpec>),
           })
         }),
       ],


### PR DESCRIPTION
When mixing machines and machine classes, keep the machines aligned with each other in the cluster machine list on the cluster page. Also refactor the OverviewContent watches to useResourceWatch.

Fixes #2054