### PR TITLE
feat(installation-media): replace edit naming with clone for installation media

### DIFF
--- a/frontend/src/components/common/Icon/icons.ts
+++ b/frontend/src/components/common/Icon/icons.ts
@@ -36,6 +36,9 @@ export const icons = {
   'arrow-right-square': defineAsyncComponent(() => import('../../icons/IconArrowRightSquare.vue')),
   'arrow-right': defineAsyncComponent(() => import('../../icons/IconArrowRight.vue')),
   'arrow-up-circle': ArrowUpCircleIcon,
+  'arrow-up-on-square-stack': defineAsyncComponent(
+    () => import('../../icons/IconArrowUpOnSquareStack.vue'),
+  ),
   'arrow-up-tray': ArrowUpTrayIcon,
   'arrow-up': defineAsyncComponent(() => import('../../icons/IconArrowUp.vue')),
   attention: defineAsyncComponent(() => import('../../icons/IconAttention.vue')),

--- a/frontend/src/components/icons/IconArrowUpOnSquareStack.vue
+++ b/frontend/src/components/icons/IconArrowUpOnSquareStack.vue
@@ -1,0 +1,22 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="size-6"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M7.5 7.5h-.75A2.25 2.25 0 0 0 4.5 9.75v7.5a2.25 2.25 0 0 0 2.25 2.25h7.5a2.25 2.25 0 0 0 2.25-2.25v-7.5a2.25 2.25 0 0 0-2.25-2.25h-.75m0-3-3-3m0 0-3 3m3-3v11.25m6-2.25h.75a2.25 2.25 0 0 1 2.25 2.25v7.5a2.25 2.25 0 0 1-2.25 2.25h-7.5a2.25 2.25 0 0 1-2.25-2.25v-.75"
+    />
+  </svg>
+</template>

--- a/frontend/src/views/omni/InstallationMedia/InstallationMedia.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMedia.vue
@@ -78,7 +78,7 @@ async function deleteItem(id: string) {
   confirmDeleteModalOpen.value = false
 }
 
-function editPreset(preset: (typeof presets.value)[number]) {
+function clonePreset(preset: (typeof presets.value)[number]) {
   formState.value = presetToFormState(preset.spec)
 
   router.push({ name: 'InstallationMediaCreate' })
@@ -136,8 +136,12 @@ function editPreset(preset: (typeof presets.value)[number]) {
                 />
               </Tooltip>
 
-              <Tooltip description="Edit">
-                <IconButton aria-label="edit" icon="edit" @click="() => editPreset(preset)" />
+              <Tooltip description="Clone">
+                <IconButton
+                  aria-label="clone"
+                  icon="arrow-up-on-square-stack"
+                  @click="() => clonePreset(preset)"
+                />
               </Tooltip>
 
               <Tooltip description="Download">


### PR DESCRIPTION
Since in the edit flow for installation media we are actually saving new copies rather than editing, we can change the labelling from "Edit" to "Clone". Also changed the icon.

