### PR TITLE
fix: fix config patches encryption when encryption is disabled

### DIFF
--- a/client/api/omni/specs/compression.go
+++ b/client/api/omni/specs/compression.go
@@ -68,14 +68,12 @@ func getCompressionConfig(opts []CompressionOption) CompressionConfig {
 	}
 
 	config := options.Config.ValueOr(GetCompressionConfig())
-	config.MinThreshold = options.minThreshold.ValueOr(config.MinThreshold)
 
 	return config
 }
 
 type compressionOptions struct {
-	Config       optional.Optional[CompressionConfig]
-	minThreshold optional.Optional[int]
+	Config optional.Optional[CompressionConfig]
 }
 
 // CompressionOption is a functional option for configuring compression.
@@ -85,13 +83,6 @@ type CompressionOption func(*compressionOptions)
 func WithConfigCompressionOption(config CompressionConfig) CompressionOption {
 	return func(opts *compressionOptions) {
 		opts.Config = optional.Some(config)
-	}
-}
-
-// WithCompressionMinThreshold returns a CompressionOption that sets the min threshold for compression.
-func WithCompressionMinThreshold(threshold int) CompressionOption {
-	return func(opts *compressionOptions) {
-		opts.minThreshold = optional.Some(threshold)
 	}
 }
 

--- a/client/pkg/compression/compression_test.go
+++ b/client/pkg/compression/compression_test.go
@@ -14,7 +14,6 @@ import (
 	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
@@ -22,9 +21,10 @@ func TestClusterMachineConfigPatchesYAML(t *testing.T) {
 	res := omni.NewClusterMachineConfigPatches("test")
 
 	// set some patches
+	compressionConfig := specs.GetCompressionConfig()
 
-	aString := strings.Repeat("a", constants.CompressionThresholdBytes)
-	bString := strings.Repeat("b", constants.CompressionThresholdBytes)
+	aString := strings.Repeat("a", compressionConfig.MinThreshold)
+	bString := strings.Repeat("b", compressionConfig.MinThreshold)
 
 	err := res.TypedSpec().Value.SetUncompressedPatches([]string{aString, bString})
 	require.NoError(t, err)
@@ -65,8 +65,10 @@ func TestClusterMachineConfigPatchesYAML(t *testing.T) {
 func TestClusterMachineConfigPatchesJSON(t *testing.T) {
 	res := omni.NewClusterMachineConfigPatches("test")
 
-	aString := strings.Repeat("a", constants.CompressionThresholdBytes)
-	bString := strings.Repeat("b", constants.CompressionThresholdBytes)
+	compressionConfig := specs.GetCompressionConfig()
+
+	aString := strings.Repeat("a", compressionConfig.MinThreshold)
+	bString := strings.Repeat("b", compressionConfig.MinThreshold)
 
 	// set some patches
 

--- a/client/pkg/template/template_test.go
+++ b/client/pkg/template/template_test.go
@@ -292,17 +292,15 @@ machine:
 }
 
 func TestTranslate(t *testing.T) {
-	previousCompressionConfig := specs.GetCompressionConfig()
+	// DO NOT ADD t.Parallel() HERE, as this test modifies global compression config.
+	// Replace the global compression config temporarily to disable compression.
+	originalCompressionConfig := specs.GetCompressionConfig()
 
-	// disable resource compression for the test
 	compressionConfig, err := compression.BuildConfig(false, false, false)
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		specs.SetCompressionConfig(previousCompressionConfig)
-	})
-
 	specs.SetCompressionConfig(compressionConfig)
+	defer specs.SetCompressionConfig(originalCompressionConfig)
 
 	t.Chdir("testdata")
 

--- a/internal/backend/runtime/omni/controllers/omni/clustermachine/patches.go
+++ b/internal/backend/runtime/omni/controllers/omni/clustermachine/patches.go
@@ -140,6 +140,6 @@ func setPatches(clusterMachineConfigPatches *omni.ClusterMachineConfigPatches, p
 			func(in *omni.ConfigPatch) *specs.ConfigPatchSpec { return in.TypedSpec().Value },
 			slices.Values(patches),
 		),
-		specs.GetCompressionConfig().Enabled,
+		specs.GetCompressionConfig(),
 	)
 }

--- a/internal/backend/runtime/omni/controllers/omni/clustermachine/patches_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/clustermachine/patches_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package clustermachine_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+)
+
+func TestFromConfigPatches(t *testing.T) {
+	// DO NOT ADD t.Parallel() HERE, as this test modifies global compression config.
+	originalConfig := specs.GetCompressionConfig()
+	defer specs.SetCompressionConfig(originalConfig)
+
+	largePatchData := strings.Repeat("A", originalConfig.MinThreshold+100)
+	smallPatchData := "small-patch-data"
+
+	t.Run("compression disabled with large patches does not compress", func(t *testing.T) {
+		disabledConfig := originalConfig
+		disabledConfig.Enabled = false
+		specs.SetCompressionConfig(disabledConfig)
+
+		largePatch := &specs.ConfigPatchSpec{Data: largePatchData}
+		smallPatch := &specs.ConfigPatchSpec{Data: smallPatchData}
+
+		target := &specs.ClusterMachineConfigPatchesSpec{}
+		patches := slices.Values([]*specs.ConfigPatchSpec{largePatch, smallPatch})
+
+		err := target.FromConfigPatches(patches, disabledConfig)
+		require.NoError(t, err)
+
+		// When compression is disabled, patches are stored uncompressed even if large.
+		assert.Empty(t, target.GetCompressedPatches(), "Expected no compressed patches when compression is disabled")
+		assert.Len(t, target.GetPatches(), 2, "Expected 2 uncompressed patches")
+		assert.Equal(t, largePatchData, target.GetPatches()[0])
+		assert.Equal(t, smallPatchData, target.GetPatches()[1])
+	})
+
+	t.Run("compression enabled with large patches compresses all", func(t *testing.T) {
+		enabledConfig := originalConfig
+		enabledConfig.Enabled = true
+		specs.SetCompressionConfig(enabledConfig)
+
+		largePatch := &specs.ConfigPatchSpec{Data: largePatchData}
+		smallPatch := &specs.ConfigPatchSpec{Data: smallPatchData}
+
+		target := &specs.ClusterMachineConfigPatchesSpec{}
+		patches := slices.Values([]*specs.ConfigPatchSpec{largePatch, smallPatch})
+
+		err := target.FromConfigPatches(patches, enabledConfig)
+		require.NoError(t, err)
+
+		// When compression is enabled and at least one patch is above threshold, all patches are compressed.
+		assert.Len(t, target.GetCompressedPatches(), 2, "Expected 2 compressed patches")
+		assert.Empty(t, target.GetPatches(), "Expected no uncompressed patches")
+
+		patchesData, err := target.GetUncompressedPatches()
+		require.NoError(t, err)
+
+		assert.Len(t, patchesData, 2)
+		assert.Equal(t, largePatchData, patchesData[0])
+		assert.Equal(t, smallPatchData, patchesData[1])
+	})
+
+	t.Run("compression enabled with only small patches does not compress", func(t *testing.T) {
+		enabledConfig := originalConfig
+		enabledConfig.Enabled = true
+		specs.SetCompressionConfig(enabledConfig)
+
+		smallPatch1 := &specs.ConfigPatchSpec{Data: "small-patch-1"}
+		smallPatch2 := &specs.ConfigPatchSpec{Data: "small-patch-2"}
+
+		target := &specs.ClusterMachineConfigPatchesSpec{}
+		patches := slices.Values([]*specs.ConfigPatchSpec{smallPatch1, smallPatch2})
+
+		err := target.FromConfigPatches(patches, enabledConfig)
+		require.NoError(t, err)
+
+		// When compression is enabled but no patch is above threshold, patches are stored uncompressed.
+		assert.Empty(t, target.GetCompressedPatches(), "Expected no compressed patches when all patches are small")
+		assert.Len(t, target.GetPatches(), 2, "Expected 2 uncompressed patches")
+		assert.Equal(t, "small-patch-1", target.GetPatches()[0])
+		assert.Equal(t, "small-patch-2", target.GetPatches()[1])
+	})
+}


### PR DESCRIPTION
When the resource compression was disabled in the Omni config, we were not generating the ClusterMachineConfigPatches correctly.

The issue was: it was attempting to "force-compress" the ClusterMachineConfigPatches when any of the patches' size was above the threshold. But when it was trying to do that, it did not override the global setting of false.

The default setting for resource compression is `true`, but when a config file is used to configure Omni, and it was not specified in the config YAML, it was getting overwritten to be `false` due to the boolean merging behavior, which was fixed in https://github.com/siderolabs/omni/pull/2150.

Also: fix the compression kicking in even in cases when it is disabled in config but above the threshold.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>