### PR TITLE
test: wait for 1 minute for cluster to be destroyed

### DIFF
--- a/frontend/e2e/talemu/clusters.spec.ts
+++ b/frontend/e2e/talemu/clusters.spec.ts
@@ -21,7 +21,7 @@ test('View all clusters', async ({ cluster, page }) => {
 })
 
 test('Create cluster using machine classes', async ({ page }) => {
-  test.setTimeout(milliseconds({ minutes: 2 }))
+  test.setTimeout(milliseconds({ minutes: 3 }))
 
   const clusterName = `e2e-cluster-${faker.string.alphanumeric(8)}`
 
@@ -65,7 +65,9 @@ test('Create cluster using machine classes', async ({ page }) => {
     await page.getByRole('button', { name: 'Destroy', exact: true }).click()
 
     await expect(page.getByText(`The Cluster ${clusterName} is tearing down`)).toBeVisible()
-    await expect(page.getByText('Cluster Not Found')).toBeVisible()
+    await expect(page.getByText('Cluster Not Found')).toBeVisible({
+      timeout: milliseconds({ minutes: 1 }),
+    })
   })
 })
 


### PR DESCRIPTION
In e2e-talemu tests, when testing the cluster created with machine classes, wait for 1 minute for cluster to be destroyed.