### PR TITLE
chore!: set minimum talos version to 1.7.0

### DIFF
--- a/client/pkg/constants/constants.go
+++ b/client/pkg/constants/constants.go
@@ -12,12 +12,12 @@ import "time"
 const SecureBoot = "secureboot"
 
 // DefaultTalosVersion is pre-selected in the UI, default image and used in the integration tests.
-//
 // tsgen:DefaultTalosVersion
 const DefaultTalosVersion = "1.11.5"
 
 // MinTalosVersion allowed to be used when creating the cluster.
-const MinTalosVersion = "1.6.0"
+// tsgen:MinTalosVersion
+const MinTalosVersion = "1.7.0"
 
 const (
 	// TalosRegistry is the default Talos repository URL.

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -31,6 +31,7 @@ export const MaxJoinTokenNameLength = 16;
 export const authPublicKeyIDQueryParam = "public-key-id";
 export const SecureBoot = "secureboot";
 export const DefaultTalosVersion = "1.11.5";
+export const MinTalosVersion = "1.7.0";
 export const PatchWeightInstallDisk = 0;
 export const PatchBaseWeightCluster = 200;
 export const PatchBaseWeightMachineSet = 400;

--- a/frontend/src/methods/useTalosctlDownloads.ts
+++ b/frontend/src/methods/useTalosctlDownloads.ts
@@ -3,9 +3,10 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 import { computedAsync } from '@vueuse/core'
-import { compareLoose } from 'semver'
+import { compareLoose, gte } from 'semver'
 import { computed } from 'vue'
 
+import { MinTalosVersion } from '@/api/resources'
 import { showError } from '@/notification'
 
 export interface TalosctlDownloadsResponse {
@@ -37,7 +38,11 @@ export function useTalosctlDownloads() {
         release_data: { available_versions },
       }: TalosctlDownloadsResponse = await response.json()
 
-      return new Map(Object.entries(available_versions).sort(([a], [b]) => compareLoose(a, b)))
+      return new Map(
+        Object.entries(available_versions)
+          .filter(([v]) => gte(v, MinTalosVersion))
+          .sort(([a], [b]) => compareLoose(a, b)),
+      )
     } catch (e) {
       showError('Error getting latest talos releases', e?.message ?? String(e))
     }

--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -381,7 +381,6 @@ const filterByLabel = (e: { key: string; value?: string }) => {
             <div class="flex flex-col gap-1 p-2">
               <p>Encrypt machine disks using Omni as a key management server.</p>
               <p>Once cluster is created it is not possible to update encryption settings.</p>
-              <p class="text-primary-p2">This feature is only available for Talos >= 1.5.0.</p>
             </div>
           </template>
           <TCheckbox

--- a/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
@@ -44,15 +44,6 @@ import type { FormState } from '@/views/omni/InstallationMedia/InstallationMedia
 
 const formState = defineModel<FormState>({ required: true })
 
-const productionGuideAvailable = computed(
-  () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.5.0'),
-)
-const troubleshootingGuideAvailable = computed(
-  () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.6.0'),
-)
-const supportsOverlay = computed(
-  () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.7.0'),
-)
 const supportsUnifiedInstaller = computed(
   () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.10.0'),
 )
@@ -203,15 +194,7 @@ const imageBaseURL = computed(
   () => `${factoryUrl.value}/image/${schematic.value?.id}/${formState.value.talosVersion}`,
 )
 
-const sbcDiskImagePath = computed(() => {
-  if (!selectedSBC.value) return
-
-  const path = supportsOverlay.value
-    ? `metal-${arch.value}.raw.xz`
-    : `metal-${selectedSBC.value.metadata.id}-${arch.value}.raw.xz`
-
-  return `${imageBaseURL.value}/${path}`
-})
+const sbcDiskImagePath = computed(() => `${imageBaseURL.value}/metal-${arch.value}.raw.xz`)
 
 const pxeBootBaseUrl = computed(() => features.value?.spec.image_factory_pxe_base_url)
 
@@ -601,7 +584,7 @@ function shortVersion(version?: string) {
         </a>
       </li>
 
-      <li v-if="productionGuideAvailable">
+      <li>
         <a
           class="link-primary"
           :href="
@@ -616,7 +599,7 @@ function shortVersion(version?: string) {
         </a>
       </li>
 
-      <li v-if="troubleshootingGuideAvailable">
+      <li>
         <a
           class="link-primary"
           :href="

--- a/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.vue
@@ -22,10 +22,6 @@ import type { FormState } from '@/views/omni/InstallationMedia/InstallationMedia
 
 const formState = defineModel<FormState>({ required: true })
 
-const supportsOverlayOptions = computed(
-  () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.7.0'),
-)
-
 const supportsCustomisingKernelArgs = computed(
   () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.10.0'),
 )
@@ -95,7 +91,7 @@ const selectedSBC = computed(() =>
 
     <p>Skip this step if unsure.</p>
 
-    <template v-if="supportsOverlayOptions && selectedSBC">
+    <template v-if="selectedSBC">
       <TextArea
         v-model="formState.overlayOptions"
         placeholder="configTxtAppend: 'dtoverlay=vc4-fkms-v3d'"

--- a/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.vue
@@ -5,7 +5,6 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { gte } from 'semver'
 import { computed } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -50,15 +49,10 @@ const selectedCloudProvider = computed(() =>
   cloudProviders.value?.find((provider) => formState.value.cloudPlatform === provider.metadata.id),
 )
 
-const isGte1_5 = computed(
-  () => formState.value.talosVersion && gte(formState.value.talosVersion, '1.5.0'),
-)
-
 const secureBootSupported = computed(
   () =>
-    isGte1_5.value &&
-    (formState.value.hardwareType === 'metal' ||
-      selectedCloudProvider.value?.spec.secure_boot_supported),
+    formState.value.hardwareType === 'metal' ||
+    selectedCloudProvider.value?.spec.secure_boot_supported,
 )
 
 const supportedArchitectures = computed(() => {

--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -135,11 +135,6 @@ const imageProfile = computed(() => {
     ? 'metal'
     : installationMedia.value.spec.profile
 
-  // legacy SBC support
-  if (installationMedia.value.spec.overlay && semver.lt(selectedTalosVersion.value, '1.7.0')) {
-    profile += `-${installationMedia.value.spec.profile}`
-  }
-
   profile += `-${installationMedia.value.spec.architecture}`
 
   if (secureBoot.value && !installationMedia.value.spec.no_secure_boot) {


### PR DESCRIPTION
BREAKING CHANGE: Set the minimum Talos version to 1.7.0. Old versions can still communicate with omni, but new clusters must be at least 1.7.0.

Closes #2096 