### PR TITLE
feat(installation-media): allow editing name for saved presets

### DIFF
--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaReview.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaReview.vue
@@ -36,10 +36,15 @@ const {
 
 <template>
   <div>
-    <PageHeader :title="`Previously saved preset &quot;${route.params.presetId}&quot;`" />
+    <PageHeader title="Previously Created Media" />
     <TSpinner v-if="presetLoading" class="mx-auto size-8" />
 
-    <Confirmation v-else-if="preset" is-review-page :model-value="presetToFormState(preset.spec)" />
+    <Confirmation
+      v-else-if="preset"
+      is-review-page
+      :reviewed-preset="preset"
+      :model-value="presetToFormState(preset.spec)"
+    />
 
     <TAlert v-else-if="err" title="Error" type="error">
       {{ err }}

--- a/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
@@ -7,31 +7,40 @@ included in the LICENSE file.
 <script setup lang="ts">
 import { useEventListener } from '@vueuse/core'
 import { gte } from 'semver'
-import { computed, useTemplateRef } from 'vue'
+import { computed, ref, useTemplateRef, watchEffect } from 'vue'
+import { useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
+import { type Resource, ResourceService } from '@/api/grpc'
+import type { InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
 import {
   type PlatformConfigSpec,
   PlatformConfigSpecBootMethod,
   type SBCConfigSpec,
 } from '@/api/omni/specs/virtual.pb'
+import { withRuntime } from '@/api/options'
 import {
   CloudPlatformConfigType,
+  DefaultNamespace,
+  InstallationMediaConfigType,
   MetalPlatformConfigType,
   PlatformMetalID,
   SBCConfigType,
   VirtualNamespace,
 } from '@/api/resources'
+import TButton from '@/components/common/Button/TButton.vue'
 import CodeBlock from '@/components/common/CodeBlock/CodeBlock.vue'
 import CopyButton from '@/components/common/CopyButton/CopyButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
+import TInput from '@/components/common/TInput/TInput.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 import TAlert from '@/components/TAlert.vue'
 import { getDocsLink, getLegacyDocsLink, majorMinorVersion } from '@/methods'
 import { useFeatures } from '@/methods/features'
 import { useDownloadImage } from '@/methods/useDownloadImage'
 import { useResourceGet } from '@/methods/useResourceGet'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { useTalosctlDownloads } from '@/methods/useTalosctlDownloads'
 import { showError } from '@/notification'
 import { formStateToPreset } from '@/views/omni/InstallationMedia/formStateToPreset'
@@ -40,11 +49,70 @@ import { usePresetDownloadLinks } from '@/views/omni/InstallationMedia/usePreset
 import { usePresetSchematic } from '@/views/omni/InstallationMedia/usePresetSchematic'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
 
-defineProps<{
+const { reviewedPreset, isReviewPage } = defineProps<{
+  reviewedPreset?: Resource<InstallationMediaConfigSpec>
   isReviewPage?: boolean
 }>()
 
 const formState = defineModel<FormState>({ required: true })
+const presetName = ref('')
+const presetNameSaving = ref(false)
+const router = useRouter()
+
+watchEffect(() => {
+  presetName.value = reviewedPreset?.metadata.id ?? ''
+})
+
+const { data: existingPreset, loading: existingPresetLoading } =
+  useResourceWatch<InstallationMediaConfigSpec>(() => ({
+    skip: !isReviewPage || !presetName.value,
+    runtime: Runtime.Omni,
+    resource: {
+      namespace: DefaultNamespace,
+      type: InstallationMediaConfigType,
+      id: presetName.value,
+    },
+  }))
+
+async function savePresetName() {
+  if (!reviewedPreset || existingPreset.value) return
+
+  try {
+    presetNameSaving.value = true
+
+    await ResourceService.Create<Resource<InstallationMediaConfigSpec>>(
+      {
+        metadata: {
+          namespace: DefaultNamespace,
+          type: InstallationMediaConfigType,
+          id: presetName.value,
+        },
+        spec: reviewedPreset.spec,
+      },
+      withRuntime(Runtime.Omni),
+    )
+
+    router.replace({
+      name: 'InstallationMediaReview',
+      params: {
+        presetId: presetName.value,
+      },
+    })
+
+    await ResourceService.Delete(
+      {
+        namespace: DefaultNamespace,
+        type: InstallationMediaConfigType,
+        id: reviewedPreset.metadata.id,
+      },
+      withRuntime(Runtime.Omni),
+    )
+  } catch (error) {
+    showError('Error', error instanceof Error ? error.message : String(error))
+  } finally {
+    presetNameSaving.value = false
+  }
+}
 
 const supportsUnifiedInstaller = computed(
   () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.10.0'),
@@ -149,6 +217,16 @@ const installerImage = computed(() =>
 <template>
   <div v-if="schematic" class="flex flex-col gap-4 text-xs">
     <h2 v-if="!isReviewPage" class="text-sm text-naturals-n14">Schematic Ready</h2>
+    <div v-else class="flex gap-2">
+      <TInput v-model.trim="presetName" title="Name" />
+      <TButton
+        type="highlighted"
+        :disabled="presetNameSaving || existingPresetLoading || !!existingPreset || !presetName"
+        @click="savePresetName"
+      >
+        Save
+      </TButton>
+    </div>
 
     <p class="flex items-center gap-1">
       Your image schematic ID is:


### PR DESCRIPTION
Allow editing name for saved InstallationMediaConfigs

Closes #2219 

<img width="693" height="355" alt="image" src="https://github.com/user-attachments/assets/dc666600-4a87-4692-97a1-a2d584ed2782" />
