### PR TITLE
fix: prevent unwanted upgrades of non-image-factory machines (backport)

### DIFF
--- a/internal/backend/kernelargs/kernelargs.go
+++ b/internal/backend/kernelargs/kernelargs.go
@@ -123,6 +123,11 @@ func Calculate(machineStatus *omni.MachineStatus, kernelArgs *omni.KernelArgs) (
 	return slices.Concat(baseArgs, extraArgs), true, nil
 }
 
+// FilterProtected filters out the "extra args" from the provided kernel args, leaving only the protected kernel arguments that cannot be modified.
+func FilterProtected(args []string) []string {
+	return xslices.Filter(args, isProtected)
+}
+
 // FilterExtras filters out the protected kernel arguments from the provided kernel args, leaving only the "extra args" that can be modified.
 func FilterExtras(args []string) []string {
 	return xslices.Filter(args, func(value string) bool {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
@@ -22,7 +22,6 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/kernelargs"
-	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/talos"
 )
 
 // ReconciliationContext describes all related data for one reconciliation call of the machine config status controller.
@@ -99,12 +98,12 @@ func (rc *ReconciliationContext) ID() string {
 }
 
 // SchematicEqual compares the schematic using the complex condition.
-func (rc *ReconciliationContext) SchematicEqual(schematicInfo talos.SchematicInfo, expectedSchematic string) bool {
+func (rc *ReconciliationContext) SchematicEqual(extensionsOnlyID, fullID, expectedSchematic string) bool {
 	if rc.compareFullSchematicID {
-		return schematicInfo.FullID == expectedSchematic
+		return fullID == expectedSchematic
 	}
 
-	return schematicInfo.Equal(expectedSchematic)
+	return extensionsOnlyID == expectedSchematic || fullID == expectedSchematic
 }
 
 // BuildReconciliationContext is the COSI reader dependent method to build the reconciliation context.
@@ -168,22 +167,21 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 		return nil, fmt.Errorf("failed to determine if kernel args update is supported for machine %q: %w", machineConfig.Metadata().ID(), err)
 	}
 
-	if compareFullSchematicID {
-		schematicMismatch = schematicMismatch || machineStatus.TypedSpec().Value.Schematic.FullId != installImage.SchematicId
-	} else {
-		schematicMismatch = schematicMismatch || machineStatus.TypedSpec().Value.Schematic.Id != installImage.SchematicId
-	}
-
-	talosVersionMismatch := strings.TrimLeft(machineStatus.TypedSpec().Value.TalosVersion, "v") != machineConfigStatus.TypedSpec().Value.TalosVersion ||
-		machineConfigStatus.TypedSpec().Value.TalosVersion != installImage.TalosVersion
-
-	return &ReconciliationContext{
+	rc := &ReconciliationContext{
 		machineStatus:          machineStatus,
-		machineStatusSnapshot:  statusSnapshot,
 		machineConfig:          machineConfig,
 		machineConfigStatus:    machineConfigStatus,
-		shouldUpgrade:          schematicMismatch || talosVersionMismatch,
-		compareFullSchematicID: compareFullSchematicID,
+		machineStatusSnapshot:  statusSnapshot,
 		installImage:           installImage,
-	}, nil
+		compareFullSchematicID: compareFullSchematicID,
+	}
+
+	schematicMismatch = schematicMismatch || !rc.SchematicEqual(rc.machineStatus.TypedSpec().Value.Schematic.Id, rc.machineStatus.TypedSpec().Value.Schematic.FullId, rc.installImage.SchematicId)
+
+	talosVersionMismatch := strings.TrimLeft(rc.machineStatus.TypedSpec().Value.TalosVersion, "v") != machineConfigStatus.TypedSpec().Value.TalosVersion ||
+		machineConfigStatus.TypedSpec().Value.TalosVersion != rc.installImage.TalosVersion
+
+	rc.shouldUpgrade = schematicMismatch || talosVersionMismatch
+
+	return rc, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -35,8 +35,8 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
-	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/internal/backend/installimage"
+	"github.com/siderolabs/omni/internal/backend/kernelargs"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/mappers"
 	talosutils "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/talos"
@@ -91,9 +91,6 @@ func NewClusterMachineConfigStatusController(imageFactoryHost string) *ClusterMa
 			qtransform.MapperSameID[*omni.ClusterMachineConfig](),
 		),
 		qtransform.WithExtraMappedInput[*infra.MachineStatus](
-			qtransform.MapperSameID[*omni.ClusterMachineConfig](),
-		),
-		qtransform.WithExtraMappedInput[*siderolink.MachineJoinConfig](
 			qtransform.MapperSameID[*omni.ClusterMachineConfig](),
 		),
 		qtransform.WithExtraMappedInput[*omni.ClusterMachine](
@@ -272,16 +269,10 @@ func (ctrl *ClusterMachineConfigStatusController) upgrade(
 		return false, err
 	}
 
-	params, err := safe.ReaderGetByID[*siderolink.MachineJoinConfig](ctx, r, rc.machineConfig.Metadata().ID())
-	if err != nil {
-		if state.IsNotFoundError(err) {
-			return false, xerrors.NewTagged[qtransform.SkipReconcileTag](err)
-		}
+	// Use the existing protected args (e.g., the siderolink args) as the fallback args if we cannot determine the actual expected args
+	fallbackKernelArgs := kernelargs.FilterProtected(rc.machineStatus.TypedSpec().Value.Schematic.KernelArgs)
 
-		return false, err
-	}
-
-	schematicInfo, err := talosutils.GetSchematicInfo(ctx, c, params.TypedSpec().Value.Config.KernelArgs)
+	schematicInfo, err := talosutils.GetSchematicInfo(ctx, c, fallbackKernelArgs)
 	if err != nil {
 		if !errors.Is(err, talosutils.ErrInvalidSchematic) {
 			return false, err
@@ -292,7 +283,7 @@ func (ctrl *ClusterMachineConfigStatusController) upgrade(
 		expectedSchematic = ""
 	}
 
-	if actualVersion == expectedVersion && rc.SchematicEqual(schematicInfo, expectedSchematic) {
+	if actualVersion == expectedVersion && rc.SchematicEqual(schematicInfo.ID, schematicInfo.FullID, expectedSchematic) {
 		rc.machineConfigStatus.TypedSpec().Value.TalosVersion = actualVersion
 		rc.machineConfigStatus.TypedSpec().Value.SchematicId = expectedSchematic
 


### PR DESCRIPTION
The schematic comparison logic had an edge case: if a machine predates the image factory, it is installed via a `ghcr.io` installer image (or a custom one). Those machines do not have the schematic meta extension on them, and Omni creates a synthetic schematic ID and properties for those. These properties do not have the "actual" kernel args of the machine, but rather, Omni sets them as what it thinks they should be (the "correct" siderolink args from the Omni perspective).

Later, if Omni gets its siderolink API advertised URL get updated, it wrongly detects those synthetic kernel args to be the "new ones (with the new URL)", hence, the desired vs actual schematic comparison returns a mismatch. And Omni does an unnecessary upgrade to that machine.

Fix this by using the "current (non-protected) args of the machine" as the synthetic args in such cases. Those "current" args will be synthetic themselves (since we cannot read them from the machine, as it does not have schematic info on it), but, it will prevent changes when the advertised URL changes.

Additionally, we have two checks to detect a schematic mismatch in the `ClusterMachineConfigStatus` controller - make them check the mismatch in the same way, to be more consistent.

(cherry picked from commit 0906bcc23c5d2e56b52fe4c3c7826afbea73dada)