### PR TITLE
fix(frontend): fix lost reactivity on cluster overview page

### DIFF
--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -72,6 +72,10 @@ export default defineConfigWithVueTs(
       'vue/no-useless-mustaches': 'error',
       'vue/require-default-prop': 'off',
 
+      // Extra rules that we want to progressively fix
+      'vue/no-ref-object-reactivity-loss': 'warn',
+      'vue/no-setup-props-reactivity-loss': 'warn',
+
       // Temporarily disabled rules
       '@typescript-eslint/no-explicit-any': 'warn',
     },

--- a/frontend/src/views/cluster/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewContent.vue
@@ -81,29 +81,29 @@ const { status: backupStatus } = setupBackupStatus()
 
 const clusterId = computed(() => currentCluster.metadata.id ?? '')
 
-const { data: kubernetesUpgradeStatus } = useResourceWatch<KubernetesUpgradeStatusSpec>({
+const { data: kubernetesUpgradeStatus } = useResourceWatch<KubernetesUpgradeStatusSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,
     type: KubernetesUpgradeStatusType,
     id: clusterId.value,
   },
-})
+}))
 
-const { data: clusterStatus } = useResourceWatch<ClusterStatusSpec>({
+const { data: clusterStatus } = useResourceWatch<ClusterStatusSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,
     type: ClusterStatusType,
     id: clusterId.value,
   },
-})
+}))
 
 const showStats = computed(() => {
   return (clusterStatus.value?.spec.machines?.total ?? 0) < clusterSizeStatsThreshold
 })
 
-const { data: usage } = useResourceWatch<KubernetesUsageSpec>({
+const { data: usage } = useResourceWatch<KubernetesUsageSpec>(() => ({
   skip: !clusterStatus.value || !showStats.value,
   runtime: Runtime.Omni,
   resource: {
@@ -111,16 +111,16 @@ const { data: usage } = useResourceWatch<KubernetesUsageSpec>({
     type: KubernetesUsageType,
     id: clusterId.value,
   },
-})
+}))
 
-const { data: talosUpgradeStatus } = useResourceWatch<TalosUpgradeStatusSpec>({
+const { data: talosUpgradeStatus } = useResourceWatch<TalosUpgradeStatusSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,
     type: TalosUpgradeStatusType,
     id: clusterId.value,
   },
-})
+}))
 
 const { canManageClusterFeatures } = setupClusterPermissions(clusterId)
 


### PR DESCRIPTION
Fix the lost reactivity on the cluster overview page in the resource watchers. Also add lint rules to potentially catch these cases. Only as warnings for now as there are many offenders requiring specific fixes.