### PR TITLE
chore: enable noImplicitAny for typescript

### DIFF
--- a/frontend/msw/helpers.ts
+++ b/frontend/msw/helpers.ts
@@ -50,7 +50,11 @@ export function createWatchStreamHandler<T = unknown, S = unknown>({
         : initialResources({ ...options, selectors })
 
       if (sort) {
-        resources.sort((a, b) => String(a.metadata[sort]).localeCompare(b.metadata[sort]))
+        resources.sort((a, b) =>
+          String(a.metadata[sort as keyof typeof a.metadata]).localeCompare(
+            String(b.metadata[sort as keyof typeof b.metadata]),
+          ),
+        )
       }
 
       const events = resources.map((r, i) => createCreatedEvent(r, i + 1))

--- a/frontend/src/api/watch.ts
+++ b/frontend/src/api/watch.ts
@@ -17,7 +17,7 @@ import { withContext, withMetadata, withRuntime } from '@/api/options'
 import type { Metadata } from '@/api/v1alpha1/resource.pb'
 
 export interface Callback {
-  (message: WatchResponse, spec: WatchEventSpec)
+  (message: WatchResponse, spec: WatchEventSpec): void
 }
 
 export type WatchEventSpec = {

--- a/frontend/src/components/common/Pagination/TPagination.vue
+++ b/frontend/src/components/common/Pagination/TPagination.vue
@@ -25,7 +25,7 @@ const currentPage = ref(1)
 const totalPageCount = computed(() => {
   return Math.ceil(items.value.length / perPage.value)
 })
-const range = (start, end) => {
+const range = (start: number, end: number) => {
   const length = end - start + 1
   return Array.from({ length }, (_, idx) => idx + start)
 }
@@ -71,9 +71,9 @@ const onPrevious = () => {
   if (currentPage.value === 1) return
   currentPage.value -= 1
 }
-const onPageClick = (value) => {
+const onPageClick = (value: number | string) => {
   if (value !== DOTS) {
-    currentPage.value = value
+    currentPage.value = +value
   }
 }
 watch(

--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -71,16 +71,16 @@ export const getStatus = (item: V1Node) => {
   return NodesViewFilterOptions.NOT_READY
 }
 
-export const formatBytes = (bytes, decimals = 2) => {
+export const formatBytes = (bytes?: number | string, decimals = 2) => {
   if (!bytes) return '0 Bytes'
 
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const i = Math.floor(Math.log(+bytes) / Math.log(k))
 
-  return (bytes / Math.pow(k, i)).toFixed(dm) + ' ' + sizes[i]
+  return (+bytes / Math.pow(k, i)).toFixed(dm) + ' ' + sizes[i]
 }
 
 export const downloadKubeconfig = async (cluster: string) => {

--- a/frontend/src/methods/labels.ts
+++ b/frontend/src/methods/labels.ts
@@ -50,7 +50,7 @@ export type Label = {
   icon?: IconType
 }
 
-const labelColors = {
+const labelColors: Record<string, string> = {
   [LabelCluster]: 'light1',
   [MachineStatusLabelAvailable]: 'yellow',
   [MachineStatusLabelInvalidState]: 'red',
@@ -114,7 +114,7 @@ export const sanitizeLabelValue = (value: string): string => {
   return value
 }
 
-const labelDescriptions = {
+const labelDescriptions: Record<string, string> = {
   [MachineStatusLabelInvalidState]:
     'The machine is expected to be unallocated, but still has the configuration of a cluster.\nIt might be required to wipe the machine bypassing Omni.',
 }

--- a/frontend/src/methods/time.ts
+++ b/frontend/src/methods/time.ts
@@ -40,8 +40,8 @@ export const parseDuration = (input: string): Duration => {
   const duration: DurationLikeObject = {}
 
   for (const s of input) {
-    if (units[s]) {
-      if (duration[units[s]] !== undefined) {
+    if (units[s as keyof typeof units]) {
+      if (duration[units[s as keyof typeof units]] !== undefined) {
         throw new Error(`failed to parse duration ${input}`)
       }
 
@@ -53,7 +53,7 @@ export const parseDuration = (input: string): Duration => {
 
       buffer = ''
 
-      duration[units[s]] = value
+      duration[units[s as keyof typeof units]] = value
 
       continue
     }

--- a/frontend/src/states/cluster-management.ts
+++ b/frontend/src/states/cluster-management.ts
@@ -512,9 +512,13 @@ export class State {
     }
 
     resources = resources.sort((a: Resource, b: Resource) => {
-      if (typesOrder[a.metadata.type!] > typesOrder[b.metadata.type!]) {
+      type TypeKey = keyof typeof typesOrder
+
+      if (typesOrder[a.metadata.type! as TypeKey] > typesOrder[b.metadata.type! as TypeKey]) {
         return -1
-      } else if (typesOrder[a.metadata.type!] < typesOrder[b.metadata.type!]) {
+      } else if (
+        typesOrder[a.metadata.type! as TypeKey] < typesOrder[b.metadata.type! as TypeKey]
+      ) {
         return 1
       }
 
@@ -558,7 +562,7 @@ export class State {
     const res: Resource<ConfigPatchSpec>[] = []
 
     for (const key in patches) {
-      const systemLabels = {}
+      const systemLabels: Record<string, string> = {}
       const patch = patches[key]
 
       if (patch.systemPatch) {
@@ -604,11 +608,10 @@ export class State {
   }
 
   private checkSchedulingEnabled(data: string) {
-    const loaded: {
-      cluster: {
-        allowSchedulingOnControlPlanes: boolean
-      }
-    } = yaml.load(data) as any
+    const loaded = yaml.load(data) as
+      | { cluster?: { allowSchedulingOnControlPlanes?: boolean } }
+      | undefined
+      | null
 
     return loaded?.cluster?.allowSchedulingOnControlPlanes
   }

--- a/frontend/src/views/cluster/ClusterMachines/MachineSetPhase.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineSetPhase.vue
@@ -60,7 +60,7 @@ const phaseIcon = (machineset: Resource<MachineSetStatusSpec>): IconType => {
   }
 }
 
-const phaseColor = (machineset): string => {
+const phaseColor = (machineset?: Resource<MachineSetStatusSpec>) => {
   switch (machineset?.spec.phase) {
     case MachineSetPhase.Upgrading:
     case MachineSetPhase.ScalingUp:

--- a/frontend/src/views/cluster/Config/PatchEdit.vue
+++ b/frontend/src/views/cluster/Config/PatchEdit.vue
@@ -386,7 +386,7 @@ const getPatchLabels = () => {
     throw new Error('failed to determine machine cluster')
   }
 
-  const labels = {
+  const labels: Record<string, string> = {
     [LabelCluster]: cluster as string,
   }
 

--- a/frontend/src/views/cluster/Nodes/NodeLogs.vue
+++ b/frontend/src/views/cluster/Nodes/NodeLogs.vue
@@ -42,7 +42,7 @@ const formatLoggingContext = (logRecord: Record<string, string>, ...exceptFields
   return res.join(' ')
 }
 
-const parsers = {
+const parsers: Record<string, (line: string) => LogLine> = {
   containerd: (line: string): LogLine => {
     const parsed = JSON.parse(line)
 

--- a/frontend/src/views/cluster/Nodes/NodeMonitor.vue
+++ b/frontend/src/views/cluster/Nodes/NodeMonitor.vue
@@ -68,9 +68,9 @@ const sort = ref('cpu')
 const sortReverse = ref(true)
 
 let memTotal = 0
-let interval
+let interval: number
 
-const sum = (obj, ...args) => {
+const sum = (obj: Record<string, number>, ...args: string[]) => {
   let res = 0
   for (const k of args) {
     res += obj[k] || 0
@@ -79,7 +79,7 @@ const sum = (obj, ...args) => {
   return res
 }
 
-const getCPUTotal = (stat) => {
+const getCPUTotal = (stat: Record<string, number>) => {
   const idle = sum(stat, 'idle', 'iowait')
   const nonIdle = sum(stat, 'user', 'nice', 'system', 'irq', 'steal', 'softIrq')
 
@@ -101,7 +101,7 @@ const loadProcs = async () => {
   const r = await MachineService.SystemStat({}, ...options)
 
   const systemStat = r.messages![0]
-  const cpuTotal = getCPUTotal(systemStat.cpu_total) / systemStat.cpu!.length
+  const cpuTotal = getCPUTotal(systemStat.cpu_total ?? {}) / systemStat.cpu!.length
 
   const total = memTotal * 1024
 
@@ -144,7 +144,7 @@ onUnmounted(() => {
   clearInterval(interval)
 })
 
-const handleCPU = (oldObj, newObj) => {
+const handleCPU = (oldObj: any, newObj: any) => {
   const delta = diff(oldObj, newObj)
   const stat = delta.cpuTotal
   const total = getCPUTotal(stat)
@@ -155,13 +155,16 @@ const handleCPU = (oldObj, newObj) => {
   }
 }
 
-const handleTotalCPU = (oldObj, newObj) => {
+const handleTotalCPU = (oldObj: any, newObj: any) => {
   const point = handleCPU(oldObj, newObj)
 
   return `${(point.user + point.system).toFixed(1)} %`
 }
 
-const handleMem = (_, m: { used: number; cached: number; buffers: number; total: number }) => {
+const handleMem = (
+  _: unknown,
+  m: { used: number; cached: number; buffers: number; total: number },
+) => {
   const used = m.used - m.cached - m.buffers
 
   const memoryInitialized = memTotal === 0
@@ -179,17 +182,20 @@ const handleMem = (_, m: { used: number; cached: number; buffers: number; total:
   }
 }
 
-const handleTotalMem = (_, m) => {
+const handleTotalMem = (
+  _: unknown,
+  m: { used: number; cached: number; buffers: number; total: number },
+) => {
   const used = m.used - m.cached - m.buffers
 
   return `${formatBytes(used * 1024)} / ${formatBytes(m.total * 1024)}`
 }
 
-const handleMaxMem = (_, m): number => {
+const handleMaxMem = (_: unknown, m: { total: number }): number => {
   return m.total
 }
 
-const handleProcs = (oldObj, newObj) => {
+const handleProcs = (oldObj: any, newObj: any) => {
   const { processCreated } = diff(oldObj, newObj)
 
   return {

--- a/frontend/src/views/cluster/Nodes/NodeOverview.vue
+++ b/frontend/src/views/cluster/Nodes/NodeOverview.vue
@@ -105,7 +105,10 @@ const stream = subscribe(
   MachineService.Events,
   {},
   (event) => {
-    if (event.data?.['@type']?.includes('machine.ServiceStateEvent')) {
+    // For some reason @type is not typed on Any
+    const data = event.data as (typeof event.data & { ['@type']?: string }) | undefined
+
+    if (data?.['@type']?.includes('machine.ServiceStateEvent')) {
       fetchServices()
     }
   },
@@ -229,7 +232,7 @@ const getCPUInfo = () => {
     return 'Not Detected'
   }
 
-  const cpus = {}
+  const cpus: Record<string, number> = {}
 
   for (const processor of processors) {
     const id = `${processor.frequency! / 1000} GHz ${processor.manufacturer}, ${processor.core_count} Cores`

--- a/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
@@ -71,11 +71,12 @@ const {
   formatter,
 } = toRefs(props)
 
-const series: Ref<Record<string, any>[]> = ref([])
-const seriesMap = {}
-const points = {}
-const flush = {}
-const total = ref()
+type Point = number | number[]
+const series = ref<{ name: string; data: Point[] }[]>([])
+const seriesMap: Record<string, { index: number; version: number }> = {}
+const points: Record<number, Point[]> = {}
+const flush: Record<number, number> = {}
+const total = ref<string>()
 
 const min: Ref<number | undefined> = ref(undefined)
 const max: Ref<number | undefined> = ref(undefined)
@@ -115,13 +116,13 @@ const handlePoint = (message: WatchResponse, spec: WatchEventSpec) => {
       }
     }
 
-    const version = resource?.metadata?.version || ''
+    const version = Number(resource?.metadata?.version ?? '')
     const meta = seriesMap[key]
     if (version <= meta.version) {
       continue
     }
 
-    let point: number | number[] = data[key]
+    let point: Point = data[key]
     const updated = resource?.metadata?.updated
     if (updated) {
       point = [DateTime.fromISO(updated.toString()).toMillis(), point]

--- a/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanelCondition.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanelCondition.vue
@@ -18,7 +18,7 @@ import OverviewRightPanelItem from '@/views/cluster/Overview/components/Overview
 
 const mapping: Record<ConditionType | number, string> = {}
 for (const key of Object.keys(ConditionType)) {
-  mapping[ConditionType[key]] = key
+  mapping[ConditionType[key as keyof typeof ConditionType]] = key
 }
 
 const getConditionName = (t?: ConditionType) => {

--- a/frontend/src/views/omni/ItemLabels/ItemLabels.vue
+++ b/frontend/src/views/omni/ItemLabels/ItemLabels.vue
@@ -58,7 +58,7 @@ const labelOrder = {
 }
 
 const getLabelOrder = (l: Label) => {
-  return labelOrder[l.id] ?? 1000
+  return labelOrder[l.id as keyof typeof labelOrder] ?? 1000
 }
 
 const labels = computed((): Array<Label> => {

--- a/frontend/src/views/omni/Modals/UpdateTalos.vue
+++ b/frontend/src/views/omni/Modals/UpdateTalos.vue
@@ -54,7 +54,7 @@ const upgradeVersions = computed(() => {
     status.value.spec.last_upgrade_version ?? '',
   ].sort(semver.compare)
 
-  const result = {}
+  const result: Record<string, string[]> = {}
 
   for (const version of sorted) {
     const majorMinor = majorMinorVersion(version)

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -7,9 +7,6 @@
 
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "noUncheckedIndexedAccess": false,
-
-    // Temporarily disabled
-    "noImplicitAny": false,
     "useUnknownInCatchVariables": false,
 
     "paths": {


### PR DESCRIPTION
Enable noImplicitAny for typescript and try to fix existing issues without changing functionality too much. This will help catch missed type errors when incorrect use (or untyped use) of things results in a variable become `any` and allowing anything to be done with it.