### PR TITLE
test: fix flaky ECDSA signature generation in TestPlainSignature

### DIFF
--- a/internal/pkg/auth/interceptor/signature_test.go
+++ b/internal/pkg/auth/interceptor/signature_test.go
@@ -214,13 +214,12 @@ func encodeRFC4754(curve elliptic.Curve, r, s *big.Int) []byte {
 	byteLen := (bitSize + 7) / 8
 	rb := r.Bytes()
 	sb := s.Bytes()
+	signature := make([]byte, byteLen*2)
 
-	rp := make([]byte, 0, byteLen-len(rb))
-	rp = append(rp, rb...)
-	sp := make([]byte, 0, byteLen-len(sb))
-	sp = append(sp, sb...)
+	copy(signature[byteLen-len(rb):], rb)
+	copy(signature[2*byteLen-len(sb):], sb)
 
-	return append(rp, sp...)
+	return signature
 }
 
 func TestPlainSignature(t *testing.T) {


### PR DESCRIPTION
The encodeRFC4754 test helper failed to pad ECDSA integers to the curve size, causing signatures to be shorter than 64 bytes when r or s had leading zeros. This resulted in intermittent verification failures. This fix ensures both values are correctly zero-padded to 32 bytes.

The actual signing code in the frontend was verified to not have the issue, as it hands over signing to the Web Crypto API.