### PR TITLE
refactor(frontend): expose all vars from watch in watch composable

### DIFF
--- a/frontend/src/methods/useResourceWatch.ts
+++ b/frontend/src/methods/useResourceWatch.ts
@@ -6,6 +6,7 @@ import { type MaybeRefOrGetter, type Ref, ref, toValue } from 'vue'
 
 import type { Resource } from '@/api/grpc'
 import type {
+  Callback,
   WatchJoinOptions,
   WatchOptions,
   WatchOptionsMulti,
@@ -20,73 +21,90 @@ interface WatchBase {
 
 interface WatchSingle<TSpec, TStatus> extends WatchBase {
   data: Ref<Resource<TSpec, TStatus> | undefined>
+  running: Ref<boolean>
 }
 
 interface WatchMulti<TSpec, TStatus> extends WatchBase {
   data: Ref<Resource<TSpec, TStatus>[]>
+  total: Ref<number>
+  running: Ref<boolean>
+}
+
+interface WatchMultiJoin<TSpec, TStatus> extends WatchBase {
+  data: Ref<Resource<TSpec, TStatus>[]>
+  total: Ref<number>
 }
 
 export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsSingle>,
+  callback?: Callback,
 ): WatchSingle<TSpec, TStatus>
 
 export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsMulti>,
+  callback?: Callback,
 ): WatchMulti<TSpec, TStatus>
 
 export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchJoinOptions[]>,
-): WatchMulti<TSpec, TStatus>
+): WatchMultiJoin<TSpec, TStatus>
 
 export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptions | WatchJoinOptions[]>,
-): WatchSingle<TSpec, TStatus> | WatchMulti<TSpec, TStatus>
+  callback?: Callback,
+): WatchSingle<TSpec, TStatus> | WatchMulti<TSpec, TStatus> | WatchMultiJoin<TSpec, TStatus>
 
 export function useResourceWatch<TSpec, TStatus>(
   opts: MaybeRefOrGetter<WatchOptions | WatchJoinOptions[]>,
+  callback?: Callback,
 ) {
   if (isWatchJoinOptions(opts)) return useWatchJoin<TSpec, TStatus>(opts)
 
   // Type guards unfortunately don't narrow generic types
   return isWatchOptionsSingle(opts as MaybeRefOrGetter<WatchOptions>)
-    ? useWatchSingle<TSpec, TStatus>(opts as MaybeRefOrGetter<WatchOptionsSingle>)
-    : useWatchMulti<TSpec, TStatus>(opts as MaybeRefOrGetter<WatchOptionsMulti>)
+    ? useWatchSingle<TSpec, TStatus>(opts as MaybeRefOrGetter<WatchOptionsSingle>, callback)
+    : useWatchMulti<TSpec, TStatus>(opts as MaybeRefOrGetter<WatchOptionsMulti>, callback)
 }
 
 function useWatchSingle<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsSingle>,
-) {
+  callback?: Callback,
+): WatchSingle<TSpec, TStatus> {
   const data = ref<Resource<TSpec, TStatus>>()
 
-  const watch = new Watch(data)
+  const watch = new Watch(data, callback)
   watch.setup(opts)
 
   return {
     data,
     err: watch.err,
     loading: watch.loading,
+    running: watch.running,
   }
 }
 
 function useWatchMulti<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsMulti>,
-) {
-  const data = ref<Resource<TSpec, TStatus>[]>([])
+  callback?: Callback,
+): WatchMulti<TSpec, TStatus> {
+  const data: Ref<Resource<TSpec, TStatus>[], Resource<TSpec, TStatus>[]> = ref([])
 
-  const watch = new Watch(data)
+  const watch = new Watch(data, callback)
   watch.setup(opts)
 
   return {
     data,
     err: watch.err,
     loading: watch.loading,
+    total: watch.total,
+    running: watch.running,
   }
 }
 
 function useWatchJoin<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchJoinOptions[]>,
-) {
-  const data = ref<Resource<TSpec, TStatus>[]>([])
+): WatchMultiJoin<TSpec, TStatus> {
+  const data: Ref<Resource<TSpec, TStatus>[], Resource<TSpec, TStatus>[]> = ref([])
 
   const watch = new WatchJoin(data)
   watch.setup(
@@ -101,6 +119,7 @@ function useWatchJoin<TSpec = unknown, TStatus = unknown>(
     data,
     err: watch.err,
     loading: watch.loading,
+    total: watch.total,
   }
 }
 

--- a/frontend/src/views/omni/Modals/components/JoinTokenWarnings.vue
+++ b/frontend/src/views/omni/Modals/components/JoinTokenWarnings.vue
@@ -7,38 +7,36 @@ included in the LICENSE file.
 
 <script setup lang="ts">
 import pluralize from 'pluralize'
-import { ref, watch } from 'vue'
+import { watch } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
 import type { JoinTokenStatusSpec } from '@/api/omni/specs/siderolink.pb'
 import { DefaultNamespace, JoinTokenStatusType } from '@/api/resources'
-import Watch from '@/api/watch'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
-const joinTokenStatus = ref<Resource<JoinTokenStatusSpec>>()
-const joinTokenStatusWatch = new Watch(joinTokenStatus)
-
-const props = defineProps<{
+const { id } = defineProps<{
   id: string
 }>()
 
-const emit = defineEmits(['ready'])
+const emit = defineEmits<{ ready: [] }>()
 
-joinTokenStatusWatch.setup({
+const {
+  data: joinTokenStatus,
+  loading,
+  running,
+} = useResourceWatch<JoinTokenStatusSpec>(() => ({
   resource: {
-    id: props.id,
+    id,
     namespace: DefaultNamespace,
     type: JoinTokenStatusType,
   },
   runtime: Runtime.Omni,
-})
+}))
 
-const loading = joinTokenStatusWatch.loading
-
-watch(joinTokenStatusWatch.running, () => {
-  if (joinTokenStatusWatch.running.value) {
+watch(running, () => {
+  if (running.value) {
     emit('ready')
   }
 })


### PR DESCRIPTION
Expose total and running from the useResourceWatch composable which are sometimes (albeit rarely) used to cover some final refactoring cases. Also fix a reactivity issue in `JoinTokenWarnings`.

Related to #1471