### PR TITLE
test: do not check for empty wipe id in static infra provider test

### DIFF
--- a/internal/integration/infra_test.go
+++ b/internal/integration/infra_test.go
@@ -336,7 +336,6 @@ func AssertInfraMachinesAreAllocated(testCtx context.Context, omniState state.St
 			// There must be an infra.Machine resource for each node
 			rtestutils.AssertResource[*infra.Machine](ctx, t, omniState, id, func(res *infra.Machine, assertion *assert.Assertions) {
 				assertion.Equal(talosVersion, res.TypedSpec().Value.ClusterTalosVersion)
-				assertion.Empty(res.TypedSpec().Value.WipeId)
 				assertion.Equal(extensions, res.TypedSpec().Value.Extensions)
 			})
 


### PR DESCRIPTION
Wipe ID on `InfraMachine` resources is empty only when a machine was **never needed to be wiped**, i.e., was never allocated to and then de-allocated from a cluster.

This is not always the case in the bare metal infra provider tests, as it runs both `ConfigPatching` and `StaticInfraProvider` integration tests at the same time. Sometimes, the latter test picked machines which were released by the former test, and those machines were already wiped at least once.