### PR TITLE
feat(frontend): add instructions on how to export cluster templates

### DIFF
--- a/frontend/e2e/talemu/clusters.spec.ts
+++ b/frontend/e2e/talemu/clusters.spec.ts
@@ -61,7 +61,7 @@ test('Create cluster using machine classes', async ({ page }) => {
   })
 
   await test.step('Destroy cluster', async () => {
-    await page.getByRole('button', { name: 'Destroy Cluster' }).click()
+    await page.getByRole('link', { name: 'Destroy Cluster' }).click()
     await page.getByRole('button', { name: 'Destroy', exact: true }).click()
 
     await expect(page.getByText(`The Cluster ${clusterName} is tearing down`)).toBeVisible()

--- a/frontend/src/components/TModal.vue
+++ b/frontend/src/components/TModal.vue
@@ -36,6 +36,9 @@ const modals: Record<string, Component> = {
   downloadTalosctlBinaries: defineAsyncComponent(
     () => import('@/views/omni/Modals/DownloadTalosctl.vue'),
   ),
+  exportClusterTemplate: defineAsyncComponent(
+    () => import('@/views/omni/Modals/ExportClusterTemplate.vue'),
+  ),
   nodeDestroy: defineAsyncComponent(() => import('@/views/omni/Modals/NodeDestroy.vue')),
   nodeDestroyCancel: defineAsyncComponent(
     () => import('@/views/omni/Modals/NodeDestroyCancel.vue'),

--- a/frontend/src/views/cluster/ManagedByTemplatesWarning.vue
+++ b/frontend/src/views/cluster/ManagedByTemplatesWarning.vue
@@ -20,9 +20,14 @@ export type WarningStyle = 'alert' | 'popup' | 'short'
 type Props = {
   resource?: Resource
   warningStyle?: WarningStyle
+  warningText?: string
 }
 
-const { resource, warningStyle = 'alert' } = defineProps<Props>()
+const {
+  resource,
+  warningText = 'It is recommended to manage it using its template and not through this UI.',
+  warningStyle = 'alert',
+} = defineProps<Props>()
 const route = useRoute()
 
 const { data: routeResource } = useResourceWatch<ClusterSpec>(() => ({
@@ -53,7 +58,7 @@ const resourceWord = computed(() => {
   <template v-if="resourceIsManagedByTemplates">
     <div v-if="warningStyle === 'alert'" class="pb-5">
       <TAlert type="warn" :title="`This ${resourceWord} is managed using cluster templates.`">
-        It is recommended to manage it using its template and not through this UI.
+        {{ warningText }}
       </TAlert>
     </div>
     <div v-else-if="warningStyle === 'popup'" class="pb-5 text-xs">
@@ -61,7 +66,7 @@ const resourceWord = computed(() => {
         This {{ resourceWord }} is managed using cluster templates.
       </p>
       <p class="py-2 font-bold text-primary-p3">
-        It is recommended to manage it using its template and not through this UI.
+        {{ warningText }}
       </p>
     </div>
     <div v-else class="text-xs">

--- a/frontend/src/views/cluster/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewContent.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watchEffect } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
@@ -64,19 +64,14 @@ type Props = {
 
 const { currentCluster } = defineProps<Props>()
 
-const enableWorkloadProxy = ref(currentCluster.spec.features?.enable_workload_proxy || false)
-const useEmbeddedDiscoveryService = ref(
-  currentCluster.spec.features?.use_embedded_discovery_service || false,
-)
+const enableWorkloadProxy = ref(false)
+const useEmbeddedDiscoveryService = ref(false)
 
-watch(
-  () => currentCluster,
-  (cluster) => {
-    enableWorkloadProxy.value = cluster.spec.features?.enable_workload_proxy || false
-    useEmbeddedDiscoveryService.value =
-      cluster.spec.features?.use_embedded_discovery_service || false
-  },
-)
+watchEffect(() => {
+  enableWorkloadProxy.value = currentCluster.spec.features?.enable_workload_proxy || false
+  useEmbeddedDiscoveryService.value =
+    currentCluster.spec.features?.use_embedded_discovery_service || false
+})
 
 const { status: backupStatus } = setupBackupStatus()
 
@@ -174,13 +169,13 @@ onMounted(async () => {
 
 <template>
   <div>
-    <div class="overview">
-      <div class="overview-container margin">
+    <div class="flex w-full items-start justify-start">
+      <div class="mr-6 w-full max-w-[80%] max-lg:mr-2 max-lg:w-full">
         <TAlert v-if="clusterLocked" title="Cluster is Locked" type="warn" class="mb-4">
           All operations on this cluster are currently disabled. Config patches can be created,
           updated or deleted but these changes will not be applied while the cluster is locked.
         </TAlert>
-        <div class="overview-charts-box relative">
+        <div class="relative mb-6 min-h-25 bg-naturals-n2 p-5">
           <div
             class="flex w-full flex-wrap gap-2 transition-opacity duration-500 *:flex-1"
             :class="{ 'opacity-25': !showStats }"
@@ -235,22 +230,22 @@ onMounted(async () => {
         </div>
         <div
           v-if="kubernetesUpgradeStatus && kubernetesUpgradeStatus.spec.step"
-          class="overview-upgrade-progress"
+          class="mb-5 rounded bg-naturals-n2 pt-5"
         >
-          <div class="overview-box-header flex items-center gap-1">
-            <span class="overview-box-title flex-1">Kubernetes Update</span>
+          <div class="flex items-center gap-1 px-6 pb-4">
+            <span class="flex-1 text-sm text-naturals-n13">Kubernetes Update</span>
             <template v-if="kubernetesUpgradeStatus.spec.current_upgrade_version">
-              <span class="overview-upgrade-version">
+              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
                 {{ kubernetesUpgradeStatus.spec.last_upgrade_version }}
               </span>
               <span>⇾</span>
-              <span class="overview-upgrade-version">
+              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
                 {{ kubernetesUpgradeStatus.spec.current_upgrade_version }}
               </span>
             </template>
             <template v-else>
-              <span class="overview-box-title">Reverting back to</span>
-              <span class="overview-upgrade-version">
+              <span class="text-sm text-naturals-n13">Reverting back to</span>
+              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
                 {{ kubernetesUpgradeStatus.spec.last_upgrade_version }}
               </span>
             </template>
@@ -285,24 +280,24 @@ onMounted(async () => {
         </div>
         <div
           v-if="talosUpgradeStatus && talosUpgradeStatus.spec.status"
-          class="overview-upgrade-progress"
+          class="mb-5 rounded bg-naturals-n2 pt-5"
         >
-          <div class="overview-box-header flex items-center gap-1">
-            <span class="overview-box-title flex-1">Talos Update</span>
+          <div class="flex items-center gap-1 px-6 pb-4">
+            <span class="flex-1 text-sm text-naturals-n13">Talos Update</span>
             <template v-if="talosUpgradeStatus.spec.current_upgrade_version">
-              <span class="overview-upgrade-version">
+              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
                 {{ talosUpgradeStatus.spec.last_upgrade_version }}
               </span>
               <span>⇾</span>
-              <span class="overview-upgrade-version">
+              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
                 {{ talosUpgradeStatus.spec.current_upgrade_version }}
               </span>
             </template>
             <template
               v-else-if="talosUpgradeStatus.spec.phase === TalosUpgradeStatusSpecPhase.Reverting"
             >
-              <span class="overview-box-title">Reverting back to</span>
-              <span class="overview-upgrade-version">
+              <span class="text-sm text-naturals-n13">Reverting back to</span>
+              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
                 {{ talosUpgradeStatus.spec.last_upgrade_version }}
               </span>
             </template>
@@ -312,7 +307,7 @@ onMounted(async () => {
                 TalosUpgradeStatusSpecPhase.UpdatingMachineSchematics
               "
             >
-              <span class="overview-box-title">Updating Machine Schematics</span>
+              <span class="text-sm text-naturals-n13">Updating Machine Schematics</span>
             </template>
           </div>
           <div class="flex min-h-20 items-center gap-2 border-t-8 border-naturals-n4 p-4 text-xs">
@@ -346,11 +341,11 @@ onMounted(async () => {
         </div>
         <div
           v-if="secretRotationStatus && secretRotationStatus.spec.status"
-          class="overview-upgrade-progress"
+          class="mb-5 rounded bg-naturals-n2 pt-5"
         >
-          <div class="overview-box-header flex items-center gap-1">
-            <span class="overview-box-title flex-1">Secret Rotation</span>
-            <span class="overview-box-title">{{ getComponentInRotation }}</span>
+          <div class="flex items-center gap-1 px-6 pb-4">
+            <span class="flex-1 text-sm text-naturals-n13">Secret Rotation</span>
+            <span class="text-sm text-naturals-n13">{{ getComponentInRotation }}</span>
           </div>
           <div class="flex min-h-20 items-center gap-2 border-t-8 border-naturals-n4 p-4 text-xs">
             <TIcon
@@ -369,9 +364,9 @@ onMounted(async () => {
           </div>
         </div>
         <div class="flex gap-5">
-          <div class="overview-card mb-5 flex-1 px-6">
+          <div class="mb-5 flex-1 rounded bg-naturals-n2 px-6 py-5">
             <div class="mb-3">
-              <span class="overview-box-title">Features</span>
+              <span class="text-sm text-naturals-n13">Features</span>
             </div>
             <div class="flex flex-col gap-2">
               <ClusterWorkloadProxyingCheckbox
@@ -391,9 +386,9 @@ onMounted(async () => {
               />
             </div>
           </div>
-          <div class="overview-card mb-5 flex-1 px-6">
+          <div class="mb-5 flex-1 rounded bg-naturals-n2 px-6 py-5">
             <div class="mb-3">
-              <span class="overview-box-title">Labels</span>
+              <span class="text-sm text-naturals-n13">Labels</span>
             </div>
             <ItemLabels
               :resource="currentCluster"
@@ -402,9 +397,9 @@ onMounted(async () => {
             />
           </div>
         </div>
-        <div class="overview-card overview-machines-list">
-          <div class="overview-box-header">
-            <span class="overview-box-title">Machines</span>
+        <div class="flex-col rounded bg-naturals-n2 pt-5">
+          <div class="flex px-6 pb-4">
+            <span class="text-sm text-naturals-n13">Machines</span>
           </div>
           <div class="grid grid-cols-[repeat(4,1fr)_--spacing(18)]">
             <ClusterMachines is-subgrid :cluster-i-d="clusterId" />
@@ -419,66 +414,3 @@ onMounted(async () => {
     </div>
   </div>
 </template>
-
-<style scoped>
-@reference "../../../../index.css";
-
-.overview-card {
-  @apply rounded bg-naturals-n2 py-5;
-}
-.divider {
-  @apply w-full bg-naturals-n4;
-  height: 1px;
-}
-.overview {
-  @apply flex w-full items-start justify-start;
-}
-.overview-container {
-  @apply mr-6 w-full;
-  max-width: 80%;
-}
-@media screen and (max-width: 1050px) {
-  .overview-container {
-    @apply mr-2 w-full;
-  }
-}
-.overview-title-box {
-  @apply flex items-center;
-  margin-bottom: 35px;
-}
-.overview-title {
-  @apply mr-2 text-xl text-naturals-n14;
-}
-.overview-icon {
-  @apply h-5 w-5 cursor-pointer fill-current text-naturals-n14;
-}
-.overview-machines-list {
-  @apply flex-col;
-  padding-bottom: 0;
-}
-.overview-kubernetes-upgrade {
-  @apply mb-5 rounded bg-naturals-n2 py-5 pb-0;
-}
-.overview-upgrade-progress {
-  @apply mb-5 rounded bg-naturals-n2 py-5 pb-0;
-}
-.overview-box-header {
-  @apply flex px-6 pb-4;
-}
-.overview-box-title {
-  @apply text-sm text-naturals-n13;
-}
-.overview-usage-subtitle {
-  @apply text-xs text-naturals-n10;
-}
-.overview-status-box {
-  @apply w-full flex-col rounded bg-naturals-n2 py-5 pb-0;
-}
-.overview-charts-box {
-  @apply mb-6 bg-naturals-n2 p-5;
-  min-height: 100px;
-}
-.overview-upgrade-version {
-  @apply rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13;
-}
-</style>

--- a/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue
@@ -6,7 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import * as semver from 'semver'
-import { computed, markRaw, type Ref, ref, toRefs } from 'vue'
+import { computed, markRaw, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -31,7 +31,6 @@ import {
   KubernetesStatusType,
   MetricsNamespace,
 } from '@/api/resources'
-import Watch from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
@@ -42,6 +41,7 @@ import { setupClusterPermissions } from '@/methods/auth'
 import { triggerEtcdBackup, updateClusterLock } from '@/methods/cluster'
 import { controlPlaneMachineSetId } from '@/methods/machineset'
 import { formatISO } from '@/methods/time'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showWarning } from '@/notification'
 import ManagedByTemplatesWarning from '@/views/cluster/ManagedByTemplatesWarning.vue'
 import OverviewOIDCToast from '@/views/cluster/Overview/components/OverviewRightPanel/OverviewOIDCToast.vue'
@@ -49,97 +49,80 @@ import OverviewRightPanelCondition from '@/views/cluster/Overview/components/Ove
 import OverviewRightPanelItem from '@/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanelItem.vue'
 import TClusterStatus from '@/views/omni/Clusters/ClusterStatus.vue'
 
+const { kubernetesUpgradeStatus, talosUpgradeStatus } = defineProps<{
+  kubernetesUpgradeStatus?: Resource<KubernetesUpgradeStatusSpec>
+  talosUpgradeStatus?: Resource<TalosUpgradeStatusSpec>
+  etcdBackups?: BackupsStatus
+}>()
+
 const route = useRoute()
 const router = useRouter()
 
-const currentCluster: Ref<Resource<ClusterStatusSpec> | undefined> = ref()
-const currentClusterWatch = new Watch(currentCluster)
-
-const backupStatus: Ref<Resource<EtcdBackupStatusSpec> | undefined> = ref()
-const backupStatusWatch = new Watch(backupStatus)
-
-const controlPlaneStatus: Ref<Resource<ControlPlaneStatusSpec> | undefined> = ref()
-const controlPlaneStatusWatch = new Watch(controlPlaneStatus)
-
-const kubernetesStatus: Ref<Resource<KubernetesStatusSpec> | undefined> = ref()
-const kubernetesStatusWatch = new Watch(kubernetesStatus)
-
-const clusterDiagnostics: Ref<Resource<ClusterDiagnosticsSpec> | undefined> = ref()
-const clusterDiagnosticsWatch = new Watch(clusterDiagnostics)
-
-const numNodesWithDiagnostics = computed(() => {
-  return clusterDiagnostics.value?.spec.nodes?.length || 0
-})
-
-const numTotalDiagnostics = computed(() => {
-  const nodes: ClusterDiagnosticsSpecNode[] = clusterDiagnostics.value?.spec?.nodes || []
-  return nodes.reduce((sum, node) => sum + (node.num_diagnostics || 0), 0) || 0
-})
-
-const props = defineProps<{
-  kubernetesUpgradeStatus: Resource<KubernetesUpgradeStatusSpec> | undefined
-  talosUpgradeStatus: Resource<TalosUpgradeStatusSpec> | undefined
-  etcdBackups: BackupsStatus | undefined
-}>()
-
-enum Update {
-  Talos,
-  Kubernetes,
-}
-
-const { kubernetesUpgradeStatus, talosUpgradeStatus } = toRefs(props)
-
-currentClusterWatch.setup({
+const { data: clusterStatus } = useResourceWatch<ClusterStatusSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,
     type: ClusterStatusType,
     id: route.params.cluster as string,
   },
-})
+}))
 
-controlPlaneStatusWatch.setup({
-  runtime: Runtime.Omni,
-  resource: {
-    namespace: DefaultNamespace,
-    type: ControlPlaneStatusType,
-    id: controlPlaneMachineSetId(route.params.cluster as string),
-  },
-})
-
-kubernetesStatusWatch.setup({
-  runtime: Runtime.Omni,
-  resource: {
-    namespace: DefaultNamespace,
-    type: KubernetesStatusType,
-    id: route.params.cluster as string,
-  },
-})
-
-backupStatusWatch.setup({
+const { data: backupStatus } = useResourceWatch<EtcdBackupStatusSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
     namespace: MetricsNamespace,
     type: EtcdBackupStatusType,
     id: route.params.cluster as string,
   },
-})
+}))
 
-clusterDiagnosticsWatch.setup({
+const { data: controlPlaneStatus } = useResourceWatch<ControlPlaneStatusSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: ControlPlaneStatusType,
+    id: controlPlaneMachineSetId(route.params.cluster as string),
+  },
+}))
+
+const { data: kubernetesStatus } = useResourceWatch<KubernetesStatusSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: KubernetesStatusType,
+    id: route.params.cluster as string,
+  },
+}))
+
+const { data: clusterDiagnostics } = useResourceWatch<ClusterDiagnosticsSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,
     type: ClusterDiagnosticsType,
     id: route.params.cluster as string,
   },
+}))
+
+const numNodesWithDiagnostics = computed(() => {
+  return clusterDiagnostics.value?.spec.nodes?.length || 0
 })
+
+const numTotalDiagnostics = computed(() => {
+  const nodes: ClusterDiagnosticsSpecNode[] = clusterDiagnostics.value?.spec.nodes || []
+  return nodes.reduce((sum, node) => sum + (node.num_diagnostics || 0), 0) || 0
+})
+
+enum Update {
+  Talos,
+  Kubernetes,
+}
 
 const lastBackupError = computed(() => {
   return backupStatus.value?.spec.error
 })
 
 const backupTime = computed(() => {
-  const t = backupStatus?.value?.spec.last_backup_time
+  const t = backupStatus.value?.spec.last_backup_time
 
   if (!t) {
     return 'Never'
@@ -163,11 +146,11 @@ const runEtcdBackup = async () => {
 }
 
 const kubernetesUpgradeAvailable = () => {
-  return (kubernetesUpgradeStatus?.value?.spec?.upgrade_versions?.length ?? 0) > 0
+  return (kubernetesUpgradeStatus?.spec.upgrade_versions?.length ?? 0) > 0
 }
 
 const talosUpdateAvailable = () => {
-  return (talosUpgradeStatus?.value?.spec?.upgrade_versions?.length ?? 0) > 0
+  return (talosUpgradeStatus?.spec.upgrade_versions?.length ?? 0) > 0
 }
 
 const getUpgradeAvailable = (spec: {
@@ -185,19 +168,19 @@ const getUpgradeAvailable = (spec: {
 }
 
 const kubernetesVersion = computed(() => {
-  return getVersion(kubernetesUpgradeStatus.value!.spec)
+  return getVersion(kubernetesUpgradeStatus!.spec)
 })
 
 const talosVersion = computed(() => {
-  return getVersion(talosUpgradeStatus.value!.spec)
+  return getVersion(talosUpgradeStatus!.spec)
 })
 
 const newKubernetesVersionsAvailable = computed(() => {
-  return getUpgradeAvailable(kubernetesUpgradeStatus.value!.spec)
+  return getUpgradeAvailable(kubernetesUpgradeStatus!.spec)
 })
 
 const newTalosVersionsAvailable = computed(() => {
-  return getUpgradeAvailable(talosUpgradeStatus.value!.spec)
+  return getUpgradeAvailable(talosUpgradeStatus!.spec)
 })
 
 const getVersion = (spec: { last_upgrade_version?: string; current_upgrade_version?: string }) => {
@@ -223,30 +206,20 @@ const openClusterUpdate = (type: Update, locked: boolean) => {
 
   const modal = type === Update.Talos ? 'updateTalos' : 'updateKubernetes'
 
-  router.push({ query: { modal: modal, cluster: currentCluster?.value?.metadata?.id } })
-}
-
-const openDownloadSupportBundle = () => {
-  if (!canDownloadSupportBundle.value) {
-    return
-  }
-
-  router.push({
-    query: { modal: 'downloadSupportBundle', cluster: currentCluster?.value?.metadata?.id },
-  })
+  router.push({ query: { modal: modal, cluster: clusterStatus.value?.metadata.id } })
 }
 
 const locked = computed(() => {
-  return currentCluster?.value?.metadata.annotations?.[ClusterLocked] !== undefined
+  return clusterStatus.value?.metadata.annotations?.[ClusterLocked] !== undefined
 })
 
 const updateLock = async () => {
-  if (!currentCluster?.value?.metadata.id) {
+  if (!clusterStatus.value?.metadata.id) {
     return
   }
 
   try {
-    await updateClusterLock(currentCluster.value.metadata.id, !locked.value)
+    await updateClusterLock(clusterStatus.value.metadata.id, !locked.value)
   } catch (e) {
     showError('Failed To Update Cluster Lock', e.message)
   }
@@ -264,22 +237,22 @@ const {
 </script>
 
 <template>
-  <div class="overview-right-box">
-    <div class="overview-right-box-wrapper">
-      <h3 class="overview-details-title">Cluster Details</h3>
+  <div class="mb-4 h-auto max-w-[20%] min-w-67 rounded bg-naturals-n2 py-5">
+    <div class="flex flex-col gap-4 px-2 lg:px-6">
+      <h3 class="text-sm text-naturals-n13">Cluster Details</h3>
       <ManagedByTemplatesWarning warning-style="short" />
       <OverviewRightPanelItem
-        v-if="currentCluster?.metadata?.created"
+        v-if="clusterStatus?.metadata.created"
         name="Created"
-        :value="formatISO(currentCluster?.metadata?.created as string, 'yyyy-LL-dd HH:mm:ss')"
+        :value="formatISO(clusterStatus.metadata.created, 'yyyy-LL-dd HH:mm:ss')"
       />
-      <OverviewRightPanelItem v-if="currentCluster" name="Status">
-        <TClusterStatus :cluster="currentCluster" />
+      <OverviewRightPanelItem v-if="clusterStatus" name="Status">
+        <TClusterStatus :cluster="clusterStatus" />
       </OverviewRightPanelItem>
       <OverviewRightPanelItem
-        v-if="currentCluster?.spec?.machines?.total"
+        v-if="clusterStatus?.spec.machines?.total"
         name="Machines Healthy"
-        :value="`${currentCluster?.spec?.machines?.healthy ?? 0}/${currentCluster?.spec?.machines?.total}`"
+        :value="`${clusterStatus.spec.machines.healthy ?? 0}/${clusterStatus.spec.machines.total}`"
       />
       <OverviewRightPanelItem v-if="numNodesWithDiagnostics > 0" name="Node Warnings">
         <div class="flex items-center gap-1">
@@ -327,16 +300,16 @@ const {
         </Tooltip>
       </OverviewRightPanelItem>
     </div>
-    <template v-if="currentCluster?.spec">
-      <div class="divider" />
-      <div class="overview-right-box-wrapper overview-right-box-wrapper-moved">
-        <h3 class="overview-details-title">Control Plane</h3>
+    <template v-if="clusterStatus?.spec">
+      <div class="my-3 h-px bg-naturals-n4" />
+      <div class="flex flex-col gap-4 px-2 lg:px-6">
+        <h3 class="text-sm text-naturals-n13">Control Plane</h3>
         <OverviewRightPanelItem name="Ready">
-          <span :class="currentCluster?.spec?.controlplaneReady ? '' : 'text-red-r1'">
-            {{ currentCluster?.spec?.controlplaneReady ? 'Yes' : 'No' }}
+          <span :class="clusterStatus.spec.controlplaneReady ? '' : 'text-red-r1'">
+            {{ clusterStatus.spec.controlplaneReady ? 'Yes' : 'No' }}
           </span>
         </OverviewRightPanelItem>
-        <OverviewRightPanelItem v-if="currentCluster?.metadata?.created" name="Last Backup">
+        <OverviewRightPanelItem v-if="clusterStatus.metadata.created" name="Last Backup">
           <div v-if="startingEtcdBackup" class="flex gap-1">
             Starting...
             <TSpinner class="h-4 w-4" />
@@ -344,7 +317,7 @@ const {
           <template v-else>
             <Tooltip v-if="lastBackupError">
               <template #description>
-                <div class="max-w-lg break-words">{{ lastBackupError }}</div>
+                <div class="max-w-lg wrap-break-word">{{ lastBackupError }}</div>
               </template>
               <TIcon class="h-4 w-4 text-yellow-y1" icon="warning" />
             </Tooltip>
@@ -364,12 +337,12 @@ const {
           :condition="condition"
         />
       </div>
-      <div class="divider" />
-      <div class="overview-right-box-wrapper overview-right-box-wrapper-moved">
-        <h3 class="overview-details-title">Kubernetes</h3>
+      <div class="my-3 h-px bg-naturals-n4" />
+      <div class="flex flex-col gap-4 px-2 lg:px-6">
+        <h3 class="text-sm text-naturals-n13">Kubernetes</h3>
         <OverviewRightPanelItem
           name="API Available"
-          :value="currentCluster?.spec.kubernetesAPIReady ? 'Yes' : 'No'"
+          :value="clusterStatus.spec.kubernetesAPIReady ? 'Yes' : 'No'"
         />
         <OverviewRightPanelItem
           v-if="kubernetesStatus && kubernetesStatus.spec.nodes"
@@ -377,163 +350,155 @@ const {
           :value="kubernetesStatus.spec.nodes.length ?? 0"
         />
       </div>
-      <div class="divider" />
-      <div class="overview-right-box-wrapper overview-right-box-wrapper-moved">
-        <div class="overview-details-item">
-          <TButton
-            :disabled="!canDownloadKubeconfig"
-            class="overview-item-button w-full"
-            type="primary"
-            icon="kube-config"
-            icon-position="left"
-            @click="
-              () => {
-                downloadKubeconfig(currentCluster!.metadata.id!)
-                showWarning('Note on kubectl', { description: markRaw(OverviewOIDCToast) })
-              }
-            "
-          >
-            Download
-            <code>kubeconfig</code>
-          </TButton>
-        </div>
-        <div class="overview-details-item">
-          <TButton
-            :disabled="!canDownloadTalosconfig"
-            class="overview-item-button w-full"
-            type="primary"
-            icon="talos-config"
-            icon-position="left"
-            @click="() => downloadTalosconfig(currentCluster!.metadata.id!)"
-          >
-            Download
-            <code>talosconfig</code>
-          </TButton>
-        </div>
-        <div class="overview-details-item">
-          <TButton
-            :disabled="!canDownloadSupportBundle"
-            class="overview-item-button w-full"
-            type="primary"
-            icon="lifebuoy"
-            icon-position="left"
-            @click="openDownloadSupportBundle"
-          >
-            Download Support Bundle
-          </TButton>
-        </div>
+      <div class="my-3 h-px bg-naturals-n4" />
+      <div class="flex flex-col gap-4 px-2 lg:px-6">
+        <TButton
+          :disabled="!canDownloadKubeconfig"
+          type="primary"
+          icon="kube-config"
+          icon-position="left"
+          @click="
+            () => {
+              downloadKubeconfig(clusterStatus!.metadata.id!)
+              showWarning('Note on kubectl', { description: markRaw(OverviewOIDCToast) })
+            }
+          "
+        >
+          Download
+          <code>kubeconfig</code>
+        </TButton>
+
+        <TButton
+          :disabled="!canDownloadTalosconfig"
+          type="primary"
+          icon="talos-config"
+          icon-position="left"
+          @click="() => downloadTalosconfig(clusterStatus!.metadata.id!)"
+        >
+          Download
+          <code>talosconfig</code>
+        </TButton>
+
+        <TButton
+          is="router-link"
+          :disabled="!canDownloadSupportBundle"
+          type="primary"
+          icon="lifebuoy"
+          icon-position="left"
+          :to="{
+            query: { modal: 'downloadSupportBundle', cluster: clusterStatus.metadata.id },
+          }"
+        >
+          Download Support Bundle
+        </TButton>
+
+        <TButton
+          is="router-link"
+          type="primary"
+          icon="kube-config"
+          icon-position="left"
+          :to="{
+            query: { modal: 'exportClusterTemplate' },
+          }"
+        >
+          Export Cluster Template
+        </TButton>
       </div>
-      <div class="divider" />
-      <div class="overview-right-box-wrapper overview-right-box-wrapper-moved">
-        <div class="overview-details-item">
-          <Tooltip
-            class="grow"
-            :disabled="!locked"
-            :description="`Cluster scaling is disabled when the cluster is locked.`"
-          >
-            <TButton
-              is="router-link"
-              class="overview-item-button w-full"
-              type="highlighted"
-              icon="nodes"
-              icon-position="left"
-              :disabled="!canAddClusterMachines || locked"
-              :to="{
-                name: 'ClusterScale',
-                params: { cluster: currentCluster.metadata.id },
-              }"
-            >
-              Cluster Scaling
-            </TButton>
-          </Tooltip>
-        </div>
-        <div class="overview-details-item">
-          <Tooltip
-            class="grow"
-            :disabled="!locked"
-            :description="`Kubernetes updates are disabled when the cluster is locked.`"
-          >
-            <TButton
-              class="overview-item-button w-full"
-              type="primary"
-              icon="kubernetes"
-              icon-position="left"
-              :disabled="!canUpdateKubernetes || !kubernetesUpgradeAvailable() || locked"
-              @click="openClusterUpdate(Update.Kubernetes, locked)"
-            >
-              Update Kubernetes
-            </TButton>
-          </Tooltip>
-        </div>
-        <div class="overview-details-item">
-          <Tooltip
-            class="grow"
-            :disabled="!locked"
-            :description="`Talos updates are disabled when the cluster is locked.`"
-          >
-            <TButton
-              class="overview-item-button w-full"
-              type="primary"
-              icon="sidero-monochrome"
-              icon-position="left"
-              :disabled="!canUpdateTalos || !talosUpdateAvailable() || locked"
-              @click="openClusterUpdate(Update.Talos, locked)"
-            >
-              Update Talos
-            </TButton>
-          </Tooltip>
-        </div>
-        <div class="overview-details-item">
+      <div class="my-3 h-px bg-naturals-n4" />
+      <div class="flex flex-col gap-4 px-2 lg:px-6">
+        <Tooltip
+          class="grow"
+          :disabled="!locked"
+          :description="`Cluster scaling is disabled when the cluster is locked.`"
+        >
           <TButton
-            class="overview-item-button w-full"
-            type="primary"
-            icon="settings"
+            is="router-link"
+            type="highlighted"
+            icon="nodes"
             icon-position="left"
-            @click="
-              () =>
-                $router.push({
-                  name: 'ClusterConfigPatches',
-                  params: { cluster: currentCluster?.metadata?.id },
-                })
-            "
+            :disabled="!canAddClusterMachines || locked"
+            :to="{
+              name: 'ClusterScale',
+              params: { cluster: clusterStatus.metadata.id },
+            }"
           >
-            Config Patches
+            Cluster Scaling
           </TButton>
-        </div>
-        <div class="overview-details-item">
+        </Tooltip>
+
+        <Tooltip
+          class="grow"
+          :disabled="!locked"
+          :description="`Kubernetes updates are disabled when the cluster is locked.`"
+        >
           <TButton
-            class="overview-item-button w-full"
             type="primary"
-            :icon="locked ? 'locked' : 'unlocked'"
+            icon="kubernetes"
             icon-position="left"
-            @click="updateLock"
+            :disabled="!canUpdateKubernetes || !kubernetesUpgradeAvailable() || locked"
+            @click="openClusterUpdate(Update.Kubernetes, locked)"
           >
-            {{ locked ? 'Unlock Cluster' : 'Lock Cluster' }}
+            Update Kubernetes
           </TButton>
-        </div>
-        <div class="overview-details-item">
-          <Tooltip
-            class="grow"
-            :disabled="!locked"
-            :description="`Cluster deletion is disabled when the cluster is locked.`"
+        </Tooltip>
+
+        <Tooltip
+          class="grow"
+          :disabled="!locked"
+          :description="`Talos updates are disabled when the cluster is locked.`"
+        >
+          <TButton
+            type="primary"
+            icon="sidero-monochrome"
+            icon-position="left"
+            :disabled="!canUpdateTalos || !talosUpdateAvailable() || locked"
+            @click="openClusterUpdate(Update.Talos, locked)"
           >
-            <TButton
-              class="overview-item-button-red w-full"
-              type="secondary"
-              icon="delete"
-              icon-position="left"
-              :disabled="!canRemoveClusterMachines || locked"
-              @click="
-                () =>
-                  $router.push({
-                    query: { modal: 'clusterDestroy', cluster: currentCluster?.metadata?.id },
-                  })
-              "
-            >
-              Destroy Cluster
-            </TButton>
-          </Tooltip>
-        </div>
+            Update Talos
+          </TButton>
+        </Tooltip>
+
+        <TButton
+          is="router-link"
+          type="primary"
+          icon="settings"
+          icon-position="left"
+          :to="{
+            name: 'ClusterConfigPatches',
+            params: { cluster: clusterStatus.metadata.id },
+          }"
+        >
+          Config Patches
+        </TButton>
+
+        <TButton
+          type="primary"
+          :icon="locked ? 'locked' : 'unlocked'"
+          icon-position="left"
+          @click="updateLock"
+        >
+          {{ locked ? 'Unlock Cluster' : 'Lock Cluster' }}
+        </TButton>
+
+        <Tooltip
+          class="grow"
+          :disabled="!locked"
+          :description="`Cluster deletion is disabled when the cluster is locked.`"
+        >
+          <TButton
+            is="router-link"
+            class="text-red-r1"
+            type="secondary"
+            icon="delete"
+            icon-position="left"
+            :disabled="!canRemoveClusterMachines || locked"
+            :to="{
+              query: { modal: 'clusterDestroy', cluster: clusterStatus.metadata.id },
+            }"
+          >
+            Destroy Cluster
+          </TButton>
+        </Tooltip>
       </div>
     </template>
     <div v-else class="flex items-center justify-center p-4">
@@ -541,34 +506,3 @@ const {
     </div>
   </div>
 </template>
-
-<style scoped>
-@reference "../../../../../index.css";
-
-.divider {
-  @apply my-3 w-full bg-naturals-n4;
-  height: 1px;
-}
-
-.overview-right-box {
-  @apply mb-4 h-auto w-full rounded bg-naturals-n2 py-5;
-  max-width: 20%;
-  min-width: 270px;
-}
-
-.overview-right-box-wrapper {
-  @apply flex flex-col gap-4 px-2 lg:px-6;
-}
-
-.overview-details-title {
-  @apply text-sm text-naturals-n13;
-}
-
-.overview-item-button-red {
-  @apply text-red-r1;
-}
-
-.overview-details-item {
-  @apply flex items-center justify-between;
-}
-</style>

--- a/frontend/src/views/omni/Modals/ExportClusterTemplate.vue
+++ b/frontend/src/views/omni/Modals/ExportClusterTemplate.vue
@@ -1,0 +1,90 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { Runtime } from '@/api/common/omni.pb'
+import type { ClusterSpec } from '@/api/omni/specs/omni.pb'
+import { ClusterType, DefaultNamespace } from '@/api/resources'
+import TButton from '@/components/common/Button/TButton.vue'
+import CodeBlock from '@/components/common/CodeBlock/CodeBlock.vue'
+import { getDocsLink } from '@/methods'
+import { useResourceWatch } from '@/methods/useResourceWatch'
+import ManagedByTemplatesWarning from '@/views/cluster/ManagedByTemplatesWarning.vue'
+import CloseButton from '@/views/omni/Modals/CloseButton.vue'
+
+const router = useRouter()
+const route = useRoute()
+
+let closed = false
+
+const close = () => {
+  if (closed) {
+    return
+  }
+
+  closed = true
+
+  router.go(-1)
+}
+
+const clusterId = computed(() => route.params.cluster as string)
+
+const { data: cluster } = useResourceWatch<ClusterSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    type: ClusterType,
+    namespace: DefaultNamespace,
+    id: clusterId.value,
+  },
+}))
+</script>
+
+<template>
+  <div class="modal-window">
+    <div class="heading">
+      <h3 class="text-base text-naturals-n14">Export Cluster Template</h3>
+      <CloseButton @click="close" />
+    </div>
+
+    <div class="mb-5 flex flex-col gap-2 text-sm">
+      <ManagedByTemplatesWarning
+        :resource="cluster"
+        warning-text="This cluster is already managed using cluster templates. Make sure any external changes to templates have already been applied before exporting this template again, or your changes will be lost."
+      />
+
+      <p>
+        You can export the
+        <a
+          class="link-primary"
+          :href="getDocsLink('omni', '/reference/cluster-templates')"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          cluster template
+        </a>
+        for this cluster using the following
+        <code>omnictl</code>
+        command
+      </p>
+      <CodeBlock :code="`omnictl cluster template export -c ${clusterId}`" />
+    </div>
+
+    <div class="flex justify-end">
+      <TButton class="h-9 w-32" @click="close">Close</TButton>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@reference "../../../index.css";
+
+.heading {
+  @apply mb-5 flex items-center justify-between text-xl text-naturals-n14;
+}
+</style>


### PR DESCRIPTION
Add instructions on how to export cluster templates on the cluster overview page. Will be shown in a modal after clicking the "Export Cluster Template" button. Also included some refactors to watches & classes for `OverviewContent` + `OverviewRightPanel`.

Closes #2010 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5e719173-97f4-4de6-a936-72dcb61831ad" />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/c8bfbce8-53e5-4ed2-a409-c53f1e112c21" />
