### PR TITLE
refactor(installation-media): add metal id const and use gets where possible

### DIFF
--- a/client/api/omni/specs/installation_media.go
+++ b/client/api/omni/specs/installation_media.go
@@ -4,7 +4,11 @@
 
 package specs
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+)
 
 // GenerateFilename gets the final part of the image factory URL.
 func (media *InstallationMediaSpec) GenerateFilename(legacy, secureBoot, withExtension bool) string {
@@ -13,9 +17,9 @@ func (media *InstallationMediaSpec) GenerateFilename(legacy, secureBoot, withExt
 	// SBC handling
 	if media.Overlay != "" {
 		if legacy {
-			builder.WriteString("metal-" + media.Profile)
+			builder.WriteString(constants.PlatformMetal + "-" + media.Profile)
 		} else {
-			builder.WriteString("metal")
+			builder.WriteString(constants.PlatformMetal)
 		}
 	} else {
 		builder.WriteString(media.Profile)

--- a/client/pkg/constants/talos.go
+++ b/client/pkg/constants/talos.go
@@ -5,6 +5,7 @@
 package constants
 
 import (
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/resources/cluster"
 	"github.com/siderolabs/talos/pkg/machinery/resources/k8s"
 	"github.com/siderolabs/talos/pkg/machinery/resources/network"
@@ -15,6 +16,9 @@ import (
 
 // Copy Talos constants to generate them for Typescript.
 const (
+	// Types.
+	// tsgen:PlatformMetalID
+	_ = constants.PlatformMetal
 	// Types.
 	// tsgen:TalosServiceType
 	_ = v1alpha1.ServiceType

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -40,6 +40,7 @@ export const ExposedServiceLabelAnnotationKey = "omni-kube-service-exposer.sider
 export const ExposedServicePortAnnotationKey = "omni-kube-service-exposer.sidero.dev/port";
 export const ExposedServiceIconAnnotationKey = "omni-kube-service-exposer.sidero.dev/icon";
 export const ExposedServicePrefixAnnotationKey = "omni-kube-service-exposer.sidero.dev/prefix";
+export const PlatformMetalID = "metal";
 export const TalosServiceType = "Services.v1alpha1.talos.dev";
 export const TalosCPUType = "CPUStats.perf.talos.dev";
 export const TalosMemoryType = "MemoryStats.perf.talos.dev";

--- a/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.stories.ts
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { http, HttpResponse } from 'msw'
 
 import type { Resource } from '@/api/grpc'
-import type { ListRequest } from '@/api/omni/resources/resources.pb'
+import type { ListRequest, ListResponse } from '@/api/omni/resources/resources.pb'
 import { type PlatformConfigSpec, PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
 import { CloudPlatformConfigType, VirtualNamespace } from '@/api/resources'
 
@@ -27,7 +27,7 @@ export const Default = {
   parameters: {
     msw: {
       handlers: [
-        http.post<never, ListRequest>(
+        http.post<never, ListRequest, ListResponse>(
           '/omni.resources.ResourceService/List',
           async ({ request }) => {
             const { type, namespace } = await request.clone().json()

--- a/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
@@ -17,6 +17,7 @@ import {
 import {
   CloudPlatformConfigType,
   MetalPlatformConfigType,
+  PlatformMetalID,
   SBCConfigType,
   VirtualNamespace,
 } from '@/api/resources'
@@ -78,7 +79,7 @@ const { data: metalProvider } = useResourceGet<PlatformConfigSpec>(() => ({
   resource: {
     namespace: VirtualNamespace,
     type: MetalPlatformConfigType,
-    id: 'metal',
+    id: PlatformMetalID,
   },
 }))
 

--- a/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.vue
@@ -17,7 +17,7 @@ import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
 import TextArea from '@/components/common/TextArea/TextArea.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import { getDocsLink } from '@/methods'
-import { useResourceList } from '@/methods/useResourceList'
+import { useResourceGet } from '@/methods/useResourceGet'
 import type { FormState } from '@/views/omni/InstallationMedia/InstallationMediaCreate.vue'
 
 const formState = defineModel<FormState>({ required: true })
@@ -30,18 +30,15 @@ const supportsBootloaderSelection = computed(
   () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.12.0-alpha.2'),
 )
 
-const { data: SBCs } = useResourceList<SBCConfigSpec>(() => ({
+const { data: selectedSBC } = useResourceGet<SBCConfigSpec>(() => ({
   skip: formState.value.hardwareType !== 'sbc',
   runtime: Runtime.Omni,
   resource: {
     namespace: VirtualNamespace,
     type: SBCConfigType,
+    id: formState.value.sbcType,
   },
 }))
-
-const selectedSBC = computed(() =>
-  SBCs.value?.find((sbc) => sbc.metadata.id === formState.value.sbcType),
-)
 </script>
 
 <template>

--- a/frontend/src/views/omni/InstallationMedia/Steps/SBCType.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SBCType.stories.ts
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { http, HttpResponse } from 'msw'
 
 import type { Resource } from '@/api/grpc'
-import type { ListRequest } from '@/api/omni/resources/resources.pb'
+import type { ListRequest, ListResponse } from '@/api/omni/resources/resources.pb'
 import type { SBCConfigSpec } from '@/api/omni/specs/virtual.pb'
 import { SBCConfigType, VirtualNamespace } from '@/api/resources'
 
@@ -27,7 +27,7 @@ export const Default = {
   parameters: {
     msw: {
       handlers: [
-        http.post<never, ListRequest>(
+        http.post<never, ListRequest, ListResponse>(
           '/omni.resources.ResourceService/List',
           async ({ request }) => {
             const { type, namespace } = await request.clone().json()

--- a/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.stories.ts
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { http, HttpResponse } from 'msw'
 
 import type { Resource } from '@/api/grpc'
-import type { GetRequest } from '@/api/omni/resources/resources.pb'
+import type { GetRequest, GetResponse } from '@/api/omni/resources/resources.pb'
 import type { FeaturesConfigSpec, TalosVersionSpec } from '@/api/omni/specs/omni.pb'
 import type { JoinTokenStatusSpec, SiderolinkAPIConfigSpec } from '@/api/omni/specs/siderolink.pb'
 import {
@@ -81,24 +81,27 @@ export const Default = {
             })),
         }).handler,
 
-        http.post<never, GetRequest>('/omni.resources.ResourceService/Get', async ({ request }) => {
-          const { id, type, namespace } = await request.clone().json()
+        http.post<never, GetRequest, GetResponse>(
+          '/omni.resources.ResourceService/Get',
+          async ({ request }) => {
+            const { id, type, namespace } = await request.clone().json()
 
-          if (id !== ConfigID || type !== APIConfigType || namespace !== DefaultNamespace) return
+            if (id !== ConfigID || type !== APIConfigType || namespace !== DefaultNamespace) return
 
-          return HttpResponse.json({
-            body: JSON.stringify({
-              metadata: {
-                namespace: DefaultNamespace,
-                type: APIConfigType,
-                id: ConfigID,
-              },
-              spec: {
-                enforce_grpc_tunnel: true,
-              },
-            } satisfies Resource<SiderolinkAPIConfigSpec>),
-          })
-        }),
+            return HttpResponse.json({
+              body: JSON.stringify({
+                metadata: {
+                  namespace: DefaultNamespace,
+                  type: APIConfigType,
+                  id: ConfigID,
+                },
+                spec: {
+                  enforce_grpc_tunnel: true,
+                },
+              } satisfies Resource<SiderolinkAPIConfigSpec>),
+            })
+          },
+        ),
       ],
     },
   },

--- a/frontend/src/views/omni/InstallationMedia/usePresetDownloadLinks.ts
+++ b/frontend/src/views/omni/InstallationMedia/usePresetDownloadLinks.ts
@@ -11,7 +11,12 @@ import {
   PlatformConfigSpecArch,
   PlatformConfigSpecBootMethod,
 } from '@/api/omni/specs/virtual.pb'
-import { CloudPlatformConfigType, MetalPlatformConfigType, VirtualNamespace } from '@/api/resources'
+import {
+  CloudPlatformConfigType,
+  MetalPlatformConfigType,
+  PlatformMetalID,
+  VirtualNamespace,
+} from '@/api/resources'
 import { getDocsLink } from '@/methods'
 import { useFeatures } from '@/methods/features'
 import { useResourceGet } from '@/methods/useResourceGet'
@@ -40,7 +45,7 @@ export function usePresetDownloadLinks(
     resource: {
       namespace: VirtualNamespace,
       type: MetalPlatformConfigType,
-      id: 'metal',
+      id: PlatformMetalID,
     },
   }))
 

--- a/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
+++ b/frontend/src/views/omni/Modals/DownloadInstallationMedia.vue
@@ -32,6 +32,7 @@ import {
   InstallationMediaType,
   JoinTokenStatusType,
   LabelsMeta,
+  PlatformMetalID,
   SecureBoot,
   TalosVersionType,
 } from '@/api/resources'
@@ -132,7 +133,7 @@ const imageProfile = computed(() => {
   if (!installationMedia.value) return
 
   let profile = installationMedia.value.spec.overlay
-    ? 'metal'
+    ? PlatformMetalID
     : installationMedia.value.spec.profile
 
   profile += `-${installationMedia.value.spec.architecture}`

--- a/internal/backend/runtime/omni/controllers/omni/installation_media.go
+++ b/internal/backend/runtime/omni/controllers/omni/installation_media.go
@@ -47,14 +47,14 @@ var installationMedia = []installationMediaSpec{
 	{
 		Name:         "ISO (amd64)",
 		Architecture: amd64Arch,
-		Profile:      "metal",
+		Profile:      constants.PlatformMetal,
 		Type:         isoType,
 		ContentType:  "application/x-iso-stream",
 	},
 	{
 		Name:         "ISO (arm64)",
 		Architecture: arm64Arch,
-		Profile:      "metal",
+		Profile:      constants.PlatformMetal,
 		Type:         isoType,
 		ContentType:  "application/x-iso-stream",
 	},
@@ -259,14 +259,14 @@ var installationMedia = []installationMediaSpec{
 	{
 		Name:         "Generic image (amd64)",
 		Architecture: amd64Arch,
-		Profile:      "metal",
+		Profile:      constants.PlatformMetal,
 		Type:         rawType,
 		ContentType:  "application/x-xz",
 	},
 	{
 		Name:         "Generic image (arm64)",
 		Architecture: arm64Arch,
-		Profile:      "metal",
+		Profile:      constants.PlatformMetal,
 		Type:         rawType,
 		ContentType:  "application/x-xz",
 	},


### PR DESCRIPTION
- Add `PlatformMetalID` constant to frontend and use it where relevant as an ID
- Also update some places in backend with the same idea
- Remove a specific check for `'metal'` when seeing if secureboot functionality is enabled and instead use its `spec.secure_boot_supported` field which now correctly reports `true`.
- There were some lingering uses of `List` requests in places where `Get` requests were more suited and those have been replaced too.