### PR TITLE
Use one cache directory for kubectl oidc-login per cluster+identity combination

### DIFF
--- a/internal/backend/runtime/kubernetes/kubernetes.go
+++ b/internal/backend/runtime/kubernetes/kubernetes.go
@@ -240,6 +240,7 @@ users:
         - get-token
         - --oidc-issuer-url={{ .EndpointOIDC }}
         - --oidc-client-id={{ .ClientID }}
+        - --cache-dir=~/.kube/cache/oidc-login/{{ .InstanceName }}-{{ .ClusterName }}{{- if .Identity }}-{{ .Identity }}{{ end }}
         - --oidc-extra-scope=cluster:{{ .ClusterName }}
         {{- range $option := .ExtraOptions }}
         - --{{ $option }}


### PR DESCRIPTION
This PR sets a custom cache directory for the kubectl oidc-login / https://github.com/int128/kubelogin based on the cluster+identity combination.

I ran in to https://github.com/siderolabs/omni/issues/1003 when testing out multiple accounts, and used the proposed solution from the issue https://github.com/int128/kubelogin/issues/29#issuecomment-1657057575 locally / manually and it worked great.

Thought it could be a simple fix do add it in the generated kubeconfig file.