### PR TITLE
feat: clean up orphaned machine logs from sqlite

### DIFF
--- a/internal/pkg/siderolink/loghandler.go
+++ b/internal/pkg/siderolink/loghandler.go
@@ -31,7 +31,7 @@ type LogStoreManager interface {
 
 // NewLogHandler returns a new LogHandler.
 func NewLogHandler(secondaryStorageDB *sql.DB, machineMap *MachineMap, omniState state.State, storageConfig *config.LogsMachine, logger *zap.Logger) (*LogHandler, error) {
-	cache, err := NewMachineCache(secondaryStorageDB, storageConfig, logger)
+	cache, err := NewMachineCache(secondaryStorageDB, storageConfig, omniState, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create machine cache: %w", err)
 	}


### PR DESCRIPTION
Remove the logs for the non-existent machines from SQLite in the scheduled cleanup job.

This ensures that if there are some orphan machine logs written to SQLite due to the SQLite migration, they will be cleaned up.

Also, exclude the non-existent machines from the log store migration.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>