### PR TITLE
feat: create sequential stage controller

### DIFF
--- a/internal/backend/runtime/omni/controllers/sequence/context.go
+++ b/internal/backend/runtime/omni/controllers/sequence/context.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sequence
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+const sequencedStageIndex = omni.SystemLabelPrefix + "sequenced-stage-index"
+
+// Context stores the runtime, input and output resources of a sequence.
+type Context[I generic.ResourceWithRD, O generic.ResourceWithRD] struct {
+	Runtime controller.ReaderWriter
+	Input   I
+	Output  O
+	stages  []Stage[I, O]
+}
+
+// NewContext creates a new Context.
+func NewContext[I, O generic.ResourceWithRD](runtime controller.ReaderWriter, input I, output O, stages []Stage[I, O]) Context[I, O] {
+	return Context[I, O]{Runtime: runtime, Input: input, Output: output, stages: stages}
+}
+
+// StageToRun returns the stage that should be run next.
+func (c Context[I, O]) StageToRun() (*Stage[I, O], error) {
+	idx, err := c.getStageIndex()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stage index: %w", err)
+	}
+
+	return &c.stages[idx], nil
+}
+
+func (c Context[I, O]) getStageIndex() (int, error) {
+	stageIdx, ok := c.Output.Metadata().Annotations().Get(sequencedStageIndex)
+	if ok {
+		stageIndex, err := strconv.Atoi(stageIdx)
+		if err != nil {
+			return -1, fmt.Errorf("failed to parse stage index: %w", err)
+		}
+
+		if stageIndex < 0 || stageIndex >= len(c.stages) {
+			return -1, fmt.Errorf("stage index %d out of bounds (total stages: %d)", stageIndex, len(c.stages))
+		}
+
+		return stageIndex, nil
+	}
+
+	// Stage index isn't set, start from the beginning
+	return 0, nil
+}
+
+func (c Context[I, O]) incrementStageIndex() error {
+	idx, err := c.getStageIndex()
+	if err != nil {
+		return fmt.Errorf("failed to get stage index: %w", err)
+	}
+
+	nextIdx := (idx + 1) % len(c.stages)
+	c.Output.Metadata().Annotations().Set(sequencedStageIndex, strconv.Itoa(nextIdx))
+
+	return nil
+}

--- a/internal/backend/runtime/omni/controllers/sequence/sequence.go
+++ b/internal/backend/runtime/omni/controllers/sequence/sequence.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package sequence provides a generic implementation of a QController which processes a sequence of stages in order.
+package sequence
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic"
+	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
+	"github.com/siderolabs/gen/xerrors"
+	"go.uber.org/zap"
+)
+
+// Controller is a QController that processes a sequence of stages in order.
+type Controller[Input, Output generic.ResourceWithRD] struct {
+	*qtransform.QController[Input, Output]
+	sequencer Sequencer[Input, Output]
+}
+
+// NewController creates a new QController configured to run through the stages defined in the Sequencer. It handles stage lookup, execution, and error management (including requeueing).
+func NewController[Input, Output generic.ResourceWithRD](name string, sequencer Sequencer[Input, Output]) *Controller[Input, Output] {
+	ctrl := &Controller[Input, Output]{
+		sequencer: sequencer,
+	}
+
+	ctrl.QController = qtransform.NewQController(
+		qtransform.Settings[Input, Output]{
+			Name:              name,
+			MapMetadataFunc:   sequencer.MapFunc,
+			UnmapMetadataFunc: sequencer.UnmapFunc,
+			TransformExtraOutputFunc: func(ctx context.Context, r controller.ReaderWriter, logger *zap.Logger, input Input, output Output) error {
+				stages := sequencer.Stages()
+				sequenceContext := NewContext(r, input, output, stages)
+
+				if len(stages) == 0 {
+					logger.Error("no stages defined")
+
+					return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("no stages defined")
+				}
+
+				stage, err := sequenceContext.StageToRun()
+				if err != nil {
+					return fmt.Errorf("failed to get stage to run: %w", err)
+				}
+
+				logger.Info("processing stage", zap.String("stage", stage.Name()))
+
+				if err = stage.Run(ctx, logger, sequenceContext); err != nil {
+					if xerrors.TypeIs[*controller.RequeueError](err) {
+						return err
+					}
+
+					return fmt.Errorf("failed to process stage %s: %w", stage.Name(), err)
+				}
+
+				return nil
+			},
+			FinalizerRemovalExtraOutputFunc: func(ctx context.Context, r controller.ReaderWriter, logger *zap.Logger, input Input) error {
+				c, ok := sequencer.(Cleaner[Input])
+				if !ok {
+					return nil
+				}
+
+				return c.FinalizerRemoval(ctx, r, logger, input)
+			},
+		},
+		sequencer.Options()...,
+	)
+
+	return ctrl
+}

--- a/internal/backend/runtime/omni/controllers/sequence/sequence_test.go
+++ b/internal/backend/runtime/omni/controllers/sequence/sequence_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sequence_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/gen/xerrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/sequence"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock/options"
+)
+
+type fakeSequence struct{}
+
+func (f fakeSequence) MapFunc(input *omni.Cluster) *omni.ClusterStatus {
+	return omni.NewClusterStatus(input.Metadata().ID())
+}
+
+func (f fakeSequence) UnmapFunc(output *omni.ClusterStatus) *omni.Cluster {
+	return omni.NewCluster(output.Metadata().ID())
+}
+
+func (f fakeSequence) Options() []qtransform.ControllerOption {
+	return []qtransform.ControllerOption{
+		qtransform.WithExtraMappedInput[*omni.EtcdBackupStatus](
+			qtransform.MapperSameID[*omni.Cluster](),
+		),
+	}
+}
+
+func (f fakeSequence) Stages() []sequence.Stage[*omni.Cluster, *omni.ClusterStatus] {
+	getEtcdBackupStatus := func(ctx context.Context, r controller.Reader, input *omni.Cluster) (*omni.EtcdBackupStatus, error) {
+		backupStatus, err := safe.ReaderGetByID[*omni.EtcdBackupStatus](ctx, r, input.Metadata().ID())
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				return nil, xerrors.NewTagged[qtransform.SkipReconcileTag](err)
+			}
+
+			return nil, err
+		}
+
+		return backupStatus, nil
+	}
+
+	return []sequence.Stage[*omni.Cluster, *omni.ClusterStatus]{
+		sequence.NewStage("idle", func(ctx context.Context, logger *zap.Logger, sequenceContext sequence.Context[*omni.Cluster, *omni.ClusterStatus]) (completed bool, err error) {
+			r := sequenceContext.Runtime
+			input := sequenceContext.Input
+			output := sequenceContext.Output
+
+			backupStatus, err := getEtcdBackupStatus(ctx, r, input)
+			if err != nil {
+				return false, err
+			}
+
+			logger.Info("waiting for etcd backup to be triggered", zap.String("status", backupStatus.TypedSpec().Value.Status.String()))
+
+			if backupStatus.TypedSpec().Value.Status == specs.EtcdBackupStatusSpec_Ok {
+				output.Metadata().Labels().Set("etcd", "ok")
+
+				return false, nil
+			}
+
+			logger.Info("etcd backup is triggered", zap.String("status", backupStatus.TypedSpec().Value.Status.String()))
+
+			return true, controller.NewRequeueInterval(time.Millisecond)
+		}),
+		sequence.NewStage("backup", func(ctx context.Context, logger *zap.Logger, sequenceContext sequence.Context[*omni.Cluster, *omni.ClusterStatus]) (completed bool, err error) {
+			r := sequenceContext.Runtime
+			input := sequenceContext.Input
+			output := sequenceContext.Output
+
+			backupStatus, err := getEtcdBackupStatus(ctx, r, input)
+			if err != nil {
+				return false, err
+			}
+
+			logger.Info("etcd backup in progress", zap.String("status", backupStatus.TypedSpec().Value.Status.String()))
+
+			if backupStatus.TypedSpec().Value.Status != specs.EtcdBackupStatusSpec_Running {
+				output.Metadata().Labels().Set("etcd", "no-backup")
+
+				logger.Info("etcd backup failed", zap.String("status", backupStatus.TypedSpec().Value.Status.String()))
+
+				return false, nil
+			}
+
+			logger.Info("etcd backup finalizing", zap.String("status", backupStatus.TypedSpec().Value.Status.String()))
+
+			output.Metadata().Labels().Set("etcd", "running")
+
+			return true, controller.NewRequeueInterval(time.Millisecond)
+		}),
+		sequence.NewStage("done", func(ctx context.Context, logger *zap.Logger, sequenceContext sequence.Context[*omni.Cluster, *omni.ClusterStatus]) (completed bool, err error) {
+			r := sequenceContext.Runtime
+			input := sequenceContext.Input
+			output := sequenceContext.Output
+
+			backupStatus, err := getEtcdBackupStatus(ctx, r, input)
+			if err != nil {
+				return false, err
+			}
+
+			if backupStatus.TypedSpec().Value.Status != specs.EtcdBackupStatusSpec_Ok {
+				logger.Info("etcd backup has problems", zap.String("status", backupStatus.TypedSpec().Value.Status.String()))
+
+				output.Metadata().Labels().Set("etcd", "error")
+
+				return false, nil
+			}
+
+			logger.Info("etcd backup completed", zap.String("status", backupStatus.TypedSpec().Value.Status.String()))
+
+			output.Metadata().Labels().Set("etcd", "done")
+
+			return true, controller.NewRequeueInterval(time.Millisecond)
+		}),
+	}
+}
+
+func FakeSequenceController() *sequence.Controller[*omni.Cluster, *omni.ClusterStatus] {
+	return sequence.NewController[*omni.Cluster, *omni.ClusterStatus]("FakeSequenceController", &fakeSequence{})
+}
+
+func TestSequenceController(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(
+		ctx,
+		t,
+		testutils.TestOptions{},
+		func(_ context.Context, testContext testutils.TestContext) {
+			require.NoError(t, testContext.Runtime.RegisterQController(FakeSequenceController()))
+		},
+		func(ctx context.Context, testContext testutils.TestContext) {
+			st := testContext.State
+
+			clusterID := "test-cluster"
+			rmock.Mock[*omni.Cluster](ctx, t, st, options.WithID(clusterID))
+			rmock.Mock[*omni.EtcdBackupStatus](ctx, t, st, options.WithID(clusterID), options.Modify(func(res *omni.EtcdBackupStatus) error {
+				res.TypedSpec().Value.Status = specs.EtcdBackupStatusSpec_Ok
+
+				return nil
+			}))
+
+			rtestutils.AssertResource(ctx, t, st, clusterID, func(res *omni.ClusterStatus, asrt *assert.Assertions) {
+				lbl, ok := res.Metadata().Labels().Get("etcd")
+				asrt.True(ok)
+				asrt.Equal("ok", lbl)
+			})
+
+			rmock.Mock[*omni.EtcdBackupStatus](ctx, t, st, options.WithID(clusterID), options.Modify(func(res *omni.EtcdBackupStatus) error {
+				res.TypedSpec().Value.Status = specs.EtcdBackupStatusSpec_Error
+
+				return nil
+			}))
+
+			rtestutils.AssertResource(ctx, t, st, clusterID, func(res *omni.ClusterStatus, asrt *assert.Assertions) {
+				lbl, ok := res.Metadata().Labels().Get("etcd")
+				asrt.True(ok)
+				asrt.Equal("no-backup", lbl)
+			})
+
+			rmock.Mock[*omni.EtcdBackupStatus](ctx, t, st, options.WithID(clusterID), options.Modify(func(res *omni.EtcdBackupStatus) error {
+				res.TypedSpec().Value.Status = specs.EtcdBackupStatusSpec_Running
+
+				return nil
+			}))
+
+			rtestutils.AssertResource(ctx, t, st, clusterID, func(res *omni.ClusterStatus, asrt *assert.Assertions) {
+				lbl, ok := res.Metadata().Labels().Get("etcd")
+				asrt.True(ok)
+				asrt.Equal("running", lbl)
+			})
+
+			rmock.Mock[*omni.EtcdBackupStatus](ctx, t, st, options.WithID(clusterID), options.Modify(func(res *omni.EtcdBackupStatus) error {
+				res.TypedSpec().Value.Status = specs.EtcdBackupStatusSpec_Error
+
+				return nil
+			}))
+
+			rtestutils.AssertResource(ctx, t, st, clusterID, func(res *omni.ClusterStatus, asrt *assert.Assertions) {
+				lbl, ok := res.Metadata().Labels().Get("etcd")
+				asrt.True(ok)
+				asrt.Equal("error", lbl)
+			})
+
+			rmock.Mock[*omni.EtcdBackupStatus](ctx, t, st, options.WithID(clusterID), options.Modify(func(res *omni.EtcdBackupStatus) error {
+				res.TypedSpec().Value.Status = specs.EtcdBackupStatusSpec_Ok
+
+				return nil
+			}))
+
+			rtestutils.AssertResource(ctx, t, st, clusterID, func(res *omni.ClusterStatus, asrt *assert.Assertions) {
+				lbl, ok := res.Metadata().Labels().Get("etcd")
+				asrt.True(ok)
+				asrt.Equal("ok", lbl)
+			})
+		},
+	)
+}

--- a/internal/backend/runtime/omni/controllers/sequence/stage.go
+++ b/internal/backend/runtime/omni/controllers/sequence/stage.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sequence
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic"
+	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
+	"go.uber.org/zap"
+)
+
+// NewStage creates a new Stage with provided name and run function.
+//
+// The run function should return a boolean indicating whether the stage is completed and an error if any occurred during execution.
+func NewStage[Input, Output generic.ResourceWithRD](name string, run func(ctx context.Context, logger *zap.Logger, sequenceContext Context[Input, Output],
+) (completed bool, err error),
+) Stage[Input, Output] {
+	return Stage[Input, Output]{name: name, run: run}
+}
+
+// Stage implements a single stage in a sequence of stages.
+type Stage[Input, Output generic.ResourceWithRD] struct {
+	run  func(ctx context.Context, logger *zap.Logger, sequenceContext Context[Input, Output]) (completed bool, err error)
+	name string
+}
+
+// Name of the stage.
+func (s Stage[Input, Output]) Name() string {
+	return s.name
+}
+
+// Run the stage. If the stage is completed, it increments the stage index in the sequence context.
+func (s Stage[Input, Output]) Run(ctx context.Context, logger *zap.Logger, sequenceContext Context[Input, Output]) error {
+	completed, err := s.run(ctx, logger, sequenceContext)
+	if completed {
+		if indexErr := sequenceContext.incrementStageIndex(); indexErr != nil {
+			logger.Error("failed to increment stage index", zap.Error(indexErr))
+
+			return indexErr
+		}
+	}
+
+	return err
+}
+
+// Sequencer is the interface that should be implemented to utilize the sequence controller.
+type Sequencer[Input, Output generic.ResourceWithRD] interface {
+	MapFunc(Input) Output
+	UnmapFunc(Output) Input
+	Options() []qtransform.ControllerOption
+	Stages() []Stage[Input, Output]
+}
+
+// Cleaner is the interface that should be implemented to clean up resources when Input is tearing down.
+type Cleaner[Input generic.ResourceWithRD] interface {
+	FinalizerRemoval(ctx context.Context, r controller.ReaderWriter, logger *zap.Logger, input Input) error
+}


### PR DESCRIPTION
This is a specialized QController which takes a list of stages and process them sequentially.  It automatically iterates to next stage when processed stage reports completed.  After all stages are processed, controller moves back to processing the initial stage. So it's paramount that a triggering condition to be present on initial stage to kickstart the whole flow, and prevent the controller from looping infinitely.

Closes #2175
