### PR TITLE
test: add talemu fixtures and split into talemu + qemu tests

### DIFF
--- a/frontend/e2e/auth_fixtures.ts
+++ b/frontend/e2e/auth_fixtures.ts
@@ -2,10 +2,6 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
-// Copyright (c) 2025 Sidero Labs, Inc.
-//
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
 import { expect, test as base } from '@playwright/test'
 
 interface AuthFixtures {
@@ -32,6 +28,10 @@ const test = base.extend<AuthFixtures>({
 
       await page.getByRole('button', { name: 'Log In' }).click()
       await page.getByRole('heading', { name: 'Home' }).waitFor()
+
+      if (await page.getByText('Cookies for a Better Experience').isVisible()) {
+        await page.getByRole('button', { name: 'Accept', exact: true }).click()
+      }
 
       await use()
     },

--- a/frontend/e2e/constants.ts
+++ b/frontend/e2e/constants.ts
@@ -1,0 +1,5 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+export const DEFAULT_MACHINE_CLASS = 'e2e-machine-class'

--- a/frontend/e2e/qemu/clusters.spec.ts
+++ b/frontend/e2e/qemu/clusters.spec.ts
@@ -7,7 +7,7 @@ import { diff as diffJSON } from 'json-diff-ts'
 import * as uuid from 'uuid'
 import * as yaml from 'yaml'
 
-import { expect, test } from './omnictl_fixtures.js'
+import { expect, test } from '../omnictl_fixtures.js'
 
 test.describe.configure({ mode: 'serial', retries: 0 })
 

--- a/frontend/e2e/talemu/cluster_fixtures.ts
+++ b/frontend/e2e/talemu/cluster_fixtures.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import { milliseconds } from 'date-fns'
+import fs from 'fs/promises'
+import { dump } from 'js-yaml'
+
+import { DEFAULT_MACHINE_CLASS } from '../constants'
+import { expect, test as base } from '../omnictl_fixtures'
+interface Cluster {
+  name: string
+}
+
+interface ClusterFixtures {
+  cluster: Cluster
+}
+
+const test = base.extend<ClusterFixtures>({
+  cluster: [
+    async ({ omnictl }, use, testInfo) => {
+      const clusterName = `e2e-cluster-${faker.string.alphanumeric(8)}`
+
+      const clusterTemplate = [
+        {
+          kind: 'Cluster',
+          name: clusterName,
+          kubernetes: { version: 'v1.35.0' },
+          talos: { version: 'v1.12.1' },
+        },
+        {
+          kind: 'ControlPlane',
+          machineClass: { name: DEFAULT_MACHINE_CLASS, size: 1 },
+        },
+        {
+          kind: 'Workers',
+          machineClass: { name: DEFAULT_MACHINE_CLASS, size: 2 },
+        },
+      ]
+        .map((doc) => dump(doc))
+        .join('---\n')
+
+      const templatePath = testInfo.outputPath('cluster.yaml')
+      await fs.writeFile(templatePath, clusterTemplate)
+
+      // Create
+      await omnictl(['cluster', 'template', 'sync', '-f', templatePath, '--verbose'])
+
+      // Wait to be ready
+      await omnictl(['cluster', 'template', 'status', '-f', templatePath])
+
+      await use({ name: clusterName })
+
+      // Destroy
+      await omnictl(['cluster', 'delete', clusterName])
+    },
+    { timeout: milliseconds({ minutes: 1 }) },
+  ],
+})
+
+export { expect, test }

--- a/frontend/e2e/talemu/clusters.spec.ts
+++ b/frontend/e2e/talemu/clusters.spec.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { expect, test } from './cluster_fixtures'
+
+test('View all clusters', async ({ cluster, page }) => {
+  await page.goto('/')
+
+  await page
+    .locator('section')
+    .filter({ hasText: 'Recent Clusters' })
+    .getByRole('button', { name: 'View All' })
+    .click()
+
+  await expect(page).toHaveURL('/clusters')
+  await expect(page.getByRole('heading', { name: 'Clusters' })).toBeVisible()
+
+  await expect(page.getByText(cluster.name, { exact: true })).toBeVisible()
+})

--- a/frontend/e2e/talemu/csp_nonce.spec.ts
+++ b/frontend/e2e/talemu/csp_nonce.spec.ts
@@ -2,7 +2,7 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
-import { expect, test } from './auth_fixtures'
+import { expect, test } from '../auth_fixtures'
 
 /**
  * The nonce CSP header & tag are required by userpilot scripts

--- a/frontend/e2e/talemu/home.spec.ts
+++ b/frontend/e2e/talemu/home.spec.ts
@@ -6,7 +6,7 @@ import { readFile, stat } from 'node:fs/promises'
 
 import * as yaml from 'yaml'
 
-import { expect, test } from './auth_fixtures'
+import { expect, test } from '../auth_fixtures'
 
 test.describe.configure({ mode: 'parallel' })
 
@@ -191,32 +191,6 @@ test('Get audit logs', async ({ page }, testInfo) => {
   await expect(readFile(filePath, 'utf-8')).resolves.toContain(
     '"resource_type":"Identities.omni.sidero.dev"',
   )
-})
-
-test('View all clusters', async ({ page }) => {
-  await page.goto('/')
-
-  await page
-    .locator('section')
-    .filter({ hasText: 'Recent Clusters' })
-    .getByRole('button', { name: 'View All' })
-    .click()
-
-  await expect(page).toHaveURL('/clusters')
-  await expect(page.getByRole('heading', { name: 'Clusters' })).toBeVisible()
-})
-
-test('View all Machines', async ({ page }) => {
-  await page.goto('/')
-
-  await page
-    .locator('section')
-    .filter({ hasText: 'Recent Machines' })
-    .getByRole('button', { name: 'View All' })
-    .click()
-
-  await expect(page).toHaveURL('/machines')
-  await expect(page.getByRole('heading', { name: 'Machines' })).toBeVisible()
 })
 
 test('Shows general information', async ({ page }) => {

--- a/frontend/e2e/talemu/machines.spec.ts
+++ b/frontend/e2e/talemu/machines.spec.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { expect, test } from './cluster_fixtures'
+
+test('View all machines', async ({ cluster, page }) => {
+  await page.goto('/')
+
+  await page
+    .locator('section')
+    .filter({ hasText: 'Recent Machines' })
+    .getByRole('button', { name: 'View All' })
+    .click()
+
+  await expect(page).toHaveURL('/machines')
+  await expect(page.getByRole('heading', { name: 'Machines' })).toBeVisible()
+
+  await page.getByRole('textbox').fill(cluster.name)
+
+  await expect(page.getByRole('link', { name: cluster.name })).toHaveCount(3)
+})

--- a/frontend/e2e/talemu/talemu.setup.ts
+++ b/frontend/e2e/talemu/talemu.setup.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { test as setup } from '../auth_fixtures'
+import { DEFAULT_MACHINE_CLASS } from '../constants'
+
+setup('setup default machine class', async ({ page }) => {
+  await setup.step('Visit machine classes page', async () => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Machine Management' }).click()
+    await page.getByRole('link', { name: 'Classes' }).click()
+  })
+
+  await setup.step('Create machine class', async () => {
+    await page.getByRole('link', { name: 'Create Machine Class' }).click()
+
+    await page.getByRole('textbox', { name: 'Machine Class Name' }).fill(DEFAULT_MACHINE_CLASS)
+    await page.getByRole('button', { name: 'Auto Provision' }).click()
+    await page.getByText('id: Talemu').click()
+
+    await page.getByRole('button', { name: 'Create Machine Class' }).click()
+  })
+
+  await setup.step('Assert class creation', async () => {
+    await page.getByRole('heading', { name: 'Machine Classes' }).waitFor()
+    await page.getByText(DEFAULT_MACHINE_CLASS).waitFor()
+  })
+})

--- a/frontend/e2e/talemu/talemu.teardown.ts
+++ b/frontend/e2e/talemu/talemu.teardown.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { test as teardown } from '../auth_fixtures'
+import { DEFAULT_MACHINE_CLASS } from '../constants'
+
+teardown('remove default machine class', async ({ page }) => {
+  await teardown.step('Visit machine classes page', async () => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Machine Management' }).click()
+    await page.getByRole('link', { name: 'Classes' }).click()
+  })
+
+  const classRow = page.getByRole('row').filter({ hasText: DEFAULT_MACHINE_CLASS })
+
+  await teardown.step('Delete machine class', async () => {
+    await classRow.getByRole('button', { name: 'delete' }).click()
+    await page.getByRole('button', { name: 'Destroy' }).click()
+  })
+
+  await teardown.step('Assert class deletion', async () => {
+    await page.getByText('Please confirm the action').waitFor({ state: 'detached' })
+    await classRow.waitFor({ state: 'detached' })
+  })
+})

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -37,10 +37,28 @@ export default defineConfig({
 
   projects: [
     {
-      name: 'chromium',
+      name: 'talemu-setup',
+      testMatch: 'talemu/talemu.setup.ts',
+      teardown: 'talemu-teardown',
+    },
+    {
+      name: 'talemu-teardown',
+      testMatch: 'talemu/talemu.teardown.ts',
+    },
+    {
+      name: 'talemu',
       use: {
         ...devices['Desktop Chrome'],
       },
+      testMatch: 'talemu/**/*.spec.ts',
+      dependencies: ['talemu-setup'],
+    },
+    {
+      name: 'qemu',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+      testMatch: 'qemu/**/*.spec.ts',
     },
   ],
 })

--- a/frontend/src/components/common/List/TListItem.vue
+++ b/frontend/src/components/common/List/TListItem.vue
@@ -26,6 +26,7 @@ const isDropdownOpened = ref(isDefaultOpened)
         ? 'mt-1 rounded last-of-type:border-naturals-n6'
         : 'rounded-t-sm last-of-type:border-none'
     "
+    role="row"
   >
     <div class="flex items-center gap-1">
       <div v-if="$slots.details" class="flex flex-col items-center gap-2">

--- a/frontend/src/components/common/MenuItem/TMenuItem.vue
+++ b/frontend/src/components/common/MenuItem/TMenuItem.vue
@@ -73,7 +73,7 @@ const componentAttributes = props.route
   ? props.regularLink
     ? { href: props.route, target: '_blank', rel: 'noopener noreferrer' }
     : { to: props.route, exactActiveClass: 'item-active' }
-  : { class: 'select-none cursor-pointer' }
+  : { class: 'select-none cursor-pointer', role: 'button' }
 
 componentAttributes.class = (componentAttributes.class ?? '') + ' item-container'
 </script>

--- a/frontend/src/views/omni/MachineClasses/MachineClasses.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClasses.vue
@@ -5,25 +5,22 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
-
 import TButton from '@/components/common/Button/TButton.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import { canRemoveMachines } from '@/methods/auth'
 import MachineClassesList from '@/views/omni/MachineClasses/MachineClassesList.vue'
-
-const router = useRouter()
-
-const openMachineClassCreate = () => {
-  router.push({ name: 'MachineClassCreate' })
-}
 </script>
 
 <template>
   <div class="flex h-full flex-col">
     <div class="flex items-start gap-1">
       <PageHeader title="Machine Classes" class="flex-1" />
-      <TButton :disabled="!canRemoveMachines" type="highlighted" @click="openMachineClassCreate">
+      <TButton
+        is="router-link"
+        :disabled="!canRemoveMachines"
+        type="highlighted"
+        :to="{ name: 'MachineClassCreate' }"
+      >
         Create Machine Class
       </TButton>
     </div>

--- a/frontend/src/views/omni/MachineClasses/MachineClassesList.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClassesList.vue
@@ -48,6 +48,7 @@ const openMachineClassDestroy = (id: string) => {
         <div class="relative pr-3 text-naturals-n12" :class="{ 'pl-7': !item.spec.description }">
           <IconButton
             icon="delete"
+            aria-label="delete"
             class="absolute top-0 right-0 bottom-0 my-auto"
             @click="() => openMachineClassDestroy(item.metadata.id!)"
           />


### PR DESCRIPTION
- Split tests into `qemu` and `talemu` projects/folders
- Adds a setup step to the `talemu` project to create a machine class to use in fixtures
- Adds a cluster fixture to `talemu` project to create throw away clusters on demand
- Updated `View all clusters` and `View all machines` to use Talemu clusters as a POC

Closes #2129