### PR TITLE
chore: enable no-explicit-any in frontend and fix errors

### DIFF
--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -75,9 +75,6 @@ export default defineConfigWithVueTs(
       // Extra rules that we want to progressively fix
       'vue/no-ref-object-reactivity-loss': 'warn',
       'vue/no-setup-props-reactivity-loss': 'warn',
-
-      // Temporarily disabled rules
-      '@typescript-eslint/no-explicit-any': 'warn',
     },
   },
 )

--- a/frontend/src/components/common/Button/TButtonGroup.vue
+++ b/frontend/src/components/common/Button/TButtonGroup.vue
@@ -10,11 +10,10 @@ import { RadioGroup, RadioGroupOption } from '@headlessui/vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 
 type Props = {
-  modelValue: any
   deselectEnabled?: boolean
   options: {
     label: string
-    value: any
+    value: string | number
     disabled?: boolean
     tooltip?: string
   }[]
@@ -22,14 +21,14 @@ type Props = {
 
 defineProps<Props>()
 
-const emit = defineEmits(['update:modelValue'])
+const modelValue = defineModel<string | number>()
 </script>
 
 <template>
   <RadioGroup
     :model-value="modelValue"
     class="t-button-group flex gap-0.5 rounded bg-naturals-n3 p-1"
-    @update:model-value="(value) => emit('update:modelValue', value)"
+    @update:model-value="(value) => (modelValue = value)"
   >
     <RadioGroupOption
       v-for="(option, index) in options"
@@ -39,7 +38,7 @@ const emit = defineEmits(['update:modelValue'])
       as="template"
       :disabled="option.disabled"
     >
-      <div @click="() => (checked && deselectEnabled ? emit('update:modelValue', null) : null)">
+      <div @click="() => (checked && deselectEnabled ? (modelValue = undefined) : null)">
         <Tooltip :description="option.tooltip" placement="top">
           <button type="button" :class="{ checked }" :disabled="option?.disabled">
             <span>

--- a/frontend/src/components/common/Form/JsonForm.vue
+++ b/frontend/src/components/common/Form/JsonForm.vue
@@ -42,7 +42,7 @@ const errors = ref<ErrorObject[]>([])
 
 const emit = defineEmits(['update:model-value'])
 
-const onChange = async (event: { data: any; errors: any }) => {
+const onChange = async (event: { data: unknown; errors: unknown }) => {
   emit('update:model-value', event.data)
 }
 
@@ -92,7 +92,7 @@ const renderers = [
 
 const props = defineProps<{
   jsonSchema: string
-  modelValue: any
+  modelValue: unknown
 }>()
 
 const { jsonSchema, modelValue } = toRefs(props)
@@ -113,7 +113,7 @@ watch(modelValue, (val) => {
   updateErrors(val)
 })
 
-const updateErrors = async (data: any) => {
+const updateErrors = async (data: unknown) => {
   if (!jsonSchema.value) {
     return
   }

--- a/frontend/src/states/cluster-management.spec.ts
+++ b/frontend/src/states/cluster-management.spec.ts
@@ -402,7 +402,7 @@ describe('cluster-management-state', () => {
 
         expect(resources.length).toBeGreaterThan(0)
 
-        const empty: Record<string, any> = {}
+        const empty: Record<string, Record<string, never>> = {}
 
         for (const key in tt.expectedResources) {
           empty[key] = {}

--- a/frontend/src/views/cluster/Nodes/NodesList.vue
+++ b/frontend/src/views/cluster/Nodes/NodesList.vue
@@ -58,8 +58,8 @@ const opts = [
       namespace: TalosClusterNamespace,
     },
     context,
-    idFunc: (item: any): string => {
-      return item.metadata.id
+    idFunc: (item: Resource): string => {
+      return item.metadata.id!
     },
   },
 ]

--- a/frontend/src/views/omni/MachineClasses/MachineClass.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClass.vue
@@ -7,7 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import yaml from 'js-yaml'
 import type { ComputedRef, Ref } from 'vue'
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -53,12 +53,7 @@ const conditions = ref([''])
 const machineClassName = ref('')
 const machineClassMode = ref(MachineClassMode.Manual)
 
-const machineClassModeOptions: {
-  label: string
-  value: any
-  tooltip: string
-  disabled?: boolean
-}[] = [
+const machineClassModeOptions = [
   {
     label: MachineClassMode.Manual,
     value: MachineClassMode.Manual,
@@ -96,7 +91,7 @@ const kernelArguments = ref<string>('')
 const initialLabels = ref<Record<string, LabelSelectItem>>({})
 const grpcTunnelMode = ref<GrpcTunnelMode>(GrpcTunnelMode.UNSET)
 
-const providerConfigs: Ref<Record<string, Record<string, any>>> = ref({})
+const providerConfigs: Ref<Record<string, Record<string, unknown>>> = ref({})
 
 if (!props.edit) {
   notFound = ref(false)
@@ -263,7 +258,7 @@ if (props.edit) {
     ) {
       providerConfigs.value[machineClass.value.spec.auto_provision.provider_id] = yaml.load(
         machineClass.value?.spec.auto_provision?.provider_data,
-      ) as Record<string, any>
+      ) as Record<string, unknown>
     }
 
     const matchLabels = machineClass.value?.spec?.match_labels
@@ -275,7 +270,7 @@ if (props.edit) {
   })
 }
 
-const placeCaretAtEnd = (el: any) => {
+const placeCaretAtEnd = (el: HTMLElement) => {
   const range = document.createRange()
   range.selectNodeContents(el)
   range.collapse(false)
@@ -296,8 +291,7 @@ const watchOpts = computed(() => {
   }
 })
 
-const conditionElements: Ref<(Node & { focus: () => void; textContent: string }[]) | null> =
-  ref(null)
+const conditionElements = useTemplateRef('conditionElements')
 
 const updateFocus = () => {
   nextTick(() => {

--- a/frontend/src/views/omni/MachineClasses/MachineTemplate.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineTemplate.vue
@@ -28,7 +28,7 @@ const props = defineProps<{
   infraProvider: string
   initialLabels: Record<string, LabelSelectItem>
   kernelArguments: string
-  providerConfig: Record<string, any>
+  providerConfig: Record<string, unknown>
   grpcTunnel: GrpcTunnelMode
 }>()
 

--- a/frontend/src/views/omni/Modals/NodeReboot.vue
+++ b/frontend/src/views/omni/Modals/NodeReboot.vue
@@ -44,7 +44,7 @@ const reboot = async () => {
     }
 
     if (errors.length > 0) throw new Error(errors.join(', '))
-  } catch (e: any) {
+  } catch (e) {
     close()
 
     showError('Failed to Issue Reboot', e.toString())

--- a/frontend/src/views/omni/Modals/NodeShutdown.vue
+++ b/frontend/src/views/omni/Modals/NodeShutdown.vue
@@ -45,7 +45,7 @@ const shutdown = async () => {
         errors.push(`${message.metadata.hostname || nodeName} ${message.metadata.error}`)
     }
     if (errors.length > 0) throw new Error(errors.join(', '))
-  } catch (e: any) {
+  } catch (e) {
     close()
 
     showError('Failed to Issue Shutdown', e.toString())


### PR DESCRIPTION
Enable the `@typescript-eslint/no-explicit-any` lint rule to prevent using any as an escape hatch, and fix any related type errors.