### PR TITLE
refactor(frontend): refactor patches, machine class, and node destroy watches

### DIFF
--- a/frontend/src/views/cluster/Nodes/NodePatches.vue
+++ b/frontend/src/views/cluster/Nodes/NodePatches.vue
@@ -5,33 +5,26 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
+import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, MachineStatusType } from '@/api/resources'
-import Watch from '@/components/common/Watch/Watch.vue'
-
-import Patches from '../Config/Patches.vue'
+import { useResourceWatch } from '@/methods/useResourceWatch'
+import Patches from '@/views/cluster/Config/Patches.vue'
 
 const route = useRoute()
 
-const opts = computed(() => {
-  return {
-    resource: {
-      id: route.params.machine as string,
-      type: MachineStatusType,
-      namespace: DefaultNamespace,
-    },
-    runtime: Runtime.Omni,
-  }
-})
+const { data: machine } = useResourceWatch<MachineStatusSpec>(() => ({
+  resource: {
+    id: route.params.machine.toString(),
+    type: MachineStatusType,
+    namespace: DefaultNamespace,
+  },
+  runtime: Runtime.Omni,
+}))
 </script>
 
 <template>
-  <Watch spinner :opts="opts">
-    <template #default="{ data }">
-      <Patches :machine="data" />
-    </template>
-  </Watch>
+  <Patches v-if="machine" :machine />
 </template>

--- a/frontend/src/views/omni/Machines/MachinePatches.vue
+++ b/frontend/src/views/omni/Machines/MachinePatches.vue
@@ -17,7 +17,7 @@ const route = useRoute()
 
 const { data: machine } = useResourceWatch<MachineStatusSpec>(() => ({
   resource: {
-    id: route.params.machine as string,
+    id: route.params.machine.toString(),
     type: MachineStatusType,
     namespace: DefaultNamespace,
   },
@@ -26,5 +26,5 @@ const { data: machine } = useResourceWatch<MachineStatusSpec>(() => ({
 </script>
 
 <template>
-  <Patches v-if="machine" :machine="machine" />
+  <Patches v-if="machine" :machine />
 </template>


### PR DESCRIPTION
Refactor `NodePatches`, `MachineClass`, and `NodeDestroyCancel`, to use `useResourceWatch` instead of `<Watch>`. Align `NodePatches` and `MachinePatches` to be identical (they could be the same component but will keep separate for now, incase there are differing requirements later). Simplify internal `Patches` permission logic.

Related to #1471