### PR TITLE
feat: move omni schematic cache to ephemeral

### DIFF
--- a/client/pkg/omni/resources/omni/schematic.go
+++ b/client/pkg/omni/resources/omni/schematic.go
@@ -17,7 +17,7 @@ import (
 // NewSchematic creates new schematic resource.
 func NewSchematic(id resource.ID) *Schematic {
 	return typed.NewResource[SchematicSpec, SchematicExtension](
-		resource.NewMetadata(resources.DefaultNamespace, SchematicType, id, resource.VersionUndefined),
+		resource.NewMetadata(resources.EphemeralNamespace, SchematicType, id, resource.VersionUndefined),
 		protobuf.NewResourceSpec(&specs.SchematicSpec{}),
 	)
 }
@@ -46,7 +46,7 @@ func (SchematicExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             SchematicType,
 		Aliases:          []resource.Type{},
-		DefaultNamespace: resources.DefaultNamespace,
+		DefaultNamespace: resources.EphemeralNamespace,
 		PrintColumns:     []meta.PrintColumn{},
 	}
 }

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -273,6 +273,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: changeClusterMachineConfigPatchesOwner,
 				name:     "changeClusterMachineConfigPatchesOwner",
 			},
+			{
+				callback: moveSchematicCacheToEphemeral,
+				name:     "moveSchematicCacheToEphemeral",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Move the factory schematic cache in omni from the default namespace to the ephemeral one, so that it is only stored in memory. Also includes a migration to clean-up the cache from the default namespace.

Resolves #2240 