### PR TITLE
fix: prevent unwanted upgrades of non-image-factory machines (backport)

### DIFF
--- a/internal/backend/kernelargs/kernelargs.go
+++ b/internal/backend/kernelargs/kernelargs.go
@@ -123,6 +123,11 @@ func Calculate(machineStatus *omni.MachineStatus, kernelArgs *omni.KernelArgs) (
 	return slices.Concat(baseArgs, extraArgs), true, nil
 }
 
+// FilterProtected filters out the "extra args" from the provided kernel args, leaving only the protected kernel arguments that cannot be modified.
+func FilterProtected(args []string) []string {
+	return xslices.Filter(args, isProtected)
+}
+
 // FilterExtras filters out the protected kernel arguments from the provided kernel args, leaving only the "extra args" that can be modified.
 func FilterExtras(args []string) []string {
 	return xslices.Filter(args, func(value string) bool {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
@@ -28,7 +28,6 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/kernelargs"
-	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/talos"
 )
 
 // ReconciliationContext describes all related data for one reconciliation call of the machine config status controller.
@@ -110,12 +109,12 @@ func (rc *ReconciliationContext) ID() string {
 }
 
 // SchematicEqual compares the schematic using the complex condition.
-func (rc *ReconciliationContext) SchematicEqual(schematicInfo talos.SchematicInfo, expectedSchematic string) bool {
+func (rc *ReconciliationContext) SchematicEqual(extensionsOnlyID, fullID, expectedSchematic string) bool {
 	if rc.compareFullSchematicID {
-		return schematicInfo.FullID == expectedSchematic
+		return fullID == expectedSchematic
 	}
 
-	return schematicInfo.Equal(expectedSchematic)
+	return extensionsOnlyID == expectedSchematic || fullID == expectedSchematic
 }
 
 // BuildReconciliationContext is the COSI reader dependent method to build the reconciliation context.
@@ -218,11 +217,7 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 		return nil, fmt.Errorf("failed to determine if kernel args update is supported for machine %q: %w", machineConfig.Metadata().ID(), err)
 	}
 
-	if rc.compareFullSchematicID {
-		schematicMismatch = schematicMismatch || rc.machineStatus.TypedSpec().Value.Schematic.FullId != rc.installImage.SchematicId
-	} else {
-		schematicMismatch = schematicMismatch || rc.machineStatus.TypedSpec().Value.Schematic.Id != rc.installImage.SchematicId
-	}
+	schematicMismatch = schematicMismatch || !rc.SchematicEqual(rc.machineStatus.TypedSpec().Value.Schematic.Id, rc.machineStatus.TypedSpec().Value.Schematic.FullId, rc.installImage.SchematicId)
 
 	talosVersionMismatch := strings.TrimLeft(rc.machineStatus.TypedSpec().Value.TalosVersion, "v") != machineConfigStatus.TypedSpec().Value.TalosVersion ||
 		machineConfigStatus.TypedSpec().Value.TalosVersion != rc.installImage.TalosVersion


### PR DESCRIPTION
The schematic comparison logic had an edge case: if a machine predates the image factory, it is installed via a `ghcr.io` installer image (or a custom one). Those machines do not have the schematic meta extension on them, and Omni creates a synthetic schematic ID and properties for those. These properties do not have the "actual" kernel args of the machine, but rather, Omni sets them as what it thinks they should be (the "correct" siderolink args from the Omni perspective).

Later, if Omni gets its siderolink API advertised URL get updated, it wrongly detects those synthetic kernel args to be the "new ones (with the new URL)", hence, the desired vs actual schematic comparison returns a mismatch. And Omni does an unnecessary upgrade to that machine.

Fix this by using the "current (non-protected) args of the machine" as the synthetic args in such cases. Those "current" args will be synthetic themselves (since we cannot read them from the machine, as it does not have schematic info on it), but, it will prevent changes when the advertised URL changes.

Additionally, we have two checks to detect a schematic mismatch in the `ClusterMachineConfigStatus` controller - make them check the mismatch in the same way, to be more consistent.

(cherry picked from commit 0906bcc23c5d2e56b52fe4c3c7826afbea73dada)