### PR TITLE
fix: pause cluster machine watches until expanded

### DIFF
--- a/frontend/src/views/cluster/ClusterMachines/ClusterMachines.vue
+++ b/frontend/src/views/cluster/ClusterMachines/ClusterMachines.vue
@@ -23,12 +23,14 @@ import { useResourceWatch } from '@/methods/useResourceWatch'
 
 import MachineSet from './MachineSet.vue'
 
-const { clusterID } = defineProps<{
+const { clusterID, pauseWatches } = defineProps<{
   clusterID: string
+  pauseWatches?: boolean
   isSubgrid?: boolean
 }>()
 
 const { data: machineSets } = useResourceWatch<MachineSetSpec>(() => ({
+  skip: pauseWatches,
   resource: {
     type: MachineSetType,
     namespace: DefaultNamespace,
@@ -38,6 +40,7 @@ const { data: machineSets } = useResourceWatch<MachineSetSpec>(() => ({
 }))
 
 const { data: clusterDiagnostics } = useResourceWatch<ClusterDiagnosticsSpec>(() => ({
+  skip: pauseWatches,
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,

--- a/frontend/src/views/omni/Clusters/ClusterItem.vue
+++ b/frontend/src/views/omni/Clusters/ClusterItem.vue
@@ -181,7 +181,13 @@ const { height } = useElementSize(slider)
       class="col-span-full grid grid-cols-subgrid transition-all duration-300"
       :style="{ height: expanded ? `${height}px` : '0' }"
     >
-      <ClusterMachines ref="slider" class="h-min" :cluster-i-d="item.metadata.id!" is-subgrid />
+      <ClusterMachines
+        :pause-watches="!expanded"
+        ref="slider"
+        class="h-min"
+        :cluster-i-d="item.metadata.id!"
+        is-subgrid
+      />
     </section>
   </li>
 </template>


### PR DESCRIPTION
Pause cluster machine watches until they are expanded on the clusters page.

Fixes #2249