### PR TITLE
fix: prevent unwanted upgrades of non-image-factory machines

### DIFF
--- a/client/api/omni/specs/machine_status.go
+++ b/client/api/omni/specs/machine_status.go
@@ -5,5 +5,21 @@
 package specs
 
 func (spec *MachineStatusSpec) SchematicReady() bool {
-	return spec.Schematic != nil && !spec.Schematic.InAgentMode && spec.Schematic.Id != "" && spec.Schematic.FullId != ""
+	if spec.Schematic == nil {
+		return false
+	}
+
+	if spec.Schematic.InAgentMode {
+		return false
+	}
+
+	if spec.Schematic.Invalid {
+		// If the schematic is invalid, we consider it "ready" to allow it to be allocated to a cluster.
+		// This is the case for the machines which were built bypassing image factory and with extensions in them:
+		// we mark those as invalid, as we do not know if those extensions were official (available also in image factory),
+		// but those machines still need to be usable - users should be able to create clusters with those machines.
+		return true
+	}
+
+	return spec.Schematic.Id != "" && spec.Schematic.FullId != ""
 }

--- a/internal/backend/kernelargs/kernelargs.go
+++ b/internal/backend/kernelargs/kernelargs.go
@@ -122,6 +122,11 @@ func Calculate(machineStatus *omni.MachineStatus, kernelArgs *omni.KernelArgs) (
 	return slices.Concat(baseArgs, extraArgs), true, nil
 }
 
+// FilterProtected filters out the "extra args" from the provided kernel args, leaving only the protected kernel arguments that cannot be modified.
+func FilterProtected(args []string) []string {
+	return xslices.Filter(args, isProtected)
+}
+
 // FilterExtras filters out the protected kernel arguments from the provided kernel args, leaving only the "extra args" that can be modified.
 func FilterExtras(args []string) []string {
 	return xslices.Filter(args, func(value string) bool {

--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
@@ -35,14 +35,12 @@ type SchematicInfo struct {
 	InAgentMode bool
 }
 
-// Equal compares schematic id with both extensions ID and Full ID.
-func (si SchematicInfo) Equal(id string) bool {
-	return si.ID == id || si.FullID == id
-}
-
 // GetSchematicInfo uses Talos API to list all the schematics, and computes the plain schematic ID,
 // taking only the extensions into account - ignoring everything else, e.g., the kernel command line args or meta values.
-func GetSchematicInfo(ctx context.Context, c *client.Client, defaultKernelArgs []string) (SchematicInfo, error) {
+//
+// The argument fallbackKernelArgs is only used if the machine doesn't have the schematic meta extension, i.e., its installation media was created bypassing image factory -
+// in that case, we synthesize the schematic ID in a best-effort way (only if it doesn't have any extensions), and use the provided fallback kernel args as the current args of the machine.
+func GetSchematicInfo(ctx context.Context, c *client.Client, fallbackKernelArgs []string) (SchematicInfo, error) {
 	items, err := safe.StateListAll[*runtime.ExtensionStatus](ctx, c.COSI)
 	if err != nil {
 		return SchematicInfo{}, fmt.Errorf("failed to list extensions: %w", err)
@@ -118,8 +116,8 @@ func GetSchematicInfo(ctx context.Context, c *client.Client, defaultKernelArgs [
 	}
 
 	if fullID == "" { // we could not find the full ID, so we fall back to synthesizing it using the default args
-		kernelArgs = defaultKernelArgs
-		extensionsSchematic.Customization.ExtraKernelArgs = defaultKernelArgs
+		kernelArgs = fallbackKernelArgs
+		extensionsSchematic.Customization.ExtraKernelArgs = fallbackKernelArgs
 
 		fullID, err = extensionsSchematic.ID()
 		if err != nil {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -37,8 +37,8 @@ import (
 	"github.com/siderolabs/omni/client/pkg/meta"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
-	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/internal/backend/installimage"
+	"github.com/siderolabs/omni/internal/backend/kernelargs"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/mappers"
 	talosutils "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/talos"
@@ -97,9 +97,6 @@ func NewClusterMachineConfigStatusController(imageFactoryHost string) *ClusterMa
 			qtransform.MapperSameID[*omni.ClusterMachineConfig](),
 		),
 		qtransform.WithExtraMappedInput[*infra.MachineStatus](
-			qtransform.MapperSameID[*omni.ClusterMachineConfig](),
-		),
-		qtransform.WithExtraMappedInput[*siderolink.MachineJoinConfig](
 			qtransform.MapperSameID[*omni.ClusterMachineConfig](),
 		),
 		qtransform.WithExtraMappedInput[*omni.ClusterMachine](
@@ -356,16 +353,10 @@ func (ctrl *ClusterMachineConfigStatusController) upgrade(
 		return false, err
 	}
 
-	params, err := safe.ReaderGetByID[*siderolink.MachineJoinConfig](ctx, r, rc.machineConfig.Metadata().ID())
-	if err != nil {
-		if state.IsNotFoundError(err) {
-			return false, xerrors.NewTagged[qtransform.SkipReconcileTag](err)
-		}
+	// Use the existing protected args (e.g., the siderolink args) as the fallback args if we cannot determine the actual expected args
+	fallbackKernelArgs := kernelargs.FilterProtected(rc.machineStatus.TypedSpec().Value.Schematic.KernelArgs)
 
-		return false, err
-	}
-
-	schematicInfo, err := talosutils.GetSchematicInfo(ctx, c, params.TypedSpec().Value.Config.KernelArgs)
+	schematicInfo, err := talosutils.GetSchematicInfo(ctx, c, fallbackKernelArgs)
 	if err != nil {
 		if !errors.Is(err, talosutils.ErrInvalidSchematic) {
 			return false, err
@@ -376,7 +367,7 @@ func (ctrl *ClusterMachineConfigStatusController) upgrade(
 		expectedSchematic = ""
 	}
 
-	if actualVersion == expectedVersion && rc.SchematicEqual(schematicInfo, expectedSchematic) {
+	if actualVersion == expectedVersion && rc.SchematicEqual(schematicInfo.ID, schematicInfo.FullID, expectedSchematic) {
 		rc.machineConfigStatus.TypedSpec().Value.TalosVersion = actualVersion
 		rc.machineConfigStatus.TypedSpec().Value.SchematicId = expectedSchematic
 


### PR DESCRIPTION
The schematic comparison logic had an edge case: if a machine predates the image factory, it is installed via a `ghcr.io` installer image (or a custom one). Those machines do not have the schematic meta extension on them, and Omni creates a synthetic schematic ID and properties for those. These properties do not have the "actual" kernel args of the machine, but rather, Omni sets them as what it thinks they should be (the "correct" siderolink args from the Omni perspective).

Later, if Omni gets its siderolink API advertised URL get updated, it wrongly detects those synthetic kernel args to be the "new ones (with the new URL)", hence, the desired vs actual schematic comparison returns a mismatch. And Omni does an unnecessary upgrade to that machine.

Fix this by using the "current (non-protected) args of the machine" as the synthetic args in such cases. Those "current" args will be synthetic themselves (since we cannot read them from the machine, as it does not have schematic info on it), but, it will prevent changes when the advertised URL changes.

Additionally, we have two checks to detect a schematic mismatch in the `ClusterMachineConfigStatus` controller - make them check the mismatch in the same way, to be more consistent.

Unrelated to this bug, also fix the `SchematicReady` check (introduced in 1.5) to treat invalid schematics as valid, as otherwise we cannot create clusters from non-factory images.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>