### PR TITLE
fix: bind wireguard to configured address instead of all interfaces

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -62,3 +62,10 @@ title = "gRPC Tunnel Management"
 description = """\
 Added the ability to switch gRPC tunnel modes for connected machines.
 """
+
+[notes.wireguard-bind-address]
+title = "WireGuard Bind Address"
+description = """\
+The WireGuard endpoint (`services.siderolink.wireGuard.endpoint` / `--siderolink-wireguard-bind-addr`) is now respected. \
+Previously, Omni always bound to all interfaces regardless of this setting. Default remains `0.0.0.0:50180`.
+"""

--- a/internal/pkg/siderolink/bind.go
+++ b/internal/pkg/siderolink/bind.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package siderolink
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"strconv"
+	"sync"
+	"syscall"
+
+	"golang.zx2c4.com/wireguard/conn"
+)
+
+// NewBoundBind creates a Bind that listens on a specific IP address.
+//
+// This is a simplified version of wireguard-go's conn.StdNetBind. The standard
+// StdNetBind always binds to all interfaces (0.0.0.0), ignoring any specific host
+// in the endpoint configuration. This implementation respects the configured host.
+//
+// As a side benefit, this also fixes connectivity issues on macOS when multiple
+// interfaces share the same subnet (wireguard-go lacks sticky socket support on macOS).
+func NewBoundBind(bindAddr string) conn.Bind {
+	return &boundBind{bindAddr: bindAddr}
+}
+
+type boundBind struct {
+	conn     *net.UDPConn
+	bindAddr string
+	mu       sync.Mutex
+}
+
+func (b *boundBind) Open(port uint16) ([]conn.ReceiveFunc, uint16, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.conn != nil {
+		return nil, 0, conn.ErrBindAlreadyOpen
+	}
+
+	addr := net.JoinHostPort(b.bindAddr, strconv.Itoa(int(port)))
+
+	c, err := (&net.ListenConfig{}).ListenPacket(context.Background(), "udp", addr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	udpConn, ok := c.(*net.UDPConn)
+	if !ok {
+		c.Close() //nolint:errcheck
+
+		return nil, 0, errors.New("expected *net.UDPConn")
+	}
+
+	b.conn = udpConn
+
+	laddr, ok := c.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		b.conn.Close() //nolint:errcheck
+		b.conn = nil
+
+		return nil, 0, errors.New("expected *net.UDPAddr")
+	}
+
+	// Capture udpConn in closure to avoid race with Close setting b.conn = nil.
+	// This matches how StdNetBind.makeReceiveIPv4/6 works.
+	recvFunc := func(bufs [][]byte, sizes []int, eps []conn.Endpoint) (int, error) {
+		n, addr, err := udpConn.ReadFromUDP(bufs[0])
+		if err != nil {
+			return 0, err
+		}
+
+		sizes[0] = n
+		eps[0] = &conn.StdNetEndpoint{AddrPort: addr.AddrPort()}
+
+		return 1, nil
+	}
+
+	return []conn.ReceiveFunc{recvFunc}, uint16(laddr.Port), nil
+}
+
+func (b *boundBind) Send(bufs [][]byte, ep conn.Endpoint) error {
+	// Copy conn under lock to avoid race with Close.
+	// This matches how StdNetBind.Send works.
+	b.mu.Lock()
+	c := b.conn
+	b.mu.Unlock()
+
+	if c == nil {
+		return syscall.EAFNOSUPPORT
+	}
+
+	dst, ok := ep.(*conn.StdNetEndpoint)
+	if !ok {
+		return conn.ErrWrongEndpointType
+	}
+
+	for _, buf := range bufs {
+		_, err := c.WriteToUDP(buf, net.UDPAddrFromAddrPort(dst.AddrPort))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *boundBind) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.conn == nil {
+		return nil
+	}
+
+	err := b.conn.Close()
+	b.conn = nil
+
+	return err
+}
+
+func (b *boundBind) SetMark(uint32) error { return nil }
+
+func (b *boundBind) ParseEndpoint(s string) (conn.Endpoint, error) {
+	ap, err := netip.ParseAddrPort(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &conn.StdNetEndpoint{AddrPort: ap}, nil
+}
+
+func (b *boundBind) BatchSize() int { return 1 }

--- a/internal/pkg/siderolink/bind_test.go
+++ b/internal/pkg/siderolink/bind_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package siderolink_test
+
+import (
+	"net"
+	"net/netip"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/conn"
+
+	"github.com/siderolabs/omni/internal/pkg/siderolink"
+)
+
+func TestBoundBind(t *testing.T) {
+	t.Parallel()
+
+	t.Run("binds to specific address", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+
+		fns, port, err := bind.Open(0)
+		require.NoError(t, err)
+		require.NotEmpty(t, fns)
+		require.NotZero(t, port)
+
+		t.Cleanup(func() {
+			require.NoError(t, bind.Close())
+		})
+
+		// Verify it's actually bound to 127.0.0.1 by checking we can't connect from external
+		// We do this by trying to send to the port and verifying the local address
+		testConn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: int(port)})
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			testConn.Close() //nolint:errcheck
+		})
+
+		localAddr, ok := testConn.LocalAddr().(*net.UDPAddr)
+		require.True(t, ok, "local address should be UDPAddr")
+		assert.True(t, localAddr.IP.IsLoopback(), "connection should be on loopback")
+	})
+
+	t.Run("open returns error if already open", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+
+		_, _, err := bind.Open(0)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			bind.Close() //nolint:errcheck
+		})
+
+		_, _, err = bind.Open(0)
+		require.ErrorIs(t, err, conn.ErrBindAlreadyOpen)
+	})
+
+	t.Run("close is idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+
+		_, _, err := bind.Open(0)
+		require.NoError(t, err)
+
+		require.NoError(t, bind.Close())
+		require.NoError(t, bind.Close())
+	})
+
+	t.Run("send and receive", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+
+		fns, port, err := bind.Open(0)
+		require.NoError(t, err)
+		require.Len(t, fns, 1)
+
+		t.Cleanup(func() {
+			require.NoError(t, bind.Close())
+		})
+
+		// Create a client to send data to the bind
+		clientConn, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: int(port)})
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			clientConn.Close() //nolint:errcheck
+		})
+
+		// Send test data
+		testData := []byte("hello wireguard")
+		_, err = clientConn.Write(testData)
+		require.NoError(t, err)
+
+		// Receive using the bind's receive function
+		bufs := make([][]byte, 1)
+		bufs[0] = make([]byte, 1024)
+		sizes := make([]int, 1)
+		eps := make([]conn.Endpoint, 1)
+
+		n, err := fns[0](bufs, sizes, eps)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+		assert.Equal(t, len(testData), sizes[0])
+		assert.Equal(t, testData, bufs[0][:sizes[0]])
+		assert.NotNil(t, eps[0])
+
+		// Send data back using the bind
+		replyData := []byte("hello back")
+		err = bind.Send([][]byte{replyData}, eps[0])
+		require.NoError(t, err)
+
+		// Receive the reply on the client
+		buf := make([]byte, 1024)
+		n2, err := clientConn.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, replyData, buf[:n2])
+	})
+
+	t.Run("parse endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+
+		ep, err := bind.ParseEndpoint("192.168.1.1:51820")
+		require.NoError(t, err)
+
+		assert.Equal(t, "192.168.1.1:51820", ep.DstToString())
+		assert.Equal(t, netip.MustParseAddr("192.168.1.1"), ep.DstIP())
+	})
+
+	t.Run("parse endpoint invalid", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+
+		_, err := bind.ParseEndpoint("invalid")
+		require.Error(t, err)
+	})
+
+	t.Run("batch size is 1", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+		assert.Equal(t, 1, bind.BatchSize())
+	})
+
+	t.Run("set mark returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+		assert.NoError(t, bind.SetMark(42))
+	})
+
+	t.Run("concurrent send and close", func(t *testing.T) {
+		t.Parallel()
+
+		bind := siderolink.NewBoundBind("127.0.0.1")
+
+		_, port, err := bind.Open(0)
+		require.NoError(t, err)
+
+		ep, err := bind.ParseEndpoint("127.0.0.1:" + strconv.Itoa(int(port)))
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+
+		// Start multiple goroutines sending
+		for range 10 {
+			wg.Go(func() {
+				for range 100 {
+					bind.Send([][]byte{[]byte("test")}, ep) //nolint:errcheck
+				}
+			})
+		}
+
+		// Close while sends are happening
+		require.NoError(t, bind.Close())
+
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
Having issues with wireguard connectivity from QEMU machines to Omni running on macOS revealed an issue: If macOS has multiple interfaces with IPs in the same subnet (for example connected both via ethernet and Wi-Fi), it could respond to WireGuard packets not from the interface they are received from, but from the other one, even when the wg endpoint was explicitly set to be a specific IP:PORT in Omni config. And this was breaking wg handshakes.

The core issue seems to be the wireguard-go library not implementing sticky sockets (`IP_PKTINFO`) on macOS.

While investigating, we found that the standard wireguard-go `StdNetBind` always binds to all interfaces (`0.0.0.0`), ignoring any specific host in the endpoint configuration. Add a custom bind implementation that respects the configured host.

This fixes the macOS issue as a side benefit.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>