### PR TITLE
feat(frontend): constrain machine label width

### DIFF
--- a/frontend/src/components/common/Labels/Labels.vue
+++ b/frontend/src/components/common/Labels/Labels.vue
@@ -15,8 +15,8 @@ export interface LabelSelectItem {
 import { ref } from 'vue'
 
 import TButton from '@/components/common/Button/TButton.vue'
-import TIcon from '@/components/common/Icon/TIcon.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
+import ItemLabel from '@/views/omni/ItemLabels/ItemLabel.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -78,26 +78,18 @@ const removeLabel = async (key: string) => {
 
 <template>
   <div class="flex flex-wrap items-center gap-1.5 text-xs">
-    <span
+    <ItemLabel
       v-for="(label, key) in modelValue"
       :key="key"
-      class="flex cursor-pointer items-center"
-      :class="`resource-label label-${label.color ?? defaultColor}`"
-    >
-      <template v-if="label.value">
-        {{ key }}:
-        <span class="font-semibold">{{ label.value }}</span>
-      </template>
-      <span v-else class="font-semibold">
-        {{ key }}
-      </span>
-      <TIcon
-        v-if="label.canRemove"
-        icon="close"
-        class="destroy-label-button"
-        @click.stop="() => removeLabel(key)"
-      />
-    </span>
+      :label="{
+        key,
+        id: key,
+        value: label.value,
+        color: label.color ?? defaultColor,
+        removable: label.canRemove,
+      }"
+      :remove-label="removeLabel"
+    />
     <TInput
       v-if="addingLabel"
       v-model="currentLabel"
@@ -111,11 +103,3 @@ const removeLabel = async (key: string) => {
     <TButton v-else-if="!readonly" icon="tag" size="sm" @click.stop="editLabels">new label</TButton>
   </div>
 </template>
-
-<style>
-@reference "../../../index.css";
-
-.destroy-label-button {
-  @apply -mr-1 ml-1 inline-block h-3 w-3 cursor-pointer rounded-full transition-all hover:bg-naturals-n14 hover:text-naturals-n1;
-}
-</style>

--- a/frontend/src/components/common/Tooltip/Tooltip.vue
+++ b/frontend/src/components/common/Tooltip/Tooltip.vue
@@ -19,6 +19,7 @@ const {
   open = undefined,
   keepOpen,
   placement = 'auto-start',
+  delayDuration = 0,
   offsetDistance = 10,
   offsetSkid = 30,
 } = defineProps<{

--- a/frontend/src/methods/cluster.spec.ts
+++ b/frontend/src/methods/cluster.spec.ts
@@ -17,13 +17,6 @@ vi.mock('@/api/grpc', () => ({
   },
 }))
 
-vi.mock('@/api/resources', () => ({
-  DefaultNamespace: 'default',
-  ClusterType: 'Cluster',
-  FeaturesConfigType: 'FeaturesConfig',
-  FeaturesConfigID: 'FeaturesConfigID',
-}))
-
 vi.mock('@/api/options', () => ({
   withRuntime: vi.fn((runtime: Runtime) => ({ runtime })),
 }))

--- a/frontend/src/methods/labels.ts
+++ b/frontend/src/methods/labels.ts
@@ -3,7 +3,30 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 
-import { InfraProviderLabelPrefix, LabelInfraProviderID, SystemLabelPrefix } from '@/api/resources'
+import {
+  InfraProviderLabelPrefix,
+  LabelCluster,
+  LabelControlPlaneRole,
+  LabelInfraProviderID,
+  LabelWorkerRole,
+  MachineStatusLabelArch,
+  MachineStatusLabelAvailable,
+  MachineStatusLabelConnected,
+  MachineStatusLabelCores,
+  MachineStatusLabelCPU,
+  MachineStatusLabelDisconnected,
+  MachineStatusLabelInstance,
+  MachineStatusLabelInvalidState,
+  MachineStatusLabelMem,
+  MachineStatusLabelNet,
+  MachineStatusLabelPlatform,
+  MachineStatusLabelRegion,
+  MachineStatusLabelStorage,
+  MachineStatusLabelTalosVersion,
+  MachineStatusLabelZone,
+  SystemLabelPrefix,
+} from '@/api/resources'
+import type { IconType } from '@/components/common/Icon/TIcon.vue'
 
 export const parseLabels = (...labels: string[]): Record<string, string> => {
   const labelsMap: Record<string, string> = {}
@@ -24,28 +47,28 @@ export type Label = {
   color: string
   removable?: boolean
   description?: string
-  icon?: string
+  icon?: IconType
 }
 
 const labelColors = {
-  cluster: 'light1',
-  available: 'yellow',
-  'invalid-state': 'red',
-  connected: 'green',
-  disconnected: 'red',
-  platform: 'blue1',
-  cores: 'cyan',
-  mem: 'blue2',
-  storage: 'violet',
-  net: 'blue3',
-  cpu: 'orange',
-  arch: 'light2',
-  region: 'light3',
-  zone: 'light4',
-  instance: 'light5',
-  'talos-version': 'light7',
-  'role-controlplane': 'yellow',
-  'role-worker': 'yellow',
+  [LabelCluster]: 'light1',
+  [MachineStatusLabelAvailable]: 'yellow',
+  [MachineStatusLabelInvalidState]: 'red',
+  [MachineStatusLabelConnected]: 'green',
+  [MachineStatusLabelDisconnected]: 'red',
+  [MachineStatusLabelPlatform]: 'blue1',
+  [MachineStatusLabelCores]: 'cyan',
+  [MachineStatusLabelMem]: 'blue2',
+  [MachineStatusLabelStorage]: 'violet',
+  [MachineStatusLabelNet]: 'blue3',
+  [MachineStatusLabelCPU]: 'orange',
+  [MachineStatusLabelArch]: 'light2',
+  [MachineStatusLabelRegion]: 'light3',
+  [MachineStatusLabelZone]: 'light4',
+  [MachineStatusLabelInstance]: 'light5',
+  [MachineStatusLabelTalosVersion]: 'light7',
+  [LabelControlPlaneRole]: 'yellow',
+  [LabelWorkerRole]: 'yellow',
 }
 
 export const getLabelColor = (labelKey: string) => {
@@ -92,35 +115,31 @@ export const sanitizeLabelValue = (value: string): string => {
 }
 
 const labelDescriptions = {
-  'invalid-state':
+  [MachineStatusLabelInvalidState]:
     'The machine is expected to be unallocated, but still has the configuration of a cluster.\nIt might be required to wipe the machine bypassing Omni.',
 }
 
 export const getLabelFromID = (key: string, value: string): Label => {
-  const isUser = key.indexOf(SystemLabelPrefix) !== 0
-
-  let strippedKey = key.replace(new RegExp(`^${SystemLabelPrefix}`), '')
-  let icon: string | undefined
-  let color = getLabelColor(strippedKey)
-  let description = labelDescriptions[strippedKey]
-
-  if (key.indexOf(InfraProviderLabelPrefix) === 0 && key !== LabelInfraProviderID) {
-    const parts = strippedKey.split('/')
-    strippedKey = parts[parts.length - 1]
-
-    icon = 'server-network'
-    color = 'green'
-
-    description = `Defined by the infra provider "${parts[1]}""`
+  const label: Label = {
+    key,
+    id: key.replace(new RegExp(`^${SystemLabelPrefix}`), ''),
+    value,
+    color: getLabelColor(key),
+    removable: !key.startsWith(SystemLabelPrefix),
+    description: labelDescriptions[key],
   }
 
-  return {
-    key: key,
-    id: strippedKey,
-    value: value,
-    color: color,
-    removable: isUser,
-    description: description,
-    icon: icon,
+  if (key.startsWith(InfraProviderLabelPrefix) && key !== LabelInfraProviderID) {
+    const parts = label.id.split('/')
+
+    return {
+      ...label,
+      id: parts.at(-1) ?? '',
+      color: 'green',
+      description: `Defined by the infra provider "${parts[1] ?? ''}""`,
+      icon: 'server-network',
+    }
   }
+
+  return label
 }

--- a/frontend/src/views/omni/ItemLabels/ItemLabel.vue
+++ b/frontend/src/views/omni/ItemLabels/ItemLabel.vue
@@ -5,54 +5,52 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import type { IconType } from '@/components/common/Icon/TIcon.vue'
+import { computed } from 'vue'
+
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 import type { Label } from '@/methods/labels'
 
-defineProps<{
+const { label } = defineProps<{
   label: Label
+  small?: boolean
   removeLabel?: (key: string) => Promise<void>
 }>()
 
 defineEmits<{
   filterLabel: [Label]
 }>()
+
+const description = computed(() => {
+  const fullLabel = [label.id, label.value].filter(Boolean).join(':')
+
+  if (!label.description) return fullLabel
+
+  return `${fullLabel}\n\n${label.description}`
+})
 </script>
 
 <template>
-  <component
-    :is="label.description ? Tooltip : 'div'"
-    :description="label.description"
-    placement="bottom-start"
-  >
+  <Tooltip :description="description" :delay-duration="500" placement="bottom-start">
     <button
-      class="flex cursor-pointer items-center transition-all"
-      :class="`resource-label label-${label.color}`"
+      class="inline-flex items-center gap-1 transition-all"
+      :class="[`resource-label label-${label.color}`, small ? 'max-w-50' : 'max-w-75']"
       @click.stop="$emit('filterLabel', label)"
     >
-      <TIcon v-if="label.icon" :icon="label.icon as IconType" class="mr-1 -ml-1 h-3.5 w-3.5" />
-      <template v-if="label.value">
-        {{ label.id }}:
-        <span class="font-semibold">{{ label.value }}</span>
-      </template>
-      <span v-else class="font-semibold">
+      <TIcon v-if="label.icon" :icon="label.icon" class="-ml-1 size-3.5 shrink-0" />
+      <!-- prettier-ignore -->
+      <span v-if="label.value" class="truncate">
+        {{ label.id }}:<span class="font-semibold">{{ label.value }}</span>
+      </span>
+      <span v-else class="truncate font-semibold">
         {{ label.id }}
       </span>
       <TIcon
         v-if="label.removable && removeLabel"
         icon="close"
-        class="destroy-label-button"
+        class="-mr-1 size-3 shrink-0 cursor-pointer rounded-full transition-all hover:bg-naturals-n14 hover:text-naturals-n1"
         @click.stop="() => removeLabel?.(label.key)"
       />
     </button>
-  </component>
+  </Tooltip>
 </template>
-
-<style scoped>
-@reference "../../../index.css";
-
-.destroy-label-button {
-  @apply -mr-1 ml-1 inline-block h-3 w-3 cursor-pointer rounded-full transition-all hover:bg-naturals-n14 hover:text-naturals-n1;
-}
-</style>

--- a/frontend/src/views/omni/ItemLabels/ItemLabels.stories.ts
+++ b/frontend/src/views/omni/ItemLabels/ItemLabels.stories.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { fn } from 'storybook/test'
+
+import {
+  LabelCluster,
+  LabelControlPlaneRole,
+  LabelWorkerRole,
+  MachineStatusLabelArch,
+  MachineStatusLabelAvailable,
+  MachineStatusLabelConnected,
+  MachineStatusLabelCores,
+  MachineStatusLabelCPU,
+  MachineStatusLabelDisconnected,
+  MachineStatusLabelInstance,
+  MachineStatusLabelInvalidState,
+  MachineStatusLabelMem,
+  MachineStatusLabelNet,
+  MachineStatusLabelPlatform,
+  MachineStatusLabelRegion,
+  MachineStatusLabelStorage,
+  MachineStatusLabelTalosVersion,
+  MachineStatusLabelZone,
+} from '@/api/resources'
+
+import ItemLabels from './ItemLabels.vue'
+
+const meta: Meta<typeof ItemLabels> = {
+  component: ItemLabels,
+  args: {
+    addLabelFunc: fn(),
+    removeLabelFunc: fn(),
+    resource: {
+      spec: {},
+      metadata: {
+        id: faker.string.uuid(),
+        labels: faker.helpers
+          .multiple(
+            () => [
+              faker.helpers.arrayElement([
+                LabelCluster,
+                MachineStatusLabelAvailable,
+                MachineStatusLabelInvalidState,
+                MachineStatusLabelConnected,
+                MachineStatusLabelDisconnected,
+                MachineStatusLabelPlatform,
+                MachineStatusLabelCores,
+                MachineStatusLabelMem,
+                MachineStatusLabelStorage,
+                MachineStatusLabelNet,
+                MachineStatusLabelCPU,
+                MachineStatusLabelArch,
+                MachineStatusLabelRegion,
+                MachineStatusLabelZone,
+                MachineStatusLabelInstance,
+                MachineStatusLabelTalosVersion,
+                LabelControlPlaneRole,
+                LabelWorkerRole,
+              ]),
+              faker.helpers.maybe(() =>
+                faker.helpers.arrayElement([faker.hacker.verb(), faker.lorem.sentence()]),
+              ),
+            ],
+            {
+              count: 20,
+            },
+          )
+          .reduce<Record<string, string>>(
+            (prev, [key, value = '']) => ({ ...prev, [key]: value }),
+            {},
+          ),
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/views/omni/ItemLabels/LabelsInput.vue
+++ b/frontend/src/views/omni/ItemLabels/LabelsInput.vue
@@ -242,6 +242,7 @@ watch(filterValue, async (val: string, old: string) => {
           :class="selectedLabel === index ? 'border-white' : 'border-transparent'"
         >
           <ItemLabel
+            small
             :label="{
               ...label,
               removable: true,


### PR DESCRIPTION
Constain machine label widths to 200px in the search bar and 300px in lists, with a tooltip on hover for the full text.

Resolves #913 