### PR TITLE
fix: prevent ClusterMachine creation when Machine is not allocated

### DIFF
--- a/internal/backend/runtime/omni/controllers/helpers/helpers.go
+++ b/internal/backend/runtime/omni/controllers/helpers/helpers.go
@@ -220,7 +220,7 @@ func GetTalosClient[T interface {
 		return nil, err
 	}
 
-	if machineStatusSnapshot == nil || machineStatusSnapshot.TypedSpec().Value.MachineStatus.Stage == machine.MachineStatusEvent_MAINTENANCE {
+	if machineStatusSnapshot != nil && machineStatusSnapshot.TypedSpec().Value.MachineStatus.Stage == machine.MachineStatusEvent_MAINTENANCE {
 		return createInsecureClient()
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/control_planes_handler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/control_planes_handler_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/machineset"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/pkg/check"
 )
@@ -29,6 +30,7 @@ func TestControlPlanesHandler(t *testing.T) {
 		name                         string
 		machineSet                   *specs.MachineSetSpec
 		machineSetNodes              []*omni.MachineSetNode
+		machineStatuses              []*system.ResourceLabels[*omni.MachineStatus]
 		clusterMachines              []*omni.ClusterMachine
 		clusterMachineConfigStatuses []*omni.ClusterMachineConfigStatus
 		clusterMachineConfigPatches  []*omni.ClusterMachineConfigPatches
@@ -46,6 +48,11 @@ func TestControlPlanesHandler(t *testing.T) {
 				omni.NewMachineSetNode("b", machineSet),
 				omni.NewMachineSetNode("c", machineSet),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+				system.NewResourceLabels[*omni.MachineStatus]("c"),
+			},
 			expectOperations: []machineset.Operation{
 				&machineset.Create{ID: "a"},
 				&machineset.Create{ID: "b"},
@@ -59,6 +66,11 @@ func TestControlPlanesHandler(t *testing.T) {
 				omni.NewMachineSetNode("a", machineSet),
 				omni.NewMachineSetNode("b", machineSet),
 				omni.NewMachineSetNode("c", machineSet),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+				system.NewResourceLabels[*omni.MachineStatus]("c"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				omni.NewClusterMachine("a"),
@@ -74,6 +86,9 @@ func TestControlPlanesHandler(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", machineSet),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				omni.NewClusterMachine("a"),
 				tearingDownNoFinalizers(omni.NewClusterMachine("b")),
@@ -88,6 +103,9 @@ func TestControlPlanesHandler(t *testing.T) {
 			machineSet: &specs.MachineSetSpec{},
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", machineSet),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				omni.NewClusterMachine("a"),
@@ -117,6 +135,9 @@ func TestControlPlanesHandler(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", machineSet),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				omni.NewClusterMachine("a"),
 				omni.NewClusterMachine("c"),
@@ -141,6 +162,9 @@ func TestControlPlanesHandler(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", machineSet),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				omni.NewClusterMachine("a"),
 			},
@@ -164,6 +188,10 @@ func TestControlPlanesHandler(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", machineSet),
 				omni.NewMachineSetNode("b", machineSet),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions[*omni.ClusterMachine, *omni.ConfigPatch](withVersion(omni.NewClusterMachine("a"), version.Next())),
@@ -200,6 +228,9 @@ func TestControlPlanesHandler(t *testing.T) {
 			machineSet: &specs.MachineSetSpec{},
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", machineSet),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions[*omni.ClusterMachine, *omni.ConfigPatch](withVersion(omni.NewClusterMachine("a"), version)),
@@ -241,6 +272,7 @@ func TestControlPlanesHandler(t *testing.T) {
 				newHealthyLB(cluster.Metadata().ID()),
 				patchHelper,
 				tt.machineSetNodes,
+				tt.machineStatuses,
 				tt.clusterMachines,
 				tt.clusterMachineConfigStatuses,
 				tt.clusterMachineConfigPatches,

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/operations_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/operations_test.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/machineset"
 )
@@ -113,6 +114,9 @@ func TestCreate(t *testing.T) {
 		},
 		[]*omni.MachineSetNode{
 			omni.NewMachineSetNode("aa", machineSet),
+		},
+		[]*system.ResourceLabels[*omni.MachineStatus]{
+			system.NewResourceLabels[*omni.MachineStatus]("aa"),
 		},
 		nil,
 		nil,
@@ -213,6 +217,9 @@ func TestUpdate(t *testing.T) {
 			patchHelper,
 			[]*omni.MachineSetNode{
 				omni.NewMachineSetNode("aa", machineSet),
+			},
+			[]*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("aa"),
 			},
 			[]*omni.ClusterMachine{
 				clusterMachine,
@@ -333,6 +340,10 @@ func TestTeardown(t *testing.T) {
 			omni.NewMachineSetNode("aa", machineSet),
 			omni.NewMachineSetNode("bb", machineSet),
 		},
+		[]*system.ResourceLabels[*omni.MachineStatus]{
+			system.NewResourceLabels[*omni.MachineStatus]("aa"),
+			system.NewResourceLabels[*omni.MachineStatus]("bb"),
+		},
 		clusterMachines,
 		nil,
 		nil,
@@ -406,6 +417,7 @@ func TestDestroy(t *testing.T) {
 		machineSet,
 		newHealthyLB(cluster.Metadata().ID()),
 		&fakePatchHelper{},
+		nil,
 		nil,
 		clusterMachines,
 		nil,

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/reconciliation_context_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/reconciliation_context_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/machineset"
 )
@@ -56,6 +57,7 @@ func TestReconciliationContext(t *testing.T) {
 		machineSet                   *specs.MachineSetSpec
 		lbUnhealthy                  bool
 		machineSetNodes              []*omni.MachineSetNode
+		machineStatuses              []*system.ResourceLabels[*omni.MachineStatus]
 		clusterMachines              []*omni.ClusterMachine
 		clusterMachineConfigStatuses []*omni.ClusterMachineConfigStatus
 		clusterMachineConfigPatches  []*omni.ClusterMachineConfigPatches
@@ -93,6 +95,9 @@ func TestReconciliationContext(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", omni.NewMachineSet("")),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(withVersion(omni.NewClusterMachine("a"), version), configPatches...),
 			},
@@ -119,6 +124,9 @@ func TestReconciliationContext(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", omni.NewMachineSet("")),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+			},
 			clusterMachineConfigStatuses: []*omni.ClusterMachineConfigStatus{
 				withClusterMachineVersionSetter(omni.NewClusterMachineConfigStatus("a"), version),
 			},
@@ -139,6 +147,9 @@ func TestReconciliationContext(t *testing.T) {
 			},
 			machineSetNodes: []*omni.MachineSetNode{
 				tearingDown(omni.NewMachineSetNode("a", newMachineSet(1))),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(withVersion(omni.NewClusterMachine("a"), version), configPatches...),
@@ -167,6 +178,9 @@ func TestReconciliationContext(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				lockedMachine,
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus](lockedMachine.Metadata().ID()),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				withVersion(omni.NewClusterMachine("b"), version),
 			},
@@ -187,6 +201,10 @@ func TestReconciliationContext(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				lockedMachine,
 				omni.NewMachineSetNode("c", omni.NewMachineSet("")),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus](lockedMachine.Metadata().ID()),
+				system.NewResourceLabels[*omni.MachineStatus]("c"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withVersion(omni.NewClusterMachine("b"), version),
@@ -248,6 +266,9 @@ func TestReconciliationContext(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", omni.NewMachineSet("")),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+			},
 			clusterMachineConfigStatuses: []*omni.ClusterMachineConfigStatus{
 				omni.NewClusterMachineConfigStatus("a"),
 			},
@@ -274,6 +295,9 @@ func TestReconciliationContext(t *testing.T) {
 			},
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", omni.NewMachineSet("")),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			clusterMachineConfigStatuses: []*omni.ClusterMachineConfigStatus{
 				withClusterMachineVersionSetter(omni.NewClusterMachineConfigStatus("a"), version),
@@ -330,6 +354,7 @@ func TestReconciliationContext(t *testing.T) {
 				loadbalancerStatus,
 				&fakePatchHelper{},
 				tt.machineSetNodes,
+				tt.machineStatuses,
 				tt.clusterMachines,
 				tt.clusterMachineConfigStatuses,
 				tt.clusterMachineConfigPatches,

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/status_handler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/status_handler_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/machineset"
 )
 
@@ -53,6 +54,7 @@ func TestStatusHandler(t *testing.T) {
 		name                   string
 		machineSet             *omni.MachineSet
 		machineSetNodes        []*omni.MachineSetNode
+		machineStatuses        []*system.ResourceLabels[*omni.MachineStatus]
 		clusterMachines        []*omni.ClusterMachine
 		clusterMachineStatuses []*omni.ClusterMachineStatus
 		expectedStatus         *specs.MachineSetStatusSpec
@@ -71,6 +73,10 @@ func TestStatusHandler(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", ms),
 				omni.NewMachineSetNode("b", ms),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(omni.NewClusterMachine("a"), patches...),
@@ -98,6 +104,10 @@ func TestStatusHandler(t *testing.T) {
 				omni.NewMachineSetNode("a", ms),
 				omni.NewMachineSetNode("b", ms),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				omni.NewClusterMachine("a"),
 				omni.NewClusterMachine("b"),
@@ -122,6 +132,9 @@ func TestStatusHandler(t *testing.T) {
 			name: "scaling down",
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", ms),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(omni.NewClusterMachine("a"), patches...),
@@ -149,6 +162,10 @@ func TestStatusHandler(t *testing.T) {
 				omni.NewMachineSetNode("a", ms),
 				omni.NewMachineSetNode("b", ms),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(omni.NewClusterMachine("a"), patches...),
 			},
@@ -172,6 +189,10 @@ func TestStatusHandler(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", ms),
 				omni.NewMachineSetNode("b", ms),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(omni.NewClusterMachine("a"), patches...),
@@ -199,6 +220,10 @@ func TestStatusHandler(t *testing.T) {
 				omni.NewMachineSetNode("a", ms),
 				omni.NewMachineSetNode("b", ms),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(omni.NewClusterMachine("a"), patches...),
 				withUpdateInputVersions(omni.NewClusterMachine("b"), patches...),
@@ -224,6 +249,9 @@ func TestStatusHandler(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("b", ms),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(omni.NewClusterMachine("a"), patches...),
 			},
@@ -246,6 +274,9 @@ func TestStatusHandler(t *testing.T) {
 			name: "scaling up machine class",
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", ms),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			machineSet: newMachineSet(4),
 			clusterMachines: []*omni.ClusterMachine{
@@ -273,6 +304,9 @@ func TestStatusHandler(t *testing.T) {
 			name: "scaling down machine class",
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", ms),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			machineSet: newMachineSet(0),
 			clusterMachines: []*omni.ClusterMachine{
@@ -302,6 +336,10 @@ func TestStatusHandler(t *testing.T) {
 				omni.NewMachineSetNode("a", ms),
 				omni.NewMachineSetNode("b", ms),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions(omni.NewClusterMachine("a"), patches...),
 				withUpdateInputVersions(omni.NewClusterMachine("b"), patches...),
@@ -327,6 +365,10 @@ func TestStatusHandler(t *testing.T) {
 			machineSetNodes: []*omni.MachineSetNode{
 				withLabels(omni.NewMachineSetNode("a", ms), pair.MakePair(omni.MachineLocked, "")),
 				withLabels(omni.NewMachineSetNode("b", ms), pair.MakePair(omni.MachineLocked, "")),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				omni.NewClusterMachine("a"),
@@ -383,6 +425,7 @@ func TestStatusHandler(t *testing.T) {
 				newHealthyLB("test"),
 				&fakePatchHelper{},
 				tt.machineSetNodes,
+				tt.machineStatuses,
 				tt.clusterMachines,
 				clusterMachineConfigStatuses,
 				clusterMachineConfigPatches,

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/workers_handler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/workers_handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/machineset"
 )
 
@@ -26,6 +27,7 @@ func TestWorkersHandler(t *testing.T) {
 		name                         string
 		machineSet                   *specs.MachineSetSpec
 		machineSetNodes              []*omni.MachineSetNode
+		machineStatuses              []*system.ResourceLabels[*omni.MachineStatus]
 		clusterMachines              []*omni.ClusterMachine
 		clusterMachineConfigStatuses []*omni.ClusterMachineConfigStatus
 		clusterMachineConfigPatches  []*omni.ClusterMachineConfigPatches
@@ -43,6 +45,11 @@ func TestWorkersHandler(t *testing.T) {
 				omni.NewMachineSetNode("b", machineSet),
 				omni.NewMachineSetNode("c", machineSet),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+				system.NewResourceLabels[*omni.MachineStatus]("c"),
+			},
 			expectOperations: []machineset.Operation{
 				&machineset.Create{ID: "a"},
 				&machineset.Create{ID: "b"},
@@ -56,6 +63,11 @@ func TestWorkersHandler(t *testing.T) {
 				omni.NewMachineSetNode("a", machineSet),
 				omni.NewMachineSetNode("b", machineSet),
 				omni.NewMachineSetNode("c", machineSet),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+				system.NewResourceLabels[*omni.MachineStatus]("c"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions[*omni.ClusterMachine, *omni.ConfigPatch](withVersion(omni.NewClusterMachine("a"), version)),
@@ -77,6 +89,9 @@ func TestWorkersHandler(t *testing.T) {
 			machineSet: &specs.MachineSetSpec{},
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", machineSet),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions[*omni.ClusterMachine, *omni.ConfigPatch](withVersion(omni.NewClusterMachine("a"), version)),
@@ -103,6 +118,11 @@ func TestWorkersHandler(t *testing.T) {
 				omni.NewMachineSetNode("a", machineSet),
 				omni.NewMachineSetNode("b", machineSet),
 				omni.NewMachineSetNode("c", machineSet),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+				system.NewResourceLabels[*omni.MachineStatus]("b"),
+				system.NewResourceLabels[*omni.MachineStatus]("c"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions[*omni.ClusterMachine, *omni.ConfigPatch](withVersion(omni.NewClusterMachine("a"), version)),
@@ -144,6 +164,9 @@ func TestWorkersHandler(t *testing.T) {
 			clusterMachines: []*omni.ClusterMachine{
 				omni.NewClusterMachine("a"),
 			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
+			},
 			expectOperations: []machineset.Operation{
 				&machineset.Update{
 					ID: "a",
@@ -155,6 +178,9 @@ func TestWorkersHandler(t *testing.T) {
 			machineSet: &specs.MachineSetSpec{},
 			machineSetNodes: []*omni.MachineSetNode{
 				omni.NewMachineSetNode("a", machineSet),
+			},
+			machineStatuses: []*system.ResourceLabels[*omni.MachineStatus]{
+				system.NewResourceLabels[*omni.MachineStatus]("a"),
 			},
 			clusterMachines: []*omni.ClusterMachine{
 				withUpdateInputVersions[*omni.ClusterMachine, *omni.ConfigPatch](withVersion(omni.NewClusterMachine("a"), version)),
@@ -186,6 +212,7 @@ func TestWorkersHandler(t *testing.T) {
 					tt.pendingConfigPatches,
 				},
 				tt.machineSetNodes,
+				tt.machineStatuses,
 				tt.clusterMachines,
 				tt.clusterMachineConfigStatuses,
 				tt.clusterMachineConfigPatches,

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -667,6 +667,7 @@ func (ctrl *MachineStatusController) setClusterRelation(in inputs, machineStatus
 		machineStatus.Metadata().Labels().Set(omni.MachineStatusLabelAvailable, "")
 
 		machineStatus.Metadata().Labels().Delete(omni.LabelCluster)
+		machineStatus.Metadata().Labels().Delete(omni.LabelMachineSet)
 		machineStatus.Metadata().Labels().Delete(omni.LabelControlPlaneRole)
 		machineStatus.Metadata().Labels().Delete(omni.LabelWorkerRole)
 
@@ -685,7 +686,13 @@ func (ctrl *MachineStatusController) setClusterRelation(in inputs, machineStatus
 	_, controlPlane := labels.Get(omni.LabelControlPlaneRole)
 	_, worker := labels.Get(omni.LabelWorkerRole)
 
+	machineSet, machineSetOk := labels.Get(omni.LabelMachineSet)
+	if !machineSetOk {
+		return fmt.Errorf("malformed ClusterMachine resource: no %q label, machine set ownership unknown", omni.LabelMachineSet)
+	}
+
 	machineStatus.Metadata().Labels().Set(omni.LabelCluster, cluster)
+	machineStatus.Metadata().Labels().Set(omni.LabelMachineSet, machineSet)
 
 	switch {
 	case controlPlane:

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -525,12 +525,18 @@ func (suite *OmniSuite) createClusterWithTalosVersion(clusterName string, contro
 			clusterMachine.Metadata().Labels().Set(omni.LabelControlPlaneRole, "")
 			clusterMachine.Metadata().Labels().Set(omni.LabelMachineSet, cpMachineSet.Metadata().ID())
 
+			machineStatus.Metadata().Labels().Set(omni.LabelControlPlaneRole, "")
+			machineStatus.Metadata().Labels().Set(omni.LabelMachineSet, cpMachineSet.Metadata().ID())
+
 			machineStatus.TypedSpec().Value.Role = specs.MachineStatusSpec_CONTROL_PLANE
 
 			machineSetNode = omni.NewMachineSetNode(clusterMachine.Metadata().ID(), cpMachineSet)
 		} else {
 			clusterMachine.Metadata().Labels().Set(omni.LabelWorkerRole, "")
 			clusterMachine.Metadata().Labels().Set(omni.LabelMachineSet, workersMachineSet.Metadata().ID())
+
+			machineStatus.Metadata().Labels().Set(omni.LabelWorkerRole, "")
+			machineStatus.Metadata().Labels().Set(omni.LabelMachineSet, workersMachineSet.Metadata().ID())
 
 			machineStatus.TypedSpec().Value.Role = specs.MachineStatusSpec_WORKER
 


### PR DESCRIPTION
Prevent creation of `ClusterMachines`s from MachineSetNode when associated `Machine`s are not allocated yet.
