### PR TITLE
fix: fix regressions on service api url generation

### DIFF
--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -223,7 +223,8 @@
           "type": "string"
         },
         "advertisedURL": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^https://"
         },
         "certFile": {
           "type": "string"


### PR DESCRIPTION
SideroLink API URL generation had a special case compared to other services: it used the `grpc://` scheme when it as insecure, not `http://`.

This special case was accidentally removed in the config schema implementation in https://github.com/siderolabs/omni/pull/2150.

Bring back the logic and add unit tests for it.

Additionally, add a validation for the Kuberentes proxy advertised URL in the config schema to validate that it always uses https:// scheme.