### PR TITLE
fix: handle deletion event on InstallationMediaConfig validation

### DIFF
--- a/frontend/src/views/omni/Clusters/ClusterItem.vue
+++ b/frontend/src/views/omni/Clusters/ClusterItem.vue
@@ -182,8 +182,8 @@ const { height } = useElementSize(slider)
       :style="{ height: expanded ? `${height}px` : '0' }"
     >
       <ClusterMachines
-        :pause-watches="!expanded"
         ref="slider"
+        :pause-watches="!expanded"
         class="h-min"
         :cluster-i-d="item.metadata.id!"
         is-subgrid

--- a/frontend/src/views/omni/InstallationMedia/DownloadPresetModal.vue
+++ b/frontend/src/views/omni/InstallationMedia/DownloadPresetModal.vue
@@ -123,7 +123,7 @@ async function close() {
       </TableRoot>
 
       <div class="flex gap-1">
-        <p class="flex items-center gap-1.5 text-xs" v-if="imageIsGenerating">
+        <p v-if="imageIsGenerating" class="flex items-center gap-1.5 text-xs">
           <TSpinner class="size-3" />
           <span>Generating image...</span>
         </p>

--- a/internal/backend/runtime/omni/export_test.go
+++ b/internal/backend/runtime/omni/export_test.go
@@ -109,3 +109,7 @@ func InfraProviderValidationOptions(st state.State) []validated.StateOption {
 func RotateSecretsValidationOptions(st state.State) []validated.StateOption {
 	return rotateSecretsValidationOptions(st)
 }
+
+func InstallationMediaConfigValidationOptions() []validated.StateOption {
+	return installationMediaConfigValidationOptions()
+}

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -351,7 +351,7 @@ func NewRuntime(talosClientFactory *talos.ClientFactory, dnsService *dns.Service
 		defaultJoinTokenValidationOptions(defaultState),
 		importedClusterSecretValidationOptions(defaultState, config.Config.Features.GetEnableClusterImport()),
 		infraProviderValidationOptions(defaultState),
-		installationMediaConfigOptions(),
+		installationMediaConfigValidationOptions(),
 		rotateSecretsValidationOptions(defaultState),
 	)
 

--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -1554,8 +1554,12 @@ func infraProviderValidationOptions(st state.State) []validated.StateOption {
 	}
 }
 
-func installationMediaConfigOptions() []validated.StateOption {
+func installationMediaConfigValidationOptions() []validated.StateOption {
 	validateInstallationMedia := func(res *omni.InstallationMediaConfig) error {
+		if res.Metadata().Phase() == resource.PhaseTearingDown {
+			return nil
+		}
+
 		if res.TypedSpec().Value.TalosVersion == "" {
 			return errors.New("invalid installation media config: talos version is required")
 		}


### PR DESCRIPTION
While tearing down an InstallationMediaConfig we were still trying to apply validations. Deletion fails for resources that were created before validation rules were created and is in invalid state.

Fixes: #2253