### PR TITLE
fix: solve new machines not joining omni if they are part of a cluster

### DIFF
--- a/internal/backend/runtime/omni/controllers/helpers/helpers.go
+++ b/internal/backend/runtime/omni/controllers/helpers/helpers.go
@@ -220,7 +220,7 @@ func GetTalosClient[T interface {
 		return nil, err
 	}
 
-	if machineStatusSnapshot != nil && machineStatusSnapshot.TypedSpec().Value.MachineStatus.Stage == machine.MachineStatusEvent_MAINTENANCE {
+	if machineStatusSnapshot == nil || machineStatusSnapshot.TypedSpec().Value.MachineStatus.Stage == machine.MachineStatusEvent_MAINTENANCE {
 		return createInsecureClient()
 	}
 


### PR DESCRIPTION
When a new machine is added to omni, we were checking whether the machine is in maintenance mode by using `machinestatus.stage` under `MachineStatusSnapshot` resource. However, at this point MachineStatusSnapshot doesn't exist yet.

Fixed the condition to also check existence of MachineStatusSnapshot as well as machine status stage.

Fixes: #1966
