### PR TITLE
feat: add config descriptions in schema, use them in flags

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,398 +26,474 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/jsonschema"
 	"github.com/siderolabs/omni/internal/version"
 )
 
-var rootCmdFlagBinder *FlagBinder
-
-// rootCmd represents the base command when called without any subcommands.
-var rootCmd = &cobra.Command{
-	Use:          "omni",
-	Short:        "Omni Kubernetes management platform service",
-	Long:         "This executable runs both Omni frontend and Omni backend",
-	SilenceUsage: true,
-	Version:      version.Tag,
-	RunE: func(*cobra.Command, []string) error {
-		if err := rootCmdFlagBinder.BindAll(); err != nil {
-			return fmt.Errorf("failed to bind flags: %w", err)
-		}
-
-		var loggerConfig zap.Config
-
-		if constants.IsDebugBuild {
-			loggerConfig = zap.NewDevelopmentConfig()
-			loggerConfig.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-		} else {
-			loggerConfig = zap.NewProductionConfig()
-		}
-
-		if !rootCmdArgs.debug {
-			loggerConfig.Level.SetLevel(zap.InfoLevel)
-		} else {
-			loggerConfig.Level.SetLevel(zap.DebugLevel)
-		}
-
-		logger, err := loggerConfig.Build(
-			zap.AddStacktrace(zapcore.FatalLevel), // only print stack traces for fatal errors
-		)
-		if err != nil {
-			return fmt.Errorf("failed to set up logging: %w", err)
-		}
-
-		signals := make(chan os.Signal, 1)
-
-		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		// do not use signal.NotifyContext as it doesn't support any ways to log the received signal
-		panichandler.Go(func() {
-			s := <-signals
-
-			logger.Warn("signal received, stopping Omni", zap.String("signal", s.String()))
-
-			cancel()
-		}, logger)
-
-		configs := make([]*config.Params, 0, 2)
-
-		if rootCmdArgs.configPath != "" {
-			var fileConfig *config.Params
-
-			if fileConfig, err = config.LoadFromFile(rootCmdArgs.configPath); err != nil {
-				return fmt.Errorf("failed to load config from file: %w", err)
-			}
-
-			configs = append(configs, fileConfig)
-		}
-
-		configs = append(configs, flagConfig) // flags have the highest priority
-
-		config, err := app.PrepareConfig(logger, configs...)
-		if err != nil {
-			return err
-		}
-
-		ctx = actor.MarkContextAsInternalActor(ctx)
-
-		state, err := omni.NewState(ctx, config, logger, prometheus.DefaultRegisterer)
-		if err != nil {
-			return err
-		}
-
-		defer func() {
-			if err = state.Close(); err != nil {
-				logger.Error("failed to close the state gracefully", zap.Error(err))
-			}
-		}()
-
-		if err = config.ValidateState(ctx, state.Default()); err != nil {
-			return err
-		}
-
-		if constants.IsDebugBuild {
-			logger.Warn("running debug build")
-		}
-
-		return app.Run(ctx, state, config, logger)
-	},
-}
-
-var rootCmdArgs struct {
-	configPath string
-	debug      bool
-}
-
-// Execute the command.
+// Execute builds and runs the root command.
 func Execute() error {
-	return newCommand().Execute()
+	rootCmd, err := buildRootCommand()
+	if err != nil {
+		return fmt.Errorf("failed to build root command: %w", err)
+	}
+
+	return rootCmd.Execute()
 }
 
-var flagConfig = &config.Params{}
+func buildRootCommand() (*cobra.Command, error) {
+	configSchema, schemaErr := config.ParseSchema()
+	if schemaErr != nil {
+		return nil, fmt.Errorf("failed to parse config schema: %w", schemaErr)
+	}
 
-func newCommand() *cobra.Command {
+	var (
+		rootCmdFlagBinder *FlagBinder
+		configPath        string
+		debug             bool
+		flagConfig        = &config.Params{}
+	)
+
+	rootCmd := &cobra.Command{
+		Use:          "omni",
+		Short:        "Omni Kubernetes management platform service",
+		Long:         "This executable runs both Omni frontend and Omni backend",
+		SilenceUsage: true,
+		Version:      version.Tag,
+		RunE: func(*cobra.Command, []string) error {
+			if err := rootCmdFlagBinder.BindAll(); err != nil {
+				return fmt.Errorf("failed to bind flags: %w", err)
+			}
+
+			var loggerConfig zap.Config
+
+			if constants.IsDebugBuild {
+				loggerConfig = zap.NewDevelopmentConfig()
+				loggerConfig.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+			} else {
+				loggerConfig = zap.NewProductionConfig()
+			}
+
+			if !debug {
+				loggerConfig.Level.SetLevel(zap.InfoLevel)
+			} else {
+				loggerConfig.Level.SetLevel(zap.DebugLevel)
+			}
+
+			logger, err := loggerConfig.Build(
+				zap.AddStacktrace(zapcore.FatalLevel), // only print stack traces for fatal errors
+			)
+			if err != nil {
+				return fmt.Errorf("failed to set up logging: %w", err)
+			}
+
+			signals := make(chan os.Signal, 1)
+
+			signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// do not use signal.NotifyContext as it doesn't support any ways to log the received signal
+			panichandler.Go(func() {
+				s := <-signals
+
+				logger.Warn("signal received, stopping Omni", zap.String("signal", s.String()))
+
+				cancel()
+			}, logger)
+
+			configs := make([]*config.Params, 0, 2)
+
+			if configPath != "" {
+				var fileConfig *config.Params
+
+				if fileConfig, err = config.LoadFromFile(configPath); err != nil {
+					return fmt.Errorf("failed to load config from file: %w", err)
+				}
+
+				configs = append(configs, fileConfig)
+			}
+
+			configs = append(configs, flagConfig) // flags have the highest priority
+
+			config, err := app.PrepareConfig(logger, configSchema, configs...)
+			if err != nil {
+				return err
+			}
+
+			ctx = actor.MarkContextAsInternalActor(ctx)
+
+			state, err := omni.NewState(ctx, config, logger, prometheus.DefaultRegisterer)
+			if err != nil {
+				return err
+			}
+
+			defer func() {
+				if err = state.Close(); err != nil {
+					logger.Error("failed to close the state gracefully", zap.Error(err))
+				}
+			}()
+
+			if err = config.ValidateState(ctx, state.Default()); err != nil {
+				return err
+			}
+
+			if constants.IsDebugBuild {
+				logger.Warn("running debug build")
+			}
+
+			return app.Run(ctx, state, config, logger)
+		},
+	}
+
 	rootCmdFlagBinder = NewFlagBinder(rootCmd)
 
-	rootCmd.Flags().StringVar(&rootCmdArgs.configPath, "config-path", "", "load the config from the file, flags have bigger priority")
-	rootCmd.Flags().BoolVar(&rootCmdArgs.debug, "debug", constants.IsDebugBuild, "enable debug logs.")
+	rootCmd.Flags().StringVar(&configPath, "config-path", "", "load the config from the file, flags have bigger priority")
+	rootCmd.Flags().BoolVar(&debug, "debug", constants.IsDebugBuild, "enable debug logs.")
 
-	rootCmdFlagBinder.StringVar("account-id", "instance account ID, should never be changed.", &flagConfig.Account.Id)
-	rootCmdFlagBinder.StringVar("name", "instance user-facing name.", &flagConfig.Account.Name)
-	rootCmdFlagBinder.StringVar("user-pilot-app-token", "user pilot app token.", &flagConfig.Account.UserPilot.AppToken)
+	rootCmdFlagBinder.StringVar("account-id", flagDescription("account.id", configSchema), &flagConfig.Account.Id)
+	rootCmdFlagBinder.StringVar("name", flagDescription("account.name", configSchema), &flagConfig.Account.Name)
+	rootCmdFlagBinder.StringVar("user-pilot-app-token", flagDescription("account.userPilot.appToken", configSchema), &flagConfig.Account.UserPilot.AppToken)
 
-	defineServiceFlags()
-	defineAuthFlags()
-	defineLogsFlags()
-	defineStorageFlags()
-	defineRegistriesFlags()
-	defineFeatureFlags()
-	defineDebugFlags()
-	defineEtcdBackupsFlags()
+	if err := defineServiceFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema); err != nil {
+		return nil, fmt.Errorf("failed to define service flags: %w", err)
+	}
 
-	return rootCmd
+	defineAuthFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema)
+
+	if err := defineLogsFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema); err != nil {
+		return nil, fmt.Errorf("failed to define logs flags: %w", err)
+	}
+
+	if err := defineStorageFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema); err != nil {
+		return nil, fmt.Errorf("failed to define storage flags: %w", err)
+	}
+
+	defineRegistriesFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema)
+	defineFeatureFlags(rootCmdFlagBinder, flagConfig, configSchema)
+	defineDebugFlags(rootCmdFlagBinder, flagConfig, configSchema)
+	defineEtcdBackupsFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema)
+
+	return rootCmd, nil
 }
 
-func defineServiceFlags() {
+func defineServiceFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) error {
 	// API
-	rootCmdFlagBinder.StringVar("bind-addr", "start HTTP + API server on the defined address.", &flagConfig.Services.Api.Endpoint)
-	rootCmdFlagBinder.StringVar("advertised-api-url", "advertised API frontend URL.", &flagConfig.Services.Api.AdvertisedURL)
-	rootCmdFlagBinder.StringVar("key", "TLS key file", &flagConfig.Services.Api.KeyFile)
-	rootCmdFlagBinder.StringVar("cert", "TLS cert file", &flagConfig.Services.Api.CertFile)
+	rootCmdFlagBinder.StringVar("bind-addr", flagDescription("services.api.endpoint", schema), &flagConfig.Services.Api.Endpoint)
+	rootCmdFlagBinder.StringVar("advertised-api-url", flagDescription("services.api.advertisedURL", schema), &flagConfig.Services.Api.AdvertisedURL)
+	rootCmdFlagBinder.StringVar("key", flagDescription("services.api.keyFile", schema), &flagConfig.Services.Api.KeyFile)
+	rootCmdFlagBinder.StringVar("cert", flagDescription("services.api.certFile", schema), &flagConfig.Services.Api.CertFile)
 
 	// Metrics
-	rootCmdFlagBinder.StringVar("metrics-bind-addr", "start Prometheus HTTP server on the defined address.", &flagConfig.Services.Metrics.Endpoint)
+	rootCmdFlagBinder.StringVar("metrics-bind-addr", flagDescription("services.metrics.endpoint", schema), &flagConfig.Services.Metrics.Endpoint)
 
 	// KubernetesProxy
-	rootCmdFlagBinder.StringVar("k8s-proxy-bind-addr", "start Kubernetes proxy on the defined address.", &flagConfig.Services.KubernetesProxy.Endpoint)
+	rootCmdFlagBinder.StringVar("k8s-proxy-bind-addr", flagDescription("services.kubernetesProxy.endpoint", schema), &flagConfig.Services.KubernetesProxy.Endpoint)
 
-	rootCmdFlagBinder.StringVar("advertised-kubernetes-proxy-url", "advertised Kubernetes proxy URL.", &flagConfig.Services.KubernetesProxy.AdvertisedURL)
+	rootCmdFlagBinder.StringVar("advertised-kubernetes-proxy-url", flagDescription("services.kubernetesProxy.advertisedURL", schema), &flagConfig.Services.KubernetesProxy.AdvertisedURL)
 
 	// Siderolink
-	rootCmdFlagBinder.StringVar("siderolink-wireguard-bind-addr", "SideroLink WireGuard bind address.", &flagConfig.Services.Siderolink.WireGuard.Endpoint)
+	rootCmdFlagBinder.StringVar("siderolink-wireguard-bind-addr", flagDescription("services.siderolink.wireGuard.endpoint", schema), &flagConfig.Services.Siderolink.WireGuard.Endpoint)
 	rootCmdFlagBinder.StringVar("siderolink-wireguard-advertised-addr",
-		"advertised wireguard address which is passed down to the nodes.", &flagConfig.Services.Siderolink.WireGuard.AdvertisedEndpoint)
+		flagDescription("services.siderolink.wireGuard.advertisedEndpoint", schema), &flagConfig.Services.Siderolink.WireGuard.AdvertisedEndpoint)
 	rootCmdFlagBinder.BoolVar("siderolink-disable-last-endpoint",
-		"do not populate last known peer endpoint for the WireGuard peers", &flagConfig.Services.Siderolink.DisableLastEndpoint)
+		flagDescription("services.siderolink.disableLastEndpoint", schema), &flagConfig.Services.Siderolink.DisableLastEndpoint)
 	rootCmdFlagBinder.BoolVar("siderolink-use-grpc-tunnel",
-		"use gRPC tunnel to wrap WireGuard traffic instead of UDP. When enabled, "+
-			"the SideroLink connections from Talos machines will be configured to use the tunnel mode, regardless of their individual configuration. ",
+		flagDescription("services.siderolink.useGRPCTunnel", schema),
 		&flagConfig.Services.Siderolink.UseGRPCTunnel,
 	)
-	rootCmdFlagBinder.IntVar("event-sink-port", "event sink bind port.", &flagConfig.Services.Siderolink.EventSinkPort)
-	rootCmdFlagBinder.IntVar("log-server-port", "port for TCP log server", &flagConfig.Services.Siderolink.LogServerPort)
-	EnumVar(rootCmdFlagBinder, "join-tokens-mode", "configures Talos machine join flow to use secure node tokens", &flagConfig.Services.Siderolink.JoinTokensMode)
+	rootCmdFlagBinder.IntVar("event-sink-port", flagDescription("services.siderolink.eventSinkPort", schema), &flagConfig.Services.Siderolink.EventSinkPort)
+	rootCmdFlagBinder.IntVar("log-server-port", flagDescription("services.siderolink.logServerPort", schema), &flagConfig.Services.Siderolink.LogServerPort)
+	EnumVar(rootCmdFlagBinder, "join-tokens-mode", flagDescription("services.siderolink.joinTokensMode", schema), &flagConfig.Services.Siderolink.JoinTokensMode)
 
 	// MachineAPI
 	for _, prefix := range []string{"siderolink", "machine"} {
-		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-bind-addr", prefix), "machine API provision bind address.", &flagConfig.Services.MachineAPI.Endpoint)
-		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-cert", prefix), "machine API TLS cert file path.", &flagConfig.Services.MachineAPI.CertFile)
-		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-key", prefix), "machine API TLS cert file path.", &flagConfig.Services.MachineAPI.KeyFile)
-		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-advertised-url", prefix), "machine API advertised API URL.", &flagConfig.Services.MachineAPI.AdvertisedURL)
+		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-bind-addr", prefix), flagDescription("services.machineAPI.endpoint", schema), &flagConfig.Services.MachineAPI.Endpoint)
+		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-cert", prefix), flagDescription("services.machineAPI.certFile", schema), &flagConfig.Services.MachineAPI.CertFile)
+		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-key", prefix), flagDescription("services.machineAPI.keyFile", schema), &flagConfig.Services.MachineAPI.KeyFile)
+		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-advertised-url", prefix), flagDescription("services.machineAPI.advertisedURL", schema), &flagConfig.Services.MachineAPI.AdvertisedURL)
 	}
 
-	rootCmd.Flags().MarkDeprecated("siderolink-api-bind-addr", "--deprecated, use --machine-api-bind-addr") //nolint:errcheck
-	rootCmd.Flags().MarkDeprecated("siderolink-api-cert", "deprecated, use --machine-api-cert")             //nolint:errcheck
-	rootCmd.Flags().MarkDeprecated("siderolink-api-key", "deprecated, use --machine-api-key")               //nolint:errcheck
+	if err := rootCmd.Flags().MarkDeprecated("siderolink-api-bind-addr", "--deprecated, use --machine-api-bind-addr"); err != nil {
+		return err
+	}
+
+	if err := rootCmd.Flags().MarkDeprecated("siderolink-api-cert", "deprecated, use --machine-api-cert"); err != nil {
+		return err
+	}
+
+	if err := rootCmd.Flags().MarkDeprecated("siderolink-api-key", "deprecated, use --machine-api-key"); err != nil {
+		return err
+	}
 
 	// LoadBalancer
-	rootCmdFlagBinder.IntVar("lb-min-port", "cluster load balancer port range min value.", &flagConfig.Services.LoadBalancer.MinPort)
-	rootCmdFlagBinder.IntVar("lb-max-port", "cluster load balancer port range max value.", &flagConfig.Services.LoadBalancer.MaxPort)
+	rootCmdFlagBinder.IntVar("lb-min-port", flagDescription("services.loadBalancer.minPort", schema), &flagConfig.Services.LoadBalancer.MinPort)
+	rootCmdFlagBinder.IntVar("lb-max-port", flagDescription("services.loadBalancer.maxPort", schema), &flagConfig.Services.LoadBalancer.MaxPort)
 
-	rootCmdFlagBinder.IntVar("local-resource-server-port", "port for local read-only public resource server.", &flagConfig.Services.LocalResourceService.Port)
+	rootCmdFlagBinder.IntVar("local-resource-server-port", flagDescription("services.localResourceService.port", schema), &flagConfig.Services.LocalResourceService.Port)
 
-	rootCmdFlagBinder.BoolVar("local-resource-server-enabled", "enable local read-only public resource server.", &flagConfig.Services.LocalResourceService.Enabled)
+	rootCmdFlagBinder.BoolVar("local-resource-server-enabled", flagDescription("services.localResourceService.enabled", schema), &flagConfig.Services.LocalResourceService.Enabled)
 
 	// Embedded discovery service
 	rootCmdFlagBinder.BoolVar("embedded-discovery-service-enabled",
-		"enable embedded discovery service, binds only to the SideroLink WireGuard address", &flagConfig.Services.EmbeddedDiscoveryService.Enabled)
+		flagDescription("services.embeddedDiscoveryService.enabled", schema), &flagConfig.Services.EmbeddedDiscoveryService.Enabled)
 
-	rootCmdFlagBinder.IntVar("embedded-discovery-service-endpoint", "embedded discovery service port to listen on", &flagConfig.Services.EmbeddedDiscoveryService.Port)
-	rootCmd.Flags().MarkDeprecated("embedded-discovery-service-endpoint", "use --embedded-discovery-service-port") //nolint:errcheck
+	rootCmdFlagBinder.IntVar("embedded-discovery-service-endpoint", flagDescription("services.embeddedDiscoveryService.port", schema), &flagConfig.Services.EmbeddedDiscoveryService.Port)
 
-	rootCmdFlagBinder.IntVar("embedded-discovery-service-port", "embedded discovery service port to listen on", &flagConfig.Services.EmbeddedDiscoveryService.Port)
+	if err := rootCmd.Flags().MarkDeprecated("embedded-discovery-service-endpoint", "use --embedded-discovery-service-port"); err != nil {
+		return err
+	}
+
+	rootCmdFlagBinder.IntVar("embedded-discovery-service-port", flagDescription("services.embeddedDiscoveryService.port", schema), &flagConfig.Services.EmbeddedDiscoveryService.Port)
 
 	rootCmdFlagBinder.BoolVar("embedded-discovery-service-snapshots-enabled",
-		"enable snapshots for the embedded discovery service", &flagConfig.Services.EmbeddedDiscoveryService.SnapshotsEnabled)
+		flagDescription("services.embeddedDiscoveryService.snapshotsEnabled", schema), &flagConfig.Services.EmbeddedDiscoveryService.SnapshotsEnabled)
 
 	//nolint:staticcheck
 	rootCmdFlagBinder.StringVar("embedded-discovery-service-snapshot-path",
-		"path to the file for storing the embedded discovery service state",
+		flagDescription("services.embeddedDiscoveryService.snapshotsPath", schema),
 		&flagConfig.Services.EmbeddedDiscoveryService.SnapshotsPath,
 	)
 
-	//nolint:errcheck
-	rootCmd.Flags().MarkDeprecated("embedded-discovery-service-snapshot-path", "this flag is kept for the SQLite migration, and will be removed in future versions")
+	if err := rootCmd.Flags().MarkDeprecated("embedded-discovery-service-snapshot-path", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+		return err
+	}
 
 	rootCmdFlagBinder.DurationVar("embedded-discovery-service-snapshot-interval",
-		"interval for saving the embedded discovery service state", &flagConfig.Services.EmbeddedDiscoveryService.SnapshotsInterval)
+		flagDescription("services.embeddedDiscoveryService.snapshotsInterval", schema), &flagConfig.Services.EmbeddedDiscoveryService.SnapshotsInterval)
 	rootCmdFlagBinder.StringVar("embedded-discovery-service-log-level",
-		"log level for the embedded discovery service - it has no effect if it is lower (more verbose) than the main log level", &flagConfig.Services.EmbeddedDiscoveryService.LogLevel)
+		flagDescription("services.embeddedDiscoveryService.logLevel", schema), &flagConfig.Services.EmbeddedDiscoveryService.LogLevel)
 	rootCmdFlagBinder.DurationVar("embedded-discovery-service-sqlite-timeout",
-		"SQLite timeout for the embedded discovery service", &flagConfig.Services.EmbeddedDiscoveryService.SqliteTimeout)
+		flagDescription("services.embeddedDiscoveryService.sqliteTimeout", schema), &flagConfig.Services.EmbeddedDiscoveryService.SqliteTimeout)
 
 	// DevServerProxy
-	rootCmdFlagBinder.StringVar("frontend-dst", "destination address non API requests from proxy server.", &flagConfig.Services.DevServerProxy.ProxyTo)
-	rootCmdFlagBinder.StringVar("frontend-bind", "proxy server which will redirect all non API requests to the defined frontend server.", &flagConfig.Services.DevServerProxy.Endpoint)
+	rootCmdFlagBinder.StringVar("frontend-dst", flagDescription("services.devServerProxy.proxyTo", schema), &flagConfig.Services.DevServerProxy.ProxyTo)
+	rootCmdFlagBinder.StringVar("frontend-bind", flagDescription("services.devServerProxy.endpoint", schema), &flagConfig.Services.DevServerProxy.Endpoint)
+
+	return nil
 }
 
-func defineAuthFlags() {
+func defineAuthFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
 	// Auth0
 	rootCmdFlagBinder.BoolVar("auth-auth0-enabled",
-		"enable Auth0 authentication. Once set to true, it cannot be set back to false.", &flagConfig.Auth.Auth0.Enabled)
-	rootCmdFlagBinder.StringVar("auth-auth0-client-id", "Auth0 application client ID.", &flagConfig.Auth.Auth0.ClientID)
-	rootCmdFlagBinder.StringVar("auth-auth0-domain", "Auth0 application domain.", &flagConfig.Auth.Auth0.Domain)
+		flagDescription("auth.auth0.enabled", schema), &flagConfig.Auth.Auth0.Enabled)
+	rootCmdFlagBinder.StringVar("auth-auth0-client-id", flagDescription("auth.auth0.clientID", schema), &flagConfig.Auth.Auth0.ClientID)
+	rootCmdFlagBinder.StringVar("auth-auth0-domain", flagDescription("auth.auth0.domain", schema), &flagConfig.Auth.Auth0.Domain)
 	rootCmdFlagBinder.BoolVar("auth-auth0-use-form-data",
-		"When true, data to the token endpoint is transmitted as x-www-form-urlencoded data instead of JSON. The default is false", &flagConfig.Auth.Auth0.UseFormData)
+		flagDescription("auth.auth0.useFormData", schema), &flagConfig.Auth.Auth0.UseFormData)
 
 	// Webauthn
 	rootCmdFlagBinder.BoolVar("auth-webauthn-enabled",
-		"enable WebAuthn authentication. Once set to true, it cannot be set back to false.", &flagConfig.Auth.Webauthn.Enabled)
+		flagDescription("auth.webauthn.enabled", schema), &flagConfig.Auth.Webauthn.Enabled)
 	rootCmdFlagBinder.BoolVar("auth-webauthn-required",
-		"require WebAuthn authentication. Once set to true, it cannot be set back to false.", &flagConfig.Auth.Webauthn.Required)
+		flagDescription("auth.webauthn.required", schema), &flagConfig.Auth.Webauthn.Required)
 
 	rootCmdFlagBinder.BoolVar("auth-saml-enabled",
-		"enabled SAML authentication.", &flagConfig.Auth.Saml.Enabled,
+		flagDescription("auth.saml.enabled", schema), &flagConfig.Auth.Saml.Enabled,
 	)
-	rootCmdFlagBinder.StringVar("auth-saml-url", "SAML identity provider metadata URL (mutually exclusive with --auth-saml-metadata", &flagConfig.Auth.Saml.Url)
-	rootCmdFlagBinder.StringVar("auth-saml-metadata", "SAML identity provider metadata file path (mutually exclusive with --auth-saml-url).", &flagConfig.Auth.Saml.Metadata)
-	rootCmd.Flags().Var(&flagConfig.Auth.Saml.LabelRules, "auth-saml-label-rules", "defines mapping of SAML assertion attributes into Omni identity labels")
-	rootCmd.Flags().Var(&flagConfig.Auth.Saml.AttributeRules, "auth-saml-attribute-rules", "defines additional identity, fullname, firstname and lastname mappings")
-	rootCmdFlagBinder.StringVar("auth-saml-name-id-format", "allows setting name ID format for the account", &flagConfig.Auth.Saml.NameIDFormat)
-	rootCmd.Flags().StringSliceVar(&flagConfig.Auth.InitialUsers, "initial-users", flagConfig.Auth.InitialUsers, "initial set of user emails. these users will be created on startup.")
-	rootCmdFlagBinder.DurationVar("public-key-pruning-interval", "interval between public key pruning runs.", &flagConfig.Auth.KeyPruner.Interval)
-	rootCmdFlagBinder.BoolVar("suspended", "start omni in suspended (read-only) mode.", &flagConfig.Auth.Suspended)
+	rootCmdFlagBinder.StringVar("auth-saml-url", flagDescription("auth.saml.url", schema), &flagConfig.Auth.Saml.Url)
+	rootCmdFlagBinder.StringVar("auth-saml-metadata", flagDescription("auth.saml.metadata", schema), &flagConfig.Auth.Saml.Metadata)
+	rootCmd.Flags().Var(&flagConfig.Auth.Saml.LabelRules, "auth-saml-label-rules", flagDescription("auth.saml.labelRules", schema))
+	rootCmd.Flags().Var(&flagConfig.Auth.Saml.AttributeRules, "auth-saml-attribute-rules", flagDescription("auth.saml.attributeRules", schema))
+	rootCmdFlagBinder.StringVar("auth-saml-name-id-format", flagDescription("auth.saml.nameIDFormat", schema), &flagConfig.Auth.Saml.NameIDFormat)
+	rootCmd.Flags().StringSliceVar(&flagConfig.Auth.InitialUsers, "initial-users", flagConfig.Auth.InitialUsers, flagDescription("auth.initialUsers", schema))
+	rootCmdFlagBinder.DurationVar("public-key-pruning-interval", flagDescription("auth.keyPruner.interval", schema), &flagConfig.Auth.KeyPruner.Interval)
+	rootCmdFlagBinder.BoolVar("suspended", flagDescription("auth.suspended", schema), &flagConfig.Auth.Suspended)
 
 	rootCmdFlagBinder.BoolVar("create-initial-service-account",
-		"create and dump a service account credentials on the first start of Omni", &flagConfig.Auth.InitialServiceAccount.Enabled)
+		flagDescription("auth.initialServiceAccount.enabled", schema), &flagConfig.Auth.InitialServiceAccount.Enabled)
 
-	rootCmdFlagBinder.StringVar("initial-service-account-key-path", "dump the initial service account key into the path", &flagConfig.Auth.InitialServiceAccount.KeyPath)
+	rootCmdFlagBinder.StringVar("initial-service-account-key-path", flagDescription("auth.initialServiceAccount.keyPath", schema), &flagConfig.Auth.InitialServiceAccount.KeyPath)
 
-	rootCmdFlagBinder.StringVar("initial-service-account-role", "the initial service account access role", &flagConfig.Auth.InitialServiceAccount.Role)
+	rootCmdFlagBinder.StringVar("initial-service-account-role", flagDescription("auth.initialServiceAccount.role", schema), &flagConfig.Auth.InitialServiceAccount.Role)
 
 	rootCmdFlagBinder.DurationVar("initial-service-account-lifetime",
-		"the lifetime duration of the initial service account key", &flagConfig.Auth.InitialServiceAccount.Lifetime)
+		flagDescription("auth.initialServiceAccount.lifetime", schema), &flagConfig.Auth.InitialServiceAccount.Lifetime)
 
 	rootCmd.MarkFlagsMutuallyExclusive("auth-saml-url", "auth-saml-metadata")
 
 	// OIDC
-	rootCmdFlagBinder.BoolVar("auth-oidc-enabled", "enable OIDC authentication.", &flagConfig.Auth.Oidc.Enabled)
-	rootCmdFlagBinder.StringVar("auth-oidc-provider-url", "OIDC authentication provider URL.", &flagConfig.Auth.Oidc.ProviderURL)
-	rootCmdFlagBinder.StringVar("auth-oidc-client-id", "OIDC authentication client ID.", &flagConfig.Auth.Oidc.ClientID)
-	rootCmdFlagBinder.StringVar("auth-oidc-client-secret", "OIDC authentication client secret.", &flagConfig.Auth.Oidc.ClientSecret)
-	rootCmd.Flags().StringSliceVar(&flagConfig.Auth.Oidc.Scopes, "auth-oidc-scopes", flagConfig.Auth.Oidc.Scopes, "OIDC authentication scopes.")
-	rootCmdFlagBinder.StringVar("auth-oidc-logout-url", "OIDC logout URL.", &flagConfig.Auth.Oidc.LogoutURL)
-	rootCmdFlagBinder.BoolVar("auth-oidc-allow-unverified-email", "Allow OIDC tokens without email_verified claim.", &flagConfig.Auth.Oidc.AllowUnverifiedEmail)
+	rootCmdFlagBinder.BoolVar("auth-oidc-enabled", flagDescription("auth.oidc.enabled", schema), &flagConfig.Auth.Oidc.Enabled)
+	rootCmdFlagBinder.StringVar("auth-oidc-provider-url", flagDescription("auth.oidc.providerURL", schema), &flagConfig.Auth.Oidc.ProviderURL)
+	rootCmdFlagBinder.StringVar("auth-oidc-client-id", flagDescription("auth.oidc.clientID", schema), &flagConfig.Auth.Oidc.ClientID)
+	rootCmdFlagBinder.StringVar("auth-oidc-client-secret", flagDescription("auth.oidc.clientSecret", schema), &flagConfig.Auth.Oidc.ClientSecret)
+	rootCmd.Flags().StringSliceVar(&flagConfig.Auth.Oidc.Scopes, "auth-oidc-scopes", flagConfig.Auth.Oidc.Scopes, flagDescription("auth.oidc.scopes", schema))
+	rootCmdFlagBinder.StringVar("auth-oidc-logout-url", flagDescription("auth.oidc.logoutURL", schema), &flagConfig.Auth.Oidc.LogoutURL)
+	rootCmdFlagBinder.BoolVar("auth-oidc-allow-unverified-email", flagDescription("auth.oidc.allowUnverifiedEmail", schema), &flagConfig.Auth.Oidc.AllowUnverifiedEmail)
 }
 
 //nolint:staticcheck // defineLogsFlags uses deprecated fields for backwards-compatibility
-func defineLogsFlags() {
-	rootCmdFlagBinder.DurationVar("machine-log-sqlite-timeout", "sqlite timeout for machine logs", &flagConfig.Logs.Machine.Storage.SqliteTimeout)
-	rootCmdFlagBinder.DurationVar("machine-log-cleanup-interval", "interval between machine log cleanup runs", &flagConfig.Logs.Machine.Storage.CleanupInterval)
-	rootCmdFlagBinder.DurationVar("machine-log-cleanup-older-than", "age threshold for machine log entries to be cleaned up", &flagConfig.Logs.Machine.Storage.CleanupOlderThan)
-	rootCmdFlagBinder.IntVar("machine-log-max-lines-per-machine", "maximum number of log lines to keep per machine", &flagConfig.Logs.Machine.Storage.MaxLinesPerMachine)
+func defineLogsFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) error {
+	rootCmdFlagBinder.DurationVar("machine-log-sqlite-timeout", flagDescription("logs.machine.storage.sqliteTimeout", schema), &flagConfig.Logs.Machine.Storage.SqliteTimeout)
+	rootCmdFlagBinder.DurationVar("machine-log-cleanup-interval", flagDescription("logs.machine.storage.cleanupInterval", schema), &flagConfig.Logs.Machine.Storage.CleanupInterval)
+	rootCmdFlagBinder.DurationVar("machine-log-cleanup-older-than", flagDescription("logs.machine.storage.cleanupOlderThan", schema), &flagConfig.Logs.Machine.Storage.CleanupOlderThan)
+	rootCmdFlagBinder.IntVar("machine-log-max-lines-per-machine", flagDescription("logs.machine.storage.maxLinesPerMachine", schema), &flagConfig.Logs.Machine.Storage.MaxLinesPerMachine)
 	rootCmdFlagBinder.Float64Var("machine-log-cleanup-probability",
-		"probability of running a size-based cleanup after each log write", &flagConfig.Logs.Machine.Storage.CleanupProbability)
+		flagDescription("logs.machine.storage.cleanupProbability", schema), &flagConfig.Logs.Machine.Storage.CleanupProbability)
 
-	rootCmd.Flags().MarkHidden("machine-log-cleanup-probability") //nolint:errcheck
+	if err := rootCmd.Flags().MarkHidden("machine-log-cleanup-probability"); err != nil {
+		return err
+	}
 
 	rootCmd.Flags().StringSliceVar(&flagConfig.Logs.ResourceLogger.Types, "log-resource-updates-types",
-		flagConfig.Logs.ResourceLogger.Types, "list of resource types whose updates should be logged")
-	rootCmdFlagBinder.StringVar("log-resource-updates-log-level", "log level for resource updates", &flagConfig.Logs.ResourceLogger.LogLevel)
-	rootCmdFlagBinder.BoolVar("audit-log-enabled", "enable audit logging", &flagConfig.Logs.Audit.Enabled)
-	rootCmdFlagBinder.DurationVar("audit-log-sqlite-timeout", "sqlite timeout for audit logs", &flagConfig.Logs.Audit.SqliteTimeout)
-	rootCmdFlagBinder.BoolVar("enable-stripe-reporting", "enable Stripe machine usage reporting", &flagConfig.Logs.Stripe.Enabled)
-	rootCmdFlagBinder.Uint32Var("stripe-minimum-commit", "Minimum number of machines to report to Stripe for the given account", &flagConfig.Logs.Stripe.MinCommit)
+		flagConfig.Logs.ResourceLogger.Types, flagDescription("logs.resourceLogger.types", schema))
+	rootCmdFlagBinder.StringVar("log-resource-updates-log-level", flagDescription("logs.resourceLogger.logLevel", schema), &flagConfig.Logs.ResourceLogger.LogLevel)
+	rootCmdFlagBinder.BoolVar("audit-log-enabled", flagDescription("logs.audit.enabled", schema), &flagConfig.Logs.Audit.Enabled)
+	rootCmdFlagBinder.DurationVar("audit-log-sqlite-timeout", flagDescription("logs.audit.sqliteTimeout", schema), &flagConfig.Logs.Audit.SqliteTimeout)
+	rootCmdFlagBinder.BoolVar("enable-stripe-reporting", flagDescription("logs.stripe.enabled", schema), &flagConfig.Logs.Stripe.Enabled)
+	rootCmdFlagBinder.Uint32Var("stripe-minimum-commit", flagDescription("logs.stripe.minCommit", schema), &flagConfig.Logs.Stripe.MinCommit)
 
 	// Deprecated logs flags, kept for backwards-compatibility
 	//
 	//nolint:staticcheck,errcheck
 	{
-		rootCmdFlagBinder.StringVar("audit-log-dir", "Directory for audit log storage", &flagConfig.Logs.Audit.Path)
-		rootCmdFlagBinder.IntVar("machine-log-buffer-capacity", "initial buffer capacity for machine logs in bytes", &flagConfig.Logs.Machine.BufferInitialCapacity)
-		rootCmdFlagBinder.IntVar("machine-log-buffer-max-capacity", "max buffer capacity for machine logs in bytes", &flagConfig.Logs.Machine.BufferMaxCapacity)
-		rootCmdFlagBinder.IntVar("machine-log-buffer-safe-gap", "safety gap for machine log buffer in bytes", &flagConfig.Logs.Machine.BufferSafetyGap)
-		rootCmdFlagBinder.IntVar("machine-log-num-compressed-chunks", "number of compressed log chunks to keep", &flagConfig.Logs.Machine.Storage.NumCompressedChunks)
-		rootCmdFlagBinder.BoolVar("machine-log-storage-enabled", "enable machine log storage", &flagConfig.Logs.Machine.Storage.Enabled)
-		rootCmdFlagBinder.StringVar("machine-log-storage-path", "path of the directory for storing machine logs", &flagConfig.Logs.Machine.Storage.Path)
-		rootCmdFlagBinder.StringVar("log-storage-path", "path of the directory for storing machine logs", &flagConfig.Logs.Machine.Storage.Path)
+		rootCmdFlagBinder.StringVar("audit-log-dir", flagDescription("logs.audit.path", schema), &flagConfig.Logs.Audit.Path)
+		rootCmdFlagBinder.IntVar("machine-log-buffer-capacity", flagDescription("logs.machine.bufferInitialCapacity", schema), &flagConfig.Logs.Machine.BufferInitialCapacity)
+		rootCmdFlagBinder.IntVar("machine-log-buffer-max-capacity", flagDescription("logs.machine.bufferMaxCapacity", schema), &flagConfig.Logs.Machine.BufferMaxCapacity)
+		rootCmdFlagBinder.IntVar("machine-log-buffer-safe-gap", flagDescription("logs.machine.bufferSafetyGap", schema), &flagConfig.Logs.Machine.BufferSafetyGap)
+		rootCmdFlagBinder.IntVar("machine-log-num-compressed-chunks", flagDescription("logs.machine.storage.numCompressedChunks", schema), &flagConfig.Logs.Machine.Storage.NumCompressedChunks)
+		rootCmdFlagBinder.BoolVar("machine-log-storage-enabled", flagDescription("logs.machine.storage.enabled", schema), &flagConfig.Logs.Machine.Storage.Enabled)
+		rootCmdFlagBinder.StringVar("machine-log-storage-path", flagDescription("logs.machine.storage.path", schema), &flagConfig.Logs.Machine.Storage.Path)
+		rootCmdFlagBinder.StringVar("log-storage-path", flagDescription("logs.machine.storage.path", schema), &flagConfig.Logs.Machine.Storage.Path)
 
-		rootCmd.Flags().MarkDeprecated("audit-log-dir", "this flag is kept for the SQLite migration, and will be removed in future versions")
-		rootCmd.Flags().MarkDeprecated("machine-log-buffer-capacity", "this flag is kept for the SQLite migration, and will be removed in future versions")
-		rootCmd.Flags().MarkDeprecated("machine-log-buffer-max-capacity", "this flag is kept for the SQLite migration, and will be removed in future versions")
-		rootCmd.Flags().MarkDeprecated("machine-log-buffer-safe-gap", "this flag is kept for the SQLite migration, and will be removed in future versions")
-		rootCmd.Flags().MarkDeprecated("machine-log-num-compressed-chunks", "this flag is kept for the SQLite migration, and will be removed in future versions")
-		rootCmd.Flags().MarkDeprecated("machine-log-storage-enabled", "this flag is kept for the SQLite migration, and will be removed in future versions")
-		rootCmd.Flags().MarkDeprecated("machine-log-storage-path", "this flag is kept for the SQLite migration, and will be removed in future versions")
-		rootCmd.Flags().MarkDeprecated("log-storage-path", "use --machine-log-storage-path")
+		if err := rootCmd.Flags().MarkDeprecated("audit-log-dir", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+			return err
+		}
+
+		if err := rootCmd.Flags().MarkDeprecated("machine-log-buffer-capacity", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+			return err
+		}
+
+		if err := rootCmd.Flags().MarkDeprecated("machine-log-buffer-max-capacity", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+			return err
+		}
+
+		if err := rootCmd.Flags().MarkDeprecated("machine-log-buffer-safe-gap", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+			return err
+		}
+
+		if err := rootCmd.Flags().MarkDeprecated("machine-log-num-compressed-chunks", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+			return err
+		}
+
+		if err := rootCmd.Flags().MarkDeprecated("machine-log-storage-enabled", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+			return err
+		}
+
+		if err := rootCmd.Flags().MarkDeprecated("machine-log-storage-path", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+			return err
+		}
+
+		if err := rootCmd.Flags().MarkDeprecated("log-storage-path", "use --machine-log-storage-path"); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
-func defineStorageFlags() {
-	EnumVar(rootCmdFlagBinder, "storage-kind", "storage type: etcd|boltdb.", &flagConfig.Storage.Default.Kind)
-	rootCmdFlagBinder.BoolVar("etcd-embedded", "use embedded etcd server.", &flagConfig.Storage.Default.Etcd.Embedded)
-	rootCmdFlagBinder.BoolVar("etcd-embedded-unsafe-fsync", "disable fsync in the embedded etcd server (dangerous).", &flagConfig.Storage.Default.Etcd.EmbeddedUnsafeFsync)
-	rootCmdFlagBinder.StringVar("etcd-embedded-db-path", "path to the embedded etcd database.", &flagConfig.Storage.Default.Etcd.EmbeddedDBPath)
+func defineStorageFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) error {
+	EnumVar(rootCmdFlagBinder, "storage-kind", flagDescription("storage.default.kind", schema), &flagConfig.Storage.Default.Kind)
+	rootCmdFlagBinder.BoolVar("etcd-embedded", flagDescription("storage.default.etcd.embedded", schema), &flagConfig.Storage.Default.Etcd.Embedded)
+	rootCmdFlagBinder.BoolVar("etcd-embedded-unsafe-fsync", flagDescription("storage.default.etcd.embeddedUnsafeFsync", schema), &flagConfig.Storage.Default.Etcd.EmbeddedUnsafeFsync)
+	rootCmdFlagBinder.StringVar("etcd-embedded-db-path", flagDescription("storage.default.etcd.embeddedDBPath", schema), &flagConfig.Storage.Default.Etcd.EmbeddedDBPath)
 
 	ensure.NoError(rootCmd.Flags().MarkHidden("etcd-embedded-unsafe-fsync"))
 
-	rootCmd.Flags().StringSliceVar(&flagConfig.Storage.Default.Etcd.Endpoints, "etcd-endpoints", flagConfig.Storage.Default.Etcd.Endpoints, "external etcd endpoints.")
-	rootCmdFlagBinder.DurationVar("etcd-dial-keepalive-time", "external etcd client keep-alive time (interval).", &flagConfig.Storage.Default.Etcd.DialKeepAliveTime)
-	rootCmdFlagBinder.DurationVar("etcd-dial-keepalive-timeout", "external etcd client keep-alive timeout.", &flagConfig.Storage.Default.Etcd.DialKeepAliveTimeout)
-	rootCmdFlagBinder.StringVar("etcd-ca-path", "external etcd CA path.", &flagConfig.Storage.Default.Etcd.CaFile)
-	rootCmdFlagBinder.StringVar("etcd-client-cert-path", "external etcd client cert path.", &flagConfig.Storage.Default.Etcd.CertFile)
-	rootCmdFlagBinder.StringVar("etcd-client-key-path", "external etcd client key path.", &flagConfig.Storage.Default.Etcd.KeyFile)
-	rootCmdFlagBinder.StringVar("private-key-source", "file containing private key to use for decrypting master key slot.", &flagConfig.Storage.Default.Etcd.PrivateKeySource)
+	rootCmd.Flags().StringSliceVar(&flagConfig.Storage.Default.Etcd.Endpoints, "etcd-endpoints", flagConfig.Storage.Default.Etcd.Endpoints, flagDescription("storage.default.etcd.endpoints", schema))
+	rootCmdFlagBinder.DurationVar("etcd-dial-keepalive-time", flagDescription("storage.default.etcd.dialKeepAliveTime", schema), &flagConfig.Storage.Default.Etcd.DialKeepAliveTime)
+	rootCmdFlagBinder.DurationVar("etcd-dial-keepalive-timeout", flagDescription("storage.default.etcd.dialKeepAliveTimeout", schema), &flagConfig.Storage.Default.Etcd.DialKeepAliveTimeout)
+	rootCmdFlagBinder.StringVar("etcd-ca-path", flagDescription("storage.default.etcd.caFile", schema), &flagConfig.Storage.Default.Etcd.CaFile)
+	rootCmdFlagBinder.StringVar("etcd-client-cert-path", flagDescription("storage.default.etcd.certFile", schema), &flagConfig.Storage.Default.Etcd.CertFile)
+	rootCmdFlagBinder.StringVar("etcd-client-key-path", flagDescription("storage.default.etcd.keyFile", schema), &flagConfig.Storage.Default.Etcd.KeyFile)
+	rootCmdFlagBinder.StringVar("private-key-source", flagDescription("storage.default.etcd.privateKeySource", schema), &flagConfig.Storage.Default.Etcd.PrivateKeySource)
 
 	rootCmd.Flags().StringSliceVar(&flagConfig.Storage.Default.Etcd.PublicKeyFiles, "public-key-files", flagConfig.Storage.Default.Etcd.PublicKeyFiles,
-		"list of paths to files containing public keys to use for encrypting keys slots.")
+		flagDescription("storage.default.etcd.publicKeyFiles", schema))
 	rootCmdFlagBinder.StringVar(
 		"secondary-storage-path",
-		fmt.Sprintf("path of the file for boltdb-backed secondary storage for frequently updated data (deprecated, see --%s).", config.SQLiteStoragePathFlag),
+		flagDescription("storage.secondary.path", schema),
 		&flagConfig.Storage.Secondary.Path, //nolint:staticcheck // backwards compatibility, remove when migration from boltdb to sqlite is done
 	)
 
-	rootCmd.Flags().MarkDeprecated("secondary-storage-path", "this flag is kept for the SQLite migration, and will be removed in future versions") //nolint:errcheck
+	if err := rootCmd.Flags().MarkDeprecated("secondary-storage-path", "this flag is kept for the SQLite migration, and will be removed in future versions"); err != nil {
+		return err
+	}
 
 	rootCmdFlagBinder.StringVar(config.SQLiteStoragePathFlag,
-		"path of the file for sqlite-backed secondary storage for frequently updated data, machine and audit logs, it is required to be set.", &flagConfig.Storage.Sqlite.Path)
+		flagDescription("storage.sqlite.path", schema), &flagConfig.Storage.Sqlite.Path)
 	rootCmdFlagBinder.StringVar("sqlite-storage-experimental-base-params",
-		"base DSN (connection string) parameters for sqlite database connection. they must not start with question mark (?). "+
-			"this flag is experimental and may be removed in future releases.", &flagConfig.Storage.Sqlite.ExperimentalBaseParams)
+		flagDescription("storage.sqlite.experimentalBaseParams", schema), &flagConfig.Storage.Sqlite.ExperimentalBaseParams)
 
 	rootCmdFlagBinder.StringVar("sqlite-storage-extra-params",
-		"extra DSN (connection string) parameters for sqlite database connection. they will be appended to the base params. they must not start with ampersand (&).",
+		flagDescription("storage.sqlite.extraParams", schema),
 		&flagConfig.Storage.Sqlite.ExtraParams)
+
+	return nil
 }
 
-func defineRegistriesFlags() {
-	rootCmdFlagBinder.StringVar("talos-installer-registry", "Talos installer image registry.", &flagConfig.Registries.Talos)
-	rootCmdFlagBinder.StringVar("kubernetes-registry", "Kubernetes container registry.", &flagConfig.Registries.Kubernetes)
-	rootCmdFlagBinder.StringVar("image-factory-address", "Image factory base URL to use.", &flagConfig.Registries.ImageFactoryBaseURL)
-	rootCmdFlagBinder.StringVar("image-factory-pxe-address", "Image factory pxe base URL to use.", &flagConfig.Registries.ImageFactoryPXEBaseURL)
+func defineRegistriesFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
+	rootCmdFlagBinder.StringVar("talos-installer-registry", flagDescription("registries.talos", schema), &flagConfig.Registries.Talos)
+	rootCmdFlagBinder.StringVar("kubernetes-registry", flagDescription("registries.kubernetes", schema), &flagConfig.Registries.Kubernetes)
+	rootCmdFlagBinder.StringVar("image-factory-address", flagDescription("registries.imageFactoryBaseURL", schema), &flagConfig.Registries.ImageFactoryBaseURL)
+	rootCmdFlagBinder.StringVar("image-factory-pxe-address", flagDescription("registries.imageFactoryPXEBaseURL", schema), &flagConfig.Registries.ImageFactoryPXEBaseURL)
 
 	rootCmd.Flags().StringSliceVar(&flagConfig.Registries.Mirrors, "registry-mirror", flagConfig.Registries.Mirrors,
-		"list of registry mirrors to use in format: <registry host>=<mirror URL>")
+		flagDescription("registries.mirrors", schema))
 }
 
-func defineFeatureFlags() {
+func defineFeatureFlags(rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
 	rootCmdFlagBinder.BoolVar("enable-talos-pre-release-versions",
-		"make Omni version discovery controler include Talos pre-release versions.", &flagConfig.Features.EnableTalosPreReleaseVersions)
+		flagDescription("features.enableTalosPreReleaseVersions", schema), &flagConfig.Features.EnableTalosPreReleaseVersions)
 
-	rootCmdFlagBinder.BoolVar("config-data-compression-enabled", "enable config data compression.", &flagConfig.Features.EnableConfigDataCompression)
+	rootCmdFlagBinder.BoolVar("config-data-compression-enabled", flagDescription("features.enableConfigDataCompression", schema), &flagConfig.Features.EnableConfigDataCompression)
 
-	rootCmdFlagBinder.BoolVar("workload-proxying-enabled", "enable workload proxying feature.", &flagConfig.Services.WorkloadProxy.Enabled)
+	rootCmdFlagBinder.BoolVar("workload-proxying-enabled", flagDescription("services.workloadProxy.enabled", schema), &flagConfig.Services.WorkloadProxy.Enabled)
 
-	rootCmdFlagBinder.StringVar("workload-proxying-subdomain", "workload proxying subdomain.", &flagConfig.Services.WorkloadProxy.Subdomain)
+	rootCmdFlagBinder.StringVar("workload-proxying-subdomain", flagDescription("services.workloadProxy.subdomain", schema), &flagConfig.Services.WorkloadProxy.Subdomain)
 
 	rootCmdFlagBinder.DurationVar("workload-proxying-stop-lbs-after",
-		"stop load balancers after this duration when workload proxying is enabled. Set to 0 to disable.", &flagConfig.Services.WorkloadProxy.StopLBsAfter)
+		flagDescription("services.workloadProxy.stopLBsAfter", schema), &flagConfig.Services.WorkloadProxy.StopLBsAfter)
 
-	rootCmdFlagBinder.BoolVar("enable-break-glass-configs", "Allows downloading admin Talos and Kubernetes configs.", &flagConfig.Features.EnableBreakGlassConfigs)
+	rootCmdFlagBinder.BoolVar("enable-break-glass-configs", flagDescription("features.enableBreakGlassConfigs", schema), &flagConfig.Features.EnableBreakGlassConfigs)
 
 	rootCmdFlagBinder.BoolVar("disable-controller-runtime-cache",
-		"disable watch-based cache for controller-runtime (affects performance)", &flagConfig.Features.DisableControllerRuntimeCache)
+		flagDescription("features.disableControllerRuntimeCache", schema), &flagConfig.Features.DisableControllerRuntimeCache)
 
-	rootCmdFlagBinder.BoolVar("enable-cluster-import", "enable EXPERIMENTAL cluster import feature.", &flagConfig.Features.EnableClusterImport)
+	rootCmdFlagBinder.BoolVar("enable-cluster-import", flagDescription("features.enableClusterImport", schema), &flagConfig.Features.EnableClusterImport)
 }
 
-func defineDebugFlags() {
-	rootCmdFlagBinder.StringVar("pprof-bind-addr", "start pprof HTTP server on the defined address (\"\" if disabled).", &flagConfig.Debug.Pprof.Endpoint)
-	rootCmdFlagBinder.StringVar("debug-server-endpoint", "start debug HTTP server on the defined address (\"\" if disabled).", &flagConfig.Debug.Server.Endpoint)
+func defineDebugFlags(rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
+	rootCmdFlagBinder.StringVar("pprof-bind-addr", flagDescription("debug.pprof.endpoint", schema), &flagConfig.Debug.Pprof.Endpoint)
+	rootCmdFlagBinder.StringVar("debug-server-endpoint", flagDescription("debug.server.endpoint", schema), &flagConfig.Debug.Server.Endpoint)
 }
 
-func defineEtcdBackupsFlags() {
-	rootCmdFlagBinder.BoolVar("etcd-backup-s3", "S3 will be used for cluster etcd backups", &flagConfig.EtcdBackup.S3Enabled)
-	rootCmdFlagBinder.StringVar("etcd-backup-local-path", "path to local directory for cluster etcd backups", &flagConfig.EtcdBackup.LocalPath)
+func defineEtcdBackupsFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
+	rootCmdFlagBinder.BoolVar("etcd-backup-s3", flagDescription("etcdBackup.s3Enabled", schema), &flagConfig.EtcdBackup.S3Enabled)
+	rootCmdFlagBinder.StringVar("etcd-backup-local-path", flagDescription("etcdBackup.localPath", schema), &flagConfig.EtcdBackup.LocalPath)
 	rootCmdFlagBinder.DurationVar("etcd-backup-tick-interval",
-		"interval between etcd backups ticks (controller events to check if any cluster needs to be backed up)", &flagConfig.EtcdBackup.TickInterval)
+		flagDescription("etcdBackup.tickInterval", schema), &flagConfig.EtcdBackup.TickInterval)
 	rootCmdFlagBinder.DurationVar("etcd-backup-jitter",
-		"jitter for etcd backups, randomly added/subtracted from the interval between automatic etcd backups", &flagConfig.EtcdBackup.Jitter)
-	rootCmdFlagBinder.DurationVar("etcd-backup-min-interval", "minimal interval between etcd backups", &flagConfig.EtcdBackup.MinInterval)
-	rootCmdFlagBinder.DurationVar("etcd-backup-max-interval", "maximal interval between etcd backups", &flagConfig.EtcdBackup.MaxInterval)
-	rootCmdFlagBinder.Uint64Var("etcd-backup-upload-limit-mbps", "throughput limit in Mbps for etcd backup uploads, zero means unlimited", &flagConfig.EtcdBackup.UploadLimitMbps)
-	rootCmdFlagBinder.Uint64Var("etcd-backup-download-limit-mbps", "throughput limit in Mbps for etcd backup downloads, zero means unlimited", &flagConfig.EtcdBackup.DownloadLimitMbps)
+		flagDescription("etcdBackup.jitter", schema), &flagConfig.EtcdBackup.Jitter)
+	rootCmdFlagBinder.DurationVar("etcd-backup-min-interval", flagDescription("etcdBackup.minInterval", schema), &flagConfig.EtcdBackup.MinInterval)
+	rootCmdFlagBinder.DurationVar("etcd-backup-max-interval", flagDescription("etcdBackup.maxInterval", schema), &flagConfig.EtcdBackup.MaxInterval)
+	rootCmdFlagBinder.Uint64Var("etcd-backup-upload-limit-mbps", flagDescription("etcdBackup.uploadLimitMbps", schema), &flagConfig.EtcdBackup.UploadLimitMbps)
+	rootCmdFlagBinder.Uint64Var("etcd-backup-download-limit-mbps", flagDescription("etcdBackup.downloadLimitMbps", schema), &flagConfig.EtcdBackup.DownloadLimitMbps)
 
 	rootCmd.MarkFlagsMutuallyExclusive("etcd-backup-s3", "etcd-backup-local-path")
+}
+
+func flagDescription(fieldPath string, schema *jsonschema.Schema) string {
+	description := schema.Description(fieldPath)
+	if description == "" {
+		panic("no description for " + fieldPath)
+	}
+
+	// remove the first two words like "XYZ is" from the description
+	parts := strings.SplitN(description, " ", 3)
+	if len(parts) < 3 {
+		return description
+	}
+
+	return strings.TrimSpace(parts[2])
 }

--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -37,14 +37,15 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 	"github.com/siderolabs/omni/internal/pkg/features"
+	"github.com/siderolabs/omni/internal/pkg/jsonschema"
 	"github.com/siderolabs/omni/internal/pkg/siderolink"
 )
 
 // PrepareConfig prepare the Omni configuration.
-func PrepareConfig(logger *zap.Logger, params ...*config.Params) (*config.Params, error) {
+func PrepareConfig(logger *zap.Logger, schema *jsonschema.Schema, params ...*config.Params) (*config.Params, error) {
 	var err error
 
-	config.Config, err = config.Init(logger, params...)
+	config.Config, err = config.Init(logger, schema, params...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/grpc/validate.go
+++ b/internal/backend/grpc/validate.go
@@ -138,7 +138,7 @@ func (s *managementServer) ValidateJSONSchema(ctx context.Context, request *mana
 		return nil, err
 	}
 
-	err = omnijsonschema.Validate(request.Data, schema)
+	err = schema.Validate(request.Data)
 	if err != nil {
 		var validationError *jsonschema.ValidationError
 		if !errors.As(err, &validationError) {

--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -1312,7 +1312,7 @@ func validateProviderData(ctx context.Context, st state.State, providerID, provi
 			return fmt.Errorf("failed to load json schema for provider %q: %w", providerID, err)
 		}
 
-		return omnijsonschema.Validate(providerData, schema)
+		return schema.Validate(providerData)
 	}
 
 	providerStatus, err := safe.ReaderGetByID[*infra.ProviderStatus](ctx, st, providerID)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -471,7 +471,12 @@ func runOmni(t *testing.T) (string, error) {
 		logger = zap.New(core)
 	}
 
-	config, err := app.PrepareConfig(logger, params)
+	configSchema, err := config.ParseSchema()
+	if err != nil {
+		return "", fmt.Errorf("failed to parse config schema: %w", err)
+	}
+
+	config, err := app.PrepareConfig(logger, configSchema, params)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Params",
+  "description": "Params is the Omni configuration root object.",
   "type": "object",
   "required": [
     "account",
@@ -20,30 +21,39 @@
   },
   "properties": {
     "account": {
+      "description": "Account contains account-related configuration.",
       "$ref": "#/definitions/Account"
     },
     "services": {
+      "description": "Services contains configuration for various services run by Omni.",
       "$ref": "#/definitions/Services"
     },
     "auth": {
+      "description": "Auth contains authentication-related configuration.",
       "$ref": "#/definitions/Auth"
     },
     "logs": {
+      "description": "Logs contains logging-related configuration.",
       "$ref": "#/definitions/Logs"
     },
     "storage": {
+      "description": "Storage contains persistent storage related configuration.",
       "$ref": "#/definitions/Storage"
     },
     "etcdBackup": {
+      "description": "EtcdBackup contains etcd backup configuration for the clusters on Omni.",
       "$ref": "#/definitions/EtcdBackup"
     },
     "registries": {
+      "description": "Registries contains container image registries configuration.",
       "$ref": "#/definitions/Registries"
     },
     "debug": {
+      "description": "Debug contains debug-related configuration.",
       "$ref": "#/definitions/Debug"
     },
     "features": {
+      "description": "Features contains feature flags to enable/disable various Omni features.",
       "$ref": "#/definitions/Features"
     }
   },
@@ -59,7 +69,7 @@
         "id": {
           "type": "string",
           "minLength": 1,
-          "description": "Stable identifier of the instance.",
+          "description": "Id is the unique UUID identifier of the account. It is used to uniquely identify the account in etcd, therefore it should never be changed after initial setup.",
           "goJSONSchema": {
             "type": "*string"
           }
@@ -67,12 +77,13 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "description": "User-facing name of the instance.",
+          "description": "Name is the human-readable name of the account.",
           "goJSONSchema": {
             "type": "*string"
           }
         },
         "userPilot": {
+          "description": "UserPilot contains UserPilot-related configuration.",
           "$ref": "#/definitions/UserPilot"
         }
       }
@@ -81,6 +92,7 @@
       "type": "object",
       "properties": {
         "appToken": {
+          "description": "AppToken is the UserPilot application token.",
           "type": "string"
         }
       }
@@ -95,6 +107,7 @@
       "properties": {
         "talos": {
           "type": "string",
+          "description": "Talos is the Talos installer registry configuration.",
           "minLength": 1,
           "goJSONSchema": {
             "type": "*string"
@@ -102,6 +115,7 @@
         },
         "kubernetes": {
           "type": "string",
+          "description": "Kubernetes is the Kubernetes container registry configuration.",
           "minLength": 1,
           "goJSONSchema": {
             "type": "*string"
@@ -109,15 +123,18 @@
         },
         "imageFactoryBaseURL": {
           "type": "string",
+          "description": "ImageFactoryBaseURL is the base URL of the Image Factory service used to build custom machine images.",
           "minLength": 1,
           "goJSONSchema": {
             "type": "*string"
           }
         },
         "imageFactoryPXEBaseURL": {
+          "description": "ImageFactoryPXEBaseURL is the base URL of the Image Factory PXE endpoint used to build custom PXE boot images.",
           "type": "string"
         },
         "mirrors": {
+          "description": "Mirrors is the list of container image registry mirrors. Used mainly for the development purposes. It must be in the format: <registry host>=<mirror URL>",
           "type": "array",
           "goJSONSchema": {
             "extraTags": {
@@ -146,34 +163,43 @@
       ],
       "properties": {
         "api": {
+          "description": "Api contains API/UI service configuration.",
           "$ref": "#/definitions/Service"
         },
         "devServerProxy": {
+          "description": "DevServerProxy is the node dev server proxy service configuration. It exists for the development purposes only.",
           "$ref": "#/definitions/DevServerProxyService"
         },
         "metrics": {
+          "description": "Metrics contains metrics service configuration.",
           "$ref": "#/definitions/Service"
         },
         "kubernetesProxy": {
+          "description": "KubernetesProxy contains Kubernetes proxy service configuration. It is the service responsible for proxying Kubernetes API requests to the clusters.",
           "$ref": "#/definitions/KubernetesProxyService"
         },
         "siderolink": {
+          "description": "Siderolink contains SideroLink service configuration. It is the service responsible for node<>Omni connectivity via WireGuard.",
           "$ref": "#/definitions/SiderolinkService"
         },
         "machineAPI": {
-          "$ref": "#/definitions/Service",
-          "description": "Config for MachineAPI"
+          "description": "MachineAPI contains SideroLink API service configuration. It is responsible for provisioning SideroLink connections by validating node join requests and issuing machine join tokens.",
+          "$ref": "#/definitions/Service"
         },
         "localResourceService": {
+          "description": "LocalResourceService contains local resource service configuration. Omni runs a local service to allow access to its resources without authorization checks. It is primarily used by infra providers (e.g., sidecars).",
           "$ref": "#/definitions/LocalResourceService"
         },
         "embeddedDiscoveryService": {
+          "description": "EmbeddedDiscoveryService contains embedded discovery service configuration. Omni can run an embedded discovery service to allow nodes to discover each other, instead of them resorting to discovery.talos.dev.",
           "$ref": "#/definitions/EmbeddedDiscoveryService"
         },
         "loadBalancer": {
+          "description": "LoadBalancer contains load balancer service configuration. It is responsible for creating and managing load balancers of the clusters' control planes.",
           "$ref": "#/definitions/LoadBalancerService"
         },
         "workloadProxy": {
+          "description": "WorkloadProxy contains workload proxy service configuration. It is responsible for exposing workloads run on the clusters via Omni to the outside world.",
           "$ref": "#/definitions/WorkloadProxy"
         }
       }
@@ -182,36 +208,45 @@
       "type": "object",
       "properties": {
         "endpoint": {
+          "description": "Endpoint is the network endpoint the service listens on. It is in the form \"host:port\".",
           "type": "string"
         },
         "advertisedURL": {
+          "description": "AdvertisedURL is the URL that the service advertises to clients. It is in the form \"http(s)://host:port\". When not set, it is generated by the system based on the endpoint and TLS cert/key configuration.",
           "type": "string"
         },
         "certFile": {
+          "description": "CertFile is the path to the TLS certificate file for the service.",
           "type": "string"
         },
         "keyFile": {
+          "description": "KeyFile is the path to the TLS key file for the service.",
           "type": "string"
         }
       }
     },
     "DevServerProxyService": {
       "type": "object",
-      "description": "Embeds Service",
+      "description": "DevServerProxyService contains development server proxy service configuration.",
       "properties": {
         "endpoint": {
+          "description": "Endpoint is the network endpoint the dev server proxy service listens on. It is in the form \"host:port\".",
           "type": "string"
         },
         "advertisedURL": {
+          "description": "AdvertisedURL is the URL that the dev server proxy service advertises to clients. It is in the form \"http(s)://host:port\". When not set, it is generated by the system based on the endpoint and TLS cert/key configuration.",
           "type": "string"
         },
         "certFile": {
+          "description": "CertFile is the path to the TLS certificate file for the dev server proxy service.",
           "type": "string"
         },
         "keyFile": {
+          "description": "KeyFile is the path to the TLS key file for the dev server proxy service.",
           "type": "string"
         },
         "proxyTo": {
+          "description": "ProxyTo is the address to which the dev server proxy service forwards incoming requests. It is in the form \"http(s)://host:port\".",
           "type": "string"
         }
       }
@@ -220,16 +255,20 @@
       "type": "object",
       "properties": {
         "endpoint": {
+          "description": "Endpoint is the network endpoint the Kubernetes proxy service listens on. It is in the form \"host:port\".",
           "type": "string"
         },
         "advertisedURL": {
+          "description": "AdvertisedURL is the URL that the Kubernetes proxy service advertises to clients. It is in the form \"https://host:port\". When not set, it is generated by the system based on the endpoint and TLS cert/key configuration.",
           "type": "string",
           "pattern": "^https://"
         },
         "certFile": {
+          "description": "CertFile is the path to the TLS certificate file for the Kubernetes proxy service.",
           "type": "string"
         },
         "keyFile": {
+          "description": "KeyFile is the path to the TLS key file for the Kubernetes proxy service.",
           "type": "string"
         }
       }
@@ -241,9 +280,11 @@
       ],
       "properties": {
         "wireGuard": {
+          "description": "WireGuard contains WireGuard-specific configuration for the SideroLink service.",
           "$ref": "#/definitions/SiderolinkWireGuard"
         },
         "joinTokensMode": {
+          "description": "JoinTokensMode configures how machine join tokens are generated and used. Set to strict to use the secure join tokens mode.",
           "type": "string",
           "enum": [
             "strict",
@@ -252,15 +293,19 @@
           ]
         },
         "disableLastEndpoint": {
+          "description": "DisableLastEndpoint controls whether the SideroLink service should stop using the last known endpoint of a node when it becomes unreachable via WireGuard.",
           "type": "boolean"
         },
         "useGRPCTunnel": {
+          "description": "UseGRPCTunnel controls whether the SideroLink service should tunnel WireGuard traffic over gRPC, in setups where direct Wireguard connectivity is not possible (e.g., due to firewall restrictions). When enabled, the SideroLink connections from Talos machines will be configured to use the tunnel mode, regardless of their individual configuration.",
           "type": "boolean"
         },
         "eventSinkPort": {
+          "description": "EventSinkPort is the port to be used by the nodes to publish their events over SideroLink to Omni.",
           "type": "integer"
         },
         "logServerPort": {
+          "description": "LogServerPort is the port to be used by the nodes to send their logs over SideroLink to Omni.",
           "type": "integer"
         }
       }
@@ -269,9 +314,11 @@
       "type": "object",
       "properties": {
         "endpoint": {
+          "description": "Endpoint is the network endpoint the WireGuard interface listens on. It is in the form \"ip:port\" (IP address is required, not hostname).",
           "type": "string"
         },
         "advertisedEndpoint": {
+          "description": "AdvertisedEndpoint is the endpoint that the SideroLink service advertises to nodes for WireGuard connectivity. It is in the form \"ip:port\" (IP address is required, not hostname). When not set, it is generated by the system based on the WireGuard endpoint.",
           "type": "string"
         }
       }
@@ -280,9 +327,11 @@
       "type": "object",
       "properties": {
         "enabled": {
+          "description": "Enabled controls whether the local resource service is enabled.",
           "type": "boolean"
         },
         "port": {
+          "description": "Port is the network port the local resource service listens on.",
           "type": "integer"
         }
       }
@@ -291,19 +340,24 @@
       "type": "object",
       "properties": {
         "enabled": {
+          "description": "Enabled controls whether the embedded discovery service is enabled. It binds only to the SideroLink WireGuard address.",
           "type": "boolean"
         },
         "port": {
+          "description": "Port is the network port the embedded discovery service listens on.",
           "type": "integer"
         },
         "snapshotsEnabled": {
+          "description": "SnapshotsEnabled controls whether the embedded discovery service periodically persists snapshots of its state to disk.",
           "type": "boolean"
         },
         "snapshotsPath": {
+          "description": "SnapshotsPath is the path where the embedded discovery service persists its snapshots. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "string",
           "deprecated": true
         },
         "snapshotsInterval": {
+          "description": "SnapshotsInterval is the interval at which the embedded discovery service persists snapshots of its state.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -311,9 +365,11 @@
           }
         },
         "logLevel": {
+          "description": "LogLevel is the logging level used by the embedded discovery service.",
           "type": "string"
         },
         "sqliteTimeout": {
+          "description": "SqliteTimeout is the timeout for SQLite operations used by the embedded discovery service.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -326,12 +382,15 @@
       "type": "object",
       "properties": {
         "minPort": {
+          "description": "MinPort is the minimum port number that can be picked by the load balancer service when allocating a new LB port to a cluster.",
           "type": "integer"
         },
         "maxPort": {
+          "description": "MaxPort is the maximum port number that can be picked by the load balancer service when allocating a new LB port to a cluster.",
           "type": "integer"
         },
         "dialTimeout": {
+          "description": "DialTimeout is the timeout used by the load balancer service when dialing backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -339,6 +398,7 @@
           }
         },
         "keepAlivePeriod": {
+          "description": "KeepAlivePeriod is the period used by the load balancer service for keep-alive pings to backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -346,6 +406,7 @@
           }
         },
         "tcpUserTimeout": {
+          "description": "TCPUserTimeout is the TCP user timeout value set on connections between the load balancer and backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -353,6 +414,7 @@
           }
         },
         "healthCheckInterval": {
+          "description": "HealthCheckInterval is the interval between health checks performed by the load balancer service on backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -360,6 +422,7 @@
           }
         },
         "healthCheckTimeout": {
+          "description": "HealthCheckTimeout is the timeout for health checks performed by the load balancer service on backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -372,12 +435,15 @@
       "type": "object",
       "properties": {
         "subdomain": {
+          "description": "Subdomain is the subdomain used by the workload proxy service to expose workloads. This subdomain lives at the same level as Omni, for example, if Omni is accessible at \"omni.example.com\", and the subdomain is \"omni-apps\", workloads will be exposed at \"<service-prefix>.omni-apps.example.com\".",
           "type": "string"
         },
         "enabled": {
+          "description": "Enabled controls whether the workload proxy service is enabled.",
           "type": "boolean"
         },
         "stopLBsAfter": {
+          "description": "StopLBsAfter is the duration after which the workload proxy service stops load balancers for workloads that have not received any traffic.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -513,30 +579,38 @@
       },
       "properties": {
         "auth0": {
+          "description": "Auth0 contains Auth0 authentication provider configuration.",
           "$ref": "#/definitions/Auth0"
         },
         "webauthn": {
+          "description": "Webauthn contains WebAuthn authentication configuration. It is NOT SUPPORTED as it is currently unimplemented.",
           "$ref": "#/definitions/WebAuthn"
         },
         "saml": {
+          "description": "Saml contains SAML authentication provider configuration.",
           "$ref": "#/definitions/SAML"
         },
         "oidc": {
+          "description": "Oidc contains OIDC authentication provider configuration.",
           "$ref": "#/definitions/OIDC"
         },
         "initialUsers": {
+          "description": "InitialUsers is a list of emails which should be created as admins when Omni is run for the first time.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "keyPruner": {
+          "description": "KeyPruner contains configuration for the public keys pruner (cleanup of old/expired keys).",
           "$ref": "#/definitions/KeyPrunerConfig"
         },
         "suspended": {
+          "description": "Suspended is whether the Omni account is suspended. If true, Omni will run on read-only mode with a warning banner displayed in the UI.",
           "type": "boolean"
         },
         "initialServiceAccount": {
+          "description": "InitialServiceAccount contains configuration for the initial service account created when Omni is run for the first time.",
           "$ref": "#/definitions/InitialServiceAccount"
         }
       }
@@ -545,6 +619,7 @@
       "type": "object",
       "properties": {
         "initialUsers": {
+          "description": "InitialUsers is a list of emails which should be created as admins when Omni is run for the first time. DEPRECATED: use params.auth.initialUsers instead, this will be removed.",
           "type": "array",
           "items": {
             "type": "string"
@@ -552,15 +627,19 @@
           "deprecated": true
         },
         "domain": {
+          "description": "Domain is the Auth0 domain.",
           "type": "string"
         },
         "clientID": {
+          "description": "ClientID is the Auth0 client ID.",
           "type": "string"
         },
         "useFormData": {
+          "description": "UseFormData controls whether the Auth0 provider should use form data for authentication requests. When true, data to the token endpoint is transmitted as x-www-form-urlencoded data instead of JSON.",
           "type": "boolean"
         },
         "enabled": {
+          "description": "Enabled controls whether the Auth0 authentication provider is enabled. Once set to true, it cannot be set back to false.",
           "type": "boolean"
         }
       }
@@ -569,10 +648,14 @@
       "type": "object",
       "properties": {
         "enabled": {
-          "type": "boolean"
+          "description": "Enabled controls whether WebAuthn authentication is enabled. It is NOT SUPPORTED as it is currently unimplemented.",
+          "type": "boolean",
+          "const": false
         },
         "required": {
-          "type": "boolean"
+          "description": "Required controls whether WebAuthn authentication is required. It is NOT SUPPORTED as it is currently unimplemented.",
+          "type": "boolean",
+          "const": false
         }
       }
     },
@@ -580,27 +663,34 @@
       "type": "object",
       "properties": {
         "providerURL": {
+          "description": "ProviderURL is the OIDC provider URL.",
           "type": "string"
         },
         "clientID": {
+          "description": "ClientID is the OIDC client ID.",
           "type": "string"
         },
         "clientSecret": {
+          "description": "ClientSecret is the OIDC client secret.",
           "type": "string"
         },
         "logoutURL": {
+          "description": "LogoutURL is the OIDC logout URL.",
           "type": "string"
         },
         "scopes": {
+          "description": "Scopes is the list of OIDC scopes to request during authentication.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "enabled": {
+          "description": "Enabled controls whether the OIDC authentication provider is enabled.",
           "type": "boolean"
         },
         "allowUnverifiedEmail": {
+          "description": "AllowUnverifiedEmail controls whether users with unverified emails (without email_verified claim) are allowed to authenticate.",
           "type": "boolean"
         }
       }
@@ -619,27 +709,33 @@
       },
       "properties": {
         "labelRules": {
+          "description": "LabelRules defines mapping of SAML assertion attributes into Omni identity labels.",
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
         "attributeRules": {
+          "description": "AttributeRules defines additional identity, fullname, firstname and lastname mappings.",
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
         "url": {
+          "description": "URL is the SAML provider URL. Mutually exclusive with metadata URL (.metadata).",
           "type": "string"
         },
         "metadata": {
+          "description": "Metadata is the SAML provider metadata URL. Mutually exclusive with URL (.url).",
           "type": "string"
         },
         "nameIDFormat": {
+          "description": "NameIDFormat is the SAML NameID format to be used.",
           "type": "string"
         },
         "enabled": {
+          "description": "Enabled controls whether the SAML authentication provider is enabled.",
           "type": "boolean"
         }
       }
@@ -648,6 +744,7 @@
       "type": "object",
       "properties": {
         "interval": {
+          "description": "Interval is the interval at which the key pruner runs.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -660,15 +757,19 @@
       "type": "object",
       "properties": {
         "role": {
+          "description": "Role is the role assigned to the initial service account.",
           "type": "string"
         },
         "keyPath": {
+          "description": "KeyPath is the path where the initial service account key is stored.",
           "type": "string"
         },
         "name": {
+          "description": "Name is the name of the initial service account.",
           "type": "string"
         },
         "lifetime": {
+          "description": "Lifetime is the lifetime of the initial service account key.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -676,6 +777,7 @@
           }
         },
         "enabled": {
+          "description": "Enabled controls whether the initial service account is created. This happens only on the first start of Omni.",
           "type": "boolean"
         }
       }
@@ -690,15 +792,19 @@
       ],
       "properties": {
         "machine": {
+          "description": "Machine contains machine logs configuration.",
           "$ref": "#/definitions/LogsMachine"
         },
         "audit": {
+          "description": "Audit contains audit logs configuration.",
           "$ref": "#/definitions/LogsAudit"
         },
         "resourceLogger": {
+          "description": "ResourceLogger contains resource logger configuration. It logs the diffs for the watched resources when they are updated.",
           "$ref": "#/definitions/ResourceLoggerConfig"
         },
         "stripe": {
+          "description": "Stripe contains Stripe logs configuration.",
           "$ref": "#/definitions/LogsStripe"
         }
       }
@@ -710,17 +816,21 @@
       ],
       "properties": {
         "storage": {
+          "description": "Storage contains configuration for machine logs storage.",
           "$ref": "#/definitions/LogsMachineStorage"
         },
         "bufferInitialCapacity": {
+          "description": "BufferInitialCapacity is the initial capacity of the in-memory circular buffer for machine logs. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "integer",
           "deprecated": true
         },
         "bufferMaxCapacity": {
+          "description": "BufferMaxCapacity is the maximum capacity of the in-memory circular buffer for machine logs. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "integer",
           "deprecated": true
         },
         "bufferSafetyGap": {
+          "description": "BufferSafetyGap is the safety gap to avoid overwriting logs that are being read while writing new logs into the circular buffer. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "integer",
           "deprecated": true
         }
@@ -730,14 +840,17 @@
       "type": "object",
       "properties": {
         "enabled": {
+          "description": "Enabled controls whether machine logs storage is enabled. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "boolean",
           "deprecated": true
         },
         "path": {
+          "description": "Path is the path where machine logs are stored. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "string",
           "deprecated": true
         },
         "flushPeriod": {
+          "description": "FlushPeriod is the period at which machine logs are flushed to storage. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -746,14 +859,17 @@
           "deprecated": true
         },
         "flushJitter": {
+          "description": "FlushJitter is the jitter added to the flush period to avoid thundering herd problem. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "number",
           "deprecated": true
         },
         "numCompressedChunks": {
+          "description": "NumCompressedChunks is the number of compressed chunks to keep in memory before flushing to storage. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "integer",
           "deprecated": true
         },
         "sqliteTimeout": {
+          "description": "SqliteTimeout is the timeout for SQLite operations used for machine logs storage.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -761,6 +877,7 @@
           }
         },
         "cleanupInterval": {
+          "description": "CleanupInterval is the interval at which old machine logs are cleaned up.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -768,6 +885,7 @@
           }
         },
         "cleanupOlderThan": {
+          "description": "CleanupOlderThan is the duration after which machine logs are considered old and eligible for cleanup.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -775,9 +893,11 @@
           }
         },
         "maxLinesPerMachine": {
+          "description": "MaxLinesPerMachine is the maximum number of log lines to keep per machine.",
           "type": "integer"
         },
         "cleanupProbability": {
+          "description": "CleanupProbability is the probability of triggering the cleanup on each log write for that machine.",
           "type": "number"
         }
       }
@@ -786,13 +906,16 @@
       "type": "object",
       "properties": {
         "enabled": {
+          "description": "Enabled controls whether audit logging is enabled.",
           "type": "boolean"
         },
         "path": {
+          "description": "Path is the path where audit logs are stored. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "type": "string",
           "deprecated": true
         },
         "sqliteTimeout": {
+          "description": "SqliteTimeout is the timeout for SQLite operations used for audit logs storage.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -805,9 +928,11 @@
       "type": "object",
       "properties": {
         "logLevel": {
+          "description": "LogLevel is the logging level used by the resource logger.",
           "type": "string"
         },
         "types": {
+          "description": "Types is the list of resource types to be logged by the resource logger.",
           "type": "array",
           "goJSONSchema": {
             "extraTags": {
@@ -824,9 +949,11 @@
       "type": "object",
       "properties": {
         "enabled": {
+          "description": "Enabled controls whether Stripe logging is enabled.",
           "type": "boolean"
         },
         "minCommit": {
+          "description": "MinCommit is the minimum number of machines committed for billing purposes, reported to Stripe for the given account.",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -845,16 +972,20 @@
       ],
       "properties": {
         "default": {
+          "description": "Default contains the default storage backend configuration.",
           "$ref": "#/definitions/StorageDefault"
         },
         "vault": {
+          "description": "Vault contains HashiCorp Vault storage backend configuration. It is used to store the storage encryption key, used to encrypt sensitive data at rest in etcd.",
           "$ref": "#/definitions/Vault"
         },
         "secondary": {
+          "description": "Secondary contains the secondary storage backend configuration. It is used to store frequently updated and less critical data. DEPRECATED: they are now stored in SQLite, and this parameter exists for the migration purposes only, and will be removed.",
           "$ref": "#/definitions/BoltDB",
           "deprecated": true
         },
         "sqlite": {
+          "description": "Sqlite contains SQLite storage backend configuration. It is used to store machine logs, audit logs, discovery service state, and as the secondary storage for the frequently updated and less critical data.",
           "$ref": "#/definitions/SQLite"
         }
       }
@@ -863,9 +994,11 @@
       "type": "object",
       "properties": {
         "url": {
+          "description": "Url is the URL of the Vault server.",
           "type": "string"
         },
         "token": {
+          "description": "Token is the authentication token for the Vault server. It is read from VAULT_TOKEN env var when not set. It is recommended to be passed as env var instead of being stored in the config file.",
           "type": "string"
         }
       }
@@ -878,6 +1011,7 @@
       ],
       "properties": {
         "kind": {
+          "description": "Kind is the kind of the default storage backend.",
           "type": "string",
           "enum": [
             "etcd",
@@ -885,9 +1019,11 @@
           ]
         },
         "boltdb": {
+          "description": "Boltdb contains BoltDB storage backend configuration.",
           "$ref": "#/definitions/BoltDB"
         },
         "etcd": {
+          "description": "Etcd contains etcd storage backend configuration.",
           "$ref": "#/definitions/EtcdParams"
         }
       }
@@ -896,6 +1032,7 @@
       "type": "object",
       "properties": {
         "path": {
+          "description": "Path is the path where the BoltDB database file is stored.",
           "type": "string"
         }
       }
@@ -907,6 +1044,7 @@
       ],
       "properties": {
         "path": {
+          "description": "Path is the path where the SQLite database file is stored.",
           "type": "string",
           "minLength": 1,
           "goJSONSchema": {
@@ -914,10 +1052,14 @@
           }
         },
         "experimentalBaseParams": {
-          "type": "string"
+          "description": "ExperimentalBaseParams contains the base parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. This flag is experimental and may be removed in future versions. It must not start with a question mark (?).",
+          "type": "string",
+          "pattern": "^(?:$|[^?].*)"
         },
         "extraParams": {
-          "type": "string"
+          "description": "ExtraParams contains the extra parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. It must not start with an ampersand (&).",
+          "type": "string",
+          "pattern": "^(?:$|[^&].*)"
         }
       }
     },
@@ -928,6 +1070,7 @@
       ],
       "properties": {
         "endpoints": {
+          "description": "Endpoints is the list of etcd endpoints. Only used when external etcd is used (i.e., embedded is false).",
           "type": "array",
           "goJSONSchema": {
             "extraTags": {
@@ -939,6 +1082,7 @@
           }
         },
         "dialKeepAliveTime": {
+          "description": "DialKeepAliveTime is the keep-alive time for etcd client connections.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -946,6 +1090,7 @@
           }
         },
         "dialKeepAliveTimeout": {
+          "description": "DialKeepAliveTimeout is the keep-alive timeout for etcd client connections.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -953,27 +1098,35 @@
           }
         },
         "caFile": {
+          "description": "CaFile is the path to the CA certificate file for etcd client connections.",
           "type": "string"
         },
         "certFile": {
+          "description": "CertFile is the path to the TLS certificate file for etcd client connections.",
           "type": "string"
         },
         "keyFile": {
+          "description": "KeyFile is the path to the TLS key file for etcd client connections.",
           "type": "string"
         },
         "embedded": {
+          "description": "Embedded controls whether to use embedded etcd server as the storage backend.",
           "type": "boolean"
         },
         "embeddedDBPath": {
+          "description": "EmbeddedDBPath is the path where the embedded etcd database files are stored.",
           "type": "string"
         },
         "embeddedUnsafeFsync": {
+          "description": "EmbeddedUnsafeFsync controls whether the embedded etcd server should skip fsync calls for improved performance at the cost of durability.",
           "type": "boolean"
         },
         "runElections": {
+          "description": "RunElections controls whether the embedded etcd server should run leader elections. Should be false for single-node Omni installations.",
           "type": "boolean"
         },
         "privateKeySource": {
+          "description": "PrivateKeySource is the source of the private key for the embedded etcd server. It is used for decrypting master key slot.",
           "type": "string",
           "minLength": 1,
           "goJSONSchema": {
@@ -981,6 +1134,7 @@
           }
         },
         "publicKeyFiles": {
+          "description": "PublicKeyFiles is the list of public key files for the embedded etcd server. They are used for encrypting keys slots.",
           "type": "array",
           "goJSONSchema": {
             "extraTags": {
@@ -1014,12 +1168,15 @@
       },
       "properties": {
         "localPath": {
+          "description": "LocalPath is the local path where etcd backups are stored before being uploaded to remote storage. Mutually exclusive with s3Enabled (.s3Enabled).",
           "type": "string"
         },
         "s3Enabled": {
+          "description": "S3Enabled controls whether an S3-compatible storage is used for etcd backups. Mutually exclusive with localPath (.localPath).",
           "type": "boolean"
         },
         "tickInterval": {
+          "description": "TickInterval is the interval between etcd backups ticks (controller events to check if any cluster needs to be backed up)",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -1027,6 +1184,7 @@
           }
         },
         "minInterval": {
+          "description": "MinInterval is the minimum interval between two etcd backups for a cluster.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -1034,6 +1192,7 @@
           }
         },
         "maxInterval": {
+          "description": "MaxInterval is the maximum interval between two etcd backups for a cluster.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -1041,6 +1200,7 @@
           }
         },
         "uploadLimitMbps": {
+          "description": "UploadLimitMbps is the optional upload bandwidth limit for etcd backups to remote storage in megabits per second. If not specified or is set to 0, it is unlimited.",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -1048,6 +1208,7 @@
           }
         },
         "downloadLimitMbps": {
+          "description": "DownloadLimitMbps is the optional download bandwidth limit for etcd backups from remote storage in megabits per second. If not specified or is set to 0, it is unlimited.",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -1055,6 +1216,7 @@
           }
         },
         "jitter": {
+          "description": "Jitter is the jitter for etcd backups, randomly added/subtracted from the interval between automatic etcd backups.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
           "goJSONSchema": {
@@ -1071,9 +1233,11 @@
       ],
       "properties": {
         "server": {
+          "description": "Server contains debug server configuration.",
           "$ref": "#/definitions/DebugServer"
         },
         "pprof": {
+          "description": "Pprof contains pprof profiling configuration.",
           "$ref": "#/definitions/DebugPprof"
         }
       }
@@ -1082,6 +1246,7 @@
       "type": "object",
       "properties": {
         "endpoint": {
+          "description": "Endpoint is the network endpoint the debug server listens on. It is in the form \"[host]:port\".",
           "type": "string"
         }
       }
@@ -1090,6 +1255,7 @@
       "type": "object",
       "properties": {
         "endpoint": {
+          "description": "Endpoint is the network endpoint the pprof server listens on. It is in the form \"[host]:port\".",
           "type": "string"
         }
       }
@@ -1098,18 +1264,23 @@
       "type": "object",
       "properties": {
         "enableTalosPreReleaseVersions": {
+          "description": "EnableTalosPreReleaseVersions controls whether pre-release Talos versions (e.g., release candidates, betas) are available for selection when creating/upgrading clusters.",
           "type": "boolean"
         },
         "enableBreakGlassConfigs": {
+          "description": "EnableBreakGlassConfigs controls whether break-glass machine configurations are enabled. Break-glass configs allow direct access to the machines without going through Omni. Recommended to be disabled.",
           "type": "boolean"
         },
         "enableConfigDataCompression": {
+          "description": "EnableConfigDataCompression controls whether machine configuration data stored in etcd is compressed to save space.",
           "type": "boolean"
         },
         "enableClusterImport": {
+          "description": "EnableClusterImport controls whether the cluster import feature is enabled. When enabled, users can import existing Talos clusters into Omni.",
           "type": "boolean"
         },
         "disableControllerRuntimeCache": {
+          "description": "DisableControllerRuntimeCache controls whether the controller-runtime cache is disabled. When disabled, etcd is accessed for all reads. Recommended to be enabled, unless debugging specific issues.",
           "type": "boolean"
         }
       }

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -5,537 +5,645 @@ package config
 import "time"
 
 type Account struct {
-	// Stable identifier of the instance.
+	// Id is the unique UUID identifier of the account. It is used to uniquely
+	// identify the account in etcd, therefore it should never be changed after
+	// initial setup.
 	Id *string `json:"id" yaml:"id"`
 
-	// User-facing name of the instance.
+	// Name is the human-readable name of the account.
 	Name *string `json:"name" yaml:"name"`
 
-	// UserPilot corresponds to the JSON schema field "userPilot".
+	// UserPilot contains UserPilot-related configuration.
 	UserPilot UserPilot `json:"userPilot" yaml:"userPilot"`
 }
 
 type Auth struct {
-	// Auth0 corresponds to the JSON schema field "auth0".
+	// Auth0 contains Auth0 authentication provider configuration.
 	Auth0 Auth0 `json:"auth0" yaml:"auth0"`
 
-	// InitialServiceAccount corresponds to the JSON schema field
-	// "initialServiceAccount".
+	// InitialServiceAccount contains configuration for the initial service account
+	// created when Omni is run for the first time.
 	InitialServiceAccount InitialServiceAccount `json:"initialServiceAccount" yaml:"initialServiceAccount"`
 
-	// InitialUsers corresponds to the JSON schema field "initialUsers".
+	// InitialUsers is a list of emails which should be created as admins when Omni is
+	// run for the first time.
 	InitialUsers []string `json:"initialUsers,omitempty" yaml:"initialUsers,omitempty"`
 
-	// KeyPruner corresponds to the JSON schema field "keyPruner".
+	// KeyPruner contains configuration for the public keys pruner (cleanup of
+	// old/expired keys).
 	KeyPruner KeyPrunerConfig `json:"keyPruner" yaml:"keyPruner"`
 
-	// Oidc corresponds to the JSON schema field "oidc".
+	// Oidc contains OIDC authentication provider configuration.
 	Oidc OIDC `json:"oidc" yaml:"oidc"`
 
-	// Saml corresponds to the JSON schema field "saml".
+	// Saml contains SAML authentication provider configuration.
 	Saml SAML `json:"saml" yaml:"saml"`
 
-	// Suspended corresponds to the JSON schema field "suspended".
+	// Suspended is whether the Omni account is suspended. If true, Omni will run on
+	// read-only mode with a warning banner displayed in the UI.
 	Suspended *bool `json:"suspended,omitempty" yaml:"suspended,omitempty"`
 
-	// Webauthn corresponds to the JSON schema field "webauthn".
+	// Webauthn contains WebAuthn authentication configuration. It is NOT SUPPORTED as
+	// it is currently unimplemented.
 	Webauthn WebAuthn `json:"webauthn" yaml:"webauthn"`
 }
 
 type Auth0 struct {
-	// ClientID corresponds to the JSON schema field "clientID".
+	// ClientID is the Auth0 client ID.
 	ClientID *string `json:"clientID,omitempty" yaml:"clientID,omitempty"`
 
-	// Domain corresponds to the JSON schema field "domain".
+	// Domain is the Auth0 domain.
 	Domain *string `json:"domain,omitempty" yaml:"domain,omitempty"`
 
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether the Auth0 authentication provider is enabled. Once set
+	// to true, it cannot be set back to false.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// InitialUsers corresponds to the JSON schema field "initialUsers".
+	// InitialUsers is a list of emails which should be created as admins when Omni is
+	// run for the first time. DEPRECATED: use params.auth.initialUsers instead, this
+	// will be removed.
 	InitialUsers []string `json:"initialUsers,omitempty" yaml:"initialUsers,omitempty"`
 
-	// UseFormData corresponds to the JSON schema field "useFormData".
+	// UseFormData controls whether the Auth0 provider should use form data for
+	// authentication requests. When true, data to the token endpoint is transmitted
+	// as x-www-form-urlencoded data instead of JSON.
 	UseFormData *bool `json:"useFormData,omitempty" yaml:"useFormData,omitempty"`
 }
 
 type BoltDB struct {
-	// Path corresponds to the JSON schema field "path".
+	// Path is the path where the BoltDB database file is stored.
 	Path *string `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
 type Debug struct {
-	// Pprof corresponds to the JSON schema field "pprof".
+	// Pprof contains pprof profiling configuration.
 	Pprof DebugPprof `json:"pprof" yaml:"pprof"`
 
-	// Server corresponds to the JSON schema field "server".
+	// Server contains debug server configuration.
 	Server DebugServer `json:"server" yaml:"server"`
 }
 
 type DebugPprof struct {
-	// Endpoint corresponds to the JSON schema field "endpoint".
+	// Endpoint is the network endpoint the pprof server listens on. It is in the form
+	// "[host]:port".
 	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 }
 
 type DebugServer struct {
-	// Endpoint corresponds to the JSON schema field "endpoint".
+	// Endpoint is the network endpoint the debug server listens on. It is in the form
+	// "[host]:port".
 	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 }
 
-// Embeds Service
+// DevServerProxyService contains development server proxy service configuration.
 type DevServerProxyService struct {
-	// AdvertisedURL corresponds to the JSON schema field "advertisedURL".
+	// AdvertisedURL is the URL that the dev server proxy service advertises to
+	// clients. It is in the form "http(s)://host:port". When not set, it is generated
+	// by the system based on the endpoint and TLS cert/key configuration.
 	AdvertisedURL *string `json:"advertisedURL,omitempty" yaml:"advertisedURL,omitempty"`
 
-	// CertFile corresponds to the JSON schema field "certFile".
+	// CertFile is the path to the TLS certificate file for the dev server proxy
+	// service.
 	CertFile *string `json:"certFile,omitempty" yaml:"certFile,omitempty"`
 
-	// Endpoint corresponds to the JSON schema field "endpoint".
+	// Endpoint is the network endpoint the dev server proxy service listens on. It is
+	// in the form "host:port".
 	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 
-	// KeyFile corresponds to the JSON schema field "keyFile".
+	// KeyFile is the path to the TLS key file for the dev server proxy service.
 	KeyFile *string `json:"keyFile,omitempty" yaml:"keyFile,omitempty"`
 
-	// ProxyTo corresponds to the JSON schema field "proxyTo".
+	// ProxyTo is the address to which the dev server proxy service forwards incoming
+	// requests. It is in the form "http(s)://host:port".
 	ProxyTo *string `json:"proxyTo,omitempty" yaml:"proxyTo,omitempty"`
 }
 
 type EmbeddedDiscoveryService struct {
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether the embedded discovery service is enabled. It binds
+	// only to the SideroLink WireGuard address.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// LogLevel corresponds to the JSON schema field "logLevel".
+	// LogLevel is the logging level used by the embedded discovery service.
 	LogLevel *string `json:"logLevel,omitempty" yaml:"logLevel,omitempty"`
 
-	// Port corresponds to the JSON schema field "port".
+	// Port is the network port the embedded discovery service listens on.
 	Port *int `json:"port,omitempty" yaml:"port,omitempty"`
 
-	// SnapshotsEnabled corresponds to the JSON schema field "snapshotsEnabled".
+	// SnapshotsEnabled controls whether the embedded discovery service periodically
+	// persists snapshots of its state to disk.
 	SnapshotsEnabled *bool `json:"snapshotsEnabled,omitempty" yaml:"snapshotsEnabled,omitempty"`
 
-	// SnapshotsInterval corresponds to the JSON schema field "snapshotsInterval".
+	// SnapshotsInterval is the interval at which the embedded discovery service
+	// persists snapshots of its state.
 	SnapshotsInterval *time.Duration `json:"snapshotsInterval,omitempty" yaml:"snapshotsInterval,omitempty"`
 
-	// SnapshotsPath corresponds to the JSON schema field "snapshotsPath".
+	// SnapshotsPath is the path where the embedded discovery service persists its
+	// snapshots. DEPRECATED: they are now stored in SQLite, and this parameter exists
+	// for the migration purposes only, and will be removed.
 	SnapshotsPath *string `json:"snapshotsPath,omitempty" yaml:"snapshotsPath,omitempty"`
 
-	// SqliteTimeout corresponds to the JSON schema field "sqliteTimeout".
+	// SqliteTimeout is the timeout for SQLite operations used by the embedded
+	// discovery service.
 	SqliteTimeout *time.Duration `json:"sqliteTimeout,omitempty" yaml:"sqliteTimeout,omitempty"`
 }
 
 type EtcdBackup struct {
-	// DownloadLimitMbps corresponds to the JSON schema field "downloadLimitMbps".
+	// DownloadLimitMbps is the optional download bandwidth limit for etcd backups
+	// from remote storage in megabits per second. If not specified or is set to 0, it
+	// is unlimited.
 	DownloadLimitMbps *uint64 `json:"downloadLimitMbps,omitempty" yaml:"downloadLimitMbps,omitempty"`
 
-	// Jitter corresponds to the JSON schema field "jitter".
+	// Jitter is the jitter for etcd backups, randomly added/subtracted from the
+	// interval between automatic etcd backups.
 	Jitter *time.Duration `json:"jitter,omitempty" yaml:"jitter,omitempty"`
 
-	// LocalPath corresponds to the JSON schema field "localPath".
+	// LocalPath is the local path where etcd backups are stored before being uploaded
+	// to remote storage. Mutually exclusive with s3Enabled (.s3Enabled).
 	LocalPath *string `json:"localPath,omitempty" yaml:"localPath,omitempty"`
 
-	// MaxInterval corresponds to the JSON schema field "maxInterval".
+	// MaxInterval is the maximum interval between two etcd backups for a cluster.
 	MaxInterval *time.Duration `json:"maxInterval,omitempty" yaml:"maxInterval,omitempty"`
 
-	// MinInterval corresponds to the JSON schema field "minInterval".
+	// MinInterval is the minimum interval between two etcd backups for a cluster.
 	MinInterval *time.Duration `json:"minInterval,omitempty" yaml:"minInterval,omitempty"`
 
-	// S3Enabled corresponds to the JSON schema field "s3Enabled".
+	// S3Enabled controls whether an S3-compatible storage is used for etcd backups.
+	// Mutually exclusive with localPath (.localPath).
 	S3Enabled *bool `json:"s3Enabled,omitempty" yaml:"s3Enabled,omitempty"`
 
-	// TickInterval corresponds to the JSON schema field "tickInterval".
+	// TickInterval is the interval between etcd backups ticks (controller events to
+	// check if any cluster needs to be backed up)
 	TickInterval *time.Duration `json:"tickInterval,omitempty" yaml:"tickInterval,omitempty"`
 
-	// UploadLimitMbps corresponds to the JSON schema field "uploadLimitMbps".
+	// UploadLimitMbps is the optional upload bandwidth limit for etcd backups to
+	// remote storage in megabits per second. If not specified or is set to 0, it is
+	// unlimited.
 	UploadLimitMbps *uint64 `json:"uploadLimitMbps,omitempty" yaml:"uploadLimitMbps,omitempty"`
 }
 
 type EtcdParams struct {
-	// CaFile corresponds to the JSON schema field "caFile".
+	// CaFile is the path to the CA certificate file for etcd client connections.
 	CaFile *string `json:"caFile,omitempty" yaml:"caFile,omitempty"`
 
-	// CertFile corresponds to the JSON schema field "certFile".
+	// CertFile is the path to the TLS certificate file for etcd client connections.
 	CertFile *string `json:"certFile,omitempty" yaml:"certFile,omitempty"`
 
-	// DialKeepAliveTime corresponds to the JSON schema field "dialKeepAliveTime".
+	// DialKeepAliveTime is the keep-alive time for etcd client connections.
 	DialKeepAliveTime *time.Duration `json:"dialKeepAliveTime,omitempty" yaml:"dialKeepAliveTime,omitempty"`
 
-	// DialKeepAliveTimeout corresponds to the JSON schema field
-	// "dialKeepAliveTimeout".
+	// DialKeepAliveTimeout is the keep-alive timeout for etcd client connections.
 	DialKeepAliveTimeout *time.Duration `json:"dialKeepAliveTimeout,omitempty" yaml:"dialKeepAliveTimeout,omitempty"`
 
-	// Embedded corresponds to the JSON schema field "embedded".
+	// Embedded controls whether to use embedded etcd server as the storage backend.
 	Embedded *bool `json:"embedded,omitempty" yaml:"embedded,omitempty"`
 
-	// EmbeddedDBPath corresponds to the JSON schema field "embeddedDBPath".
+	// EmbeddedDBPath is the path where the embedded etcd database files are stored.
 	EmbeddedDBPath *string `json:"embeddedDBPath,omitempty" yaml:"embeddedDBPath,omitempty"`
 
-	// EmbeddedUnsafeFsync corresponds to the JSON schema field "embeddedUnsafeFsync".
+	// EmbeddedUnsafeFsync controls whether the embedded etcd server should skip fsync
+	// calls for improved performance at the cost of durability.
 	EmbeddedUnsafeFsync *bool `json:"embeddedUnsafeFsync,omitempty" yaml:"embeddedUnsafeFsync,omitempty"`
 
-	// Endpoints corresponds to the JSON schema field "endpoints".
+	// Endpoints is the list of etcd endpoints. Only used when external etcd is used
+	// (i.e., embedded is false).
 	Endpoints []string `json:"endpoints,omitempty" yaml:"endpoints,omitempty" merge:"replace"`
 
-	// KeyFile corresponds to the JSON schema field "keyFile".
+	// KeyFile is the path to the TLS key file for etcd client connections.
 	KeyFile *string `json:"keyFile,omitempty" yaml:"keyFile,omitempty"`
 
-	// PrivateKeySource corresponds to the JSON schema field "privateKeySource".
+	// PrivateKeySource is the source of the private key for the embedded etcd server.
+	// It is used for decrypting master key slot.
 	PrivateKeySource *string `json:"privateKeySource" yaml:"privateKeySource"`
 
-	// PublicKeyFiles corresponds to the JSON schema field "publicKeyFiles".
+	// PublicKeyFiles is the list of public key files for the embedded etcd server.
+	// They are used for encrypting keys slots.
 	PublicKeyFiles []string `json:"publicKeyFiles,omitempty" yaml:"publicKeyFiles,omitempty" merge:"replace"`
 
-	// RunElections corresponds to the JSON schema field "runElections".
+	// RunElections controls whether the embedded etcd server should run leader
+	// elections. Should be false for single-node Omni installations.
 	RunElections *bool `json:"runElections,omitempty" yaml:"runElections,omitempty"`
 }
 
 type Features struct {
-	// DisableControllerRuntimeCache corresponds to the JSON schema field
-	// "disableControllerRuntimeCache".
+	// DisableControllerRuntimeCache controls whether the controller-runtime cache is
+	// disabled. When disabled, etcd is accessed for all reads. Recommended to be
+	// enabled, unless debugging specific issues.
 	DisableControllerRuntimeCache *bool `json:"disableControllerRuntimeCache,omitempty" yaml:"disableControllerRuntimeCache,omitempty"`
 
-	// EnableBreakGlassConfigs corresponds to the JSON schema field
-	// "enableBreakGlassConfigs".
+	// EnableBreakGlassConfigs controls whether break-glass machine configurations are
+	// enabled. Break-glass configs allow direct access to the machines without going
+	// through Omni. Recommended to be disabled.
 	EnableBreakGlassConfigs *bool `json:"enableBreakGlassConfigs,omitempty" yaml:"enableBreakGlassConfigs,omitempty"`
 
-	// EnableClusterImport corresponds to the JSON schema field "enableClusterImport".
+	// EnableClusterImport controls whether the cluster import feature is enabled.
+	// When enabled, users can import existing Talos clusters into Omni.
 	EnableClusterImport *bool `json:"enableClusterImport,omitempty" yaml:"enableClusterImport,omitempty"`
 
-	// EnableConfigDataCompression corresponds to the JSON schema field
-	// "enableConfigDataCompression".
+	// EnableConfigDataCompression controls whether machine configuration data stored
+	// in etcd is compressed to save space.
 	EnableConfigDataCompression *bool `json:"enableConfigDataCompression,omitempty" yaml:"enableConfigDataCompression,omitempty"`
 
-	// EnableTalosPreReleaseVersions corresponds to the JSON schema field
-	// "enableTalosPreReleaseVersions".
+	// EnableTalosPreReleaseVersions controls whether pre-release Talos versions
+	// (e.g., release candidates, betas) are available for selection when
+	// creating/upgrading clusters.
 	EnableTalosPreReleaseVersions *bool `json:"enableTalosPreReleaseVersions,omitempty" yaml:"enableTalosPreReleaseVersions,omitempty"`
 }
 
 type InitialServiceAccount struct {
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether the initial service account is created. This happens
+	// only on the first start of Omni.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// KeyPath corresponds to the JSON schema field "keyPath".
+	// KeyPath is the path where the initial service account key is stored.
 	KeyPath *string `json:"keyPath,omitempty" yaml:"keyPath,omitempty"`
 
-	// Lifetime corresponds to the JSON schema field "lifetime".
+	// Lifetime is the lifetime of the initial service account key.
 	Lifetime *time.Duration `json:"lifetime,omitempty" yaml:"lifetime,omitempty"`
 
-	// Name corresponds to the JSON schema field "name".
+	// Name is the name of the initial service account.
 	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 
-	// Role corresponds to the JSON schema field "role".
+	// Role is the role assigned to the initial service account.
 	Role *string `json:"role,omitempty" yaml:"role,omitempty"`
 }
 
 type KeyPrunerConfig struct {
-	// Interval corresponds to the JSON schema field "interval".
+	// Interval is the interval at which the key pruner runs.
 	Interval *time.Duration `json:"interval,omitempty" yaml:"interval,omitempty"`
 }
 
 type KubernetesProxyService struct {
-	// AdvertisedURL corresponds to the JSON schema field "advertisedURL".
+	// AdvertisedURL is the URL that the Kubernetes proxy service advertises to
+	// clients. It is in the form "https://host:port". When not set, it is generated
+	// by the system based on the endpoint and TLS cert/key configuration.
 	AdvertisedURL *string `json:"advertisedURL,omitempty" yaml:"advertisedURL,omitempty"`
 
-	// CertFile corresponds to the JSON schema field "certFile".
+	// CertFile is the path to the TLS certificate file for the Kubernetes proxy
+	// service.
 	CertFile *string `json:"certFile,omitempty" yaml:"certFile,omitempty"`
 
-	// Endpoint corresponds to the JSON schema field "endpoint".
+	// Endpoint is the network endpoint the Kubernetes proxy service listens on. It is
+	// in the form "host:port".
 	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 
-	// KeyFile corresponds to the JSON schema field "keyFile".
+	// KeyFile is the path to the TLS key file for the Kubernetes proxy service.
 	KeyFile *string `json:"keyFile,omitempty" yaml:"keyFile,omitempty"`
 }
 
 type LoadBalancerService struct {
-	// DialTimeout corresponds to the JSON schema field "dialTimeout".
+	// DialTimeout is the timeout used by the load balancer service when dialing
+	// backend control plane nodes.
 	DialTimeout *time.Duration `json:"dialTimeout,omitempty" yaml:"dialTimeout,omitempty"`
 
-	// HealthCheckInterval corresponds to the JSON schema field "healthCheckInterval".
+	// HealthCheckInterval is the interval between health checks performed by the load
+	// balancer service on backend control plane nodes.
 	HealthCheckInterval *time.Duration `json:"healthCheckInterval,omitempty" yaml:"healthCheckInterval,omitempty"`
 
-	// HealthCheckTimeout corresponds to the JSON schema field "healthCheckTimeout".
+	// HealthCheckTimeout is the timeout for health checks performed by the load
+	// balancer service on backend control plane nodes.
 	HealthCheckTimeout *time.Duration `json:"healthCheckTimeout,omitempty" yaml:"healthCheckTimeout,omitempty"`
 
-	// KeepAlivePeriod corresponds to the JSON schema field "keepAlivePeriod".
+	// KeepAlivePeriod is the period used by the load balancer service for keep-alive
+	// pings to backend control plane nodes.
 	KeepAlivePeriod *time.Duration `json:"keepAlivePeriod,omitempty" yaml:"keepAlivePeriod,omitempty"`
 
-	// MaxPort corresponds to the JSON schema field "maxPort".
+	// MaxPort is the maximum port number that can be picked by the load balancer
+	// service when allocating a new LB port to a cluster.
 	MaxPort *int `json:"maxPort,omitempty" yaml:"maxPort,omitempty"`
 
-	// MinPort corresponds to the JSON schema field "minPort".
+	// MinPort is the minimum port number that can be picked by the load balancer
+	// service when allocating a new LB port to a cluster.
 	MinPort *int `json:"minPort,omitempty" yaml:"minPort,omitempty"`
 
-	// TcpUserTimeout corresponds to the JSON schema field "tcpUserTimeout".
+	// TCPUserTimeout is the TCP user timeout value set on connections between the
+	// load balancer and backend control plane nodes.
 	TcpUserTimeout *time.Duration `json:"tcpUserTimeout,omitempty" yaml:"tcpUserTimeout,omitempty"`
 }
 
 type LocalResourceService struct {
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether the local resource service is enabled.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// Port corresponds to the JSON schema field "port".
+	// Port is the network port the local resource service listens on.
 	Port *int `json:"port,omitempty" yaml:"port,omitempty"`
 }
 
 type Logs struct {
-	// Audit corresponds to the JSON schema field "audit".
+	// Audit contains audit logs configuration.
 	Audit LogsAudit `json:"audit" yaml:"audit"`
 
-	// Machine corresponds to the JSON schema field "machine".
+	// Machine contains machine logs configuration.
 	Machine LogsMachine `json:"machine" yaml:"machine"`
 
-	// ResourceLogger corresponds to the JSON schema field "resourceLogger".
+	// ResourceLogger contains resource logger configuration. It logs the diffs for
+	// the watched resources when they are updated.
 	ResourceLogger ResourceLoggerConfig `json:"resourceLogger" yaml:"resourceLogger"`
 
-	// Stripe corresponds to the JSON schema field "stripe".
+	// Stripe contains Stripe logs configuration.
 	Stripe LogsStripe `json:"stripe" yaml:"stripe"`
 }
 
 type LogsAudit struct {
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether audit logging is enabled.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// Path corresponds to the JSON schema field "path".
+	// Path is the path where audit logs are stored. DEPRECATED: they are now stored
+	// in SQLite, and this parameter exists for the migration purposes only, and will
+	// be removed.
 	Path *string `json:"path,omitempty" yaml:"path,omitempty"`
 
-	// SqliteTimeout corresponds to the JSON schema field "sqliteTimeout".
+	// SqliteTimeout is the timeout for SQLite operations used for audit logs storage.
 	SqliteTimeout *time.Duration `json:"sqliteTimeout,omitempty" yaml:"sqliteTimeout,omitempty"`
 }
 
 type LogsMachine struct {
-	// BufferInitialCapacity corresponds to the JSON schema field
-	// "bufferInitialCapacity".
+	// BufferInitialCapacity is the initial capacity of the in-memory circular buffer
+	// for machine logs. DEPRECATED: they are now stored in SQLite, and this parameter
+	// exists for the migration purposes only, and will be removed.
 	BufferInitialCapacity *int `json:"bufferInitialCapacity,omitempty" yaml:"bufferInitialCapacity,omitempty"`
 
-	// BufferMaxCapacity corresponds to the JSON schema field "bufferMaxCapacity".
+	// BufferMaxCapacity is the maximum capacity of the in-memory circular buffer for
+	// machine logs. DEPRECATED: they are now stored in SQLite, and this parameter
+	// exists for the migration purposes only, and will be removed.
 	BufferMaxCapacity *int `json:"bufferMaxCapacity,omitempty" yaml:"bufferMaxCapacity,omitempty"`
 
-	// BufferSafetyGap corresponds to the JSON schema field "bufferSafetyGap".
+	// BufferSafetyGap is the safety gap to avoid overwriting logs that are being read
+	// while writing new logs into the circular buffer. DEPRECATED: they are now
+	// stored in SQLite, and this parameter exists for the migration purposes only,
+	// and will be removed.
 	BufferSafetyGap *int `json:"bufferSafetyGap,omitempty" yaml:"bufferSafetyGap,omitempty"`
 
-	// Storage corresponds to the JSON schema field "storage".
+	// Storage contains configuration for machine logs storage.
 	Storage LogsMachineStorage `json:"storage" yaml:"storage"`
 }
 
 type LogsMachineStorage struct {
-	// CleanupInterval corresponds to the JSON schema field "cleanupInterval".
+	// CleanupInterval is the interval at which old machine logs are cleaned up.
 	CleanupInterval *time.Duration `json:"cleanupInterval,omitempty" yaml:"cleanupInterval,omitempty"`
 
-	// CleanupOlderThan corresponds to the JSON schema field "cleanupOlderThan".
+	// CleanupOlderThan is the duration after which machine logs are considered old
+	// and eligible for cleanup.
 	CleanupOlderThan *time.Duration `json:"cleanupOlderThan,omitempty" yaml:"cleanupOlderThan,omitempty"`
 
-	// CleanupProbability corresponds to the JSON schema field "cleanupProbability".
+	// CleanupProbability is the probability of triggering the cleanup on each log
+	// write for that machine.
 	CleanupProbability *float64 `json:"cleanupProbability,omitempty" yaml:"cleanupProbability,omitempty"`
 
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether machine logs storage is enabled. DEPRECATED: they are
+	// now stored in SQLite, and this parameter exists for the migration purposes
+	// only, and will be removed.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// FlushJitter corresponds to the JSON schema field "flushJitter".
+	// FlushJitter is the jitter added to the flush period to avoid thundering herd
+	// problem. DEPRECATED: they are now stored in SQLite, and this parameter exists
+	// for the migration purposes only, and will be removed.
 	FlushJitter *float64 `json:"flushJitter,omitempty" yaml:"flushJitter,omitempty"`
 
-	// FlushPeriod corresponds to the JSON schema field "flushPeriod".
+	// FlushPeriod is the period at which machine logs are flushed to storage.
+	// DEPRECATED: they are now stored in SQLite, and this parameter exists for the
+	// migration purposes only, and will be removed.
 	FlushPeriod *time.Duration `json:"flushPeriod,omitempty" yaml:"flushPeriod,omitempty"`
 
-	// MaxLinesPerMachine corresponds to the JSON schema field "maxLinesPerMachine".
+	// MaxLinesPerMachine is the maximum number of log lines to keep per machine.
 	MaxLinesPerMachine *int `json:"maxLinesPerMachine,omitempty" yaml:"maxLinesPerMachine,omitempty"`
 
-	// NumCompressedChunks corresponds to the JSON schema field "numCompressedChunks".
+	// NumCompressedChunks is the number of compressed chunks to keep in memory before
+	// flushing to storage. DEPRECATED: they are now stored in SQLite, and this
+	// parameter exists for the migration purposes only, and will be removed.
 	NumCompressedChunks *int `json:"numCompressedChunks,omitempty" yaml:"numCompressedChunks,omitempty"`
 
-	// Path corresponds to the JSON schema field "path".
+	// Path is the path where machine logs are stored. DEPRECATED: they are now stored
+	// in SQLite, and this parameter exists for the migration purposes only, and will
+	// be removed.
 	Path *string `json:"path,omitempty" yaml:"path,omitempty"`
 
-	// SqliteTimeout corresponds to the JSON schema field "sqliteTimeout".
+	// SqliteTimeout is the timeout for SQLite operations used for machine logs
+	// storage.
 	SqliteTimeout *time.Duration `json:"sqliteTimeout,omitempty" yaml:"sqliteTimeout,omitempty"`
 }
 
 type LogsStripe struct {
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether Stripe logging is enabled.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// MinCommit corresponds to the JSON schema field "minCommit".
+	// MinCommit is the minimum number of machines committed for billing purposes,
+	// reported to Stripe for the given account.
 	MinCommit *uint32 `json:"minCommit,omitempty" yaml:"minCommit,omitempty"`
 }
 
 type OIDC struct {
-	// AllowUnverifiedEmail corresponds to the JSON schema field
-	// "allowUnverifiedEmail".
+	// AllowUnverifiedEmail controls whether users with unverified emails (without
+	// email_verified claim) are allowed to authenticate.
 	AllowUnverifiedEmail *bool `json:"allowUnverifiedEmail,omitempty" yaml:"allowUnverifiedEmail,omitempty"`
 
-	// ClientID corresponds to the JSON schema field "clientID".
+	// ClientID is the OIDC client ID.
 	ClientID *string `json:"clientID,omitempty" yaml:"clientID,omitempty"`
 
-	// ClientSecret corresponds to the JSON schema field "clientSecret".
+	// ClientSecret is the OIDC client secret.
 	ClientSecret *string `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
 
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether the OIDC authentication provider is enabled.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// LogoutURL corresponds to the JSON schema field "logoutURL".
+	// LogoutURL is the OIDC logout URL.
 	LogoutURL *string `json:"logoutURL,omitempty" yaml:"logoutURL,omitempty"`
 
-	// ProviderURL corresponds to the JSON schema field "providerURL".
+	// ProviderURL is the OIDC provider URL.
 	ProviderURL *string `json:"providerURL,omitempty" yaml:"providerURL,omitempty"`
 
-	// Scopes corresponds to the JSON schema field "scopes".
+	// Scopes is the list of OIDC scopes to request during authentication.
 	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 }
 
+// Params is the Omni configuration root object.
 type Params struct {
-	// Account corresponds to the JSON schema field "account".
+	// Account contains account-related configuration.
 	Account Account `json:"account" yaml:"account"`
 
-	// Auth corresponds to the JSON schema field "auth".
+	// Auth contains authentication-related configuration.
 	Auth Auth `json:"auth" yaml:"auth"`
 
-	// Debug corresponds to the JSON schema field "debug".
+	// Debug contains debug-related configuration.
 	Debug Debug `json:"debug" yaml:"debug"`
 
-	// EtcdBackup corresponds to the JSON schema field "etcdBackup".
+	// EtcdBackup contains etcd backup configuration for the clusters on Omni.
 	EtcdBackup EtcdBackup `json:"etcdBackup" yaml:"etcdBackup"`
 
-	// Features corresponds to the JSON schema field "features".
+	// Features contains feature flags to enable/disable various Omni features.
 	Features Features `json:"features" yaml:"features"`
 
-	// Logs corresponds to the JSON schema field "logs".
+	// Logs contains logging-related configuration.
 	Logs Logs `json:"logs" yaml:"logs"`
 
-	// Registries corresponds to the JSON schema field "registries".
+	// Registries contains container image registries configuration.
 	Registries Registries `json:"registries" yaml:"registries"`
 
-	// Services corresponds to the JSON schema field "services".
+	// Services contains configuration for various services run by Omni.
 	Services Services `json:"services" yaml:"services"`
 
-	// Storage corresponds to the JSON schema field "storage".
+	// Storage contains persistent storage related configuration.
 	Storage Storage `json:"storage" yaml:"storage"`
 }
 
 type Registries struct {
-	// ImageFactoryBaseURL corresponds to the JSON schema field "imageFactoryBaseURL".
+	// ImageFactoryBaseURL is the base URL of the Image Factory service used to build
+	// custom machine images.
 	ImageFactoryBaseURL *string `json:"imageFactoryBaseURL" yaml:"imageFactoryBaseURL"`
 
-	// ImageFactoryPXEBaseURL corresponds to the JSON schema field
-	// "imageFactoryPXEBaseURL".
+	// ImageFactoryPXEBaseURL is the base URL of the Image Factory PXE endpoint used
+	// to build custom PXE boot images.
 	ImageFactoryPXEBaseURL *string `json:"imageFactoryPXEBaseURL,omitempty" yaml:"imageFactoryPXEBaseURL,omitempty"`
 
-	// Kubernetes corresponds to the JSON schema field "kubernetes".
+	// Kubernetes is the Kubernetes container registry configuration.
 	Kubernetes *string `json:"kubernetes" yaml:"kubernetes"`
 
-	// Mirrors corresponds to the JSON schema field "mirrors".
+	// Mirrors is the list of container image registry mirrors. Used mainly for the
+	// development purposes. It must be in the format: <registry host>=<mirror URL>
 	Mirrors []string `json:"mirrors,omitempty" yaml:"mirrors,omitempty" merge:"replace"`
 
-	// Talos corresponds to the JSON schema field "talos".
+	// Talos is the Talos installer registry configuration.
 	Talos *string `json:"talos" yaml:"talos"`
 }
 
 type ResourceLoggerConfig struct {
-	// LogLevel corresponds to the JSON schema field "logLevel".
+	// LogLevel is the logging level used by the resource logger.
 	LogLevel *string `json:"logLevel,omitempty" yaml:"logLevel,omitempty"`
 
-	// Types corresponds to the JSON schema field "types".
+	// Types is the list of resource types to be logged by the resource logger.
 	Types []string `json:"types,omitempty" yaml:"types,omitempty" merge:"replace"`
 }
 
 type SAML struct {
-	// AttributeRules corresponds to the JSON schema field "attributeRules".
+	// AttributeRules defines additional identity, fullname, firstname and lastname
+	// mappings.
 	AttributeRules SAMLAttributeRules `json:"attributeRules" yaml:"attributeRules"`
 
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether the SAML authentication provider is enabled.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// LabelRules corresponds to the JSON schema field "labelRules".
+	// LabelRules defines mapping of SAML assertion attributes into Omni identity
+	// labels.
 	LabelRules SAMLLabelRules `json:"labelRules" yaml:"labelRules"`
 
-	// Metadata corresponds to the JSON schema field "metadata".
+	// Metadata is the SAML provider metadata URL. Mutually exclusive with URL (.url).
 	Metadata *string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	// NameIDFormat corresponds to the JSON schema field "nameIDFormat".
+	// NameIDFormat is the SAML NameID format to be used.
 	NameIDFormat *string `json:"nameIDFormat,omitempty" yaml:"nameIDFormat,omitempty"`
 
-	// Url corresponds to the JSON schema field "url".
+	// URL is the SAML provider URL. Mutually exclusive with metadata URL (.metadata).
 	Url *string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
+// AttributeRules defines additional identity, fullname, firstname and lastname
+// mappings.
 type SAMLAttributeRules map[string]string
 
+// LabelRules defines mapping of SAML assertion attributes into Omni identity
+// labels.
 type SAMLLabelRules map[string]string
 
 type SQLite struct {
-	// ExperimentalBaseParams corresponds to the JSON schema field
-	// "experimentalBaseParams".
+	// ExperimentalBaseParams contains the base parameters to be used when opening the
+	// SQLite database connection. This can cause data corruption if set incorrectly,
+	// modify at your own risk. This flag is experimental and may be removed in future
+	// versions. It must not start with a question mark (?).
 	ExperimentalBaseParams *string `json:"experimentalBaseParams,omitempty" yaml:"experimentalBaseParams,omitempty"`
 
-	// ExtraParams corresponds to the JSON schema field "extraParams".
+	// ExtraParams contains the extra parameters to be used when opening the SQLite
+	// database connection. This can cause data corruption if set incorrectly, modify
+	// at your own risk. It must not start with an ampersand (&).
 	ExtraParams *string `json:"extraParams,omitempty" yaml:"extraParams,omitempty"`
 
-	// Path corresponds to the JSON schema field "path".
+	// Path is the path where the SQLite database file is stored.
 	Path *string `json:"path" yaml:"path"`
 }
 
 type Service struct {
-	// AdvertisedURL corresponds to the JSON schema field "advertisedURL".
+	// AdvertisedURL is the URL that the service advertises to clients. It is in the
+	// form "http(s)://host:port". When not set, it is generated by the system based
+	// on the endpoint and TLS cert/key configuration.
 	AdvertisedURL *string `json:"advertisedURL,omitempty" yaml:"advertisedURL,omitempty"`
 
-	// CertFile corresponds to the JSON schema field "certFile".
+	// CertFile is the path to the TLS certificate file for the service.
 	CertFile *string `json:"certFile,omitempty" yaml:"certFile,omitempty"`
 
-	// Endpoint corresponds to the JSON schema field "endpoint".
+	// Endpoint is the network endpoint the service listens on. It is in the form
+	// "host:port".
 	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 
-	// KeyFile corresponds to the JSON schema field "keyFile".
+	// KeyFile is the path to the TLS key file for the service.
 	KeyFile *string `json:"keyFile,omitempty" yaml:"keyFile,omitempty"`
 }
 
 type Services struct {
-	// Api corresponds to the JSON schema field "api".
+	// Api contains API/UI service configuration.
 	Api Service `json:"api" yaml:"api"`
 
-	// DevServerProxy corresponds to the JSON schema field "devServerProxy".
+	// DevServerProxy is the node dev server proxy service configuration. It exists
+	// for the development purposes only.
 	DevServerProxy DevServerProxyService `json:"devServerProxy" yaml:"devServerProxy"`
 
-	// EmbeddedDiscoveryService corresponds to the JSON schema field
-	// "embeddedDiscoveryService".
+	// EmbeddedDiscoveryService contains embedded discovery service configuration.
+	// Omni can run an embedded discovery service to allow nodes to discover each
+	// other, instead of them resorting to discovery.talos.dev.
 	EmbeddedDiscoveryService EmbeddedDiscoveryService `json:"embeddedDiscoveryService" yaml:"embeddedDiscoveryService"`
 
-	// KubernetesProxy corresponds to the JSON schema field "kubernetesProxy".
+	// KubernetesProxy contains Kubernetes proxy service configuration. It is the
+	// service responsible for proxying Kubernetes API requests to the clusters.
 	KubernetesProxy KubernetesProxyService `json:"kubernetesProxy" yaml:"kubernetesProxy"`
 
-	// LoadBalancer corresponds to the JSON schema field "loadBalancer".
+	// LoadBalancer contains load balancer service configuration. It is responsible
+	// for creating and managing load balancers of the clusters' control planes.
 	LoadBalancer LoadBalancerService `json:"loadBalancer" yaml:"loadBalancer"`
 
-	// LocalResourceService corresponds to the JSON schema field
-	// "localResourceService".
+	// LocalResourceService contains local resource service configuration. Omni runs a
+	// local service to allow access to its resources without authorization checks. It
+	// is primarily used by infra providers (e.g., sidecars).
 	LocalResourceService LocalResourceService `json:"localResourceService" yaml:"localResourceService"`
 
-	// Config for MachineAPI
+	// MachineAPI contains SideroLink API service configuration. It is responsible for
+	// provisioning SideroLink connections by validating node join requests and
+	// issuing machine join tokens.
 	MachineAPI Service `json:"machineAPI" yaml:"machineAPI"`
 
-	// Metrics corresponds to the JSON schema field "metrics".
+	// Metrics contains metrics service configuration.
 	Metrics Service `json:"metrics" yaml:"metrics"`
 
-	// Siderolink corresponds to the JSON schema field "siderolink".
+	// Siderolink contains SideroLink service configuration. It is the service
+	// responsible for node<>Omni connectivity via WireGuard.
 	Siderolink SiderolinkService `json:"siderolink" yaml:"siderolink"`
 
-	// WorkloadProxy corresponds to the JSON schema field "workloadProxy".
+	// WorkloadProxy contains workload proxy service configuration. It is responsible
+	// for exposing workloads run on the clusters via Omni to the outside world.
 	WorkloadProxy WorkloadProxy `json:"workloadProxy" yaml:"workloadProxy"`
 }
 
 type SiderolinkService struct {
-	// DisableLastEndpoint corresponds to the JSON schema field "disableLastEndpoint".
+	// DisableLastEndpoint controls whether the SideroLink service should stop using
+	// the last known endpoint of a node when it becomes unreachable via WireGuard.
 	DisableLastEndpoint *bool `json:"disableLastEndpoint,omitempty" yaml:"disableLastEndpoint,omitempty"`
 
-	// EventSinkPort corresponds to the JSON schema field "eventSinkPort".
+	// EventSinkPort is the port to be used by the nodes to publish their events over
+	// SideroLink to Omni.
 	EventSinkPort *int `json:"eventSinkPort,omitempty" yaml:"eventSinkPort,omitempty"`
 
-	// JoinTokensMode corresponds to the JSON schema field "joinTokensMode".
+	// JoinTokensMode configures how machine join tokens are generated and used. Set
+	// to strict to use the secure join tokens mode.
 	JoinTokensMode *SiderolinkServiceJoinTokensMode `json:"joinTokensMode,omitempty" yaml:"joinTokensMode,omitempty"`
 
-	// LogServerPort corresponds to the JSON schema field "logServerPort".
+	// LogServerPort is the port to be used by the nodes to send their logs over
+	// SideroLink to Omni.
 	LogServerPort *int `json:"logServerPort,omitempty" yaml:"logServerPort,omitempty"`
 
-	// UseGRPCTunnel corresponds to the JSON schema field "useGRPCTunnel".
+	// UseGRPCTunnel controls whether the SideroLink service should tunnel WireGuard
+	// traffic over gRPC, in setups where direct Wireguard connectivity is not
+	// possible (e.g., due to firewall restrictions). When enabled, the SideroLink
+	// connections from Talos machines will be configured to use the tunnel mode,
+	// regardless of their individual configuration.
 	UseGRPCTunnel *bool `json:"useGRPCTunnel,omitempty" yaml:"useGRPCTunnel,omitempty"`
 
-	// WireGuard corresponds to the JSON schema field "wireGuard".
+	// WireGuard contains WireGuard-specific configuration for the SideroLink service.
 	WireGuard SiderolinkWireGuard `json:"wireGuard" yaml:"wireGuard"`
 }
 
@@ -546,35 +654,46 @@ const SiderolinkServiceJoinTokensModeLegacyAllowed SiderolinkServiceJoinTokensMo
 const SiderolinkServiceJoinTokensModeStrict SiderolinkServiceJoinTokensMode = "strict"
 
 type SiderolinkWireGuard struct {
-	// AdvertisedEndpoint corresponds to the JSON schema field "advertisedEndpoint".
+	// AdvertisedEndpoint is the endpoint that the SideroLink service advertises to
+	// nodes for WireGuard connectivity. It is in the form "ip:port" (IP address is
+	// required, not hostname). When not set, it is generated by the system based on
+	// the WireGuard endpoint.
 	AdvertisedEndpoint *string `json:"advertisedEndpoint,omitempty" yaml:"advertisedEndpoint,omitempty"`
 
-	// Endpoint corresponds to the JSON schema field "endpoint".
+	// Endpoint is the network endpoint the WireGuard interface listens on. It is in
+	// the form "ip:port" (IP address is required, not hostname).
 	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 }
 
 type Storage struct {
-	// Default corresponds to the JSON schema field "default".
+	// Default contains the default storage backend configuration.
 	Default StorageDefault `json:"default" yaml:"default"`
 
-	// Secondary corresponds to the JSON schema field "secondary".
+	// Secondary contains the secondary storage backend configuration. It is used to
+	// store frequently updated and less critical data. DEPRECATED: they are now
+	// stored in SQLite, and this parameter exists for the migration purposes only,
+	// and will be removed.
 	Secondary BoltDB `json:"secondary" yaml:"secondary"`
 
-	// Sqlite corresponds to the JSON schema field "sqlite".
+	// Sqlite contains SQLite storage backend configuration. It is used to store
+	// machine logs, audit logs, discovery service state, and as the secondary storage
+	// for the frequently updated and less critical data.
 	Sqlite SQLite `json:"sqlite" yaml:"sqlite"`
 
-	// Vault corresponds to the JSON schema field "vault".
+	// Vault contains HashiCorp Vault storage backend configuration. It is used to
+	// store the storage encryption key, used to encrypt sensitive data at rest in
+	// etcd.
 	Vault Vault `json:"vault" yaml:"vault"`
 }
 
 type StorageDefault struct {
-	// Boltdb corresponds to the JSON schema field "boltdb".
+	// Boltdb contains BoltDB storage backend configuration.
 	Boltdb BoltDB `json:"boltdb" yaml:"boltdb"`
 
-	// Etcd corresponds to the JSON schema field "etcd".
+	// Etcd contains etcd storage backend configuration.
 	Etcd EtcdParams `json:"etcd" yaml:"etcd"`
 
-	// Kind corresponds to the JSON schema field "kind".
+	// Kind is the kind of the default storage backend.
 	Kind *StorageDefaultKind `json:"kind,omitempty" yaml:"kind,omitempty"`
 }
 
@@ -584,33 +703,41 @@ const StorageDefaultKindBoltdb StorageDefaultKind = "boltdb"
 const StorageDefaultKindEtcd StorageDefaultKind = "etcd"
 
 type UserPilot struct {
-	// AppToken corresponds to the JSON schema field "appToken".
+	// AppToken is the UserPilot application token.
 	AppToken *string `json:"appToken,omitempty" yaml:"appToken,omitempty"`
 }
 
 type Vault struct {
-	// Token corresponds to the JSON schema field "token".
+	// Token is the authentication token for the Vault server. It is read from
+	// VAULT_TOKEN env var when not set. It is recommended to be passed as env var
+	// instead of being stored in the config file.
 	Token *string `json:"token,omitempty" yaml:"token,omitempty"`
 
-	// Url corresponds to the JSON schema field "url".
+	// Url is the URL of the Vault server.
 	Url *string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
 type WebAuthn struct {
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether WebAuthn authentication is enabled. It is NOT
+	// SUPPORTED as it is currently unimplemented.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// Required corresponds to the JSON schema field "required".
+	// Required controls whether WebAuthn authentication is required. It is NOT
+	// SUPPORTED as it is currently unimplemented.
 	Required *bool `json:"required,omitempty" yaml:"required,omitempty"`
 }
 
 type WorkloadProxy struct {
-	// Enabled corresponds to the JSON schema field "enabled".
+	// Enabled controls whether the workload proxy service is enabled.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
-	// StopLBsAfter corresponds to the JSON schema field "stopLBsAfter".
+	// StopLBsAfter is the duration after which the workload proxy service stops load
+	// balancers for workloads that have not received any traffic.
 	StopLBsAfter *time.Duration `json:"stopLBsAfter,omitempty" yaml:"stopLBsAfter,omitempty"`
 
-	// Subdomain corresponds to the JSON schema field "subdomain".
+	// Subdomain is the subdomain used by the workload proxy service to expose
+	// workloads. This subdomain lives at the same level as Omni, for example, if Omni
+	// is accessible at "omni.example.com", and the subdomain is "omni-apps",
+	// workloads will be exposed at "<service-prefix>.omni-apps.example.com".
 	Subdomain *string `json:"subdomain,omitempty" yaml:"subdomain,omitempty"`
 }


### PR DESCRIPTION
Rework root command to get the flag descriptions from the JSON schema.

Mainly done to generate documentation and the `config` reference/comments in Helm chart v2 `values.yaml`.

The output after the changes:
```
Flags:
      --account-id string                                       the unique UUID identifier of the account. It is used to uniquely identify the account in etcd, therefore it should never be changed after initial setup.
      --advertised-api-url string                               the URL that the service advertises to clients. It is in the form "http(s)://host:port". When not set, it is generated by the system based on the endpoint and TLS cert/key configuration.
      --advertised-kubernetes-proxy-url string                  the URL that the Kubernetes proxy service advertises to clients. It is in the form "https://host:port". When not set, it is generated by the system based on the endpoint and TLS cert/key configuration.
      --audit-log-enabled                                       whether audit logging is enabled.
      --audit-log-sqlite-timeout duration                       the timeout for SQLite operations used for audit logs storage.
      --auth-auth0-client-id string                             the Auth0 client ID.
      --auth-auth0-domain string                                the Auth0 domain.
      --auth-auth0-enabled                                      whether the Auth0 authentication provider is enabled. Once set to true, it cannot be set back to false.
      --auth-auth0-use-form-data                                whether the Auth0 provider should use form data for authentication requests. When true, data to the token endpoint is transmitted as x-www-form-urlencoded data instead of JSON.
      --auth-oidc-allow-unverified-email                        whether users with unverified emails (without email_verified claim) are allowed to authenticate.
      --auth-oidc-client-id string                              the OIDC client ID.
      --auth-oidc-client-secret string                          the OIDC client secret.
      --auth-oidc-enabled                                       whether the OIDC authentication provider is enabled.
      --auth-oidc-logout-url string                             the OIDC logout URL.
      --auth-oidc-provider-url string                           the OIDC provider URL.
      --auth-oidc-scopes strings                                the list of OIDC scopes to request during authentication.
      --auth-saml-attribute-rules JSON encoded key/value map    additional identity, fullname, firstname and lastname mappings. (default null)
      --auth-saml-enabled                                       whether the SAML authentication provider is enabled.
      --auth-saml-label-rules JSON encoded key/value map        mapping of SAML assertion attributes into Omni identity labels. (default null)
      --auth-saml-metadata string                               the SAML provider metadata URL. Mutually exclusive with URL (.url).
      --auth-saml-name-id-format string                         the SAML NameID format to be used.
      --auth-saml-url string                                    the SAML provider URL. Mutually exclusive with metadata URL (.metadata).
      --auth-webauthn-enabled                                   whether WebAuthn authentication is enabled. It is NOT SUPPORTED as it is currently unimplemented.
      --auth-webauthn-required                                  whether WebAuthn authentication is required. It is NOT SUPPORTED as it is currently unimplemented.
      --bind-addr string                                        the network endpoint the service listens on. It is in the form "host:port".
      --cert string                                             the path to the TLS certificate file for the service.
      --config-data-compression-enabled                         whether machine configuration data stored in etcd is compressed to save space.
      --config-path string                                      load the config from the file, flags have bigger priority
      --create-initial-service-account                          whether the initial service account is created. This happens only on the first start of Omni.
      --debug                                                   enable debug logs. (default true)
      --debug-server-endpoint string                            the network endpoint the debug server listens on. It is in the form "[host]:port".
      --disable-controller-runtime-cache                        whether the controller-runtime cache is disabled. When disabled, etcd is accessed for all reads. Recommended to be enabled, unless debugging specific issues.
      --embedded-discovery-service-enabled                      whether the embedded discovery service is enabled. It binds only to the SideroLink WireGuard address.
      --embedded-discovery-service-log-level string             the logging level used by the embedded discovery service.
      --embedded-discovery-service-port int                     the network port the embedded discovery service listens on.
      --embedded-discovery-service-snapshot-interval duration   the interval at which the embedded discovery service persists snapshots of its state.
      --embedded-discovery-service-snapshots-enabled            whether the embedded discovery service periodically persists snapshots of its state to disk.
      --embedded-discovery-service-sqlite-timeout duration      the timeout for SQLite operations used by the embedded discovery service.
      --enable-break-glass-configs                              whether break-glass machine configurations are enabled. Break-glass configs allow direct access to the machines without going through Omni. Recommended to be disabled.
      --enable-cluster-import                                   whether the cluster import feature is enabled. When enabled, users can import existing Talos clusters into Omni.
      --enable-stripe-reporting                                 whether Stripe logging is enabled.
      --enable-talos-pre-release-versions                       whether pre-release Talos versions (e.g., release candidates, betas) are available for selection when creating/upgrading clusters.
      --etcd-backup-download-limit-mbps uint                    the optional download bandwidth limit for etcd backups from remote storage in megabits per second. If not specified or is set to 0, it is unlimited.
      --etcd-backup-jitter duration                             the jitter for etcd backups, randomly added/subtracted from the interval between automatic etcd backups.
      --etcd-backup-local-path string                           the local path where etcd backups are stored before being uploaded to remote storage. Mutually exclusive with s3Enabled (.s3Enabled).
      --etcd-backup-max-interval duration                       the maximum interval between two etcd backups for a cluster.
      --etcd-backup-min-interval duration                       the minimum interval between two etcd backups for a cluster.
      --etcd-backup-s3                                          whether an S3-compatible storage is used for etcd backups. Mutually exclusive with localPath (.localPath).
      --etcd-backup-tick-interval duration                      the interval between etcd backups ticks (controller events to check if any cluster needs to be backed up)
      --etcd-backup-upload-limit-mbps uint                      the optional upload bandwidth limit for etcd backups to remote storage in megabits per second. If not specified or is set to 0, it is unlimited.
      --etcd-ca-path string                                     the path to the CA certificate file for etcd client connections.
      --etcd-client-cert-path string                            the path to the TLS certificate file for etcd client connections.
      --etcd-client-key-path string                             the path to the TLS key file for etcd client connections.
      --etcd-dial-keepalive-time duration                       the keep-alive time for etcd client connections.
      --etcd-dial-keepalive-timeout duration                    the keep-alive timeout for etcd client connections.
      --etcd-embedded                                           whether to use embedded etcd server as the storage backend.
      --etcd-embedded-db-path string                            the path where the embedded etcd database files are stored.
      --etcd-endpoints strings                                  the list of etcd endpoints. Only used when external etcd is used (i.e., embedded is false).
      --event-sink-port int                                     the port to be used by the nodes to publish their events over SideroLink to Omni.
      --frontend-bind string                                    the network endpoint the dev server proxy service listens on. It is in the form "host:port".
      --frontend-dst string                                     the address to which the dev server proxy service forwards incoming requests. It is in the form "http(s)://host:port".
  -h, --help                                                    help for omni
      --image-factory-address string                            the base URL of the Image Factory service used to build custom machine images.
      --image-factory-pxe-address string                        the base URL of the Image Factory PXE endpoint used to build custom PXE boot images.
      --initial-service-account-key-path string                 the path where the initial service account key is stored.
      --initial-service-account-lifetime duration               the lifetime of the initial service account key.
      --initial-service-account-role string                     the role assigned to the initial service account.
      --initial-users strings                                   a list of emails which should be created as admins when Omni is run for the first time.
      --join-tokens-mode string                                 how machine join tokens are generated and used. Set to strict to use the secure join tokens mode.
      --k8s-proxy-bind-addr string                              the network endpoint the Kubernetes proxy service listens on. It is in the form "host:port".
      --key string                                              the path to the TLS key file for the service.
      --kubernetes-registry string                              the Kubernetes container registry configuration.
      --lb-max-port int                                         the maximum port number that can be picked by the load balancer service when allocating a new LB port to a cluster.
      --lb-min-port int                                         the minimum port number that can be picked by the load balancer service when allocating a new LB port to a cluster.
      --local-resource-server-enabled                           whether the local resource service is enabled.
      --local-resource-server-port int                          the network port the local resource service listens on.
      --log-resource-updates-log-level string                   the logging level used by the resource logger.
      --log-resource-updates-types strings                      the list of resource types to be logged by the resource logger.
      --log-server-port int                                     the port to be used by the nodes to send their logs over SideroLink to Omni.
      --machine-api-advertised-url string                       the URL that the service advertises to clients. It is in the form "http(s)://host:port". When not set, it is generated by the system based on the endpoint and TLS cert/key configuration.
      --machine-api-bind-addr string                            the network endpoint the service listens on. It is in the form "host:port".
      --machine-api-cert string                                 the path to the TLS certificate file for the service.
      --machine-api-key string                                  the path to the TLS key file for the service.
      --machine-log-cleanup-interval duration                   the interval at which old machine logs are cleaned up.
      --machine-log-cleanup-older-than duration                 the duration after which machine logs are considered old and eligible for cleanup.
      --machine-log-max-lines-per-machine int                   the maximum number of log lines to keep per machine.
      --machine-log-sqlite-timeout duration                     the timeout for SQLite operations used for machine logs storage.
      --metrics-bind-addr string                                the network endpoint the service listens on. It is in the form "host:port".
      --name string                                             the human-readable name of the account.
      --pprof-bind-addr string                                  the network endpoint the pprof server listens on. It is in the form "[host]:port".
      --private-key-source string                               the source of the private key for the embedded etcd server. It is used for decrypting master key slot.
      --public-key-files strings                                the list of public key files for the embedded etcd server. They are used for encrypting keys slots.
      --public-key-pruning-interval duration                    the interval at which the key pruner runs.
      --registry-mirror strings                                 the list of container image registry mirrors. Used mainly for the development purposes. It must be in the format: <registry host>=<mirror URL>
      --siderolink-api-advertised-url string                    the URL that the service advertises to clients. It is in the form "http(s)://host:port". When not set, it is generated by the system based on the endpoint and TLS cert/key configuration.
      --siderolink-disable-last-endpoint                        whether the SideroLink service should stop using the last known endpoint of a node when it becomes unreachable via WireGuard.
      --siderolink-use-grpc-tunnel                              whether the SideroLink service should tunnel WireGuard traffic over gRPC, in setups where direct Wireguard connectivity is not possible (e.g., due to firewall restrictions). When enabled, the SideroLink connections from Talos machines will be configured to use the tunnel mode, regardless of their individual configuration.
      --siderolink-wireguard-advertised-addr string             the endpoint that the SideroLink service advertises to nodes for WireGuard connectivity. It is in the form "ip:port" (IP address is required, not hostname). When not set, it is generated by the system based on the WireGuard endpoint.
      --siderolink-wireguard-bind-addr string                   the network endpoint the WireGuard interface listens on. It is in the form "ip:port" (IP address is required, not hostname).
      --sqlite-storage-experimental-base-params string          the base parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. This flag is experimental and may be removed in future versions. It must not start with a question mark (?).
      --sqlite-storage-extra-params string                      the extra parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. It must not start with an ampersand (&).
      --sqlite-storage-path string                              the path where the SQLite database file is stored.
      --storage-kind string                                     the kind of the default storage backend.
      --stripe-minimum-commit uint32                            the minimum number of machines committed for billing purposes, reported to Stripe for the given account.
      --suspended                                               whether the Omni account is suspended. If true, Omni will run on read-only mode with a warning banner displayed in the UI.
      --talos-installer-registry string                         the Talos installer registry configuration.
      --user-pilot-app-token string                             the UserPilot application token.
  -v, --version                                                 version for omni
      --workload-proxying-enabled                               whether the workload proxy service is enabled.
      --workload-proxying-stop-lbs-after duration               the duration after which the workload proxy service stops load balancers for workloads that have not received any traffic.
      --workload-proxying-subdomain string                      the subdomain used by the workload proxy service to expose workloads. This subdomain lives at the same level as Omni, for example, if Omni is accessible at "omni.example.com", and the subdomain is "omni-apps", workloads will be exposed at "<service-prefix>.omni-apps.example.com".
```