### PR TITLE
refactor(installation-media): extract schematic generation and download links

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -7029,7 +7029,7 @@ func (x *MachineConfigDiffSpec) GetDiff() string {
 type InstallationMediaConfigSpec struct {
 	state             protoimpl.MessageState             `protogen:"open.v1"`
 	TalosVersion      string                             `protobuf:"bytes,1,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
-	Architecture      string                             `protobuf:"bytes,2,opt,name=architecture,proto3" json:"architecture,omitempty"`
+	Architecture      PlatformConfigSpec_Arch            `protobuf:"varint,2,opt,name=architecture,proto3,enum=specs.PlatformConfigSpec_Arch" json:"architecture,omitempty"`
 	InstallExtensions []string                           `protobuf:"bytes,3,rep,name=install_extensions,json=installExtensions,proto3" json:"install_extensions,omitempty"`
 	KernelArgs        string                             `protobuf:"bytes,4,opt,name=kernel_args,json=kernelArgs,proto3" json:"kernel_args,omitempty"`
 	Cloud             *InstallationMediaConfigSpec_Cloud `protobuf:"bytes,5,opt,name=cloud,proto3" json:"cloud,omitempty"`
@@ -7080,11 +7080,11 @@ func (x *InstallationMediaConfigSpec) GetTalosVersion() string {
 	return ""
 }
 
-func (x *InstallationMediaConfigSpec) GetArchitecture() string {
+func (x *InstallationMediaConfigSpec) GetArchitecture() PlatformConfigSpec_Arch {
 	if x != nil {
 		return x.Architecture
 	}
-	return ""
+	return PlatformConfigSpec_AMD64
 }
 
 func (x *InstallationMediaConfigSpec) GetInstallExtensions() []string {
@@ -9457,7 +9457,7 @@ var File_omni_specs_omni_proto protoreflect.FileDescriptor
 
 const file_omni_specs_omni_proto_rawDesc = "" +
 	"\n" +
-	"\x15omni/specs/omni.proto\x12\x05specs\x1a\x1btalos/machine/machine.proto\x1a omni/management/management.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\x8e\x01\n" +
+	"\x15omni/specs/omni.proto\x12\x05specs\x1a\x1btalos/machine/machine.proto\x1a\x18omni/specs/virtual.proto\x1a omni/management/management.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto\"\x8e\x01\n" +
 	"\vMachineSpec\x12-\n" +
 	"\x12management_address\x18\x01 \x01(\tR\x11managementAddress\x12\x1c\n" +
 	"\tconnected\x18\x02 \x01(\bR\tconnected\x12&\n" +
@@ -10166,10 +10166,10 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12 \n" +
 	"\vinitialized\x18\x03 \x01(\bR\vinitialized\"+\n" +
 	"\x15MachineConfigDiffSpec\x12\x12\n" +
-	"\x04diff\x18\x01 \x01(\tR\x04diff\"\xf8\x05\n" +
+	"\x04diff\x18\x01 \x01(\tR\x04diff\"\x98\x06\n" +
 	"\x1bInstallationMediaConfigSpec\x12#\n" +
-	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12\"\n" +
-	"\farchitecture\x18\x02 \x01(\tR\farchitecture\x12-\n" +
+	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12B\n" +
+	"\farchitecture\x18\x02 \x01(\x0e2\x1e.specs.PlatformConfigSpec.ArchR\farchitecture\x12-\n" +
 	"\x12install_extensions\x18\x03 \x03(\tR\x11installExtensions\x12\x1f\n" +
 	"\vkernel_args\x18\x04 \x01(\tR\n" +
 	"kernelArgs\x12>\n" +
@@ -10393,7 +10393,8 @@ var file_omni_specs_omni_proto_goTypes = []any{
 	(*durationpb.Duration)(nil),                               // 156: google.protobuf.Duration
 	(*timestamppb.Timestamp)(nil),                             // 157: google.protobuf.Timestamp
 	(*machine.MachineStatusEvent)(nil),                        // 158: machine.MachineStatusEvent
-	(management.SchematicBootloader)(0),                       // 159: management.SchematicBootloader
+	(PlatformConfigSpec_Arch)(0),                              // 159: specs.PlatformConfigSpec.Arch
+	(management.SchematicBootloader)(0),                       // 160: management.SchematicBootloader
 }
 var file_omni_specs_omni_proto_depIdxs = []int32{
 	115, // 0: specs.MachineStatusSpec.hardware:type_name -> specs.MachineStatusSpec.HardwareStatus
@@ -10471,34 +10472,35 @@ var file_omni_specs_omni_proto_depIdxs = []int32{
 	150, // 72: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
 	151, // 73: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
 	152, // 74: specs.InfraProviderCombinedStatusSpec.health:type_name -> specs.InfraProviderCombinedStatusSpec.Health
-	153, // 75: specs.InstallationMediaConfigSpec.cloud:type_name -> specs.InstallationMediaConfigSpec.Cloud
-	154, // 76: specs.InstallationMediaConfigSpec.sbc:type_name -> specs.InstallationMediaConfigSpec.SBC
-	3,   // 77: specs.InstallationMediaConfigSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	155, // 78: specs.InstallationMediaConfigSpec.machine_labels:type_name -> specs.InstallationMediaConfigSpec.MachineLabelsEntry
-	159, // 79: specs.InstallationMediaConfigSpec.bootloader:type_name -> management.SchematicBootloader
-	121, // 80: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
-	122, // 81: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
-	123, // 82: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
-	124, // 83: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
-	24,  // 84: specs.MachineStatusSpec.Schematic.overlay:type_name -> specs.Overlay
-	25,  // 85: specs.MachineStatusSpec.Schematic.meta_values:type_name -> specs.MetaValue
-	125, // 86: specs.MachineStatusSpec.Schematic.initial_state:type_name -> specs.MachineStatusSpec.Schematic.InitialState
-	10,  // 87: specs.MachineSetSpec.MachineClass.allocation_type:type_name -> specs.MachineSetSpec.MachineClass.Type
-	11,  // 88: specs.MachineSetSpec.MachineAllocation.allocation_type:type_name -> specs.MachineSetSpec.MachineAllocation.Type
-	131, // 89: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
-	2,   // 90: specs.ControlPlaneStatusSpec.Condition.type:type_name -> specs.ConditionType
-	14,  // 91: specs.ControlPlaneStatusSpec.Condition.status:type_name -> specs.ControlPlaneStatusSpec.Condition.Status
-	15,  // 92: specs.ControlPlaneStatusSpec.Condition.severity:type_name -> specs.ControlPlaneStatusSpec.Condition.Severity
-	135, // 93: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
-	25,  // 94: specs.MachineClassSpec.Provision.meta_values:type_name -> specs.MetaValue
-	3,   // 95: specs.MachineClassSpec.Provision.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	23,  // 96: specs.MachineConfigGenOptionsSpec.InstallImage.security_state:type_name -> specs.SecurityState
-	18,  // 97: specs.MachineExtensionsStatusSpec.Item.phase:type_name -> specs.MachineExtensionsStatusSpec.Item.Phase
-	98,  // [98:98] is the sub-list for method output_type
-	98,  // [98:98] is the sub-list for method input_type
-	98,  // [98:98] is the sub-list for extension type_name
-	98,  // [98:98] is the sub-list for extension extendee
-	0,   // [0:98] is the sub-list for field type_name
+	159, // 75: specs.InstallationMediaConfigSpec.architecture:type_name -> specs.PlatformConfigSpec.Arch
+	153, // 76: specs.InstallationMediaConfigSpec.cloud:type_name -> specs.InstallationMediaConfigSpec.Cloud
+	154, // 77: specs.InstallationMediaConfigSpec.sbc:type_name -> specs.InstallationMediaConfigSpec.SBC
+	3,   // 78: specs.InstallationMediaConfigSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
+	155, // 79: specs.InstallationMediaConfigSpec.machine_labels:type_name -> specs.InstallationMediaConfigSpec.MachineLabelsEntry
+	160, // 80: specs.InstallationMediaConfigSpec.bootloader:type_name -> management.SchematicBootloader
+	121, // 81: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
+	122, // 82: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
+	123, // 83: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
+	124, // 84: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
+	24,  // 85: specs.MachineStatusSpec.Schematic.overlay:type_name -> specs.Overlay
+	25,  // 86: specs.MachineStatusSpec.Schematic.meta_values:type_name -> specs.MetaValue
+	125, // 87: specs.MachineStatusSpec.Schematic.initial_state:type_name -> specs.MachineStatusSpec.Schematic.InitialState
+	10,  // 88: specs.MachineSetSpec.MachineClass.allocation_type:type_name -> specs.MachineSetSpec.MachineClass.Type
+	11,  // 89: specs.MachineSetSpec.MachineAllocation.allocation_type:type_name -> specs.MachineSetSpec.MachineAllocation.Type
+	131, // 90: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
+	2,   // 91: specs.ControlPlaneStatusSpec.Condition.type:type_name -> specs.ConditionType
+	14,  // 92: specs.ControlPlaneStatusSpec.Condition.status:type_name -> specs.ControlPlaneStatusSpec.Condition.Status
+	15,  // 93: specs.ControlPlaneStatusSpec.Condition.severity:type_name -> specs.ControlPlaneStatusSpec.Condition.Severity
+	135, // 94: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
+	25,  // 95: specs.MachineClassSpec.Provision.meta_values:type_name -> specs.MetaValue
+	3,   // 96: specs.MachineClassSpec.Provision.grpc_tunnel:type_name -> specs.GrpcTunnelMode
+	23,  // 97: specs.MachineConfigGenOptionsSpec.InstallImage.security_state:type_name -> specs.SecurityState
+	18,  // 98: specs.MachineExtensionsStatusSpec.Item.phase:type_name -> specs.MachineExtensionsStatusSpec.Item.Phase
+	99,  // [99:99] is the sub-list for method output_type
+	99,  // [99:99] is the sub-list for method input_type
+	99,  // [99:99] is the sub-list for extension type_name
+	99,  // [99:99] is the sub-list for extension extendee
+	0,   // [0:99] is the sub-list for field type_name
 }
 
 func init() { file_omni_specs_omni_proto_init() }
@@ -10506,6 +10508,7 @@ func file_omni_specs_omni_proto_init() {
 	if File_omni_specs_omni_proto != nil {
 		return
 	}
+	file_omni_specs_virtual_proto_init()
 	file_omni_specs_omni_proto_msgTypes[51].OneofWrappers = []any{
 		(*OngoingTaskSpec_TalosUpgrade)(nil),
 		(*OngoingTaskSpec_KubernetesUpgrade)(nil),

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -4,6 +4,7 @@ package specs;
 option go_package = "github.com/siderolabs/omni/client/api/omni/specs";
 
 import "talos/machine/machine.proto";
+import "omni/specs/virtual.proto";
 import "omni/management/management.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
@@ -1437,7 +1438,7 @@ message InstallationMediaConfigSpec {
   }
 
   string talos_version = 1;
-  string architecture = 2;
+  PlatformConfigSpec.Arch architecture = 2;
   repeated string install_extensions = 3;
   string kernel_args = 4;
 

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -14180,12 +14180,10 @@ func (m *InstallationMediaConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, 
 			dAtA[i] = 0x1a
 		}
 	}
-	if len(m.Architecture) > 0 {
-		i -= len(m.Architecture)
-		copy(dAtA[i:], m.Architecture)
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Architecture)))
+	if m.Architecture != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Architecture))
 		i--
-		dAtA[i] = 0x12
+		dAtA[i] = 0x10
 	}
 	if len(m.TalosVersion) > 0 {
 		i -= len(m.TalosVersion)
@@ -17115,9 +17113,8 @@ func (m *InstallationMediaConfigSpec) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
-	l = len(m.Architecture)
-	if l > 0 {
-		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	if m.Architecture != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Architecture))
 	}
 	if len(m.InstallExtensions) > 0 {
 		for _, s := range m.InstallExtensions {
@@ -35848,10 +35845,10 @@ func (m *InstallationMediaConfigSpec) UnmarshalVT(dAtA []byte) error {
 			m.TalosVersion = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 2:
-			if wireType != 2 {
+			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Architecture", wireType)
 			}
-			var stringLen uint64
+			m.Architecture = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -35861,24 +35858,11 @@ func (m *InstallationMediaConfigSpec) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				m.Architecture |= PlatformConfigSpec_Arch(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return protohelpers.ErrInvalidLength
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Architecture = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InstallExtensions", wireType)

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -8,6 +8,7 @@ import * as GoogleProtobufDuration from "../../google/protobuf/duration.pb"
 import * as GoogleProtobufTimestamp from "../../google/protobuf/timestamp.pb"
 import * as MachineMachine from "../../talos/machine/machine.pb"
 import * as ManagementManagement from "../management/management.pb"
+import * as SpecsVirtual from "./virtual.pb"
 
 type Absent<T, K extends keyof T> = { [k in Exclude<keyof T, K>]?: undefined };
 type OneOf<T> =
@@ -955,7 +956,7 @@ export type InstallationMediaConfigSpecSBC = {
 
 export type InstallationMediaConfigSpec = {
   talos_version?: string
-  architecture?: string
+  architecture?: SpecsVirtual.PlatformConfigSpecArch
   install_extensions?: string[]
   kernel_args?: string
   cloud?: InstallationMediaConfigSpecCloud

--- a/frontend/src/views/omni/InstallationMedia/SavePresetModal.vue
+++ b/frontend/src/views/omni/InstallationMedia/SavePresetModal.vue
@@ -5,12 +5,11 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { type Resource, ResourceService } from '@/api/grpc'
-import { GrpcTunnelMode, type InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
-import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
+import { type InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
 import { withRuntime } from '@/api/options'
 import { DefaultNamespace, InstallationMediaConfigType } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
@@ -18,6 +17,7 @@ import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError } from '@/notification'
+import { formStateToPreset } from '@/views/omni/InstallationMedia/formStateToPreset'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
 
@@ -45,17 +45,6 @@ const { data: existingPreset, loading: existingPresetLoading } =
     },
   }))
 
-const arch = computed(() => {
-  switch (formState.machineArch) {
-    case PlatformConfigSpecArch.AMD64:
-      return 'amd64'
-    case PlatformConfigSpecArch.ARM64:
-      return 'arm64'
-    default:
-      return formState.hardwareType === 'sbc' ? 'arm64' : undefined
-  }
-})
-
 async function save() {
   try {
     saving.value = true
@@ -67,31 +56,7 @@ async function save() {
           type: InstallationMediaConfigType,
           id: name.value,
         },
-        spec: {
-          architecture: arch.value,
-          bootloader: formState.bootloader,
-          cloud:
-            formState.hardwareType === 'cloud' ? { platform: formState.cloudPlatform } : undefined,
-          sbc:
-            formState.hardwareType === 'sbc'
-              ? {
-                  overlay: formState.sbcType,
-                  overlay_options: formState.overlayOptions,
-                }
-              : undefined,
-          grpc_tunnel: formState.useGrpcTunnel ? GrpcTunnelMode.ENABLED : GrpcTunnelMode.DISABLED,
-          talos_version: formState.talosVersion,
-          install_extensions: formState.systemExtensions,
-          join_token: formState.joinToken,
-          kernel_args: formState.cmdline,
-          machine_labels: formState.machineUserLabels
-            ? Object.entries(formState.machineUserLabels).reduce<Record<string, string>>(
-                (prev, [key, { value }]) => ({ ...prev, [key]: value }),
-                {},
-              )
-            : undefined,
-          secure_boot: formState.secureBoot,
-        },
+        spec: formStateToPreset(formState),
       },
       withRuntime(Runtime.Omni),
     )

--- a/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
@@ -5,26 +5,17 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computedAsync } from '@vueuse/core'
-import { dump } from 'js-yaml'
 import { gte, parse } from 'semver'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import {
-  type CreateSchematicRequestOverlay,
-  CreateSchematicRequestSiderolinkGRPCTunnelMode,
-  ManagementService,
-} from '@/api/omni/management/management.pb'
-import {
   type PlatformConfigSpec,
-  PlatformConfigSpecArch,
   PlatformConfigSpecBootMethod,
   type SBCConfigSpec,
 } from '@/api/omni/specs/virtual.pb'
 import {
   CloudPlatformConfigType,
-  LabelsMeta,
   MetalPlatformConfigType,
   SBCConfigType,
   VirtualNamespace,
@@ -38,9 +29,11 @@ import TAlert from '@/components/TAlert.vue'
 import { getDocsLink, getLegacyDocsLink } from '@/methods'
 import { useFeatures } from '@/methods/features'
 import { useResourceGet } from '@/methods/useResourceGet'
-import { useResourceList } from '@/methods/useResourceList'
 import { useTalosctlDownloads } from '@/methods/useTalosctlDownloads'
+import { formStateToPreset } from '@/views/omni/InstallationMedia/formStateToPreset'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
+import { usePresetDownloadLinks } from '@/views/omni/InstallationMedia/usePresetDownloadLinks'
+import { usePresetSchematic } from '@/views/omni/InstallationMedia/usePresetSchematic'
 
 const formState = defineModel<FormState>({ required: true })
 
@@ -51,17 +44,6 @@ const talosctlAvailable = computed(
   () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.11.0-alpha.3'),
 )
 
-const arch = computed(() => {
-  switch (formState.value.machineArch) {
-    case PlatformConfigSpecArch.AMD64:
-      return 'amd64'
-    case PlatformConfigSpecArch.ARM64:
-      return 'arm64'
-    default:
-      return formState.value.hardwareType === 'sbc' ? 'arm64' : undefined
-  }
-})
-
 const { data: features } = useFeatures()
 
 const { downloads } = useTalosctlDownloads()
@@ -70,21 +52,23 @@ const talosctlPaths = computed(
   () => downloads.value?.get(`v${formState.value.talosVersion}`)?.map((v) => v.url) ?? [],
 )
 
-const { data: cloudProviders } = useResourceList<PlatformConfigSpec>(() => ({
+const { data: selectedCloudProvider } = useResourceGet<PlatformConfigSpec>(() => ({
   skip: formState.value.hardwareType !== 'cloud',
   runtime: Runtime.Omni,
   resource: {
     namespace: VirtualNamespace,
     type: CloudPlatformConfigType,
+    id: formState.value.cloudPlatform,
   },
 }))
 
-const { data: SBCs } = useResourceList<SBCConfigSpec>(() => ({
+const { data: selectedSBC } = useResourceGet<SBCConfigSpec>(() => ({
   skip: formState.value.hardwareType !== 'sbc',
   runtime: Runtime.Omni,
   resource: {
     namespace: VirtualNamespace,
     type: SBCConfigType,
+    id: formState.value.sbcType,
   },
 }))
 
@@ -99,72 +83,8 @@ const { data: metalProvider } = useResourceGet<PlatformConfigSpec>(() => ({
 }))
 
 const selectedPlatform = computed(() =>
-  formState.value.hardwareType === 'metal'
-    ? metalProvider.value
-    : cloudProviders.value?.find(
-        (provider) => formState.value.cloudPlatform === provider.metadata.id,
-      ),
+  formState.value.hardwareType === 'metal' ? metalProvider.value : selectedCloudProvider.value,
 )
-
-const selectedSBC = computed(() =>
-  SBCs.value?.find((sbc) => sbc.metadata.id === formState.value.sbcType),
-)
-
-const schematicLoading = ref(false)
-const schematicError = ref<string>()
-
-const schematic = computedAsync(async () => {
-  schematicLoading.value = true
-
-  if (formState.value.hardwareType === 'sbc' && !selectedSBC.value) return
-
-  const machineLabels = Object.entries(formState.value.machineUserLabels ?? {}).reduce<
-    Record<string, string>
-  >(
-    (prev, [key, { value }]) => ({
-      ...prev,
-      [key]: value,
-    }),
-    {},
-  )
-
-  try {
-    let overlay: CreateSchematicRequestOverlay | undefined
-
-    if (selectedSBC.value) {
-      overlay = {
-        name: selectedSBC.value.spec.overlay_name,
-        image: selectedSBC.value.spec.overlay_image,
-        options: formState.value.overlayOptions,
-      }
-    }
-
-    const { schematic_id, schematic_yml } = await ManagementService.CreateSchematic({
-      extensions: formState.value.systemExtensions,
-      extra_kernel_args: formState.value.cmdline?.split(' ').filter((item) => item.trim()),
-      meta_values: {
-        [LabelsMeta]: dump({ machineLabels }),
-      },
-      overlay: overlay,
-      talos_version: formState.value.talosVersion,
-      secure_boot: formState.value.secureBoot,
-      siderolink_grpc_tunnel_mode: formState.value.useGrpcTunnel
-        ? CreateSchematicRequestSiderolinkGRPCTunnelMode.ENABLED
-        : CreateSchematicRequestSiderolinkGRPCTunnelMode.DISABLED,
-      join_token: formState.value.joinToken,
-      bootloader: formState.value.bootloader,
-    })
-
-    return {
-      id: schematic_id,
-      yml: schematic_yml,
-    }
-  } catch (error) {
-    schematicError.value = error?.message || String(error)
-  } finally {
-    schematicLoading.value = false
-  }
-})
 
 const secureBootSuffix = computed(() => {
   if (!formState.value.secureBoot) {
@@ -182,44 +102,19 @@ const notOnlyDiskImage = computed(
     ) ?? false,
 )
 
+const preset = computed(() => formStateToPreset(formState.value))
+
+const { schematic, schematicLoading, schematicError } = usePresetSchematic(preset)
+const schematicId = computed(() => schematic.value?.id ?? '')
+
+const { links } = usePresetDownloadLinks(schematicId, preset)
+
 const factoryUrl = computed(() => features.value?.spec.image_factory_base_url)
 
 const installerImage = computed(() =>
   supportsUnifiedInstaller.value
-    ? `${factoryUrl.value}/${formState.value.hardwareType}-installer${secureBootSuffix.value}/${schematic.value?.id}:${formState.value.talosVersion}`
-    : `${factoryUrl.value}/installer/${schematic.value?.id}:${formState.value.talosVersion}`,
-)
-
-const imageBaseURL = computed(
-  () => `${factoryUrl.value}/image/${schematic.value?.id}/${formState.value.talosVersion}`,
-)
-
-const sbcDiskImagePath = computed(() => `${imageBaseURL.value}/metal-${arch.value}.raw.xz`)
-
-const pxeBootBaseUrl = computed(() => features.value?.spec.image_factory_pxe_base_url)
-
-const pxeBootURL = computed(() =>
-  selectedPlatform.value
-    ? `${pxeBootBaseUrl.value}/${schematic.value?.id}/${formState.value.talosVersion}/${selectedPlatform.value?.metadata.id}-${arch.value}${secureBootSuffix.value}`
-    : undefined,
-)
-
-const platformDiskImagePath = computed(() =>
-  selectedPlatform.value
-    ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}${secureBootSuffix.value}.${selectedPlatform.value.spec.disk_image_suffix}`
-    : undefined,
-)
-
-const qcow2DiskImagePath = computed(() =>
-  selectedPlatform.value
-    ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}.qcow2`
-    : undefined,
-)
-
-const isoPath = computed(() =>
-  selectedPlatform.value
-    ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}${secureBootSuffix.value}.iso`
-    : undefined,
+    ? `${factoryUrl.value}/${formState.value.hardwareType}-installer${secureBootSuffix.value}/${schematicId.value}:${formState.value.talosVersion}`
+    : `${factoryUrl.value}/installer/${schematicId.value}:${formState.value.talosVersion}`,
 )
 
 function shortVersion(version?: string) {
@@ -254,188 +149,34 @@ function shortVersion(version?: string) {
     </p>
     <p v-else-if="selectedSBC">Use the following disk image for {{ selectedSBC.spec.label }}:</p>
 
-    <dl class="flex flex-col gap-2 [&_dd+dt]:mt-2 [&_dt]:font-medium [&_dt]:text-naturals-n14">
-      <template v-if="selectedSBC">
-        <dt>Disk Image</dt>
-        <dd>
-          <a
-            class="link-primary"
-            :href="sbcDiskImagePath"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {{ sbcDiskImagePath }}
+    <dl class="flex flex-col gap-2">
+      <template v-for="{ label, link, documentation, copyOnly } in links" :key="link">
+        <dt class="font-medium text-naturals-n14 not-first-of-type:mt-2">
+          {{ label }}
+          <Tooltip v-if="documentation" description="Documentation">
+            <a
+              class="link-primary align-bottom"
+              :href="documentation.link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <TIcon icon="documentation" :aria-label="documentation.label" class="size-4" />
+            </a>
+          </Tooltip>
+        </dt>
+
+        <dd v-if="copyOnly" class="flex items-center gap-1">
+          <code class="whitespace-wrap rounded bg-naturals-n4 px-2 py-1 wrap-anywhere">
+            {{ link }}
+          </code>
+          <CopyButton :text="link" />
+        </dd>
+
+        <dd v-else>
+          <a class="link-primary" :href="link" target="_blank" rel="noopener noreferrer">
+            {{ link }}
           </a>
         </dd>
-      </template>
-
-      <template
-        v-for="bootMethod in selectedPlatform.spec.boot_methods"
-        v-else-if="selectedPlatform"
-        :key="bootMethod"
-      >
-        <template v-if="bootMethod === PlatformConfigSpecBootMethod.DISK_IMAGE">
-          <template v-if="formState.secureBoot">
-            <dt>
-              SecureBoot Disk Image
-              <Tooltip v-if="formState.hardwareType === 'metal'" description="Documentation">
-                <a
-                  class="link-primary align-bottom"
-                  :href="
-                    getDocsLink(
-                      'talos',
-                      '/platform-specific-installations/bare-metal-platforms/secureboot',
-                      { talosVersion: formState.talosVersion! },
-                    )
-                  "
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <TIcon
-                    icon="documentation"
-                    aria-label="SecureBoot documentation"
-                    class="size-4"
-                  />
-                </a>
-              </Tooltip>
-            </dt>
-            <dd>
-              <a
-                class="link-primary"
-                :href="platformDiskImagePath"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {{ platformDiskImagePath }}
-              </a>
-            </dd>
-          </template>
-          <template v-else>
-            <template v-if="formState.hardwareType === 'metal'">
-              <dt>Disk Image (raw)</dt>
-              <dd>
-                <a
-                  class="link-primary"
-                  :href="platformDiskImagePath"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {{ platformDiskImagePath }}
-                </a>
-              </dd>
-              <dt>Disk Image (qcow2)</dt>
-              <dd>
-                <a
-                  class="link-primary"
-                  :href="qcow2DiskImagePath"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {{ qcow2DiskImagePath }}
-                </a>
-              </dd>
-            </template>
-            <template v-else>
-              <dt>Disk Image</dt>
-              <dd>
-                <a
-                  class="link-primary"
-                  :href="platformDiskImagePath"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {{ platformDiskImagePath }}
-                </a>
-              </dd>
-            </template>
-          </template>
-        </template>
-        <template v-else-if="bootMethod === PlatformConfigSpecBootMethod.ISO">
-          <template v-if="formState.secureBoot">
-            <dt>
-              SecureBoot ISO
-              <Tooltip description="Documentation">
-                <a
-                  class="link-primary align-bottom"
-                  :href="
-                    getDocsLink(
-                      'talos',
-                      '/platform-specific-installations/bare-metal-platforms/secureboot',
-                      { talosVersion: formState.talosVersion! },
-                    )
-                  "
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <TIcon
-                    icon="documentation"
-                    aria-label="SecureBoot documentation"
-                    class="size-4"
-                  />
-                </a>
-              </Tooltip>
-            </dt>
-            <dd>
-              <a class="link-primary" :href="isoPath" target="_blank" rel="noopener noreferrer">
-                {{ isoPath }}
-              </a>
-            </dd>
-          </template>
-          <template v-else>
-            <dt>
-              ISO
-              <Tooltip v-if="formState.hardwareType === 'metal'" description="Documentation">
-                <a
-                  class="link-primary align-bottom"
-                  :href="
-                    getDocsLink(
-                      'talos',
-                      '/platform-specific-installations/bare-metal-platforms/iso',
-                      { talosVersion: formState.talosVersion! },
-                    )
-                  "
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <TIcon icon="documentation" aria-label="ISO documentation" class="size-4" />
-                </a>
-              </Tooltip>
-            </dt>
-            <dd>
-              <a class="link-primary" :href="isoPath" target="_blank" rel="noopener noreferrer">
-                {{ isoPath }}
-              </a>
-            </dd>
-          </template>
-        </template>
-        <template v-else-if="bootMethod === PlatformConfigSpecBootMethod.PXE">
-          <dt>
-            <template v-if="formState.secureBoot">SecureBoot PXE (iPXE script)</template>
-            <template v-else>PXE boot (iPXE script)</template>
-            <Tooltip v-if="formState.hardwareType === 'metal'" description="Documentation">
-              <a
-                class="link-primary ml-1 align-bottom"
-                :href="
-                  getDocsLink(
-                    'talos',
-                    '/platform-specific-installations/bare-metal-platforms/pxe',
-                    { talosVersion: formState.talosVersion! },
-                  )
-                "
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <TIcon icon="documentation" aria-label="PXE documentation" class="size-4" />
-              </a>
-            </Tooltip>
-          </dt>
-          <dd class="flex items-center gap-1">
-            <code class="whitespace-wrap rounded bg-naturals-n4 px-2 py-1 wrap-anywhere">
-              {{ pxeBootURL }}
-            </code>
-            <CopyButton :text="pxeBootURL" />
-          </dd>
-        </template>
       </template>
     </dl>
 

--- a/frontend/src/views/omni/InstallationMedia/formStateToPreset.ts
+++ b/frontend/src/views/omni/InstallationMedia/formStateToPreset.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { GrpcTunnelMode, type InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
+import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
+
+export function formStateToPreset(formState: FormState): InstallationMediaConfigSpec {
+  return {
+    architecture: formState.machineArch,
+    bootloader: formState.bootloader,
+    cloud:
+      formState.hardwareType === 'cloud'
+        ? {
+            platform: formState.cloudPlatform,
+          }
+        : undefined,
+    sbc:
+      formState.hardwareType === 'sbc'
+        ? {
+            overlay: formState.sbcType,
+            overlay_options: formState.overlayOptions,
+          }
+        : undefined,
+    grpc_tunnel: formState.useGrpcTunnel ? GrpcTunnelMode.ENABLED : GrpcTunnelMode.DISABLED,
+    talos_version: formState.talosVersion,
+    install_extensions: formState.systemExtensions,
+    join_token: formState.joinToken,
+    kernel_args: formState.cmdline,
+    machine_labels: formState.machineUserLabels
+      ? Object.entries(formState.machineUserLabels).reduce<Record<string, string>>(
+          (prev, [key, { value }]) => ({ ...prev, [key]: value }),
+          {},
+        )
+      : undefined,
+    secure_boot: formState.secureBoot,
+  }
+}

--- a/frontend/src/views/omni/InstallationMedia/usePresetDownloadLinks.ts
+++ b/frontend/src/views/omni/InstallationMedia/usePresetDownloadLinks.ts
@@ -1,0 +1,209 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { computed, type MaybeRefOrGetter, toValue } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import type { InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
+import {
+  type PlatformConfigSpec,
+  PlatformConfigSpecArch,
+  PlatformConfigSpecBootMethod,
+} from '@/api/omni/specs/virtual.pb'
+import { CloudPlatformConfigType, MetalPlatformConfigType, VirtualNamespace } from '@/api/resources'
+import { getDocsLink } from '@/methods'
+import { useFeatures } from '@/methods/features'
+import { useResourceGet } from '@/methods/useResourceGet'
+
+export function usePresetDownloadLinks(
+  schematicId: MaybeRefOrGetter<string>,
+  presetRef: MaybeRefOrGetter<InstallationMediaConfigSpec>,
+) {
+  const isMetal = computed(() => !toValue(presetRef).cloud && !toValue(presetRef).sbc)
+
+  const { data: features } = useFeatures()
+
+  const { data: selectedCloudProvider } = useResourceGet<PlatformConfigSpec>(() => ({
+    skip: !toValue(presetRef).cloud,
+    runtime: Runtime.Omni,
+    resource: {
+      namespace: VirtualNamespace,
+      type: CloudPlatformConfigType,
+      id: toValue(presetRef).cloud?.platform,
+    },
+  }))
+
+  const { data: metalProvider } = useResourceGet<PlatformConfigSpec>(() => ({
+    skip: !isMetal.value,
+    runtime: Runtime.Omni,
+    resource: {
+      namespace: VirtualNamespace,
+      type: MetalPlatformConfigType,
+      id: 'metal',
+    },
+  }))
+
+  const selectedPlatform = computed(() =>
+    isMetal.value ? metalProvider.value : selectedCloudProvider.value,
+  )
+
+  const secureBootSuffix = computed(() => (toValue(presetRef).secure_boot ? '-secureboot' : ''))
+  const arch = computed(() => {
+    const preset = toValue(presetRef)
+
+    switch (preset.architecture) {
+      case PlatformConfigSpecArch.AMD64:
+        return 'amd64'
+      case PlatformConfigSpecArch.ARM64:
+        return 'arm64'
+      default:
+        return preset.sbc ? 'arm64' : undefined
+    }
+  })
+
+  const imageBaseURL = computed(
+    () =>
+      `${features.value?.spec.image_factory_base_url}/image/${toValue(schematicId)}/${toValue(presetRef).talos_version}`,
+  )
+
+  const sbcDiskImagePath = computed(() => `${imageBaseURL.value}/metal-${arch.value}.raw.xz`)
+
+  const pxeBootURL = computed(() =>
+    selectedPlatform.value
+      ? `${features.value?.spec.image_factory_pxe_base_url}/${toValue(schematicId)}/${toValue(presetRef).talos_version}/${selectedPlatform.value.metadata.id}-${arch.value}${secureBootSuffix.value}`
+      : undefined,
+  )
+
+  const platformDiskImagePath = computed(() =>
+    selectedPlatform.value
+      ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}${secureBootSuffix.value}.${selectedPlatform.value.spec.disk_image_suffix}`
+      : undefined,
+  )
+
+  const qcow2DiskImagePath = computed(() =>
+    selectedPlatform.value
+      ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}.qcow2`
+      : undefined,
+  )
+
+  const isoPath = computed(() =>
+    selectedPlatform.value
+      ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}${secureBootSuffix.value}.iso`
+      : undefined,
+  )
+
+  const links = computed(() => {
+    const preset = toValue(presetRef)
+
+    if (preset.sbc) {
+      return [{ label: 'Disk Image', link: sbcDiskImagePath.value }]
+    }
+
+    if (!selectedPlatform.value?.spec.boot_methods) {
+      return []
+    }
+
+    interface DownloadLink {
+      label: string
+      link: string
+      copyOnly?: boolean
+      documentation?: {
+        label: string
+        link: string
+      }
+    }
+
+    return selectedPlatform.value.spec.boot_methods.flatMap<DownloadLink>((bootMethod) => {
+      switch (bootMethod) {
+        case PlatformConfigSpecBootMethod.DISK_IMAGE: {
+          if (!platformDiskImagePath.value) return []
+
+          if (preset.secure_boot) {
+            return {
+              label: 'SecureBoot Disk Image',
+              link: platformDiskImagePath.value,
+              documentation: isMetal.value
+                ? {
+                    label: 'SecureBoot documentation',
+                    link: getDocsLink(
+                      'talos',
+                      '/platform-specific-installations/bare-metal-platforms/secureboot',
+                      { talosVersion: preset.talos_version },
+                    ),
+                  }
+                : undefined,
+            }
+          }
+
+          if (isMetal.value && qcow2DiskImagePath.value) {
+            return [
+              { label: 'Disk Image (raw)', link: platformDiskImagePath.value },
+              { label: 'Disk Image (qcow2)', link: qcow2DiskImagePath.value },
+            ]
+          }
+
+          return { label: 'Disk Image', link: platformDiskImagePath.value }
+        }
+
+        case PlatformConfigSpecBootMethod.ISO: {
+          if (!isoPath.value) return []
+
+          if (preset.secure_boot) {
+            return {
+              label: 'SecureBoot ISO',
+              link: isoPath.value,
+              documentation: {
+                label: 'SecureBoot documentation',
+                link: getDocsLink(
+                  'talos',
+                  '/platform-specific-installations/bare-metal-platforms/secureboot',
+                  { talosVersion: preset.talos_version },
+                ),
+              },
+            }
+          }
+
+          return {
+            label: 'ISO',
+            link: isoPath.value,
+            documentation: isMetal.value
+              ? {
+                  label: 'ISO documentation',
+                  link: getDocsLink(
+                    'talos',
+                    '/platform-specific-installations/bare-metal-platforms/iso',
+                    { talosVersion: preset.talos_version },
+                  ),
+                }
+              : undefined,
+          }
+        }
+
+        case PlatformConfigSpecBootMethod.PXE: {
+          if (!pxeBootURL.value) return []
+
+          return {
+            label: preset.secure_boot ? 'SecureBoot PXE (iPXE script)' : 'PXE boot (iPXE script)',
+            link: pxeBootURL.value,
+            copyOnly: true,
+            documentation: isMetal.value
+              ? {
+                  label: 'PXE documentation',
+                  link: getDocsLink(
+                    'talos',
+                    '/platform-specific-installations/bare-metal-platforms/pxe',
+                    { talosVersion: preset.talos_version },
+                  ),
+                }
+              : undefined,
+          }
+        }
+      }
+
+      return []
+    })
+  })
+
+  return { links }
+}

--- a/frontend/src/views/omni/InstallationMedia/usePresetSchematic.ts
+++ b/frontend/src/views/omni/InstallationMedia/usePresetSchematic.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { computedAsync } from '@vueuse/core'
+import { dump } from 'js-yaml'
+import { type MaybeRefOrGetter, ref, toValue } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import {
+  type CreateSchematicRequestOverlay,
+  CreateSchematicRequestSiderolinkGRPCTunnelMode,
+  ManagementService,
+} from '@/api/omni/management/management.pb'
+import { GrpcTunnelMode, type InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
+import { type SBCConfigSpec } from '@/api/omni/specs/virtual.pb'
+import { LabelsMeta, SBCConfigType, VirtualNamespace } from '@/api/resources'
+import { useResourceGet } from '@/methods/useResourceGet'
+
+export function usePresetSchematic(presetRef: MaybeRefOrGetter<InstallationMediaConfigSpec>) {
+  const { data: selectedSBC } = useResourceGet<SBCConfigSpec>(() => ({
+    skip: !toValue(presetRef).sbc,
+    runtime: Runtime.Omni,
+    resource: {
+      namespace: VirtualNamespace,
+      type: SBCConfigType,
+      id: toValue(presetRef).sbc?.overlay,
+    },
+  }))
+
+  const schematicLoading = ref(false)
+  const schematicError = ref<string>()
+
+  const schematic = computedAsync(async () => {
+    const preset = toValue(presetRef)
+
+    let overlay: CreateSchematicRequestOverlay | undefined
+
+    if (preset.sbc) {
+      if (!selectedSBC.value) return
+
+      overlay = {
+        name: selectedSBC.value.spec.overlay_name,
+        image: selectedSBC.value.spec.overlay_image,
+        options: preset.sbc.overlay_options,
+      }
+    }
+
+    try {
+      schematicLoading.value = true
+
+      const { schematic_id, schematic_yml } = await ManagementService.CreateSchematic({
+        extensions: preset.install_extensions,
+        extra_kernel_args: preset.kernel_args?.split(' ').filter((item) => item.trim()),
+        meta_values: {
+          [LabelsMeta]: dump({ machineLabels: preset.machine_labels ?? {} }),
+        },
+        overlay,
+        talos_version: preset.talos_version,
+        secure_boot: preset.secure_boot,
+        siderolink_grpc_tunnel_mode:
+          preset.grpc_tunnel === GrpcTunnelMode.ENABLED
+            ? CreateSchematicRequestSiderolinkGRPCTunnelMode.ENABLED
+            : CreateSchematicRequestSiderolinkGRPCTunnelMode.DISABLED,
+        join_token: preset.join_token,
+        bootloader: preset.bootloader,
+      })
+
+      return {
+        id: schematic_id,
+        yml: schematic_yml,
+      }
+    } catch (error) {
+      schematicError.value = error?.message || String(error)
+    } finally {
+      schematicLoading.value = false
+    }
+  })
+
+  return { schematic, schematicError, schematicLoading }
+}


### PR DESCRIPTION
Extract schematic generation and download links from the confirmation step of the installation media wizard to allow for re-use inside the download modal of the list view.

Related to #2003

<img width="866" height="478" alt="image" src="https://github.com/user-attachments/assets/65bc33c9-5b01-4759-b242-cf5d2608507e" />
