### PR TITLE
fix: stop generating node unique token in `NodeUniqueTokenStatus`

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/pending_machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/pending_machine_status.go
@@ -48,7 +48,7 @@ func NewPendingMachineStatusController() *PendingMachineStatusController {
 			TransformFunc: handler.reconcileRunning,
 		},
 		qtransform.WithExtraMappedInput[*siderolink.LinkStatus](
-			qtransform.MapperFuncFromTyped[*siderolink.LinkStatus](
+			qtransform.MapperFuncFromTyped(
 				func(_ context.Context, _ *zap.Logger, _ controller.QRuntime, res *siderolink.LinkStatus) ([]resource.Pointer, error) {
 					return []resource.Pointer{
 						siderolink.NewPendingMachine(res.TypedSpec().Value.LinkId, nil).Metadata(),


### PR DESCRIPTION
Instead, create the `PendingMachine` resource there and let `PendingMachineStatus` controller handle node unique token creation instead.