### PR TITLE
fix: don't submit empty machine labels to create schematic

### DIFF
--- a/frontend/src/views/omni/InstallationMedia/usePresetSchematic.ts
+++ b/frontend/src/views/omni/InstallationMedia/usePresetSchematic.ts
@@ -52,9 +52,10 @@ export function usePresetSchematic(presetRef: MaybeRefOrGetter<InstallationMedia
       const { schematic_id, schematic_yml } = await ManagementService.CreateSchematic({
         extensions: preset.install_extensions,
         extra_kernel_args: preset.kernel_args?.split(' ').filter((item) => item.trim()),
-        meta_values: {
-          [LabelsMeta]: dump({ machineLabels: preset.machine_labels ?? {} }),
-        },
+        meta_values:
+          preset.machine_labels && Object.keys(preset.machine_labels).length > 0
+            ? { [LabelsMeta]: dump({ machineLabels: preset.machine_labels }) }
+            : undefined,
         overlay,
         talos_version: preset.talos_version,
         secure_boot: preset.secure_boot,


### PR DESCRIPTION
When creating a schematic in the wizard, do not submit an empty object for `LabelsMeta` when we have no labels. Instead just omit the field from the object.

i.e. before:
```yml
customization:
    extraKernelArgs:
        - siderolink.api=grpc://127.0.0.1:8090?jointoken=w7uVuW3zbVKIYQuzEcyetAHeYMeo5q2L9RvkAVfCfSCD
        - talos.events.sink=[fdae:41e4:649b:9303::1]:8091
        - talos.logging.kernel=tcp://[fdae:41e4:649b:9303::1]:8092
    meta:
        - key: 12
          value: |
            machineLabels: {}
```

after:
```yml
customization:
    extraKernelArgs:
        - siderolink.api=grpc://127.0.0.1?jointoken=w7uVuW3zbVKIYQuzEcyetAHeYMeo5q2L9RvkAVfCfSCD
        - talos.events.sink=[fdae:41e4:649b:9303::1]:8091
        - talos.logging.kernel=tcp://[fdae:41e4:649b:9303::1]:8092
```