### PR TITLE
fix: check config generation errors before computing redacted configs

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -177,7 +177,7 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileRunning(
 	}
 
 	if err = ctrl.computePendingUpdates(ctx, r, rc); err != nil {
-		return err
+		return fmt.Errorf("failed to compute pending updates: %w", err)
 	}
 
 	if rc.locked {
@@ -218,7 +218,7 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileRunning(
 
 	buffer, err := machineConfig.TypedSpec().Value.GetUncompressedData()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get uncompressed config: %w", err)
 	}
 
 	defer buffer.Free()

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -500,7 +500,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 	t.Run("generationErrorPropagation", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*5)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{}, addControllers, func(ctx context.Context, testContext testutils.TestContext) {
@@ -513,7 +513,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 				options.Modify(func(res *omni.ClusterMachineConfig) error {
 					res.TypedSpec().Value.GenerationError = "TestGenerationErrorPropagation error"
 
-					return nil
+					return res.TypedSpec().Value.SetUncompressedData(nil)
 				}),
 			)
 


### PR DESCRIPTION
If config generation failed with an error, the config data would be empty.


(cherry picked from commit dc2c94805c1f762084a4e927dcfd12fe26172cb6)