### PR TITLE
fix: apply AccessPolicy rules on gRPC proxy for Talos backend

### DIFF
--- a/internal/backend/grpc/router/router.go
+++ b/internal/backend/grpc/router/router.go
@@ -214,7 +214,7 @@ func (r *Router) getTalosBackend(ctx context.Context, md metadata.MD) ([]proxy.B
 
 		r.metricActiveClients.Inc()
 
-		backend := NewTalosBackend(id, clusterName, r.nodeResolver, conn, r.authEnabled, r.verifier)
+		backend := NewTalosBackend(id, clusterName, r.nodeResolver, conn, r.authEnabled, r.verifier, r.cosiState)
 		r.talosBackends.Add(id, backend)
 
 		runtime.AddCleanup(backend, func(m prometheus.Gauge) { m.Dec() }, r.metricActiveClients)

--- a/internal/backend/grpc/router/talos_backend.go
+++ b/internal/backend/grpc/router/talos_backend.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/blang/semver/v4"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/go-api-signature/pkg/message"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/siderolabs/omni/internal/backend/dns"
 	"github.com/siderolabs/omni/internal/pkg/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 	"github.com/siderolabs/omni/internal/pkg/grpcutil"
@@ -56,8 +58,9 @@ var adminMethodSet = xslices.ToSet([]string{
 
 // TalosBackend implements a backend (proxying one2one to a Talos node).
 type TalosBackend struct {
-	conn         *grpc.ClientConn
 	nodeResolver NodeResolver
+	omniState    state.State
+	conn         *grpc.ClientConn
 	verifier     grpc.UnaryServerInterceptor
 	name         string
 	clusterName  string
@@ -65,7 +68,7 @@ type TalosBackend struct {
 }
 
 // NewTalosBackend builds new Talos API backend.
-func NewTalosBackend(name, clusterName string, nodeResolver NodeResolver, conn *grpc.ClientConn, authEnabled bool, verifier grpc.UnaryServerInterceptor) *TalosBackend {
+func NewTalosBackend(name, clusterName string, nodeResolver NodeResolver, conn *grpc.ClientConn, authEnabled bool, verifier grpc.UnaryServerInterceptor, st state.State) *TalosBackend {
 	backend := &TalosBackend{
 		name:         name,
 		clusterName:  clusterName,
@@ -73,6 +76,7 @@ func NewTalosBackend(name, clusterName string, nodeResolver NodeResolver, conn *
 		conn:         conn,
 		authEnabled:  authEnabled,
 		verifier:     verifier,
+		omniState:    st,
 	}
 
 	return backend
@@ -113,6 +117,11 @@ func (backend *TalosBackend) GetConnection(ctx context.Context, fullMethodName s
 	)
 	if err != nil {
 		// authentication failed
+		return ctx, nil, err
+	}
+
+	ctx, err = accesspolicy.ApplyClusterAccessPolicy(ctx, backend.clusterName, backend.omniState)
+	if err != nil {
 		return ctx, nil, err
 	}
 

--- a/internal/pkg/auth/accesspolicy/cluster.go
+++ b/internal/pkg/auth/accesspolicy/cluster.go
@@ -67,3 +67,30 @@ func RoleForCluster(ctx context.Context, id resource.ID, st state.State) (role.R
 
 	return maxRole, checkResult.MatchesAllClusters, nil
 }
+
+// ApplyClusterAccessPolicy checks the ACLs for the user in the context against the given cluster ID.
+// If there is a match and the matched role is higher than the user's role,
+// a child context containing the given role will be returned.
+func ApplyClusterAccessPolicy(ctx context.Context, clusterName string, st state.State) (context.Context, error) {
+	clusterRole, _, err := RoleForCluster(ctx, clusterName, st)
+	if err != nil {
+		return nil, err
+	}
+
+	userRole := role.None
+
+	if val, ok := ctxstore.Value[auth.RoleContextKey](ctx); ok {
+		userRole = val.Role
+	}
+
+	newRole, err := role.Max(userRole, clusterRole)
+	if err != nil {
+		return nil, err
+	}
+
+	if newRole == userRole {
+		return ctx, nil
+	}
+
+	return ctxstore.WithValue(ctx, auth.RoleContextKey{Role: newRole}), nil
+}


### PR DESCRIPTION
Apply AccessPolicy rules on gRPC proxy for Talos backend

Fixes: #2221
