### PR TITLE
refactor: remove global config, inject it to services

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -116,7 +116,7 @@ func buildRootCommand() (*cobra.Command, error) {
 
 			configs = append(configs, flagConfig) // flags have the highest priority
 
-			config, err := app.PrepareConfig(logger, configSchema, configs...)
+			config, err := config.Init(logger, configSchema, configs...)
 			if err != nil {
 				return err
 			}

--- a/internal/backend/grpc/export_test.go
+++ b/internal/backend/grpc/export_test.go
@@ -18,11 +18,12 @@ type ManagementServer = managementServer
 type AuthServer = authServer
 
 //nolint:revive
-func NewManagementServer(st state.State, imageFactoryClient *imagefactory.Client, logger *zap.Logger) *ManagementServer {
+func NewManagementServer(st state.State, imageFactoryClient *imagefactory.Client, logger *zap.Logger, enableBreakGlassConfigs bool) *ManagementServer {
 	return &ManagementServer{
-		omniState:          st,
-		imageFactoryClient: imageFactoryClient,
-		logger:             logger,
+		omniState:               st,
+		imageFactoryClient:      imageFactoryClient,
+		logger:                  logger,
+		enableBreakGlassConfigs: enableBreakGlassConfigs,
 	}
 }
 

--- a/internal/backend/grpc/grpc.go
+++ b/internal/backend/grpc/grpc.go
@@ -53,8 +53,13 @@ func MakeServiceServers(
 	imageFactoryClient *imagefactory.Client,
 	logger *zap.Logger,
 	auditor AuditLogger,
+	services config.Services,
+	talosRegistry string,
+	accountName string,
+	k8sProxyURL string,
+	enableBreakGlassConfigs bool,
 ) iter.Seq2[ServiceServer, error] {
-	dest, err := generateDest(config.Config.Services.Api.URL())
+	dest, err := generateDest(services.Api.URL())
 	if err != nil {
 		return func(yield func(ServiceServer, error) bool) {
 			yield(nil, fmt.Errorf("error generating destination: %w", err))
@@ -63,7 +68,7 @@ func MakeServiceServers(
 
 	auth, err := newAuthServer(
 		state,
-		config.Config.Services,
+		services,
 		logger.With(logging.Component("auth_server")),
 	)
 	if err != nil {
@@ -89,6 +94,10 @@ func MakeServiceServers(
 			imageFactoryClient,
 			auditor,
 			dest,
+			talosRegistry,
+			accountName,
+			k8sProxyURL,
+			enableBreakGlassConfigs,
 		),
 		auth,
 		&COSIResourceServer{

--- a/internal/backend/grpc/grpc_test.go
+++ b/internal/backend/grpc/grpc_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/auth/interceptor"
+	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 type GrpcSuite struct {
@@ -95,11 +96,11 @@ func (suite *GrpcSuite) SetupTest() {
 
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zap.InfoLevel, 30*time.Second)
 
-	kubernetesRuntime, err := kubernetes.New(st.Default())
+	kubernetesRuntime, err := kubernetes.New(st.Default(), "", "", "")
 	suite.Require().NoError(err)
 
 	suite.runtime, err = omniruntime.NewRuntime(
-		clientFactory, dnsService, workloadProxyReconciler, nil,
+		config.Default(), clientFactory, dnsService, workloadProxyReconciler, nil,
 		imageFactoryClient, nil, nil, nil, st,
 		prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)),
 	)
@@ -323,6 +324,7 @@ func (suite *GrpcSuite) newServer(imageFactoryClient *imagefactory.Client, logge
 		suite.state,
 		imageFactoryClient,
 		logger,
+		false,
 	))
 
 	go func() {

--- a/internal/backend/installimage/installimage.go
+++ b/internal/backend/installimage/installimage.go
@@ -14,11 +14,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	appconfig "github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // Build builds the install image for the provided properties.
-func Build(imageFactoryHost string, resID resource.ID, installImage *specs.MachineConfigGenOptionsSpec_InstallImage) (string, error) {
+func Build(imageFactoryHost string, resID resource.ID, installImage *specs.MachineConfigGenOptionsSpec_InstallImage, talosRegistry string) (string, error) {
 	if imageFactoryHost == "" {
 		return "", fmt.Errorf("image factory host is not set")
 	}
@@ -74,5 +73,5 @@ func Build(imageFactoryHost string, resID resource.ID, installImage *specs.Machi
 		return imageFactoryHost + "/" + installerName + "/" + schematicID + ":" + desiredTalosVersion, nil
 	}
 
-	return appconfig.Config.Registries.GetTalos() + ":" + desiredTalosVersion, nil
+	return talosRegistry + ":" + desiredTalosVersion, nil
 }

--- a/internal/backend/oidc/oidc.go
+++ b/internal/backend/oidc/oidc.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/internal/backend/oidc/internal/storage"
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 func init() {
@@ -40,16 +39,11 @@ type Provider struct {
 }
 
 // NewProvider creates new OIDC provider.
-func NewProvider(store Storage) (*Provider, error) {
-	issuerEndpoint, err := config.Config.GetOIDCIssuerEndpoint()
-	if err != nil {
-		return nil, err
-	}
-
+func NewProvider(store Storage, issuerEndpoint string) (*Provider, error) {
 	// generate fresh crypto key time, as all auth requests are ephemeral in the storage
 	var cryptoKey [32]byte
 
-	_, err = rand.Read(cryptoKey[:])
+	_, err := rand.Read(cryptoKey[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate crypto key: %w", err)
 	}

--- a/internal/backend/runtime/kubernetes/kubernetes_test.go
+++ b/internal/backend/runtime/kubernetes/kubernetes_test.go
@@ -63,7 +63,7 @@ var oidcKubeconfig3 []byte
 var adminKubeconfig []byte
 
 func TestOIDCKubeconfig(t *testing.T) {
-	r, err := kubernetes.New(nil)
+	r, err := kubernetes.New(nil, "http://localhost:8080/oidc", "default", "https://localhost:8095")
 	require.NoError(t, err)
 
 	kubeconfig, err := r.GetOIDCKubeconfig(&common.Context{
@@ -82,7 +82,7 @@ func TestOIDCKubeconfig(t *testing.T) {
 }
 
 func TestOIDCKubeconfigWithExtraOptions(t *testing.T) {
-	r, err := kubernetes.New(nil)
+	r, err := kubernetes.New(nil, "http://localhost:8080/oidc", "default", "https://localhost:8095")
 	require.NoError(t, err)
 
 	kubeconfig, err := r.GetOIDCKubeconfig(&common.Context{
@@ -103,7 +103,7 @@ func TestOIDCKubeconfigWithExtraOptions(t *testing.T) {
 func TestBreakGlassKubeconfig(t *testing.T) {
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 
-	r, err := kubernetes.New(st)
+	r, err := kubernetes.New(st, "", "", "")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)

--- a/internal/backend/runtime/omni/controllers/omni/connection_params.go
+++ b/internal/backend/runtime/omni/controllers/omni/connection_params.go
@@ -28,10 +28,10 @@ type ConnectionParamsController = qtransform.QController[*siderolinkres.Config, 
 // ConnectionParamsControllerName is the name of the connection params controller.
 const ConnectionParamsControllerName = "ConnectionParamsController"
 
-// NewConnectionParamsController instanciates the connection params controller.
+// NewConnectionParamsController instantiates the connection params controller.
 //
 //nolint:staticcheck
-func NewConnectionParamsController() *ConnectionParamsController {
+func NewConnectionParamsController(machineAPIURL string, siderolinkCfg config.SiderolinkService) *ConnectionParamsController {
 	return qtransform.NewQController(
 		qtransform.Settings[*siderolinkres.Config, *siderolinkres.ConnectionParams]{ //nolint:staticcheck
 			Name: ConnectionParamsControllerName,
@@ -45,11 +45,11 @@ func NewConnectionParamsController() *ConnectionParamsController {
 			TransformFunc: func(ctx context.Context, r controller.Reader, logger *zap.Logger, siderolinkConfig *siderolinkres.Config, params *siderolinkres.ConnectionParams) error {
 				spec := params.TypedSpec().Value
 
-				spec.ApiEndpoint = config.Config.Services.MachineAPI.URL()
+				spec.ApiEndpoint = machineAPIURL
 				spec.WireguardEndpoint = siderolinkConfig.TypedSpec().Value.AdvertisedEndpoint
-				spec.UseGrpcTunnel = config.Config.Services.Siderolink.GetUseGRPCTunnel()
-				spec.LogsPort = int32(config.Config.Services.Siderolink.GetLogServerPort())
-				spec.EventsPort = int32(config.Config.Services.Siderolink.GetEventSinkPort())
+				spec.UseGrpcTunnel = siderolinkCfg.GetUseGRPCTunnel()
+				spec.LogsPort = int32(siderolinkCfg.GetLogServerPort())
+				spec.EventsPort = int32(siderolinkCfg.GetEventSinkPort())
 
 				defaultJoinToken, err := safe.ReaderGetByID[*siderolinkres.DefaultJoinToken](ctx, r, siderolinkres.DefaultJoinTokenID)
 				if err != nil {

--- a/internal/backend/runtime/omni/controllers/omni/etcd_backup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcd_backup_test.go
@@ -58,7 +58,7 @@ import (
 var secretsJSON []byte
 
 func beforeStart(st state.State, t *testing.T, rt *runtime.Runtime) {
-	kubernetesRuntime, err := kubernetes.NewWithTTL(st, 0)
+	kubernetesRuntime, err := kubernetes.NewWithTTL(st, 0, "", "", "")
 	require.NoError(t, err)
 
 	require.NoError(t, rt.RegisterController(omnictrl.NewClusterController(kubernetesRuntime)))

--- a/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/filestore.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/filestore.go
@@ -15,7 +15,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/etcdbackup"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/etcdbackup/crypt"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/etcdbackup/fstore"
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 type fileStoreFactory struct {
@@ -27,7 +26,7 @@ type fileStoreFactory struct {
 func NewFileStoreStoreFactory(path string) Factory {
 	return &fileStoreFactory{
 		store: crypt.NewStore(fstore.NewFileStore(path)),
-		path:  config.Config.EtcdBackup.GetLocalPath(),
+		path:  path,
 	}
 }
 

--- a/internal/backend/runtime/omni/controllers/omni/installation_media.go
+++ b/internal/backend/runtime/omni/controllers/omni/installation_media.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 const (
@@ -272,7 +271,16 @@ var installationMedia = []installationMediaSpec{
 }
 
 // InstallationMediaController manages omni.InstallationMedia.
-type InstallationMediaController struct{}
+type InstallationMediaController struct {
+	accountName string
+}
+
+// NewInstallationMediaController creates a new InstallationMediaController.
+func NewInstallationMediaController(accountName string) *InstallationMediaController {
+	return &InstallationMediaController{
+		accountName: accountName,
+	}
+}
 
 // Name implements controller.Controller interface.
 func (ctrl *InstallationMediaController) Name() string {
@@ -312,7 +320,7 @@ func (ctrl *InstallationMediaController) Run(ctx context.Context, r controller.R
 			newMedia.TypedSpec().Value.Name = m.Name
 			newMedia.TypedSpec().Value.Profile = m.Profile
 			newMedia.TypedSpec().Value.ContentType = m.ContentType
-			newMedia.TypedSpec().Value.DestFilePrefix = fmt.Sprintf("%s-omni-%s", fname.srcPrefix, config.Config.Account.GetName())
+			newMedia.TypedSpec().Value.DestFilePrefix = fmt.Sprintf("%s-omni-%s", fname.srcPrefix, ctrl.accountName)
 			newMedia.TypedSpec().Value.Extension = fname.extension
 			newMedia.TypedSpec().Value.MinTalosVersion = m.MinTalosVersion
 			newMedia.TypedSpec().Value.Overlay = m.Overlay
@@ -332,7 +340,7 @@ func (ctrl *InstallationMediaController) Run(ctx context.Context, r controller.R
 			newMedia.TypedSpec().Value.Name = cfg.Label
 			newMedia.TypedSpec().Value.Profile = constants.PlatformMetal
 			newMedia.TypedSpec().Value.ContentType = "application/x-xz"
-			newMedia.TypedSpec().Value.DestFilePrefix = fmt.Sprintf("metal-%s-omni-%s", cfg.OverlayName, config.Config.Account.GetName())
+			newMedia.TypedSpec().Value.DestFilePrefix = fmt.Sprintf("metal-%s-omni-%s", cfg.OverlayName, ctrl.accountName)
 			newMedia.TypedSpec().Value.Extension = "raw.xz"
 			newMedia.TypedSpec().Value.NoSecureBoot = true
 			newMedia.TypedSpec().Value.MinTalosVersion = cfg.MinVersion.String()

--- a/internal/backend/runtime/omni/controllers/omni/internal/loadbalancer/loadbalancer.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/loadbalancer/loadbalancer.go
@@ -22,20 +22,20 @@ type LoadBalancer interface {
 }
 
 // NewFunc is a function type whose implementation should create a new load balancer.
-type NewFunc func(bindAddress string, bindPort int, logger *zap.Logger) (LoadBalancer, error)
+type NewFunc func(bindAddress string, bindPort int, logger *zap.Logger, lbConfig config.LoadBalancerService) (LoadBalancer, error)
 
 // DefaultNew returns a new load balancer with default settings.
-func DefaultNew(bindAddress string, bindPort int, logger *zap.Logger) (LoadBalancer, error) { //nolint:ireturn
+func DefaultNew(bindAddress string, bindPort int, logger *zap.Logger, lbConfig config.LoadBalancerService) (LoadBalancer, error) { //nolint:ireturn
 	return controlplane.NewLoadBalancer(
 		bindAddress,
 		bindPort,
 		logger.WithOptions(zap.IncreaseLevel(zap.ErrorLevel)), // silence the load balancer logs
-		controlplane.WithDialTimeout(config.Config.Services.LoadBalancer.GetDialTimeout()),
-		controlplane.WithKeepAlivePeriod(config.Config.Services.LoadBalancer.GetKeepAlivePeriod()),
-		controlplane.WithTCPUserTimeout(config.Config.Services.LoadBalancer.GetTcpUserTimeout()),
+		controlplane.WithDialTimeout(lbConfig.GetDialTimeout()),
+		controlplane.WithKeepAlivePeriod(lbConfig.GetKeepAlivePeriod()),
+		controlplane.WithTCPUserTimeout(lbConfig.GetTcpUserTimeout()),
 		controlplane.WithHealthCheckOptions(
-			upstream.WithHealthcheckInterval(config.Config.Services.LoadBalancer.GetHealthCheckInterval()),
-			upstream.WithHealthcheckTimeout(config.Config.Services.LoadBalancer.GetHealthCheckTimeout()),
+			upstream.WithHealthcheckInterval(lbConfig.GetHealthCheckInterval()),
+			upstream.WithHealthcheckTimeout(lbConfig.GetHealthCheckTimeout()),
 		),
 	)
 }

--- a/internal/backend/runtime/omni/controllers/omni/join_token_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/join_token_status.go
@@ -26,7 +26,7 @@ type JoinTokenStatusController = qtransform.QController[*siderolink.JoinToken, *
 
 const joinTokenStatusControllerName = "JoinTokenStatusController"
 
-// NewJoinTokenStatusController instanciates the join token status controller.
+// NewJoinTokenStatusController instantiates the join token status controller.
 //
 //nolint:gocognit,gocyclo,cyclop
 func NewJoinTokenStatusController() *JoinTokenStatusController {

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
@@ -38,7 +38,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/kubernetes"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/exposedservice"
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // KubernetesStatusController manages KubernetesStatus resource lifecycle.
@@ -49,13 +48,15 @@ type KubernetesStatusController struct {
 
 	advertisedAPIURL       string
 	workloadProxySubdomain string
+	workloadProxyEnabled   bool
 }
 
 // NewKubernetesStatusController creates a new KubernetesStatusController.
-func NewKubernetesStatusController(advertisedAPIURL, workloadProxySubdomain string) *KubernetesStatusController {
+func NewKubernetesStatusController(advertisedAPIURL, workloadProxySubdomain string, workloadProxyEnabled bool) *KubernetesStatusController {
 	return &KubernetesStatusController{
 		advertisedAPIURL:       advertisedAPIURL,
 		workloadProxySubdomain: workloadProxySubdomain,
+		workloadProxyEnabled:   workloadProxyEnabled,
 	}
 }
 
@@ -438,7 +439,7 @@ func (ctrl *KubernetesStatusController) startWatcher(ctx context.Context, logger
 		w.podsSync(ctx, notifyCh)
 	}, logger)
 
-	if config.Config.Services.WorkloadProxy.GetEnabled() {
+	if ctrl.workloadProxyEnabled {
 		w.serviceFactory = informers.NewSharedInformerFactory(w.client.Clientset(), 0)
 
 		if _, err = w.serviceFactory.Core().V1().Services().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/internal/backend/runtime/omni/controllers/omni/loadbalancer.go
+++ b/internal/backend/runtime/omni/controllers/omni/loadbalancer.go
@@ -19,11 +19,13 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/loadbalancer"
+	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // LoadBalancerController starts, stops and updates the statuses of load balancers.
 type LoadBalancerController struct {
 	NewLoadBalancer loadbalancer.NewFunc
+	LBConfig        config.LoadBalancerService
 
 	loadBalancers *loadbalancer.Manager
 }
@@ -65,7 +67,7 @@ func (ctrl *LoadBalancerController) Run(ctx context.Context, r controller.Runtim
 		ctrl.NewLoadBalancer = loadbalancer.DefaultNew
 	}
 
-	ctrl.loadBalancers = loadbalancer.NewManager(logger, ctrl.NewLoadBalancer)
+	ctrl.loadBalancers = loadbalancer.NewManager(logger, ctrl.NewLoadBalancer, ctrl.LBConfig)
 
 	defer func() {
 		if err := ctrl.loadBalancers.Stop(); err != nil {

--- a/internal/backend/runtime/omni/controllers/omni/loadbalancer_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/loadbalancer_test.go
@@ -20,6 +20,7 @@ import (
 	omniresources "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/loadbalancer"
+	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 type mockLoadBalancer struct {
@@ -118,7 +119,7 @@ func (suite *LoadBalancerSuite) setupMock() (<-chan *mockLoadBalancer, <-chan ne
 	mockCh := make(chan *mockLoadBalancer)
 	newLoadBalancerMethodCalled := make(chan newLoadBalancerSignature)
 
-	newMockFunc := func(bindAddress string, bindPort int, _ *zap.Logger) (loadbalancer.LoadBalancer, error) {
+	newMockFunc := func(bindAddress string, bindPort int, _ *zap.Logger, _ config.LoadBalancerService) (loadbalancer.LoadBalancer, error) {
 		mock := &mockLoadBalancer{
 			startMethodCalled:    make(chan struct{}),
 			shutdownMethodCalled: make(chan struct{}),

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_etcd_audit_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_etcd_audit_test.go
@@ -110,7 +110,7 @@ func (suite *MachineSetEtcdAuditSuite) SetupTest() {
 	suite.clientFactory = talos.NewClientFactory(suite.state, logger)
 
 	if _, err := runtime.Get(talos.Name); err != nil {
-		runtime.Install(talos.Name, talos.New(suite.clientFactory, logger))
+		runtime.Install(talos.Name, talos.New(suite.clientFactory, logger, "", ""))
 	}
 
 	suite.startRuntime()

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_link_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_link_test.go
@@ -46,7 +46,7 @@ func (suite *MachineStatusLinkSuite) SetupTest() {
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineStatusController(&imageFactoryClientMock{}, exraKernelArgsInitializer)))
 	suite.Require().NoError(suite.runtime.RegisterController(omnictrl.NewMachineStatusLinkController(suite.deltaCh)))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineJoinConfigController()))
-	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewSiderolinkAPIConfigController(serviceConfig)))
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewSiderolinkAPIConfigController(testMachineAPIURL, testSiderolinkCfg)))
 	suite.Require().NoError(suite.runtime.RegisterQController(newMockJoinTokenUsageController[*omni.Machine]()))
 }
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -61,19 +61,21 @@ type ClusterMachineConfigStatusController struct {
 	*qtransform.QController[*omni.ClusterMachineConfig, *omni.ClusterMachineConfigStatus]
 	ongoingResets    *ongoingResets
 	imageFactoryHost string
+	talosRegistry    string
 	acquireLockMu    sync.Mutex
 }
 
 // NewClusterMachineConfigStatusController initializes ClusterMachineConfigStatusController.
 //
 //nolint:gocognit,gocyclo,cyclop,maintidx
-func NewClusterMachineConfigStatusController(imageFactoryHost string) *ClusterMachineConfigStatusController {
+func NewClusterMachineConfigStatusController(imageFactoryHost, talosRegistry string) *ClusterMachineConfigStatusController {
 	ongoingResets := &ongoingResets{
 		statuses: map[string]*resetStatus{},
 	}
 
 	ctrl := &ClusterMachineConfigStatusController{
 		imageFactoryHost: imageFactoryHost,
+		talosRegistry:    talosRegistry,
 		ongoingResets:    ongoingResets,
 	}
 
@@ -374,7 +376,7 @@ func (ctrl *ClusterMachineConfigStatusController) upgrade(
 		return true, nil
 	}
 
-	image, err := installimage.Build(ctrl.imageFactoryHost, rc.ID(), rc.installImage)
+	image, err := installimage.Build(ctrl.imageFactoryHost, rc.ID(), rc.installImage, ctrl.talosRegistry)
 	if err != nil {
 		return false, err
 	}

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -47,7 +47,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 	t.Parallel()
 
 	addControllers := func(_ context.Context, testContext testutils.TestContext) {
-		require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost)))
+		require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer")))
 	}
 
 	awaitAllMachinesConfigured := func(ctx context.Context, t *testing.T, st state.State, clusterName string) {

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
@@ -33,15 +33,17 @@ type StatusController struct {
 	*qtransform.QController[*omni.MachineStatus, *omni.MachineUpgradeStatus]
 	talosClientFactory TalosClientFactory
 	imageFactoryHost   string
+	talosRegistry      string
 }
 
-func NewStatusController(imageFactoryHost string, talosClientFactory TalosClientFactory) *StatusController {
+func NewStatusController(imageFactoryHost, talosRegistry string, talosClientFactory TalosClientFactory) *StatusController {
 	if talosClientFactory == nil {
 		talosClientFactory = &talosCliFactory{}
 	}
 
 	ctrl := &StatusController{
 		imageFactoryHost:   imageFactoryHost,
+		talosRegistry:      talosRegistry,
 		talosClientFactory: talosClientFactory,
 	}
 
@@ -227,7 +229,7 @@ func (ctrl *StatusController) transform(ctx context.Context, r controller.Reader
 		SecurityState:        securityState,
 	}
 
-	installImageStr, err := installimage.Build(ctrl.imageFactoryHost, ms.Metadata().ID(), installImage)
+	installImageStr, err := installimage.Build(ctrl.imageFactoryHost, ms.Metadata().ID(), installImage, ctrl.talosRegistry)
 	if err != nil {
 		return fmt.Errorf("failed to build install image: %w", err)
 	}

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
@@ -65,7 +65,7 @@ func TestReconcile(t *testing.T) {
 	}
 
 	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(ctx context.Context, testContext testutils.TestContext) {
-		ctrl := machineupgrade.NewStatusController("mock-host", talosClientFactory)
+		ctrl := machineupgrade.NewStatusController("mock-host", "ghcr.io/siderolabs/installer", talosClientFactory)
 
 		require.NoError(t, testContext.Runtime.RegisterQController(ctrl))
 	}, func(ctx context.Context, testContext testutils.TestContext) {

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -379,7 +379,7 @@ func (suite *OmniSuite) SetupTest() {
 
 	suite.cachedState = state.WrapCore(suite.runtime.CachedState())
 
-	suite.kubernetesRuntime, err = kubernetes.NewWithTTL(suite.state, 0)
+	suite.kubernetesRuntime, err = kubernetes.NewWithTTL(suite.state, 0, "", "", "")
 	suite.Require().NoError(err)
 
 	rt.Install(kubernetes.Name, suite.kubernetesRuntime)

--- a/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
@@ -129,8 +129,8 @@ func Test_TalosCARotation(t *testing.T) {
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretRotationStatusController(&fakeRemoteGeneratorFactory{testContext.State})))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory")))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -182,8 +182,8 @@ func Test_TalosCARotation(t *testing.T) {
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretRotationStatusController(&fakeRemoteGeneratorFactory{testContext.State})))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory")))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -292,8 +292,8 @@ func Test_TalosCARotation(t *testing.T) {
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretRotationStatusController(&fakeRemoteGeneratorFactory{testContext.State})))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory")))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -368,8 +368,8 @@ func Test_TalosCARotation(t *testing.T) {
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretRotationStatusController(&fakeRemoteGeneratorFactory{testContext.State})))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory")))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -448,8 +448,8 @@ func Test_TalosCARotation(t *testing.T) {
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretRotationStatusController(&fakeRemoteGeneratorFactory{testContext.State})))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory")))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -531,8 +531,8 @@ func Test_TalosCARotation(t *testing.T) {
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretRotationStatusController(&fakeRemoteGeneratorFactory{testContext.State})))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory")))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -614,8 +614,8 @@ func Test_TalosCARotation(t *testing.T) {
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretRotationStatusController(&fakeRemoteGeneratorFactory{testContext.State})))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory")))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)

--- a/internal/backend/runtime/omni/controllers/omni/siderolink_api_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/siderolink_api_config.go
@@ -19,11 +19,11 @@ import (
 // SiderolinkAPIConfigController turns siderolink config resource into a SiderolinkAPIConfig.
 type SiderolinkAPIConfigController = qtransform.QController[*siderolink.Config, *siderolink.APIConfig]
 
-// SiderolinkAPIConfigControllerName is the name of the connection params controller.
+// SiderolinkAPIConfigControllerName is the name of the SiderolinkAPIConfig controller.
 const SiderolinkAPIConfigControllerName = "SiderolinkAPIConfigController"
 
-// NewSiderolinkAPIConfigController instanciates the connection params controller.
-func NewSiderolinkAPIConfigController(services *config.Services) *SiderolinkAPIConfigController {
+// NewSiderolinkAPIConfigController instantiates the SiderolinkAPIConfig controller.
+func NewSiderolinkAPIConfigController(machineAPIURL string, siderolinkCfg config.SiderolinkService) *SiderolinkAPIConfigController {
 	return qtransform.NewQController(
 		qtransform.Settings[*siderolink.Config, *siderolink.APIConfig]{
 			Name: SiderolinkAPIConfigControllerName,
@@ -36,11 +36,11 @@ func NewSiderolinkAPIConfigController(services *config.Services) *SiderolinkAPIC
 			TransformFunc: func(_ context.Context, _ controller.Reader, _ *zap.Logger, _ *siderolink.Config, params *siderolink.APIConfig) error {
 				spec := params.TypedSpec().Value
 
-				spec.MachineApiAdvertisedUrl = services.MachineAPI.URL()
-				spec.WireguardAdvertisedEndpoint = services.Siderolink.WireGuard.GetAdvertisedEndpoint()
-				spec.EnforceGrpcTunnel = services.Siderolink.GetUseGRPCTunnel()
-				spec.LogsPort = int32(services.Siderolink.GetLogServerPort())
-				spec.EventsPort = int32(services.Siderolink.GetEventSinkPort())
+				spec.MachineApiAdvertisedUrl = machineAPIURL
+				spec.WireguardAdvertisedEndpoint = siderolinkCfg.WireGuard.GetAdvertisedEndpoint()
+				spec.EnforceGrpcTunnel = siderolinkCfg.GetUseGRPCTunnel()
+				spec.LogsPort = int32(siderolinkCfg.GetLogServerPort())
+				spec.EventsPort = int32(siderolinkCfg.GetEventSinkPort())
 
 				return nil
 			},

--- a/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
+++ b/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
@@ -298,6 +298,7 @@ machine:
 			imageFactoryHost,
 			machineConfigGenOptions.Metadata().ID(),
 			machineConfigGenOptions.TypedSpec().Value.InstallImage,
+			"ghcr.io/siderolabs/installer",
 		)
 		if err != nil {
 			return err

--- a/internal/backend/runtime/omni/loader_test.go
+++ b/internal/backend/runtime/omni/loader_test.go
@@ -147,7 +147,7 @@ func TestNewLoader(t *testing.T) {
 				tt.pre(t)
 			}
 
-			got, err := omni.NewLoader(tt.args.source, zaptest.NewLogger(t))
+			got, err := omni.NewLoader(tt.args.source, zaptest.NewLogger(t), "", "")
 			tt.want(t, got, err)
 		})
 	}

--- a/internal/backend/runtime/omni/omni_test.go
+++ b/internal/backend/runtime/omni/omni_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
+	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 
@@ -87,10 +88,10 @@ func (suite *OmniRuntimeSuite) SetupTest() {
 	discoveryClientCache := &discoveryClientCacheMock{}
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel, 30*time.Second)
 
-	kubernetesRuntime, err := kubernetes.New(resourceState)
+	kubernetesRuntime, err := kubernetes.New(resourceState, "", "", "")
 	suite.Require().NoError(err)
 
-	suite.runtime, err = omniruntime.NewRuntime(clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
+	suite.runtime, err = omniruntime.NewRuntime(config.Default(), clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
 		omniruntime.NewMockState(resourceState), prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 
 	suite.Require().NoError(err)

--- a/internal/backend/runtime/omni/state_etcd.go
+++ b/internal/backend/runtime/omni/state_etcd.go
@@ -77,7 +77,7 @@ func newEtcdPersistentState(ctx context.Context, params *config.Params, logger *
 
 	var cipher *encryption.Cipher
 
-	cipher, err = makeCipher(accountID, params.Storage.Default.Etcd, etcdState.Client(), logger) //nolint:contextcheck
+	cipher, err = makeCipher(accountID, params.Storage.Default.Etcd, etcdState.Client(), logger, params.Storage.Vault.GetToken(), params.Storage.Vault.GetUrl()) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -105,13 +105,13 @@ func newEtcdPersistentState(ctx context.Context, params *config.Params, logger *
 	}, nil
 }
 
-func makeCipher(name string, etcdParams config.EtcdParams, etcdClient etcd.Client, logger *zap.Logger) (*encryption.Cipher, error) {
+func makeCipher(name string, etcdParams config.EtcdParams, etcdClient etcd.Client, logger *zap.Logger, vaultToken, vaultURL string) (*encryption.Cipher, error) {
 	publicKeys, err := loadPublicKeys(etcdParams)
 	if err != nil {
 		return nil, err
 	}
 
-	loader, err := NewLoader(etcdParams.GetPrivateKeySource(), logger)
+	loader, err := NewLoader(etcdParams.GetPrivateKeySource(), logger, vaultToken, vaultURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/runtime/omni/state_validation_test.go
+++ b/internal/backend/runtime/omni/state_validation_test.go
@@ -636,7 +636,7 @@ func TestMachineSetValidation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
 	t.Cleanup(cancel)
 
-	etcdBackupStoreFactory, err := store.NewStoreFactory()
+	etcdBackupStoreFactory, err := store.NewStoreFactory(config.EtcdBackup{})
 	require.NoError(t, err)
 
 	innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
@@ -909,7 +909,7 @@ func TestClusterLockedAnnotation(t *testing.T) {
 	t.Cleanup(cancel)
 
 	innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
-	etcdBackupStoreFactory, err := store.NewStoreFactory()
+	etcdBackupStoreFactory, err := store.NewStoreFactory(config.EtcdBackup{})
 	etcdBackupConfig := config.EtcdBackup{
 		TickInterval: pointer.To(time.Minute),
 		MinInterval:  pointer.To(time.Hour),
@@ -1025,7 +1025,7 @@ func TestClusterImport(t *testing.T) {
 	t.Cleanup(cancel)
 
 	innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
-	etcdBackupStoreFactory, err := store.NewStoreFactory()
+	etcdBackupStoreFactory, err := store.NewStoreFactory(config.EtcdBackup{})
 	etcdBackupConfig := config.EtcdBackup{
 		TickInterval: pointer.To(time.Minute),
 		MinInterval:  pointer.To(time.Hour),
@@ -1324,7 +1324,7 @@ func TestMachineSetClassesValidation(t *testing.T) {
 
 	innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
 
-	etcdBackupStoreFactory, err := store.NewStoreFactory()
+	etcdBackupStoreFactory, err := store.NewStoreFactory(config.EtcdBackup{})
 	require.NoError(t, err)
 
 	st := validated.NewState(innerSt,

--- a/internal/backend/runtime/omni/talosconfig_test.go
+++ b/internal/backend/runtime/omni/talosconfig_test.go
@@ -27,6 +27,7 @@ import (
 	omniruntime "github.com/siderolabs/omni/internal/backend/runtime/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
+	omniconfig "github.com/siderolabs/omni/internal/pkg/config"
 )
 
 func TestOperatorTalosconfig(t *testing.T) {
@@ -40,10 +41,10 @@ func TestOperatorTalosconfig(t *testing.T) {
 	discoveryClientCache := &discoveryClientCacheMock{}
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zapcore.InfoLevel, 30*time.Second)
 
-	kubernetesRuntime, err := kubernetes.New(st.Default())
+	kubernetesRuntime, err := kubernetes.New(st.Default(), "", "", "")
 	require.NoError(t, err)
 
-	r, err := omniruntime.NewRuntime(clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
+	r, err := omniruntime.NewRuntime(omniconfig.Default(), clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
 		st, prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 
 	require.NoError(t, err)

--- a/internal/backend/runtime/omni/virtual/state.go
+++ b/internal/backend/runtime/omni/virtual/state.go
@@ -27,7 +27,6 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
-	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 
@@ -38,13 +37,15 @@ type State struct {
 	PrimaryState state.State
 
 	computed map[resource.Type]*Computed
+	apiURL   string
 }
 
 // NewState creates new virtual state instance.
-func NewState(state state.State) *State {
+func NewState(state state.State, apiURL string) *State {
 	return &State{
 		PrimaryState: state,
 		computed:     map[resource.Type]*Computed{},
+		apiURL:       apiURL,
 	}
 }
 
@@ -357,7 +358,7 @@ func (v *State) advertisedEndpoints(_ context.Context, ptr resource.Pointer) (*v
 
 	res := virtual.NewAdvertisedEndpoints()
 
-	res.TypedSpec().Value.GrpcApiUrl = config.Config.Services.Api.URL()
+	res.TypedSpec().Value.GrpcApiUrl = v.apiURL
 
 	return res, nil
 }

--- a/internal/backend/runtime/runtime_test.go
+++ b/internal/backend/runtime/runtime_test.go
@@ -18,7 +18,7 @@ import (
 
 //nolint:iface
 func TestInstall_LookupInterface(t *testing.T) {
-	k8s, err := kubernetes.New(nil)
+	k8s, err := kubernetes.New(nil, "", "", "")
 	require.NoError(t, err)
 
 	runtime.Install(kubernetes.Name, k8s)

--- a/internal/backend/runtime/talos/talos.go
+++ b/internal/backend/runtime/talos/talos.go
@@ -28,7 +28,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/logging"
 	"github.com/siderolabs/omni/internal/backend/runtime"
 	"github.com/siderolabs/omni/internal/backend/runtime/cosi"
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // Name talos runtime string id.
@@ -38,13 +37,17 @@ var Name = common.Runtime_Talos.String()
 type Runtime struct {
 	clientFactory *ClientFactory
 	logger        *zap.Logger
+	accountName   string
+	apiURL        string
 }
 
 // New creates a new Talos runtime.
-func New(clientFactory *ClientFactory, logger *zap.Logger) *Runtime {
+func New(clientFactory *ClientFactory, logger *zap.Logger, accountName string, apiURL string) *Runtime {
 	return &Runtime{
 		clientFactory: clientFactory,
 		logger:        logger.With(logging.Component("talos_runtime")),
+		accountName:   accountName,
+		apiURL:        apiURL,
 	}
 }
 
@@ -210,8 +213,8 @@ func (r *Runtime) GetTalosconfigRaw(context *common.Context, identity string) ([
 		Identity: identity,
 	}
 
-	contextName := config.Config.Account.GetName()
-	apiURL := config.Config.Services.Api.URL()
+	contextName := r.accountName
+	apiURL := r.apiURL
 
 	cluster := ""
 

--- a/internal/backend/saml/saml.go
+++ b/internal/backend/saml/saml.go
@@ -22,17 +22,16 @@ import (
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/internal/backend/logging"
 	"github.com/siderolabs/omni/internal/backend/monitoring"
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // NewHandler creates new SAML handler.
-func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.Logger) (*samlsp.Middleware, error) {
+func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.Logger, apiURL string) (*samlsp.Middleware, error) {
 	idpMetadata, err := readMetadata(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	rootURL, err := url.Parse(config.Config.Services.Api.URL())
+	rootURL, err := url.Parse(apiURL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/services/workloadproxy/handler.go
+++ b/internal/backend/services/workloadproxy/handler.go
@@ -18,7 +18,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // ProxyProvider is a provider of HTTP proxies for the exposed services.
@@ -220,7 +219,7 @@ func (h *HTTPHandler) getSignatureCookies(request *http.Request) (publicKeyID st
 }
 
 func (h *HTTPHandler) redirectToLogin(writer http.ResponseWriter, request *http.Request) {
-	loginURL, err := url.Parse(config.Config.Services.Api.URL())
+	loginURL, err := url.Parse(h.mainURL.String())
 	if err != nil {
 		h.logger.Warn("failed to redirect to login", zap.Error(err))
 

--- a/internal/backend/services/workloadproxy/handler_test.go
+++ b/internal/backend/services/workloadproxy/handler_test.go
@@ -127,7 +127,12 @@ func TestHandler(t *testing.T) {
 
 		require.NoError(t, err)
 
-		require.Equal(t, fmt.Sprintf("https://%s-instanceid.proxy-us.example.com:%s/example", testServiceAlias, redirectedURL.Port()), redirectBackURL)
+		expectedHost := fmt.Sprintf("%s-instanceid.proxy-us.example.com", testServiceAlias)
+		if port := redirectedURL.Port(); port != "" {
+			expectedHost = fmt.Sprintf("%s:%s", expectedHost, port)
+		}
+
+		require.Equal(t, fmt.Sprintf("https://%s/example", expectedHost), redirectBackURL)
 	})
 
 	t.Run("subdomain request with cookies", func(t *testing.T) {

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -21,23 +21,23 @@ import (
 	"time"
 
 	"github.com/jxskiss/base62"
-
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 const index = "/index.html"
 
 // StaticHandler serves embedded frontend files.
 type StaticHandler struct {
-	modTime   time.Time
-	maxAgeSec int
+	modTime             time.Time
+	imageFactoryBaseURL string
+	maxAgeSec           int
 }
 
 // NewStaticHandler creates new static handler.
-func NewStaticHandler(maxAgeSec int) *StaticHandler {
+func NewStaticHandler(maxAgeSec int, imageFactoryBaseURL string) *StaticHandler {
 	return &StaticHandler{
-		modTime:   time.Now(),
-		maxAgeSec: maxAgeSec,
+		modTime:             time.Now(),
+		imageFactoryBaseURL: imageFactoryBaseURL,
+		maxAgeSec:           maxAgeSec,
 	}
 }
 
@@ -135,7 +135,7 @@ func (handler *StaticHandler) serveFile(w http.ResponseWriter, r *http.Request, 
 					fmt.Sprintf(";script-src 'self' 'nonce-%s' https://*.userpilot.io", nonce)+
 					";media-src 'self' https://js.userpilot.io"+
 					";img-src * data:"+
-					fmt.Sprintf(";connect-src 'self' %s https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io", config.Config.Registries.GetImageFactoryBaseURL())+
+					fmt.Sprintf(";connect-src 'self' %s https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io", handler.imageFactoryBaseURL)+
 					";font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.userpilot.io"+
 					// We are forced to use unsafe-inline for style-src due to monaco-editor https://github.com/microsoft/monaco-editor/issues/271
 					";style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com"+

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -477,7 +477,7 @@ func runOmni(t *testing.T) (string, error) {
 		return "", fmt.Errorf("failed to parse config schema: %w", err)
 	}
 
-	config, err := app.PrepareConfig(logger, configSchema, params)
+	config, err := config.Init(logger, configSchema, params)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/auth/auth0/token.go
+++ b/internal/pkg/auth/auth0/token.go
@@ -16,8 +16,6 @@ import (
 	"github.com/auth0/go-jwt-middleware/v2/jwks"
 	"github.com/auth0/go-jwt-middleware/v2/validator"
 	"github.com/siderolabs/go-api-signature/pkg/jwt"
-
-	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 const (
@@ -31,7 +29,7 @@ type IDTokenVerifier struct {
 }
 
 // NewIDTokenVerifier creates a new ID token verifier.
-func NewIDTokenVerifier(domain string) (*IDTokenVerifier, error) {
+func NewIDTokenVerifier(domain, clientID string) (*IDTokenVerifier, error) {
 	issuerURL, err := url.Parse("https://" + domain + "/")
 	if err != nil {
 		return nil, err
@@ -43,7 +41,7 @@ func NewIDTokenVerifier(domain string) (*IDTokenVerifier, error) {
 		provider.KeyFunc,
 		validator.RS256,
 		issuerURL.String(),
-		[]string{config.Config.Auth.Auth0.GetClientID()},
+		[]string{clientID},
 		validator.WithAllowedClockSkew(tokenValidationAllowedClockSkew),
 		validator.WithCustomClaims(func() validator.CustomClaims {
 			return &CustomIDClaims{}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -278,12 +278,7 @@ func (p *Params) Validate(schema *jsonschema.Schema) error {
 	return nil
 }
 
-var (
-	localIP = getLocalIPOrEmpty()
-
-	// Config holds the application config and provides the default values for it.
-	Config = Default()
-)
+var localIP = getLocalIPOrEmpty()
 
 // GetImageFactoryPXEBaseURL reads image factory PXE address from the args.
 func (p *Params) GetImageFactoryPXEBaseURL() (*url.URL, error) {

--- a/internal/pkg/siderolink/siderolink_test.go
+++ b/internal/pkg/siderolink/siderolink_test.go
@@ -120,9 +120,11 @@ func (suite *SiderolinkSuite) SetupTest() {
 
 	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
 
+	defaultCfg := config.Default()
+
 	params := sideromanager.Params{
 		WireguardEndpoint:  "127.0.0.1:0",
-		AdvertisedEndpoint: config.Config.Services.Siderolink.WireGuard.GetAdvertisedEndpoint() + "," + TestIP,
+		AdvertisedEndpoint: defaultCfg.Services.Siderolink.WireGuard.GetAdvertisedEndpoint() + "," + TestIP,
 		MachineAPIEndpoint: "127.0.0.1:0",
 	}
 
@@ -154,8 +156,8 @@ func (suite *SiderolinkSuite) SetupTest() {
 
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewLinkStatusController[*siderolink.PendingMachine](peers)))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewLinkStatusController[*siderolink.Link](peers)))
-	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewConnectionParamsController()))
-	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewSiderolinkAPIConfigController(&config.Config.Services)))
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewConnectionParamsController(defaultCfg.Services.MachineAPI.URL(), defaultCfg.Services.Siderolink)))
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewSiderolinkAPIConfigController(defaultCfg.Services.MachineAPI.URL(), defaultCfg.Services.Siderolink)))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewJoinTokenStatusController()))
 
 	go func() {
@@ -331,7 +333,7 @@ func (suite *SiderolinkSuite) TestNodeWithSeveralAdvertisedIPs() {
 		},
 	))(suite.T())
 
-	require.Equal(suite.T(), []string{config.Config.Services.Siderolink.WireGuard.GetAdvertisedEndpoint(), TestIP}, resp.GetEndpoints())
+	require.Equal(suite.T(), []string{config.Default().Services.Siderolink.WireGuard.GetAdvertisedEndpoint(), TestIP}, resp.GetEndpoints())
 }
 
 func (suite *SiderolinkSuite) TestVirtualNodes() {
@@ -417,7 +419,7 @@ func (suite *SiderolinkSuite) TestVirtualNodes() {
 
 	expectedResp := resp.CloneVT()
 	expectedResp.GrpcPeerAddrPort = ""
-	expectedResp.ServerEndpoint = pb.MakeEndpoints(config.Config.Services.Siderolink.WireGuard.GetAdvertisedEndpoint(), TestIP)
+	expectedResp.ServerEndpoint = pb.MakeEndpoints(config.Default().Services.Siderolink.WireGuard.GetAdvertisedEndpoint(), TestIP)
 
 	suite.Assert().NoError(err)
 


### PR DESCRIPTION
Part of the effort to improve Omni codebase, reduce the usage of globals.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>