### PR TITLE
fix: open OIDC plugin link in a new tab

### DIFF
--- a/frontend/src/views/cluster/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewContent.vue
@@ -44,7 +44,7 @@ import {
   setClusterWorkloadProxy,
   setUseEmbeddedDiscoveryService,
 } from '@/methods/cluster'
-import { embeddedDiscoveryServiceFeatureAvailable } from '@/methods/features'
+import { embeddedDiscoveryServiceFeatureAvailable, useFeatures } from '@/methods/features'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import ClusterMachines from '@/views/cluster/ClusterMachines/ClusterMachines.vue'
 import OverviewRightPanel from '@/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue'
@@ -123,6 +123,8 @@ const { data: talosUpgradeStatus } = useResourceWatch<TalosUpgradeStatusSpec>(()
 }))
 
 const { canManageClusterFeatures } = setupClusterPermissions(clusterId)
+
+const { data: features } = useFeatures()
 
 const isEmbeddedDiscoveryServiceAvailable = ref(false)
 
@@ -327,7 +329,7 @@ onMounted(async () => {
             <div class="flex flex-col gap-2">
               <ClusterWorkloadProxyingCheckbox
                 :model-value="enableWorkloadProxy"
-                :disabled="!canManageClusterFeatures"
+                :disabled="!canManageClusterFeatures || !features?.spec.enable_workload_proxying"
                 @update:model-value="(value) => setClusterWorkloadProxy(clusterId, value)"
               />
               <EmbeddedDiscoveryServiceCheckbox

--- a/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewOIDCToast.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewOIDCToast.vue
@@ -15,6 +15,8 @@ const oidcDocsLink = getDocsLink(
 
 <template>
   You will need to install the
-  <a class="link-primary" :href="oidcDocsLink">OIDC plugin</a>
+  <a class="link-primary" :href="oidcDocsLink" target="_blank" rel="noopener noreferrer">
+    OIDC plugin
+  </a>
   when using the downloaded kubeconfig in kubectl
 </template>

--- a/frontend/src/views/omni/Clusters/ClusterWorkloadProxyingCheckbox.vue
+++ b/frontend/src/views/omni/Clusters/ClusterWorkloadProxyingCheckbox.vue
@@ -12,7 +12,6 @@ import {
 } from '@/api/resources'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
-import { useFeatures } from '@/methods/features'
 
 type Props = {
   disabled?: boolean
@@ -21,14 +20,14 @@ type Props = {
 defineProps<Props>()
 
 const checked = defineModel<boolean>({ default: false })
-const { data: features } = useFeatures()
 </script>
 
 <template>
-  <Tooltip v-if="features?.spec.enable_workload_proxying" placement="bottom">
+  <Tooltip placement="bottom">
     <template #description>
       <div class="flex flex-col gap-1 p-2">
         <p>Enable HTTP proxying to the Services in the cluster through Omni.</p>
+        <p>Available only if the feature is enabled in Omni.</p>
         <p>When enabled, the Services annotated with the following annotations</p>
         <p>will be listed and accessible from the Omni Web interface:</p>
         <div class="rounded bg-naturals-n5 px-2 py-1">


### PR DESCRIPTION
Update the OIDC plugin link to open in a new tab by adding target="_blank" and rel="noopener noreferrer" attributes.

Additionally: if workload proxying feature is disabled in Omni, make its feature checkbox on cluster overview page disabled instead of completely hidden - it makes it consistent with other features and makes the feature more discoverable.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>