### PR TITLE
fix: fix schematic generation for machines in agent mode

### DIFF
--- a/client/api/omni/specs/machine_status.go
+++ b/client/api/omni/specs/machine_status.go
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package specs
+
+func (spec *MachineStatusSpec) SchematicReady() bool {
+	return spec.Schematic != nil && !spec.Schematic.InAgentMode && spec.Schematic.Id != "" && spec.Schematic.FullId != ""
+}

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -709,9 +709,8 @@ func (s *managementServer) MaintenanceUpgrade(ctx context.Context, req *manageme
 		return nil, status.Error(codes.FailedPrecondition, "machine is not in maintenance mode")
 	}
 
-	schematic := machineStatus.TypedSpec().Value.Schematic
-	if schematic == nil || schematic.FullId == "" {
-		return nil, status.Error(codes.FailedPrecondition, "machine schematic is not known yet")
+	if !machineStatus.TypedSpec().Value.SchematicReady() {
+		return nil, status.Error(codes.FailedPrecondition, "machine schematic is not ready yet")
 	}
 
 	platform := machineStatus.TypedSpec().Value.GetPlatformMetadata().GetPlatform()
@@ -726,7 +725,7 @@ func (s *managementServer) MaintenanceUpgrade(ctx context.Context, req *manageme
 
 	installImage := &specs.MachineConfigGenOptionsSpec_InstallImage{
 		TalosVersion:         req.Version,
-		SchematicId:          schematic.FullId,
+		SchematicId:          machineStatus.TypedSpec().Value.Schematic.FullId,
 		SchematicInitialized: true,
 		Platform:             platform,
 		SecurityState:        securityState,

--- a/internal/backend/kernelargs/kernelargs.go
+++ b/internal/backend/kernelargs/kernelargs.go
@@ -103,8 +103,7 @@ func UpdateSupported(machineStatus *omni.MachineStatus, getClusterMachineConfig 
 }
 
 func Calculate(machineStatus *omni.MachineStatus, kernelArgs *omni.KernelArgs) (args []string, initialized bool, err error) {
-	schematicConfig := machineStatus.TypedSpec().Value.Schematic
-	if schematicConfig == nil {
+	if !machineStatus.TypedSpec().Value.SchematicReady() {
 		return nil, false, nil
 	}
 
@@ -118,7 +117,7 @@ func Calculate(machineStatus *omni.MachineStatus, kernelArgs *omni.KernelArgs) (
 		extraArgs = kernelArgs.TypedSpec().Value.Args
 	}
 
-	baseArgs := xslices.Filter(schematicConfig.KernelArgs, isProtected)
+	baseArgs := xslices.Filter(machineStatus.TypedSpec().Value.Schematic.KernelArgs, isProtected)
 
 	return slices.Concat(baseArgs, extraArgs), true, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/infra_machine_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine_test.go
@@ -89,12 +89,11 @@ func (suite *InfraMachineControllerSuite) TestReconcile() {
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, clusterMachine))
 
-	// create schematic configuration
-	schematicConfig := omni.NewSchematicConfiguration("machine-1")
+	// create cluster with talos version
+	cluster := omni.NewCluster("test-cluster")
+	cluster.TypedSpec().Value.TalosVersion = "v42.0.0"
 
-	schematicConfig.TypedSpec().Value.TalosVersion = "v42.0.0"
-
-	suite.Require().NoError(suite.state.Create(suite.ctx, schematicConfig))
+	suite.Require().NoError(suite.state.Create(suite.ctx, cluster))
 
 	// assert that the cluster machine has the correct talos version
 	assertResource[*infra.Machine](&suite.OmniSuite, clusterMachine.Metadata(), func(r *infra.Machine, assertion *assert.Assertions) {

--- a/internal/backend/runtime/omni/controllers/omni/kernelargs/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kernelargs/status.go
@@ -40,8 +40,8 @@ func NewStatusController() *StatusController {
 				status.TypedSpec().Value.UnmetConditions = nil
 				status.TypedSpec().Value.CurrentCmdline = ms.TypedSpec().Value.KernelCmdline
 
-				if ms.TypedSpec().Value.Schematic == nil {
-					status.TypedSpec().Value.UnmetConditions = append(status.TypedSpec().Value.UnmetConditions, "Schematic information is not yet known")
+				if !ms.TypedSpec().Value.SchematicReady() {
+					status.TypedSpec().Value.UnmetConditions = append(status.TypedSpec().Value.UnmetConditions, "Schematic information is not yet ready")
 				} else {
 					status.TypedSpec().Value.CurrentArgs = kernelargs.FilterExtras(ms.TypedSpec().Value.Schematic.KernelArgs)
 				}

--- a/internal/backend/runtime/omni/controllers/omni/kernelargs/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/kernelargs/status_test.go
@@ -38,7 +38,7 @@ func TestReconcile(t *testing.T) {
 
 		rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.KernelArgsStatus, assertion *assert.Assertions) {
 			assertion.Equal([]string{
-				"Schematic information is not yet known",
+				"Schematic information is not yet ready",
 				"Talos is not installed, kernel args cannot be updated yet",
 				"Cannot determine if kernel args update is supported: SecurityState and TalosVersion are not yet set",
 			}, res.TypedSpec().Value.UnmetConditions)
@@ -59,6 +59,8 @@ func TestReconcile(t *testing.T) {
 			}
 
 			res.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+				Id:         "test-id",
+				FullId:     "test-full-id",
 				KernelArgs: []string{"arg-1", "arg-2"},
 			}
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
@@ -69,7 +69,7 @@ func GenInstallConfig(machineStatus *omni.MachineStatus, clusterMachineTalosVers
 
 		genOptions.TypedSpec().Value.InstallImage.SchematicId = clusterMachineTalosVersion.TypedSpec().Value.SchematicId
 		genOptions.TypedSpec().Value.InstallImage.TalosVersion = clusterMachineTalosVersion.TypedSpec().Value.TalosVersion
-		genOptions.TypedSpec().Value.InstallImage.SchematicInitialized = machineStatus.TypedSpec().Value.Schematic != nil
+		genOptions.TypedSpec().Value.InstallImage.SchematicInitialized = machineStatus.TypedSpec().Value.SchematicReady()
 
 		if genOptions.TypedSpec().Value.InstallImage.SchematicInitialized {
 			genOptions.TypedSpec().Value.InstallImage.SchematicInvalid = machineStatus.TypedSpec().Value.GetSchematic().GetInvalid()

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
@@ -440,11 +440,7 @@ func (suite *MachineStatusSuite) TestMachineSchematic() {
 				},
 			},
 			expected: &specs.MachineStatusSpec_Schematic{
-				Id:               defaultSchematic,
-				InitialSchematic: "",
-				FullId:           defaultSchematic,
-				InAgentMode:      true,
-				InitialState:     &specs.MachineStatusSpec_Schematic_InitialState{},
+				InAgentMode: true,
 			},
 		},
 	} {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -781,7 +781,7 @@ func (ctrl *ClusterMachineConfigStatusController) shouldResetGraceful(
 		machineSetStatus.TypedSpec().Value.Phase != specs.MachineSetPhase_Destroying, nil
 }
 
-func (h *ClusterMachineConfigStatusController) gracefulEtcdLeave(ctx context.Context, c *client.Client, id string) error {
+func (ctrl *ClusterMachineConfigStatusController) gracefulEtcdLeave(ctx context.Context, c *client.Client, id string) error {
 	_, err := c.EtcdForfeitLeadership(ctx, &machineapi.EtcdForfeitLeadershipRequest{})
 	if err != nil {
 		return fmt.Errorf("failed to forfeit leadership, node %q: %w", id, err)

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
@@ -69,14 +69,15 @@ func (ctrl *StatusController) transform(ctx context.Context, r controller.Reader
 
 	status.TypedSpec().Value.IsMaintenance = ms.TypedSpec().Value.Maintenance
 
-	schematicSpec := ms.TypedSpec().Value.Schematic
-	if schematicSpec == nil {
+	if !ms.TypedSpec().Value.SchematicReady() {
 		status.TypedSpec().Value.Phase = specs.MachineUpgradeStatusSpec_Unknown
 		status.TypedSpec().Value.Status = "schematic info is not available"
 		status.TypedSpec().Value.Error = ""
 
 		return nil
 	}
+
+	schematicSpec := ms.TypedSpec().Value.Schematic
 
 	status.TypedSpec().Value.CurrentSchematicId = schematicSpec.FullId
 

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
@@ -150,6 +150,7 @@ func TestReconcile(t *testing.T) {
 					{Key: 1, Value: "value1"},
 					{Key: 2, Value: "value2"},
 				},
+				Id:     "test-id",
 				FullId: currentSchematicID,
 				Raw:    string(currentSchematicRaw),
 				InitialState: &specs.MachineStatusSpec_Schematic_InitialState{

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -513,6 +513,7 @@ func (suite *OmniSuite) createClusterWithTalosVersion(clusterName string, contro
 		machineStatus.TypedSpec().Value.ManagementAddress = suite.socketConnectionString
 		machineStatus.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
 			Id:           defaultSchematic,
+			FullId:       defaultSchematic,
 			InitialState: &specs.MachineStatusSpec_Schematic_InitialState{},
 		}
 		machineStatus.TypedSpec().Value.InitialTalosVersion = cluster.TypedSpec().Value.TalosVersion

--- a/internal/backend/runtime/omni/controllers/omni/schematic_configuration.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic_configuration.go
@@ -143,8 +143,8 @@ func (helper *schematicConfigurationHelper) reconcile(
 	ms *omni.MachineStatus,
 	schematicConfiguration *omni.SchematicConfiguration,
 ) (*omni.MachineExtensionsStatus, error) {
-	if ms.TypedSpec().Value.Schematic == nil {
-		return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("schematic information is not yet available")
+	if !ms.TypedSpec().Value.SchematicReady() {
+		return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("schematic is not yet ready")
 	}
 
 	securityState := ms.TypedSpec().Value.SecurityState
@@ -368,8 +368,8 @@ func determineKernelArgs(ctx context.Context, machineStatus *omni.MachineStatus,
 	}
 
 	if !updateSupported {
-		if machineStatus.TypedSpec().Value.Schematic == nil {
-			return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine schematic is not yet initialized")
+		if !machineStatus.TypedSpec().Value.SchematicReady() {
+			return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine schematic is not yet ready")
 		}
 
 		// keep them unchanged - take the current args as-is
@@ -437,7 +437,7 @@ func computeMachineExtensionsStatus(ms *omni.MachineStatus, customization *machi
 		requestedExtensions set.Set[string]
 	)
 
-	if ms.TypedSpec().Value.Schematic != nil {
+	if ms.TypedSpec().Value.SchematicReady() {
 		installedExtensions = xslices.ToSet(ms.TypedSpec().Value.Schematic.Extensions)
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/schematic_configuration_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic_configuration_test.go
@@ -72,6 +72,8 @@ func (suite *SchematicConfigurationSuite) TestReconcile() {
 
 	machineStatus.TypedSpec().Value.TalosVersion = talosVersion
 	machineStatus.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+		Id:               "test-id",
+		FullId:           "test-full-id",
 		Extensions:       []string{"siderolabs/hello-world-service"},
 		InitialSchematic: expectedSchematic,
 		InitialState: &specs.MachineStatusSpec_Schematic_InitialState{

--- a/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status.go
@@ -555,8 +555,7 @@ func populateEmptySchematics(ctx context.Context, r controller.ReaderWriter, clu
 			return err
 		}
 
-		schematic := machineStatus.TypedSpec().Value.Schematic
-		if schematic == nil {
+		if !machineStatus.TypedSpec().Value.SchematicReady() {
 			return nil
 		}
 
@@ -566,7 +565,7 @@ func populateEmptySchematics(ctx context.Context, r controller.ReaderWriter, clu
 		}
 
 		return safe.WriterModify(ctx, r, clusterMachineTalosVersion, func(res *omni.ClusterMachineTalosVersion) error {
-			res.TypedSpec().Value.SchematicId = schematic.InitialSchematic
+			res.TypedSpec().Value.SchematicId = machineStatus.TypedSpec().Value.Schematic.InitialSchematic
 
 			return nil
 		})

--- a/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
+++ b/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
@@ -144,6 +144,7 @@ func init() {
 
 		res.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
 			Id:           defaultSchematic,
+			FullId:       defaultSchematic,
 			InitialState: &specs.MachineStatusSpec_Schematic_InitialState{},
 		}
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -357,7 +357,7 @@ func preRunHooks(t *testing.T, options *TestOptions) {
 
 func postRunHooks(t *testing.T, options *TestOptions) {
 	if t.Failed() {
-		t.Logf("there are failed tests, save support bundle for all cluster")
+		t.Logf("there are failed tests, save support bundle for all clusters")
 
 		saveAllSupportBundles(t, options.omniClient, options.OutputDir)
 


### PR DESCRIPTION
We had an issue with bare metal provider where two different schematic IDs would fight each other, causing machine to get installed with a wrong schematic ID, only to be upgraded to the correct one immediately, and in some cases, go into an upgrade loop between a correct and an incorrect schematic.

The cause: Omni treated schematics it observed when the machine in agent mode dialed in, and stored the information it received (like kernel args and initial schematic info). This was wrong, as agent mode information essentially meaningless.

Fix this by changing the simple check of "was the schematic info for machine X ever observed" to be "is the schematic info for machine X ready". The readiness check involves schematic being populated and machine not being in agent mode.

This change caused `SchematicConfiguration` resource to not be generated before the machine leaves the agent mode, and caused a side effect: `InfraMachineController` would not receive Talos version from it and would not populate it on the `InfraMachine` resource. And this would cause BM provider to never get notified about the fact that the machine is allocated to a cluster, and would not power it on (to PXE boot it to "regular" Talos, for it to receive the "install" call to Omni).

Change that controller to get the Talos version info directly from the Cluster resource.