### PR TITLE
feat(installation-media): remove hover on table rows and make name clickable

### DIFF
--- a/frontend/src/components/common/Table/TableRow.vue
+++ b/frontend/src/components/common/Table/TableRow.vue
@@ -7,7 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts"></script>
 
 <template>
-  <tr class="border-naturals-n5 not-in-[thead]:hover:bg-white/5">
+  <tr class="border-naturals-n5 not-in-[thead]:[[role=button]]:hover:bg-white/5">
     <slot></slot>
   </tr>
 </template>

--- a/frontend/src/views/omni/InstallationMedia/InstallationMedia.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMedia.vue
@@ -113,7 +113,17 @@ function clonePreset(preset: (typeof presets.value)[number]) {
 
       <template #body>
         <TableRow v-for="preset in presets" :key="itemID(preset)">
-          <TableCell>{{ preset.metadata.id }}</TableCell>
+          <TableCell>
+            <RouterLink
+              class="list-item-link"
+              :to="{
+                name: 'InstallationMediaReview',
+                params: { presetId: preset.metadata.id! },
+              }"
+            >
+              {{ preset.metadata.id }}
+            </RouterLink>
+          </TableCell>
           <TableCell>{{ preset.spec.talos_version }}</TableCell>
           <TableCell>
             {{


### PR DESCRIPTION
Remove the hover on table rows for the installation media list, and make the name of items clickable links.