### PR TITLE
fix(frontend): allow selecting all download options for omnictl

### DIFF
--- a/frontend/src/components/common/SelectList/TSelectList.spec.ts
+++ b/frontend/src/components/common/SelectList/TSelectList.spec.ts
@@ -9,9 +9,6 @@ import { afterEach, expect, test, vi } from 'vitest'
 
 import TSelectList from './TSelectList.vue'
 
-// Used by reka-ui select, test fails without it
-window.HTMLElement.prototype.hasPointerCapture = vi.fn()
-
 enableAutoUnmount(afterEach)
 
 test('is accessible with inline label', () => {

--- a/frontend/src/views/omni/Modals/DownloadOmnictl.spec.ts
+++ b/frontend/src/views/omni/Modals/DownloadOmnictl.spec.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { afterEach, expect, test, vi } from 'vitest'
+
+import { getPlatform } from '@/methods'
+
+import DownloadOmnictl from './DownloadOmnictl.vue'
+
+vi.mock('@/methods', () => ({
+  getDocsLink: vi.fn(() => 'https://docs.example.com'),
+  getPlatform: vi.fn(),
+}))
+
+const mockGetPlatform = vi.mocked(getPlatform)
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+test('sets default value based on platform', async () => {
+  mockGetPlatform.mockResolvedValue(['linux', 'amd64'])
+
+  render(DownloadOmnictl)
+
+  expect(await screen.findByLabelText('omnictl')).toHaveTextContent('omnictl-linux-amd64')
+})
+
+test('allows selecting other options', async () => {
+  const user = userEvent.setup()
+  mockGetPlatform.mockResolvedValue(['linux', 'amd64'])
+
+  render(DownloadOmnictl)
+
+  const trigger = await screen.findByLabelText('omnictl')
+
+  // Open dropdown
+  await user.click(trigger)
+
+  const option = screen.getByRole('option', { name: 'omnictl-darwin-arm64' })
+
+  // Select option
+  await user.click(option)
+
+  expect(trigger).toHaveTextContent('omnictl-darwin-arm64')
+})

--- a/frontend/src/views/omni/Modals/DownloadOmnictl.vue
+++ b/frontend/src/views/omni/Modals/DownloadOmnictl.vue
@@ -46,9 +46,11 @@ const defaultValue = computed(() => {
   return options.find((o) => o === `omnictl-${os}-${arch}`) ?? options[2]
 })
 
-const selectedOption = ref(defaultValue)
+const selectedOption = ref<string>()
 
 const download = () => {
+  if (!selectedOption.value) return
+
   close()
 
   const a = document.createElement('a')
@@ -101,7 +103,7 @@ const download = () => {
       <TButton class="h-9 w-32" @click="close">
         <span>Cancel</span>
       </TButton>
-      <TButton class="h-9 w-32" @click="download">
+      <TButton class="h-9 w-32" :disabled="!selectedOption" @click="download">
         <span>Download</span>
       </TButton>
     </div>

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -7,7 +7,7 @@ import 'fake-indexeddb/auto'
 
 import { server } from '@msw/server'
 import { cleanup } from '@testing-library/vue'
-import { afterAll, afterEach, beforeAll } from 'vitest'
+import { afterAll, afterEach, beforeAll, vi } from 'vitest'
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
 afterEach(() => server.resetHandlers())
@@ -18,3 +18,6 @@ afterAll(() => server.close())
  * See: https://testing-library.com/docs/vue-testing-library/setup/#cleanup
  */
 afterEach(() => cleanup())
+
+// Used by reka-ui select, tests fail without it
+window.HTMLElement.prototype.hasPointerCapture = vi.fn()


### PR DESCRIPTION
Allow selecting all download options for omnictl, not just the default. There was a bug locking the select to the default option only.

Fixes #2086 