### PR TITLE
fix(installation-media): clarify bootloader section

### DIFF
--- a/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/ExtraArgs.vue
@@ -122,27 +122,36 @@ const { data: selectedSBC } = useResourceGet<SBCConfigSpec>(() => ({
       label="Bootloader"
     >
       <RadioGroupOption :value="SchematicBootloader.BOOT_AUTO">
-        auto
+        Auto
 
-        <template #description>Automatic bootloader selection.</template>
+        <template #description>
+          Automatically select bootloader support based on image type and architecture
+          (recommended).
+        </template>
       </RadioGroupOption>
 
       <RadioGroupOption :value="SchematicBootloader.BOOT_SD">
-        sd-boot
+        UEFI only
 
-        <template #description>Use systemd-boot as bootloader if supported.</template>
+        <template #description>
+          Supports modern hardware with UEFI firmware (uses systemd-boot).
+        </template>
       </RadioGroupOption>
 
       <RadioGroupOption v-if="!formState.secureBoot" :value="SchematicBootloader.BOOT_GRUB">
-        grub
+        BIOS only
 
-        <template #description>Use GRUB as a bootloader (not supported with SecureBoot).</template>
+        <template #description>
+          Legacy hardware support, some virtual machines (uses GRUB).
+        </template>
       </RadioGroupOption>
 
       <RadioGroupOption :value="SchematicBootloader.BOOT_DUAL">
-        dual-boot
+        Dual Boot
 
-        <template #description>Use GRUB for BIOS and systemd-boot for UEFI systems.</template>
+        <template #description>
+          Universal image, includes support for BIOS and UEFI systems.
+        </template>
       </RadioGroupOption>
     </RadioGroup>
   </div>


### PR DESCRIPTION
Clarify the bootloader text in the Installation Media wizard to align with factory.

Related to:
- https://github.com/siderolabs/image-factory/pull/361

<img width="565" height="238" alt="image" src="https://github.com/user-attachments/assets/f8a7b40b-6b11-4ca7-ab90-6051f805f75f" />
