### PR TITLE
chore: update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For instructions on developing Omni, see [DEVELOPMENT.md](DEVELOPMENT.md).
 ## Community
 
 - Support: Questions, bugs, feature requests [GitHub Issues](https://github.com/siderolabs/omni/issues)
-- Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Slack: Join our [slack channel](https://taloscommunity.slack.com/). Request access via [inviter.co](https://inviter.co/sidero-labs-community).
 - Twitter: [@SideroLabs](https://twitter.com/SideroLabs)
 - Email: [info@SideroLabs.com](mailto:info@SideroLabs.com)
 

--- a/client/README.md
+++ b/client/README.md
@@ -17,7 +17,7 @@ For instructions on using Omni, see the [Documentation](https://omni.siderolabs.
 
 ## Community
 
-- Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Slack: Join our [slack channel](https://taloscommunity.slack.com/). Request access via [inviter.co](https://inviter.co/sidero-labs-community).
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/SideroLabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/SideroLabs)


### PR DESCRIPTION
This PR updates the slack links to include reference to the auto-inviter at inviter.co