### PR TITLE
test: remove machine.install.extraKernelArgs from infra machines

### DIFF
--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -333,7 +333,7 @@ func preRunHooks(t *testing.T, options *TestOptions) {
 
 	for i, cfg := range options.ProvisionConfigs {
 		if cfg.Provider.Static {
-			infraMachinesAcceptHook(t, options.omniClient.Omni().State(), cfg.Provider.ID, cfg.MachineCount, true)
+			infraMachinesAcceptHook(t, options.omniClient.Omni().State(), cfg.Provider.ID, cfg.MachineCount)
 
 			continue
 		}


### PR DESCRIPTION
With Talos 1.12, `.machine.install.extraKernelArgs` is not the right way of setting kernel args. Remove that from the infra machines (bare metal infra provider) tests.

Remove the `disableKexec` bool argument from the function, as it was always set to true.

Set the kernel arg to disable kexec in correct format, as `sysctl.kernel.kexec_load_disabled=1`, not `kexec_load_disabled=1` (was effectively no-op).