### PR TITLE
test: improve test stability

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_request_set_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_request_set_status_test.go
@@ -271,7 +271,7 @@ func (suite *MachineRequestSetStatusSuite) reconcileLabels(ctx context.Context) 
 
 					return nil
 				})
-				if err != nil {
+				if err != nil && !state.IsPhaseConflictError(err) {
 					return err
 				}
 			}

--- a/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status_test.go
@@ -160,6 +160,8 @@ func TestTalosUpgradeStatus(t *testing.T) {
 			rmock.Mock[*omni.ClusterMachineConfigStatus](ctx, t, st, testoptions.SameID(machine))
 			rmock.Mock[*omni.SchematicConfiguration](ctx, t, st, testoptions.SameID(machine),
 				testoptions.Modify(func(res *omni.SchematicConfiguration) error {
+					res.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
+
 					res.TypedSpec().Value.TalosVersion = cluster.TypedSpec().Value.TalosVersion
 					res.TypedSpec().Value.SchematicId = defaultSchematic
 
@@ -263,6 +265,10 @@ func TestTalosUpgradeStatus(t *testing.T) {
 
 					return nil
 				}))
+
+				rtestutils.AssertResource(ctx, t, st, clusterName, func(res *omni.TalosUpgradeStatus, assertions *assert.Assertions) {
+					assertions.Empty(res.TypedSpec().Value.CurrentUpgradeVersion)
+				})
 
 				rmock.MockList[*omni.SchematicConfiguration](ctx, t, st, testoptions.IDs(xslices.Map(machines, func(machine *omni.ClusterMachine) resource.ID { return machine.Metadata().ID() })),
 					testoptions.ItemOptions(

--- a/internal/backend/runtime/omni/controllers/testutils/testutils.go
+++ b/internal/backend/runtime/omni/controllers/testutils/testutils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup" //nolint:depguard // this is only used in tests
 
@@ -58,6 +59,7 @@ func (b *DynamicStateBuilder) Set(ns resource.Namespace, state state.CoreState) 
 
 type TestOptions struct {
 	StateBuilder namespaced.StateBuilder
+	LogLevel     *zapcore.Level
 	DisableCache bool
 }
 
@@ -85,7 +87,12 @@ func WithRuntime(ctx context.Context, t *testing.T, testOptions TestOptions, bef
 		testOptions.StateBuilder = inmem.Build
 	}
 
-	logger := zaptest.NewLogger(t).With(zap.String("test", t.Name()))
+	var loggerOpts []zaptest.LoggerOption
+	if testOptions.LogLevel != nil {
+		loggerOpts = append(loggerOpts, zaptest.Level(*testOptions.LogLevel))
+	}
+
+	logger := zaptest.NewLogger(t, loggerOpts...).With(zap.String("test", t.Name()))
 	st := state.WrapCore(namespaced.NewState(testOptions.StateBuilder))
 
 	var opts []options.Option

--- a/internal/integration/machines_test.go
+++ b/internal/integration/machines_test.go
@@ -196,7 +196,7 @@ func AssertControlPlaneForceReplaceMachine(testCtx context.Context, st state.Sta
 		id := freezeMachine(ctx, t, st, clusterName, options.FreezeAMachineFunc, omni.LabelControlPlaneRole)
 
 		pickUnallocatedMachines(ctx, t, st, 1, nil, func(machineIDs []resource.ID) {
-			t.Logf("Adding machine '%s' to control plane", machineIDs[0])
+			t.Logf("Adding machine %q to control plane", machineIDs[0])
 
 			bindMachine(ctx, t, st, bindMachineOptions{
 				clusterName:  clusterName,
@@ -269,5 +269,5 @@ func wipeMachine(ctx context.Context, t *testing.T, st state.State, id string, w
 	// machine should re-register
 	rtestutils.AssertResources(ctx, t, st, []string{id}, func(*omni.Machine, *assert.Assertions) {})
 
-	t.Logf("Wiped the machine '%s'", id)
+	t.Logf("Wiped the machine %q", id)
 }

--- a/internal/integration/suites_test.go
+++ b/internal/integration/suites_test.go
@@ -580,6 +580,8 @@ In between the scaling operations, assert that the cluster is ready and accessib
 
 		t.Parallel()
 
+		options.claimMachines(t, 4)
+
 		clusterName := "integration-scaling-auto-provision"
 
 		t.Run(
@@ -1300,6 +1302,8 @@ Note: this test expects all machines to be provisioned by the bare-metal infra p
 - remove links of the machines
 `)
 		t.Parallel()
+
+		options.claimMachines(t, 4)
 
 		clusterName := "integration-static-infra-provider"
 


### PR DESCRIPTION
Fix a few things in tests:
- Add the forgotten `claimMachines` calls to a few integration tests
- When picking unallocated machines in integration tests, ensure that they are unallocated by checking that here is no corresponding `MachineSetNode` resource. Previous check on the `Available` label on `MachineStatus` resource was inherently racy, as that label is set by a controller asynchronously after a machine was "picked".
- Fix the flake in TalosUpgradeStatus unit test: it was skipping reconciliation because the `SchematicConfiguration` resource was missing the cluster label, but in the same time it was not failing reliably, as it was not asserting the completion of one upgrade before starting the next one. Fix both issues.
- Fix a crash in TalosUpgradeStatusController - it was failing to read back the `ClusterMachineTalosVersion` resource it just created because it was not yet available in the controller runtime cache. Instead of reading it back after writing, simply return the created resource reference.