### PR TITLE
feat(installation-media): change installation media wizard to be route based

### DIFF
--- a/frontend/src/components/common/TInput/TInput.vue
+++ b/frontend/src/components/common/TInput/TInput.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts" generic="T extends string | number">
-import { computed, onMounted, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, useTemplateRef, watchPostEffect } from 'vue'
 
 import type { IconType } from '@/components/common/Icon/TIcon.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
@@ -82,10 +82,7 @@ const blurHandler = () => {
   emit('blur')
 }
 
-watch(
-  () => focus,
-  () => focus && inputRef.value?.focus(),
-)
+watchPostEffect(() => focus && inputRef.value?.focus())
 
 onMounted(() => focus && inputRef.value?.focus())
 </script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -246,9 +246,56 @@ export const routes: RouteRecordRaw[] = [
               {
                 path: 'create',
                 name: 'InstallationMediaCreate',
+                redirect: { name: 'InstallationMediaCreateEntry' },
                 meta: { disablePadding: true },
                 component: () =>
                   import('@/views/omni/InstallationMedia/InstallationMediaCreate.vue'),
+                children: [
+                  {
+                    path: '',
+                    name: 'InstallationMediaCreateEntry',
+                    component: () => import('@/views/omni/InstallationMedia/Steps/Entry.vue'),
+                  },
+                  {
+                    path: 'talos-version',
+                    name: 'InstallationMediaCreateTalosVersion',
+                    component: () =>
+                      import('@/views/omni/InstallationMedia/Steps/TalosVersion.vue'),
+                  },
+                  {
+                    path: 'cloud-provider',
+                    name: 'InstallationMediaCreateCloudProvider',
+                    component: () =>
+                      import('@/views/omni/InstallationMedia/Steps/CloudProvider.vue'),
+                  },
+                  {
+                    path: 'sbc-type',
+                    name: 'InstallationMediaCreateSBCType',
+                    component: () => import('@/views/omni/InstallationMedia/Steps/SBCType.vue'),
+                  },
+                  {
+                    path: 'arch',
+                    name: 'InstallationMediaCreateMachineArch',
+                    component: () => import('@/views/omni/InstallationMedia/Steps/MachineArch.vue'),
+                  },
+                  {
+                    path: 'system-extensions',
+                    name: 'InstallationMediaCreateSystemExtensions',
+                    component: () =>
+                      import('@/views/omni/InstallationMedia/Steps/SystemExtensions.vue'),
+                  },
+                  {
+                    path: 'extra-args',
+                    name: 'InstallationMediaCreateExtraArgs',
+                    component: () => import('@/views/omni/InstallationMedia/Steps/ExtraArgs.vue'),
+                  },
+                  {
+                    path: 'confirmation',
+                    name: 'InstallationMediaCreateConfirmation',
+                    component: () =>
+                      import('@/views/omni/InstallationMedia/Steps/Confirmation.vue'),
+                  },
+                ],
               },
             ],
           },

--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.spec.ts
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.spec.ts
@@ -1,0 +1,460 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { render, screen, waitFor } from '@testing-library/vue'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+vi.mock('@/notification', () => ({
+  showSuccess: vi.fn(),
+}))
+
+import InstallationMediaCreate from './InstallationMediaCreate.vue'
+
+const mockSavePresetModal = {
+  name: 'SavePresetModal',
+  template: '<div v-if="open" class="save-preset-modal"><slot /></div>',
+  props: ['open', 'formState'],
+  emits: ['close', 'saved'],
+}
+
+const routes = [
+  {
+    path: '/',
+    name: 'InstallationMediaCreateEntry',
+    component: { template: '<div>Entry</div>' },
+  },
+  {
+    path: '/talos-version',
+    name: 'InstallationMediaCreateTalosVersion',
+    component: { template: '<div>Talos Version</div>' },
+  },
+  {
+    path: '/machine-arch',
+    name: 'InstallationMediaCreateMachineArch',
+    component: { template: '<div>Machine Arch</div>' },
+  },
+  {
+    path: '/cloud-provider',
+    name: 'InstallationMediaCreateCloudProvider',
+    component: { template: '<div>Cloud Provider</div>' },
+  },
+  {
+    path: '/sbc-type',
+    name: 'InstallationMediaCreateSBCType',
+    component: { template: '<div>SBC Type</div>' },
+  },
+  {
+    path: '/system-extensions',
+    name: 'InstallationMediaCreateSystemExtensions',
+    component: { template: '<div>System Extensions</div>' },
+  },
+  {
+    path: '/extra-args',
+    name: 'InstallationMediaCreateExtraArgs',
+    component: { template: '<div>Extra Args</div>' },
+  },
+  {
+    path: '/confirmation',
+    name: 'InstallationMediaCreateConfirmation',
+    component: { template: '<div>Confirmation</div>' },
+  },
+]
+
+describe('InstallationMediaCreate', () => {
+  let router: ReturnType<typeof createRouter>
+
+  beforeEach(() => {
+    // Clear session storage before each test
+    sessionStorage.clear()
+    vi.clearAllMocks()
+
+    // Create a fresh router for each test
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes,
+    })
+  })
+
+  test('renders the component with title', async () => {
+    await router.push({ name: 'InstallationMediaCreateEntry' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: true,
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    expect(screen.getByText('Create New Media')).toBeDefined()
+  })
+
+  test('renders entry page content', async () => {
+    await router.push({ name: 'InstallationMediaCreateEntry' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: true,
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    expect(screen.getByText('Entry')).toBeDefined()
+  })
+
+  test('renders correct content for different routes', async () => {
+    await router.push({ name: 'InstallationMediaCreateTalosVersion' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: true,
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    expect(screen.getByText('Talos Version')).toBeDefined()
+  })
+
+  test('different hardware types have different flow steps', async () => {
+    const testHardwareTypes = [
+      { type: 'metal' as const, expectedSteps: 5 },
+      { type: 'cloud' as const, expectedSteps: 6 },
+      { type: 'sbc' as const, expectedSteps: 5 },
+    ]
+
+    for (const { type, expectedSteps } of testHardwareTypes) {
+      sessionStorage.clear()
+      sessionStorage.setItem(
+        '_installation_media_form',
+        JSON.stringify({
+          hardwareType: type,
+        }),
+      )
+
+      await router.push({ name: 'InstallationMediaCreateTalosVersion' })
+      await router.isReady()
+
+      const { unmount } = render(InstallationMediaCreate, {
+        global: {
+          plugins: [router],
+          components: {
+            SavePresetModal: mockSavePresetModal,
+          },
+          stubs: {
+            TIcon: true,
+            TButton: true,
+            Stepper: {
+              template:
+                '<div data-testid="stepper" :data-steps="stepCount">Stepper {{ stepCount }}</div>',
+              props: ['modelValue', 'stepCount'],
+              emits: ['update:modelValue'],
+            },
+            Tooltip: true,
+          },
+        },
+      })
+
+      // Find stepper and check step count
+      expect(screen.getByTestId('stepper').getAttribute('data-steps')).toBe(String(expectedSteps))
+
+      unmount()
+    }
+  })
+
+  test('session storage persists form state', async () => {
+    await router.push({ name: 'InstallationMediaCreateEntry' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: true,
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    // Simulate setting form state
+    const state = { hardwareType: 'metal', talosVersion: '1.8.0' }
+    sessionStorage.setItem('_installation_media_form', JSON.stringify(state))
+
+    // Verify it's stored
+    const stored = JSON.parse(sessionStorage.getItem('_installation_media_form') || '{}')
+    expect(stored.hardwareType).toBe('metal')
+    expect(stored.talosVersion).toBe('1.8.0')
+  })
+
+  test('clears session storage when visiting entry page', async () => {
+    // Set initial state
+    sessionStorage.setItem(
+      '_installation_media_form',
+      JSON.stringify({
+        hardwareType: 'metal',
+        talosVersion: '1.8.0',
+      }),
+    )
+
+    await router.push({ name: 'InstallationMediaCreateEntry' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: true,
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    // Session storage should be cleared
+    await waitFor(() => {
+      const stored = JSON.parse(sessionStorage.getItem('_installation_media_form') || '{}')
+      expect(Object.keys(stored).length).toBe(0)
+    })
+  })
+
+  test('maintains form state during navigation', async () => {
+    const testState = {
+      hardwareType: 'metal' as const,
+      talosVersion: '1.8.0',
+    }
+
+    sessionStorage.setItem('_installation_media_form', JSON.stringify(testState))
+
+    await router.push({ name: 'InstallationMediaCreateTalosVersion' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: true,
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    // Verify state is preserved
+    const stored = JSON.parse(sessionStorage.getItem('_installation_media_form') || '{}')
+    expect(stored).toEqual(testState)
+  })
+
+  test('does not render stepper on entry page', async () => {
+    await router.push({ name: 'InstallationMediaCreateEntry' })
+    await router.isReady()
+
+    const { container } = render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+          Stepper: { template: '<div class="stepper">Stepper</div>' },
+          Tooltip: true,
+        },
+      },
+    })
+
+    // Check that stepper is not rendered on entry page
+    expect(container.querySelector('.stepper')).not.toBeInTheDocument()
+  })
+
+  test('renders stepper when not on entry page', async () => {
+    sessionStorage.setItem(
+      '_installation_media_form',
+      JSON.stringify({
+        hardwareType: 'metal',
+      }),
+    )
+
+    await router.push({ name: 'InstallationMediaCreateTalosVersion' })
+    await router.isReady()
+
+    const { container } = render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+          Stepper: { template: '<div class="stepper">Stepper</div>' },
+          Tooltip: true,
+        },
+      },
+    })
+
+    // Check that stepper div exists in the container
+    expect(container.querySelector('.stepper')).toBeInTheDocument()
+  })
+
+  test('modal is initially closed', async () => {
+    await router.push({ name: 'InstallationMediaCreateTalosVersion' })
+    await router.isReady()
+
+    const { container } = render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: true,
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    // Modal is initially closed, so it shouldn't be visible
+    expect(container.querySelector('.save-preset-modal')).not.toBeInTheDocument()
+  })
+
+  test('reset button resets the form', async () => {
+    sessionStorage.setItem(
+      '_installation_media_form',
+      JSON.stringify({
+        hardwareType: 'metal',
+      }),
+    )
+
+    await router.push({ name: 'InstallationMediaCreateTalosVersion' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+          Stepper: true,
+          Tooltip: { template: '<span class="tooltip"><slot /></span>' },
+        },
+      },
+    })
+
+    screen.getByRole('link', { name: 'reset wizard' }).click()
+
+    // Session storage should be cleared
+    await waitFor(() => {
+      const stored = JSON.parse(sessionStorage.getItem('_installation_media_form') || '{}')
+      expect(Object.keys(stored).length).toBe(0)
+    })
+  })
+
+  test('renders finished button when on last step and form is saved', async () => {
+    // Pre-populate form state
+    sessionStorage.setItem(
+      '_installation_media_form',
+      JSON.stringify({
+        hardwareType: 'metal',
+        isSaved: true,
+      }),
+    )
+
+    await router.push({ name: 'InstallationMediaCreateConfirmation' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    // Should show Finished button when isSaved is true on last step
+    expect(screen.getByRole('button', { name: 'Finished' })).toBeInTheDocument()
+  })
+
+  test('renders save button when on last step and form is not saved', async () => {
+    sessionStorage.setItem(
+      '_installation_media_form',
+      JSON.stringify({
+        hardwareType: 'metal',
+        isSaved: false,
+      }),
+    )
+
+    await router.push({ name: 'InstallationMediaCreateConfirmation' })
+    await router.isReady()
+
+    render(InstallationMediaCreate, {
+      global: {
+        plugins: [router],
+        components: {
+          SavePresetModal: mockSavePresetModal,
+        },
+        stubs: {
+          TIcon: true,
+          TButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+          Stepper: true,
+          Tooltip: true,
+        },
+      },
+    })
+
+    // Should show Save button in footer when isSaved is false on last step
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.stories.ts
@@ -3,16 +3,26 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { vueRouter } from 'storybook-vue3-router'
+
+import * as SavePresetModalStories from '@/views/omni/InstallationMedia/SavePresetModal.stories'
+import * as CloudProviderStories from '@/views/omni/InstallationMedia/Steps/CloudProvider.stories'
+import CloudProvider from '@/views/omni/InstallationMedia/Steps/CloudProvider.vue'
+import * as ConfirmationStories from '@/views/omni/InstallationMedia/Steps/Confirmation.stories'
+import Confirmation from '@/views/omni/InstallationMedia/Steps/Confirmation.vue'
+import Entry from '@/views/omni/InstallationMedia/Steps/Entry.vue'
+import * as ExtraArgsStories from '@/views/omni/InstallationMedia/Steps/ExtraArgs.stories'
+import ExtraArgs from '@/views/omni/InstallationMedia/Steps/ExtraArgs.vue'
+import * as MachineArchStories from '@/views/omni/InstallationMedia/Steps/MachineArch.stories'
+import MachineArch from '@/views/omni/InstallationMedia/Steps/MachineArch.vue'
+import * as SBCTypeStories from '@/views/omni/InstallationMedia/Steps/SBCType.stories'
+import SBCType from '@/views/omni/InstallationMedia/Steps/SBCType.vue'
+import * as SystemExtensionsStories from '@/views/omni/InstallationMedia/Steps/SystemExtensions.stories'
+import SystemExtensions from '@/views/omni/InstallationMedia/Steps/SystemExtensions.vue'
+import * as TalosVersionStories from '@/views/omni/InstallationMedia/Steps/TalosVersion.stories'
+import TalosVersion from '@/views/omni/InstallationMedia/Steps/TalosVersion.vue'
 
 import InstallationMediaCreate from './InstallationMediaCreate.vue'
-import * as SavePresetModalStories from './SavePresetModal.stories'
-import * as CloudProviderStories from './Steps/CloudProvider.stories'
-import * as ConfirmationStories from './Steps/Confirmation.stories'
-import * as ExtraArgsStories from './Steps/ExtraArgs.stories'
-import * as MachineArchStories from './Steps/MachineArch.stories'
-import * as SBCTypeStories from './Steps/SBCType.stories'
-import * as SystemExtensionsStories from './Steps/SystemExtensions.stories'
-import * as TalosVersionStories from './Steps/TalosVersion.stories'
 
 const meta: Meta<typeof InstallationMediaCreate> = {
   component: InstallationMediaCreate,
@@ -28,6 +38,53 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
+  decorators: [
+    vueRouter(
+      [
+        {
+          path: '/entry',
+          name: 'InstallationMediaCreateEntry',
+          component: Entry,
+        },
+        {
+          path: '/talos-version',
+          name: 'InstallationMediaCreateTalosVersion',
+          component: TalosVersion,
+        },
+        {
+          path: '/cloud-provider',
+          name: 'InstallationMediaCreateCloudProvider',
+          component: CloudProvider,
+        },
+        {
+          path: '/sbc-type',
+          name: 'InstallationMediaCreateSBCType',
+          component: SBCType,
+        },
+        {
+          path: '/arch',
+          name: 'InstallationMediaCreateMachineArch',
+          component: MachineArch,
+        },
+        {
+          path: '/system-extensions',
+          name: 'InstallationMediaCreateSystemExtensions',
+          component: SystemExtensions,
+        },
+        {
+          path: '/extra-args',
+          name: 'InstallationMediaCreateExtraArgs',
+          component: ExtraArgs,
+        },
+        {
+          path: '/confirmation',
+          name: 'InstallationMediaCreateConfirmation',
+          component: Confirmation,
+        },
+      ],
+      { initialRoute: '/entry' },
+    ),
+  ],
   parameters: {
     msw: {
       handlers: [

--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.vue
@@ -5,8 +5,6 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script lang="ts">
-import { type Component } from 'vue'
-
 import type { SchematicBootloader } from '@/api/omni/management/management.pb'
 import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
 import TIcon from '@/components/common/Icon/TIcon.vue'
@@ -15,21 +13,33 @@ import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 
 type HardwareType = 'metal' | 'cloud' | 'sbc'
 
-const flows: Record<HardwareType, Component[]> = {
-  metal: [TalosVersionStep, MachineArchStep, SystemExtensionsStep, ExtraArgsStep, ConfirmationStep],
-  cloud: [
-    TalosVersionStep,
-    CloudProviderStep,
-    MachineArchStep,
-    SystemExtensionsStep,
-    ExtraArgsStep,
-    ConfirmationStep,
+const flows: Record<HardwareType, string[]> = {
+  metal: [
+    'InstallationMediaCreateTalosVersion',
+    'InstallationMediaCreateMachineArch',
+    'InstallationMediaCreateSystemExtensions',
+    'InstallationMediaCreateExtraArgs',
+    'InstallationMediaCreateConfirmation',
   ],
-  sbc: [TalosVersionStep, SBCTypeStep, SystemExtensionsStep, ExtraArgsStep, ConfirmationStep],
+  cloud: [
+    'InstallationMediaCreateTalosVersion',
+    'InstallationMediaCreateCloudProvider',
+    'InstallationMediaCreateMachineArch',
+    'InstallationMediaCreateSystemExtensions',
+    'InstallationMediaCreateExtraArgs',
+    'InstallationMediaCreateConfirmation',
+  ],
+  sbc: [
+    'InstallationMediaCreateTalosVersion',
+    'InstallationMediaCreateSBCType',
+    'InstallationMediaCreateSystemExtensions',
+    'InstallationMediaCreateExtraArgs',
+    'InstallationMediaCreateConfirmation',
+  ],
 }
 
 export interface FormState {
-  currentStep: number
+  isSaved?: boolean
   hardwareType?: HardwareType
   talosVersion?: string
   useGrpcTunnel?: boolean
@@ -48,67 +58,67 @@ export interface FormState {
 
 <script setup lang="ts">
 import { useSessionStorage } from '@vueuse/core'
-import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { computed, ref, watchEffect } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 
 import TButton from '@/components/common/Button/TButton.vue'
 import Stepper from '@/components/common/Stepper/Stepper.vue'
 import { showSuccess } from '@/notification'
 import SavePresetModal from '@/views/omni/InstallationMedia/SavePresetModal.vue'
-import CloudProviderStep from '@/views/omni/InstallationMedia/Steps/CloudProvider.vue'
-import ConfirmationStep from '@/views/omni/InstallationMedia/Steps/Confirmation.vue'
-import EntryStep from '@/views/omni/InstallationMedia/Steps/Entry.vue'
-import ExtraArgsStep from '@/views/omni/InstallationMedia/Steps/ExtraArgs.vue'
-import MachineArchStep from '@/views/omni/InstallationMedia/Steps/MachineArch.vue'
-import SBCTypeStep from '@/views/omni/InstallationMedia/Steps/SBCType.vue'
-import SystemExtensionsStep from '@/views/omni/InstallationMedia/Steps/SystemExtensions.vue'
-import TalosVersionStep from '@/views/omni/InstallationMedia/Steps/TalosVersion.vue'
 
 const router = useRouter()
-const defaultState: FormState = { currentStep: 0 }
+const route = useRoute()
 
-const formState = useSessionStorage<FormState>('_installation_media_form', defaultState, {
-  writeDefaults: false,
+const formState = useSessionStorage<FormState>(
+  '_installation_media_form',
+  {},
+  { writeDefaults: false },
+)
+
+watchEffect(() => {
+  if (route.name === 'InstallationMediaCreateEntry') {
+    // Reset form when on entry page
+    formState.value = {}
+  } else if (!formState.value.hardwareType) {
+    // Fail-safe to return to the start of the form if we load a future step with a blank form state
+    router.replace({ name: 'InstallationMediaCreateEntry' })
+  }
 })
 
 const currentFlowSteps = computed(() =>
   formState.value.hardwareType ? flows[formState.value.hardwareType] : null,
 )
-const currentStepComponent = computed(() =>
-  currentFlowSteps.value && formState.value.currentStep
-    ? currentFlowSteps.value[formState.value.currentStep - 1]
-    : EntryStep,
-)
 
 const stepCount = computed(() => currentFlowSteps.value?.length ?? 0)
-const isLastStep = computed(
-  () => currentFlowSteps.value && formState.value.currentStep === stepCount.value,
+const currentStep = computed(() => {
+  const currentStepName = route.name?.toString()
+
+  return currentStepName && currentFlowSteps.value
+    ? currentFlowSteps.value?.indexOf(currentStepName) + 1
+    : 0
+})
+
+const isLastStep = computed(() =>
+  currentFlowSteps.value ? currentStep.value === stepCount.value : false,
 )
 
-function goBackStep() {
-  formState.value.currentStep = Math.max(0, formState.value.currentStep - 1)
-}
+const nextStep = computed(() =>
+  !isLastStep.value ? currentFlowSteps.value?.[currentStep.value] : undefined,
+)
 
-function goNextStep() {
-  formState.value.currentStep = Math.min(stepCount.value, formState.value.currentStep + 1)
+function onStepperChange(stepperValue?: number) {
+  if (!currentFlowSteps.value || !stepperValue) return
+
+  // Stepper is not 0 indexed
+  router.push({ name: currentFlowSteps.value[stepperValue - 1] })
 }
 
 const savePresetModalOpen = ref(false)
-const isSaved = ref(false)
-
-function openSavePresetModal() {
-  savePresetModalOpen.value = true
-}
-
-function goToPresetList() {
-  formState.value = defaultState
-  router.push({ name: 'InstallationMedia' })
-}
 
 function onSaved(name: string) {
   showSuccess(`Preset saved as ${name}`)
 
-  isSaved.value = true
+  formState.value.isSaved = true
   savePresetModalOpen.value = false
 }
 </script>
@@ -118,41 +128,59 @@ function onSaved(name: string) {
     <div class="flex grow flex-col gap-6 overflow-auto p-6">
       <h1 class="shrink-0 text-xl font-medium text-naturals-n14">Create New Media</h1>
 
-      <component :is="currentStepComponent" v-model="formState" />
+      <RouterView v-model="formState" />
     </div>
 
     <div
       class="flex w-full shrink-0 items-center gap-4 border-t border-naturals-n4 bg-naturals-n1 px-4 max-md:flex-col max-md:p-4 md:h-16 md:justify-end"
     >
-      <div v-if="currentFlowSteps && formState.currentStep > 0" class="flex grow gap-4">
+      <div v-if="currentFlowSteps && currentStep > 0" class="flex grow gap-4">
         <Tooltip description="Reset wizard">
-          <button
+          <RouterLink
             class="group isolate size-6 shrink-0 overflow-hidden rounded-sm border border-red-r1 p-0.5 text-red-r1 transition hover:bg-red-r1 hover:text-naturals-n1 active:brightness-75"
-            aria-label="reset wizard"
-            @click="formState = defaultState"
+            :to="{ name: 'InstallationMediaCreateEntry' }"
           >
-            <TIcon icon="close" class="size-full" />
-          </button>
+            <TIcon icon="close" class="size-full" aria-label="reset wizard" />
+          </RouterLink>
         </Tooltip>
 
-        <Stepper v-model="formState.currentStep" :step-count="stepCount" class="mx-auto grow" />
+        <Stepper
+          :model-value="currentStep"
+          :step-count="stepCount"
+          class="mx-auto grow"
+          @update:model-value="onStepperChange"
+        />
       </div>
 
       <div class="flex items-center gap-2 max-md:self-end">
         <TButton
-          v-if="currentFlowSteps && formState.currentStep > 0"
-          :disabled="formState.currentStep <= 0 || isSaved"
-          @click="goBackStep"
+          v-if="currentFlowSteps && currentStep > 0"
+          :disabled="formState.isSaved"
+          @click="$router.back()"
         >
           Back
         </TButton>
 
         <TButton
+          is="router-link"
+          v-if="!isLastStep"
           type="highlighted"
-          @click="isLastStep ? (isSaved ? goToPresetList() : openSavePresetModal()) : goNextStep()"
+          :disabled="!nextStep"
+          :to="{ name: nextStep }"
         >
-          {{ isLastStep ? (isSaved ? 'Finished' : 'Save') : 'Next' }}
+          Next
         </TButton>
+
+        <TButton
+          is="router-link"
+          v-else-if="formState.isSaved"
+          type="highlighted"
+          :to="{ name: 'InstallationMedia' }"
+        >
+          Finished
+        </TButton>
+
+        <TButton v-else type="highlighted" @click="savePresetModalOpen = true">Save</TButton>
       </div>
     </div>
 

--- a/frontend/src/views/omni/InstallationMedia/SavePresetModal.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/SavePresetModal.stories.ts
@@ -18,7 +18,6 @@ const meta: Meta<typeof SavePresetModal> = {
   args: {
     open: true,
     formState: {
-      currentStep: 0,
       hardwareType: 'metal',
       talosVersion: '1.11.5',
       joinToken: 'w7uVuW3zbVKIYQuzEcyetAHeYMeo5q2L9RvkAVfCfSCD',

--- a/frontend/src/views/omni/InstallationMedia/SavePresetModal.vue
+++ b/frontend/src/views/omni/InstallationMedia/SavePresetModal.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, useId } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { type Resource, ResourceService } from '@/api/grpc'
@@ -70,22 +70,28 @@ async function save() {
     saving.value = false
   }
 }
+
+const titleId = useId()
 </script>
 
 <template>
   <div
+    role="dialog"
     class="fixed inset-0 z-30 flex items-center justify-center bg-naturals-n0/90"
     :class="!open && 'hidden'"
+    aria-modal="true"
+    :aria-hidden="!open"
+    :aria-labelledby="titleId"
   >
     <div class="modal-window w-auto gap-4">
       <div class="flex items-center justify-between">
-        <h3 class="text-base text-naturals-n14">Save preset</h3>
+        <h3 :id="titleId" class="text-base text-naturals-n14">Save preset</h3>
 
         <CloseButton @click="$emit('close')" />
       </div>
 
       <div class="flex flex-col gap-1">
-        <TInput v-model.trim="name" title="Name" />
+        <TInput v-model.trim="name" title="Name" :focus="open" />
         <p v-if="name && existingPreset" class="ml-2.5 text-xs text-red-r1">Name already in use</p>
       </div>
 

--- a/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.stories.ts
@@ -16,7 +16,7 @@ import CloudProvider from './CloudProvider.vue'
 const meta: Meta<typeof CloudProvider> = {
   component: CloudProvider,
   args: {
-    modelValue: { currentStep: 0 },
+    modelValue: {},
   },
 }
 

--- a/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.stories.ts
@@ -41,7 +41,6 @@ const meta: Meta<typeof Confirmation> = {
   component: Confirmation,
   args: {
     modelValue: {
-      currentStep: 0,
       hardwareType: 'metal',
       machineArch: PlatformConfigSpecArch.ARM64,
       talosVersion: DefaultTalosVersion,
@@ -191,13 +190,16 @@ export const Default = {
                 },
                 spec: {
                   label: 'Bare Metal',
+                  description: faker.commerce.productDescription(),
+                  documentation: '/talos-guides/install/bare-metal-platforms/',
+                  architectures: [PlatformConfigSpecArch.AMD64, PlatformConfigSpecArch.ARM64],
+                  secure_boot_supported: false,
                   boot_methods: [
                     PlatformConfigSpecBootMethod.DISK_IMAGE,
                     PlatformConfigSpecBootMethod.ISO,
                     PlatformConfigSpecBootMethod.PXE,
                   ],
                   disk_image_suffix: 'raw.zst',
-                  documentation: '/talos-guides/install/bare-metal-platforms/',
                 },
               } satisfies Resource<PlatformConfigSpec>),
             })

--- a/frontend/src/views/omni/InstallationMedia/Steps/Entry.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Entry.stories.ts
@@ -9,7 +9,7 @@ import Entry from './Entry.vue'
 const meta: Meta<typeof Entry> = {
   component: Entry,
   args: {
-    modelValue: { currentStep: 0 },
+    modelValue: {},
   },
 }
 

--- a/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.stories.ts
@@ -31,7 +31,7 @@ const SBC: Resource<SBCConfigSpec> = {
 const meta: Meta<typeof ExtraArgs> = {
   component: ExtraArgs,
   args: {
-    modelValue: { currentStep: 0, talosVersion: DefaultTalosVersion },
+    modelValue: { talosVersion: DefaultTalosVersion },
   },
 }
 
@@ -64,7 +64,6 @@ export const Pre1_10: Story = {
   name: 'Pre-1.10',
   args: {
     modelValue: {
-      currentStep: 0,
       secureBoot: false,
       talosVersion: '1.9.0',
     },
@@ -75,7 +74,6 @@ export const WithSecureBoot: Story = {
   ...Default,
   args: {
     modelValue: {
-      currentStep: 0,
       secureBoot: true,
     },
   },
@@ -85,7 +83,6 @@ export const WithOverlayOptions: Story = {
   ...Default,
   args: {
     modelValue: {
-      currentStep: 0,
       talosVersion: DefaultTalosVersion,
       hardwareType: 'sbc',
       sbcType: SBC.metadata.id,

--- a/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/MachineArch.stories.ts
@@ -8,7 +8,11 @@ import { http, HttpResponse } from 'msw'
 
 import type { Resource } from '@/api/grpc'
 import type { GetRequest, GetResponse } from '@/api/omni/resources/resources.pb'
-import { type PlatformConfigSpec, PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
+import {
+  type PlatformConfigSpec,
+  PlatformConfigSpecArch,
+  PlatformConfigSpecBootMethod,
+} from '@/api/omni/specs/virtual.pb'
 import { CloudPlatformConfigType, MetalPlatformConfigType, VirtualNamespace } from '@/api/resources'
 
 import MachineArch from './MachineArch.vue'
@@ -37,7 +41,7 @@ const cloudProvider: Resource<PlatformConfigSpec> = {
 const meta: Meta<typeof MachineArch> = {
   component: MachineArch,
   args: {
-    modelValue: { currentStep: 0, hardwareType: 'metal' },
+    modelValue: { hardwareType: 'metal' },
   },
 }
 
@@ -63,11 +67,17 @@ export const Default = {
                   id: faker.string.uuid(),
                 },
                 spec: {
-                  label: faker.commerce.productName(),
+                  label: 'Bare Metal',
                   description: faker.commerce.productDescription(),
-                  documentation: faker.system.directoryPath(),
+                  documentation: '/talos-guides/install/bare-metal-platforms/',
                   architectures: [PlatformConfigSpecArch.AMD64, PlatformConfigSpecArch.ARM64],
                   secure_boot_supported: false,
+                  boot_methods: [
+                    PlatformConfigSpecBootMethod.DISK_IMAGE,
+                    PlatformConfigSpecBootMethod.ISO,
+                    PlatformConfigSpecBootMethod.PXE,
+                  ],
+                  disk_image_suffix: 'raw.zst',
                 },
               } satisfies Resource<PlatformConfigSpec>),
             })
@@ -95,7 +105,6 @@ export const ForCloud: Story = {
   ...Default,
   args: {
     modelValue: {
-      currentStep: 0,
       hardwareType: 'cloud',
       cloudPlatform: cloudProvider.metadata.id,
     },

--- a/frontend/src/views/omni/InstallationMedia/Steps/SBCType.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SBCType.stories.ts
@@ -16,7 +16,7 @@ import SBCType from './SBCType.vue'
 const meta: Meta<typeof SBCType> = {
   component: SBCType,
   args: {
-    modelValue: { currentStep: 0 },
+    modelValue: {},
   },
 }
 

--- a/frontend/src/views/omni/InstallationMedia/Steps/SystemExtensions.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SystemExtensions.stories.ts
@@ -14,7 +14,7 @@ import SystemExtensions from './SystemExtensions.vue'
 const meta: Meta<typeof SystemExtensions> = {
   component: SystemExtensions,
   args: {
-    modelValue: { currentStep: 0, talosVersion: DefaultTalosVersion },
+    modelValue: { talosVersion: DefaultTalosVersion },
   },
 }
 

--- a/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.stories.ts
+++ b/frontend/src/views/omni/InstallationMedia/Steps/TalosVersion.stories.ts
@@ -27,7 +27,7 @@ import TalosVersion from './TalosVersion.vue'
 const meta: Meta<typeof TalosVersion> = {
   component: TalosVersion,
   args: {
-    modelValue: { currentStep: 0 },
+    modelValue: {},
   },
 }
 

--- a/frontend/src/views/omni/Modals/DownloadOmnictl.spec.ts
+++ b/frontend/src/views/omni/Modals/DownloadOmnictl.spec.ts
@@ -4,7 +4,8 @@
 // included in the LICENSE file.
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/vue'
-import { afterEach, expect, test, vi } from 'vitest'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
 
 import { getPlatform } from '@/methods'
 
@@ -17,14 +18,30 @@ vi.mock('@/methods', () => ({
 
 const mockGetPlatform = vi.mocked(getPlatform)
 
-afterEach(() => {
+let router: ReturnType<typeof createRouter>
+
+beforeEach(() => {
   vi.clearAllMocks()
+
+  router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: '/',
+        component: { template: '<RouterView />' },
+      },
+    ],
+  })
 })
 
 test('sets default value based on platform', async () => {
   mockGetPlatform.mockResolvedValue(['linux', 'amd64'])
 
-  render(DownloadOmnictl)
+  render(DownloadOmnictl, {
+    global: {
+      plugins: [router],
+    },
+  })
 
   expect(await screen.findByLabelText('omnictl')).toHaveTextContent('omnictl-linux-amd64')
 })
@@ -33,7 +50,11 @@ test('allows selecting other options', async () => {
   const user = userEvent.setup()
   mockGetPlatform.mockResolvedValue(['linux', 'amd64'])
 
-  render(DownloadOmnictl)
+  render(DownloadOmnictl, {
+    global: {
+      plugins: [router],
+    },
+  })
 
   const trigger = await screen.findByLabelText('omnictl')
 


### PR DESCRIPTION
Change the Installation Media wizard from JS component switching to route based switching, to allow forward/backward navigation using browser history, which is more intuitive.

Related to #2004