### PR TITLE
chore: bump node to 24.13

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.11.0
+          node-version: 24.13.0
       - name: Install dependencies
         run: npm ci
         working-directory: frontend/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-01-14T12:19:03Z by kres 8b6181b.
+# Generated on 2026-01-15T15:33:44Z by kres f7396f7.
 
 # common variables
 
@@ -83,7 +83,7 @@ COMMON_ARGS += --build-arg=DEEPCOPY_VERSION="$(DEEPCOPY_VERSION)"
 COMMON_ARGS += --build-arg=GOLANGCILINT_VERSION="$(GOLANGCILINT_VERSION)"
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION="$(GOFUMPT_VERSION)"
 COMMON_ARGS += --build-arg=TESTPKGS="$(TESTPKGS)"
-JS_TOOLCHAIN ?= docker.io/node:24.12.0-alpine
+JS_TOOLCHAIN ?= docker.io/node:24.13.0-alpine
 TOOLCHAIN ?= docker.io/golang:1.25-alpine
 
 # extra variables

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,7 +57,7 @@
         "@types/jsdom": "^27.0.0",
         "@types/lodash": "^4.17.21",
         "@types/luxon": "^3.7.1",
-        "@types/node": "^24.10.4",
+        "@types/node": "^24.10.8",
         "@types/pluralize": "^0.0.33",
         "@types/semver": "^7.7.1",
         "@vitejs/plugin-vue": "^6.0.3",
@@ -97,7 +97,7 @@
         "yaml": "^2.8.2"
       },
       "engines": {
-        "node": "^24.11.0"
+        "node": "^24.13.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -3275,9 +3275,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
-      "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
+      "version": "24.10.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.8.tgz",
+      "integrity": "sha512-r0bBaXu5Swb05doFYO2kTWHMovJnNVbCsII0fhesM8bNRlLhXIuckley4a2DaD+vOdmm5G+zGkQZAPZsF80+YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": "^24.11.0"
+    "node": "^24.13.0"
   },
   "msw": {
     "workerDirectory": [
@@ -74,7 +74,7 @@
     "@types/jsdom": "^27.0.0",
     "@types/lodash": "^4.17.21",
     "@types/luxon": "^3.7.1",
-    "@types/node": "^24.10.4",
+    "@types/node": "^24.10.8",
     "@types/pluralize": "^0.0.33",
     "@types/semver": "^7.7.1",
     "@vitejs/plugin-vue": "^6.0.3",

--- a/hack/compose/docker-compose.yml
+++ b/hack/compose/docker-compose.yml
@@ -89,7 +89,7 @@ services:
   node-dev:
     network_mode: host
     container_name: local-node
-    image: node:24.11.0-alpine
+    image: node:24.13.0-alpine
     volumes:
       - ../../frontend:/app:rw
     working_dir: /app


### PR DESCRIPTION
Bump node to 24.13 to address CVEs https://nodejs.org/en/blog/vulnerability/december-2025-security-releases