### PR TITLE
feat(frontend): add polymorphic buttons

### DIFF
--- a/frontend/src/components/common/Button/IconButton.vue
+++ b/frontend/src/components/common/Button/IconButton.vue
@@ -5,27 +5,58 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { type ButtonHTMLAttributes } from 'vue'
+import { type AnchorHTMLAttributes, type ButtonHTMLAttributes, computed, useAttrs } from 'vue'
+import type { RouterLinkProps } from 'vue-router'
+import { RouterLink } from 'vue-router'
 
 import type { IconType } from '@/components/common/Icon/TIcon.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 
-interface Props extends /* @vue-ignore */ ButtonHTMLAttributes {
+interface Props {
   icon?: IconType
   danger?: boolean
   iconClasses?: unknown
 }
 
-defineProps<Props>()
+interface ButtonProps extends /* @vue-ignore */ ButtonHTMLAttributes {
+  is?: 'button'
+  href?: never
+  to?: never
+}
+
+interface AnchorProps extends /* @vue-ignore */ AnchorHTMLAttributes {
+  // eslint-disable-next-line vue/no-required-prop-with-default
+  is: 'a'
+  href: string
+  to?: never
+}
+
+interface RLink extends RouterLinkProps {
+  // eslint-disable-next-line vue/no-required-prop-with-default
+  is: 'router-link'
+  href?: never
+  to: RouterLinkProps['to']
+}
+
+const { is = 'button', to, href } = defineProps<Props & (ButtonProps | AnchorProps | RLink)>()
+const attrs = useAttrs()
+
+const dynamicProps = computed(() => {
+  if (to) return { to }
+  if (href) return { href }
+  return { type: (attrs.type as string) || 'button' }
+})
 </script>
 
 <template>
-  <button
+  <component
+    :is="is === 'router-link' ? RouterLink : is"
+    v-bind="dynamicProps"
     class="h-6 w-6 rounded align-top text-naturals-n11 transition-all duration-100 hover:bg-naturals-n7 hover:text-naturals-n13 disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-naturals-n7"
     :class="{ 'text-red-r1': danger }"
   >
     <slot>
       <TIcon class="h-full w-full cursor-pointer p-1" :class="iconClasses" :icon="icon" />
     </slot>
-  </button>
+  </component>
 </template>

--- a/frontend/src/components/common/Button/TButton.stories.ts
+++ b/frontend/src/components/common/Button/TButton.stories.ts
@@ -49,7 +49,8 @@ const meta: Meta<typeof TButton> = {
 }
 
 export default meta
-type Story = StoryObj<typeof meta>
+// Discriminated unions in vue don't play well with storybook
+type Story = StoryObj /*<typeof meta>*/
 
 export const Default: Story = {
   render: (args) => ({

--- a/frontend/src/components/common/Button/TButton.vue
+++ b/frontend/src/components/common/Button/TButton.vue
@@ -5,13 +5,20 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import type { ButtonHTMLAttributes, HTMLAttributes } from 'vue'
+import {
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  computed,
+  type HTMLAttributes,
+} from 'vue'
+import type { RouterLinkProps } from 'vue-router'
+import { RouterLink } from 'vue-router'
 
 import type { IconType } from '@/components/common/Icon/TIcon.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import { cn } from '@/methods/utils'
 
-interface Props extends /* @vue-ignore */ Omit<ButtonHTMLAttributes, 'type'> {
+interface Props {
   type?: 'primary' | 'secondary' | 'subtle' | 'highlighted'
   size?: 'md' | 'sm' | 'xs' | 'xxs'
   icon?: IconType
@@ -19,18 +26,48 @@ interface Props extends /* @vue-ignore */ Omit<ButtonHTMLAttributes, 'type'> {
   class?: HTMLAttributes['class']
 }
 
+interface ButtonProps extends /* @vue-ignore */ Omit<ButtonHTMLAttributes, 'type'> {
+  is?: 'button'
+  href?: never
+  to?: never
+}
+
+interface AnchorProps extends /* @vue-ignore */ AnchorHTMLAttributes {
+  // eslint-disable-next-line vue/no-required-prop-with-default
+  is: 'a'
+  href: string
+  to?: never
+}
+
+interface RLink extends RouterLinkProps {
+  // eslint-disable-next-line vue/no-required-prop-with-default
+  is: 'router-link'
+  href?: never
+  to: RouterLinkProps['to']
+}
+
 const {
+  is = 'button',
+  to,
+  href,
   type = 'primary',
   size = 'md',
   iconPosition = 'right',
   icon,
   class: className,
-} = defineProps<Props>()
+} = defineProps<Props & (ButtonProps | AnchorProps | RLink)>()
+
+const dynamicProps = computed(() => {
+  if (to) return { to }
+  if (href) return { href }
+  return { type: 'button' }
+})
 </script>
 
 <template>
-  <button
-    type="button"
+  <component
+    :is="is === 'router-link' ? RouterLink : is"
+    v-bind="dynamicProps"
     class="flex items-center justify-center gap-1 rounded border transition-colors duration-200"
     :class="
       cn(
@@ -65,5 +102,5 @@ const {
         },
       ]"
     />
-  </button>
+  </component>
 </template>


### PR DESCRIPTION
Update `IconButton` and `TButton` to be polymorphic so as to act as an `<a>` or `<RouterLink>` in addition to a `<button>` when necessary.

Related to #2003