### PR TITLE
chore: add github token to chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,4 +39,5 @@ jobs:
         uses: chromaui/action@latest
         with:
           projectToken: ${{ env.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           workingDir: frontend/


### PR DESCRIPTION
~Add `GITHUB_TOKEN` to chromatic to allow storybook to add the check that it has been published to the PR~

Doesn't work.