### PR TITLE
refactor(frontend): refactor some watches to useresourcewatch

### DIFF
--- a/frontend/src/methods/node.ts
+++ b/frontend/src/methods/node.ts
@@ -2,35 +2,26 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
-
-import type { Ref } from 'vue'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
 import type { ClusterMachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import {
   ClusterMachineStatusLabelNodeName,
   ClusterMachineStatusType,
   DefaultNamespace,
 } from '@/api/resources'
-import Watch from '@/api/watch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
-export const setupNodenameWatch = (id: string | string[]): Ref<string> => {
-  const res: Ref<Resource<ClusterMachineStatusSpec> | undefined> = ref()
-
-  const w = new Watch(res)
-
-  w.setup({
+export const setupNodenameWatch = (id: string) => {
+  const { data } = useResourceWatch<ClusterMachineStatusSpec>({
     resource: {
       type: ClusterMachineStatusType,
       namespace: DefaultNamespace,
-      id: id as string,
+      id,
     },
     runtime: Runtime.Omni,
   })
 
-  return computed(() => {
-    return (res.value?.metadata?.labels ?? {})[ClusterMachineStatusLabelNodeName] ?? ''
-  })
+  return computed(() => data.value?.metadata.labels?.[ClusterMachineStatusLabelNodeName] ?? '')
 }

--- a/frontend/src/views/cluster/ClusterScoped.vue
+++ b/frontend/src/views/cluster/ClusterScoped.vue
@@ -5,42 +5,37 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
 import { EventType } from '@/api/omni/resources/resources.pb'
 import type { ClusterSpec } from '@/api/omni/specs/omni.pb'
 import { ClusterType, DefaultNamespace } from '@/api/resources'
-import Watch from '@/api/watch'
 import TAlert from '@/components/TAlert.vue'
 import { getContext } from '@/context'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const bootstrapped = ref(false)
-const cluster = ref<Resource<ClusterSpec>>()
-
-const watch = new Watch(cluster, (message) => {
-  if (message.event?.event_type === EventType.BOOTSTRAPPED) {
-    bootstrapped.value = true
-  }
-})
 
 const route = useRoute()
 const context = getContext(route)
 
-watch.setup(
-  computed(() => {
-    return {
-      runtime: Runtime.Omni,
-      resource: {
-        type: ClusterType,
-        namespace: DefaultNamespace,
-        id: route.params.cluster as string,
-      },
-      context,
-    }
+const { data: cluster } = useResourceWatch<ClusterSpec>(
+  () => ({
+    runtime: Runtime.Omni,
+    resource: {
+      type: ClusterType,
+      namespace: DefaultNamespace,
+      id: route.params.cluster as string,
+    },
+    context,
   }),
+  (message) => {
+    if (message.event?.event_type === EventType.BOOTSTRAPPED) {
+      bootstrapped.value = true
+    }
+  },
 )
 </script>
 

--- a/frontend/src/views/cluster/Nodes/NodeConfig.vue
+++ b/frontend/src/views/cluster/Nodes/NodeConfig.vue
@@ -5,45 +5,35 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import type { Ref } from 'vue'
-import { computed, defineAsyncComponent, ref } from 'vue'
+import { computed, defineAsyncComponent } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
 import type { RedactedClusterMachineConfigSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, RedactedClusterMachineConfigType } from '@/api/resources'
-import Watch from '@/api/watch'
 import { getContext } from '@/context'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const CodeEditor = defineAsyncComponent(
   () => import('@/components/common/CodeEditor/CodeEditor.vue'),
 )
 
 const route = useRoute()
+const context = getContext(route)
 
-const configs: Ref<Resource<RedactedClusterMachineConfigSpec>[]> = ref([])
-const watch = new Watch(configs)
+const { data: configs } = useResourceWatch<RedactedClusterMachineConfigSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    type: RedactedClusterMachineConfigType,
+    namespace: DefaultNamespace,
+    id: route.params.machine as string,
+  },
+  context,
+}))
 
 const config = computed(() => {
   return configs.value?.[0]?.spec?.data || ''
 })
-
-const context = getContext(route)
-
-watch.setup(
-  computed(() => {
-    return {
-      runtime: Runtime.Omni,
-      resource: {
-        type: RedactedClusterMachineConfigType,
-        namespace: DefaultNamespace,
-        id: route.params.machine as string,
-      },
-      context,
-    }
-  }),
-)
 </script>
 
 <template>

--- a/frontend/src/views/cluster/Nodes/NodesHeader.vue
+++ b/frontend/src/views/cluster/Nodes/NodesHeader.vue
@@ -5,20 +5,19 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import type { Ref } from 'vue'
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
 import { ResourceService } from '@/api/grpc'
-import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
+import type { MachineSetNodeSpec, MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { withRuntime } from '@/api/options'
 import { DefaultNamespace, MachineSetNodeType, MachineStatusType } from '@/api/resources'
-import Watch from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
 import TBreadcrumbs from '@/components/TBreadcrumbs.vue'
 import { setupClusterPermissions } from '@/methods/auth'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const route = useRoute()
 const router = useRouter()
@@ -58,9 +57,7 @@ const rebootNode = () => {
   })
 }
 
-const machineSetNode: Ref<Resource | undefined> = ref()
-const watch = new Watch(machineSetNode)
-watch.setup({
+const { data: machineSetNode, loading } = useResourceWatch<MachineSetNodeSpec>({
   resource: {
     type: MachineSetNodeType,
     id: route.params.machine as string,
@@ -68,8 +65,6 @@ watch.setup({
   },
   runtime: Runtime.Omni,
 })
-
-const loading = watch.loading
 
 const destroyNode = async () => {
   router.push({

--- a/frontend/src/views/omni/Clusters/Management/MachineSets.vue
+++ b/frontend/src/views/omni/Clusters/Management/MachineSets.vue
@@ -5,20 +5,16 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { ref } from 'vue'
-
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
+import type { MachineClassSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, LabelWorkerRole, MachineClassType } from '@/api/resources'
-import Watch from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { state } from '@/states/cluster-management'
 
 import MachineSetConfig from './MachineSetConfig.vue'
 
-const machineClasses = ref<Resource[]>([])
-const machineClassesWatch = new Watch(machineClasses)
-machineClassesWatch.setup({
+const { data: machineClasses } = useResourceWatch<MachineClassSpec>({
   resource: {
     type: MachineClassType,
     namespace: DefaultNamespace,

--- a/frontend/src/views/omni/Machines/MachinePatches.vue
+++ b/frontend/src/views/omni/Machines/MachinePatches.vue
@@ -5,32 +5,24 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
+import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, MachineStatusType } from '@/api/resources'
-import Watch from '@/api/watch'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import Patches from '@/views/cluster/Config/Patches.vue'
 
-const machine = ref<Resource>()
 const route = useRoute()
 
-const machineWatch = new Watch(machine)
-
-machineWatch.setup(
-  computed(() => {
-    return {
-      resource: {
-        id: route.params.machine as string,
-        type: MachineStatusType,
-        namespace: DefaultNamespace,
-      },
-      runtime: Runtime.Omni,
-    }
-  }),
-)
+const { data: machine } = useResourceWatch<MachineStatusSpec>(() => ({
+  resource: {
+    id: route.params.machine as string,
+    type: MachineStatusType,
+    namespace: DefaultNamespace,
+  },
+  runtime: Runtime.Omni,
+}))
 </script>
 
 <template>

--- a/frontend/src/views/omni/Modals/CreateExtensions.vue
+++ b/frontend/src/views/omni/Modals/CreateExtensions.vue
@@ -5,15 +5,14 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, ref, toRefs, watch } from 'vue'
+import { ref, toRefs, watch } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
 import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, MachineStatusType } from '@/api/resources'
-import Watch from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { closeModal } from '@/modal'
 import ExtensionsPicker from '@/views/omni/Extensions/ExtensionsPicker.vue'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
@@ -38,8 +37,14 @@ if (modelValue.value) {
   }
 }
 
-const machineStatus = ref<Resource<MachineStatusSpec>>()
-const machineStatusWatch = new Watch(machineStatus)
+const { data: machineStatus } = useResourceWatch<MachineStatusSpec>(() => ({
+  resource: {
+    id: machine.value,
+    namespace: DefaultNamespace,
+    type: MachineStatusType,
+  },
+  runtime: Runtime.Omni,
+}))
 
 watch(machineStatus, () => {
   if (modelValue.value !== undefined) {
@@ -57,19 +62,6 @@ watch(machineStatus, () => {
     requestedExtensions.value[extension] = true
   }
 })
-
-machineStatusWatch.setup(
-  computed(() => {
-    return {
-      resource: {
-        id: machine.value,
-        namespace: DefaultNamespace,
-        type: MachineStatusType,
-      },
-      runtime: Runtime.Omni,
-    }
-  }),
-)
 
 const updateExtensions = (extensions?: Record<string, boolean>) => {
   if (extensions === undefined) {

--- a/frontend/src/views/omni/Modals/DownloadSupportBundle.vue
+++ b/frontend/src/views/omni/Modals/DownloadSupportBundle.vue
@@ -11,12 +11,10 @@ import { useRoute, useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { b64Decode } from '@/api/fetch.pb'
-import type { Resource } from '@/api/grpc'
 import { ManagementService } from '@/api/omni/management/management.pb'
 import type { TalosUpgradeStatusSpec } from '@/api/omni/specs/omni.pb'
 import { withAbortController } from '@/api/options'
 import { DefaultNamespace, TalosUpgradeStatusType } from '@/api/resources'
-import Watch from '@/api/watch'
 import IconButton from '@/components/common/Button/IconButton.vue'
 import TButton from '@/components/common/Button/TButton.vue'
 import type { IconType } from '@/components/common/Icon/TIcon.vue'
@@ -25,6 +23,7 @@ import ProgressBar from '@/components/common/ProgressBar/ProgressBar.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 import { setupClusterPermissions } from '@/methods/auth'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError } from '@/notification'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
 
@@ -36,18 +35,12 @@ const selectedVersion = ref('')
 
 const clusterName = route.params.cluster as string
 
-const resource = {
-  namespace: DefaultNamespace,
-  type: TalosUpgradeStatusType,
-  id: clusterName,
-}
-
-const status: Ref<Resource<TalosUpgradeStatusSpec> | undefined> = ref()
-
-const upgradeStatusWatch = new Watch(status)
-
-upgradeStatusWatch.setup({
-  resource: resource,
+const { data: status } = useResourceWatch<TalosUpgradeStatusSpec>({
+  resource: {
+    namespace: DefaultNamespace,
+    type: TalosUpgradeStatusType,
+    id: clusterName,
+  },
   runtime: Runtime.Omni,
 })
 


### PR DESCRIPTION
Refactor some of the simpler cases of `Watch` to `useResourceWatch`. Add missing types where relevant.

Related to #1471 