### PR TITLE
refactor(frontend): rename tbutton type to variant

### DIFF
--- a/frontend/src/components/common/Button/SplitButton.vue
+++ b/frontend/src/components/common/Button/SplitButton.vue
@@ -19,7 +19,7 @@ import type { ComponentProps } from 'vue-component-type-helpers'
 import TButton from '@/components/common/Button/TButton.vue'
 
 interface Props {
-  variant?: ComponentProps<typeof TButton>['type']
+  variant?: ComponentProps<typeof TButton>['variant']
   size?: ComponentProps<typeof TButton>['size']
   actions: [string, string, ...string[]]
   disabled?: boolean
@@ -39,7 +39,7 @@ const { width } = useElementSize(triggerRef)
   <DropdownMenuRoot>
     <div v-bind="$attrs" ref="trigger" class="inline-flex -space-x-px">
       <TButton
-        :type="variant"
+        :variant="variant"
         :size
         :disabled
         class="rounded-tr-none rounded-br-none"
@@ -50,7 +50,7 @@ const { width } = useElementSize(triggerRef)
 
       <DropdownMenuTrigger aria-label="extra actions" as-child>
         <TButton
-          :type="variant"
+          :variant="variant"
           :size
           :disabled
           class="rounded-tl-none rounded-bl-none"

--- a/frontend/src/components/common/Button/TButton.stories.ts
+++ b/frontend/src/components/common/Button/TButton.stories.ts
@@ -7,7 +7,7 @@ import type { ComponentProps } from 'vue-component-type-helpers'
 
 import TButton from './TButton.vue'
 
-const types: ComponentProps<typeof TButton>['type'][] = [
+const variants: ComponentProps<typeof TButton>['variant'][] = [
   'primary',
   'secondary',
   'highlighted',
@@ -21,9 +21,9 @@ const iconPositions: ComponentProps<typeof TButton>['iconPosition'][] = ['left',
 const meta: Meta<typeof TButton> = {
   component: TButton,
   argTypes: {
-    type: {
+    variant: {
       control: 'select',
-      options: types,
+      options: variants,
     },
     size: {
       control: 'inline-radio',
@@ -70,9 +70,9 @@ export const AllButtons: Story = {
     template: iconPositions
       .flatMap((iconPosition) =>
         sizes.flatMap((size) =>
-          types.map(
-            (type) =>
-              `<TButton type="${type}" size="${size}" icon-position="${iconPosition}" v-bind="args">${type}-${size}</TButton>`,
+          variants.map(
+            (variant) =>
+              `<TButton variant="${variant}" size="${size}" icon-position="${iconPosition}" v-bind="args">${variant}-${size}</TButton>`,
           ),
         ),
       )

--- a/frontend/src/components/common/Button/TButton.vue
+++ b/frontend/src/components/common/Button/TButton.vue
@@ -10,6 +10,7 @@ import {
   type ButtonHTMLAttributes,
   computed,
   type HTMLAttributes,
+  useAttrs,
 } from 'vue'
 import type { RouterLinkProps } from 'vue-router'
 import { RouterLink } from 'vue-router'
@@ -19,14 +20,14 @@ import TIcon from '@/components/common/Icon/TIcon.vue'
 import { cn } from '@/methods/utils'
 
 interface Props {
-  type?: 'primary' | 'secondary' | 'subtle' | 'highlighted'
+  variant?: 'primary' | 'secondary' | 'subtle' | 'highlighted'
   size?: 'md' | 'sm' | 'xs' | 'xxs'
   icon?: IconType
   iconPosition?: 'left' | 'right'
   class?: HTMLAttributes['class']
 }
 
-interface ButtonProps extends /* @vue-ignore */ Omit<ButtonHTMLAttributes, 'type'> {
+interface ButtonProps extends /* @vue-ignore */ ButtonHTMLAttributes {
   is?: 'button'
   href?: never
   to?: never
@@ -52,13 +53,14 @@ const {
   is = 'button',
   to,
   href,
-  type = 'primary',
+  variant = 'primary',
   size = 'md',
   iconPosition = 'right',
   icon,
   disabled,
   class: className,
 } = defineProps<Props & (ButtonProps | AnchorProps | RLink)>()
+const attrs = useAttrs()
 
 const dynamicProps = computed(() => {
   // <a> does not support disabled, so we force <button> in that case
@@ -67,7 +69,7 @@ const dynamicProps = computed(() => {
     if (href) return { href }
   }
 
-  return { type: 'button', disabled }
+  return { type: (attrs.type as string) || 'button', disabled }
 })
 </script>
 
@@ -80,13 +82,13 @@ const dynamicProps = computed(() => {
       cn(
         {
           'border-naturals-n5 bg-naturals-n3 text-naturals-n12 hover:border-primary-p3 hover:bg-primary-p3 hover:text-naturals-n14 focus:border-primary-p2 focus:bg-primary-p2 focus:text-naturals-n14 active:border-primary-p4 active:bg-primary-p4 active:text-naturals-n14 disabled:cursor-not-allowed disabled:border-naturals-n6 disabled:bg-naturals-n4 disabled:text-naturals-n7':
-            type === 'primary',
+            variant === 'primary',
           'border-naturals-n5 bg-transparent text-naturals-n10 hover:bg-naturals-n5 hover:text-naturals-n14 focus:border-naturals-n7 focus:bg-naturals-n5 focus:text-naturals-n14 active:border-naturals-n5 active:bg-naturals-n4 active:text-naturals-n14 disabled:cursor-not-allowed disabled:border-naturals-n6 disabled:bg-transparent disabled:text-naturals-n6':
-            type === 'secondary',
+            variant === 'secondary',
           'border-none bg-transparent text-naturals-n13 hover:text-primary-p3 focus:text-primary-p2 focus:underline active:text-primary-p4 active:no-underline disabled:cursor-not-allowed disabled:text-naturals-n6':
-            type === 'subtle',
+            variant === 'subtle',
           'border-primary-p2 bg-primary-p4 text-naturals-n14 hover:border-primary-p3 hover:bg-primary-p3 hover:text-naturals-n14 focus:border-primary-p2 focus:bg-primary-p2 focus:text-naturals-n14 active:border-primary-p4 active:bg-primary-p4 active:text-naturals-n14 disabled:cursor-not-allowed disabled:border-naturals-n6 disabled:bg-naturals-n4 disabled:text-naturals-n7':
-            type === 'highlighted',
+            variant === 'highlighted',
           'px-4 py-1.5 text-sm': size === 'md',
           'px-2 py-0.5 text-sm': size === 'sm',
           'p-0 text-sm': size === 'xs',

--- a/frontend/src/components/common/Form/ArrayRenderer.vue
+++ b/frontend/src/components/common/Form/ArrayRenderer.vue
@@ -93,7 +93,7 @@ const moveDownClicked = (index: string | number) => {
         {{ control.label }}
       </div>
       <TButton
-        type="subtle"
+        variant="subtle"
         size="xxs"
         class="mx-4 mb-3 text-xs"
         icon="plus"

--- a/frontend/src/components/common/UserConsent/UserConsent.vue
+++ b/frontend/src/components/common/UserConsent/UserConsent.vue
@@ -33,7 +33,7 @@ defineEmits<{
         </p>
         <div class="flex gap-2">
           <TButton @click="$emit('decline')">Decline</TButton>
-          <TButton type="highlighted" @click="$emit('accept')">Accept</TButton>
+          <TButton variant="highlighted" @click="$emit('accept')">Accept</TButton>
         </div>
       </div>
     </div>

--- a/frontend/src/views/cluster/Backups/Backups.vue
+++ b/frontend/src/views/cluster/Backups/Backups.vue
@@ -65,7 +65,7 @@ const runEtcdBackup = async () => {
         <div>{{ clusterUUID }}</div>
         <IconButton icon="copy" @click="() => copy(clusterUUID)" />
         <TButton
-          type="highlighted"
+          variant="highlighted"
           class="ml-2"
           :disabled="startingEtcdBackup || !backupStatus.enabled"
           @click="runEtcdBackup"

--- a/frontend/src/views/cluster/Backups/BackupsList.vue
+++ b/frontend/src/views/cluster/Backups/BackupsList.vue
@@ -86,12 +86,12 @@ const openDocs = () => window.open(docsLink, '_blank')?.focus()
       >
         <div class="flex gap-1">
           Check the
-          <TButton type="subtle" size="xs" @click="openDocs">documentation</TButton>
+          <TButton variant="subtle" size="xs" @click="openDocs">documentation</TButton>
           on how to configure s3 backups using CLI.
         </div>
         <div v-if="canManageBackupStore" class="flex gap-1">
           Or
-          <TButton type="subtle" size="xs" @click="$router.push({ name: 'BackupStorage' })">
+          <TButton variant="subtle" size="xs" @click="$router.push({ name: 'BackupStorage' })">
             configure backups in the UI.
           </TButton>
         </div>

--- a/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
@@ -250,7 +250,7 @@ const sectionHeadingId = useId()
         <IconButton icon="check" @click="() => updateMachineCount()" />
         <TButton
           v-if="canUseAll"
-          type="subtle"
+          variant="subtle"
           size="xs"
           @click="() => updateMachineCount(MachineSetSpecMachineAllocationType.Unlimited)"
         >
@@ -304,7 +304,7 @@ const sectionHeadingId = useId()
       class="col-span-full flex items-center gap-1 border-t border-naturals-n4 p-4 pl-9 text-xs"
     >
       {{ pluralize('machine', hiddenMachinesCount, true) }} are hidden
-      <TButton type="subtle" size="xs" @click="showMachinesCount = undefined">
+      <TButton variant="subtle" size="xs" @click="showMachinesCount = undefined">
         <span class="text-xs">Show all...</span>
       </TButton>
     </div>

--- a/frontend/src/views/cluster/Config/PatchEdit.vue
+++ b/frontend/src/views/cluster/Config/PatchEdit.vue
@@ -538,7 +538,11 @@ onMounted(async () => {
     >
       <TButton class="secondary" @click="() => $router.push({ name: patchListPage })">Back</TButton>
       <div class="flex-1" />
-      <TButton type="highlighted" :disabled="!canManageConfigPatches || saving" @click="saveConfig">
+      <TButton
+        variant="highlighted"
+        :disabled="!canManageConfigPatches || saving"
+        @click="saveConfig"
+      >
         <TSpinner v-if="saving" class="h-5 w-5" />
         <span v-else>Save</span>
       </TButton>

--- a/frontend/src/views/cluster/Config/Patches.vue
+++ b/frontend/src/views/cluster/Config/Patches.vue
@@ -248,7 +248,7 @@ const openPatchCreate = () => {
     <ManagedByTemplatesWarning :resource="cluster" />
     <div class="flex gap-4">
       <TInput v-model="filter" class="flex-1" placeholder="Search..." icon="search" />
-      <TButton type="highlighted" :disabled="!canManageConfigPatches" @click="openPatchCreate">
+      <TButton variant="highlighted" :disabled="!canManageConfigPatches" @click="openPatchCreate">
         Create Patch
       </TButton>
     </div>

--- a/frontend/src/views/cluster/Manifest/Sync.vue
+++ b/frontend/src/views/cluster/Manifest/Sync.vue
@@ -176,7 +176,7 @@ setupSyncStream()
   <div class="flex flex-col gap-2">
     <div class="flex items-start">
       <PageHeader class="flex-1" :title="title" />
-      <TButton type="highlighted" :disabled="applyChangesDisabled" @click="applyChanges">
+      <TButton variant="highlighted" :disabled="applyChangesDisabled" @click="applyChanges">
         Apply Changes ({{ numChanges }})
       </TButton>
     </div>

--- a/frontend/src/views/cluster/Nodes/NodeExtensions.vue
+++ b/frontend/src/views/cluster/Nodes/NodeExtensions.vue
@@ -228,7 +228,7 @@ const openExtensionsUpdate = () => {
     <div
       class="sticky -bottom-6 -mx-6 -my-6 flex h-16 items-center justify-end gap-2 border-t border-naturals-n5 bg-naturals-n1 px-12 py-6 text-xs"
     >
-      <TButton type="highlighted" :disabled="!canUpdateTalos" @click="openExtensionsUpdate">
+      <TButton variant="highlighted" :disabled="!canUpdateTalos" @click="openExtensionsUpdate">
         Update Extensions
       </TButton>
     </div>

--- a/frontend/src/views/cluster/Nodes/NodesHeader.vue
+++ b/frontend/src/views/cluster/Nodes/NodesHeader.vue
@@ -99,7 +99,7 @@ const { canRebootMachines, canRemoveMachines, canAddClusterMachines } = setupClu
         class="header-button"
         icon="power"
         icon-position="left"
-        type="secondary"
+        variant="secondary"
         :disabled="!canRebootMachines"
         @click="shutdownNode"
       >
@@ -109,7 +109,7 @@ const { canRebootMachines, canRemoveMachines, canAddClusterMachines } = setupClu
         class="header-button"
         icon="reboot"
         icon-position="left"
-        type="secondary"
+        variant="secondary"
         :disabled="!canRebootMachines"
         @click="rebootNode"
       >
@@ -120,7 +120,7 @@ const { canRebootMachines, canRemoveMachines, canAddClusterMachines } = setupClu
         class="header-button delete-button"
         icon="delete"
         icon-position="left"
-        type="secondary"
+        variant="secondary"
         :disabled="!canRemoveMachines"
         @click="destroyNode"
       >
@@ -131,7 +131,7 @@ const { canRebootMachines, canRemoveMachines, canAddClusterMachines } = setupClu
         class="header-button"
         icon="rollback"
         icon-position="left"
-        type="secondary"
+        variant="secondary"
         :disabled="!canAddClusterMachines"
         @click="restoreNode"
       >

--- a/frontend/src/views/cluster/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewContent.vue
@@ -269,7 +269,7 @@ onMounted(async () => {
                 kubernetesUpgradeStatus.spec.phase === KubernetesUpgradeStatusSpecPhase.Upgrading &&
                 !clusterLocked
               "
-              type="secondary"
+              variant="secondary"
               class="place-self-end"
               icon="close"
               @click="revertKubernetesUpgrade(clusterId)"
@@ -330,7 +330,7 @@ onMounted(async () => {
                 talosUpgradeStatus.spec.current_upgrade_version &&
                 !clusterLocked
               "
-              type="secondary"
+              variant="secondary"
               class="place-self-end"
               icon="close"
               @click="revertTalosUpgrade(clusterId)"

--- a/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue
@@ -354,7 +354,7 @@ const {
       <div class="flex flex-col gap-4 px-2 lg:px-6">
         <TButton
           :disabled="!canDownloadKubeconfig"
-          type="primary"
+          variant="primary"
           icon="kube-config"
           icon-position="left"
           @click="
@@ -370,7 +370,7 @@ const {
 
         <TButton
           :disabled="!canDownloadTalosconfig"
-          type="primary"
+          variant="primary"
           icon="talos-config"
           icon-position="left"
           @click="() => downloadTalosconfig(clusterStatus!.metadata.id!)"
@@ -382,7 +382,7 @@ const {
         <TButton
           is="router-link"
           :disabled="!canDownloadSupportBundle"
-          type="primary"
+          variant="primary"
           icon="lifebuoy"
           icon-position="left"
           :to="{
@@ -394,7 +394,7 @@ const {
 
         <TButton
           is="router-link"
-          type="primary"
+          variant="primary"
           icon="kube-config"
           icon-position="left"
           :to="{
@@ -413,7 +413,7 @@ const {
         >
           <TButton
             is="router-link"
-            type="highlighted"
+            variant="highlighted"
             icon="nodes"
             icon-position="left"
             :disabled="!canAddClusterMachines || locked"
@@ -432,7 +432,7 @@ const {
           :description="`Kubernetes updates are disabled when the cluster is locked.`"
         >
           <TButton
-            type="primary"
+            variant="primary"
             icon="kubernetes"
             icon-position="left"
             :disabled="!canUpdateKubernetes || !kubernetesUpgradeAvailable() || locked"
@@ -448,7 +448,7 @@ const {
           :description="`Talos updates are disabled when the cluster is locked.`"
         >
           <TButton
-            type="primary"
+            variant="primary"
             icon="sidero-monochrome"
             icon-position="left"
             :disabled="!canUpdateTalos || !talosUpdateAvailable() || locked"
@@ -460,7 +460,7 @@ const {
 
         <TButton
           is="router-link"
-          type="primary"
+          variant="primary"
           icon="settings"
           icon-position="left"
           :to="{
@@ -472,7 +472,7 @@ const {
         </TButton>
 
         <TButton
-          type="primary"
+          variant="primary"
           :icon="locked ? 'locked' : 'unlocked'"
           icon-position="left"
           @click="updateLock"
@@ -488,7 +488,7 @@ const {
           <TButton
             is="router-link"
             class="text-red-r1"
-            type="secondary"
+            variant="secondary"
             icon="delete"
             icon-position="left"
             :disabled="!canRemoveClusterMachines || locked"

--- a/frontend/src/views/common/ConfirmModal.vue
+++ b/frontend/src/views/common/ConfirmModal.vue
@@ -35,7 +35,7 @@ defineEmits<{
 
       <div class="flex items-center justify-end gap-2">
         <TButton @click="$emit('close')">Close</TButton>
-        <TButton type="highlighted" @click="$emit('confirm')">Confirm</TButton>
+        <TButton variant="highlighted" @click="$emit('confirm')">Confirm</TButton>
       </div>
     </div>
   </div>

--- a/frontend/src/views/omni/Auth/Authenticate.vue
+++ b/frontend/src/views/omni/Auth/Authenticate.vue
@@ -283,12 +283,12 @@ const Auth = {
               :fullname="name"
             />
             <div class="flex w-full flex-col gap-3">
-              <TButton type="secondary" class="w-full" @click="logout">Switch User</TButton>
+              <TButton variant="secondary" class="w-full" @click="logout">Switch User</TButton>
               <TButton
                 v-if="$route.query[AuthFlowQueryParam] === Auth.CLI"
                 id="confirm"
                 class="w-full"
-                type="highlighted"
+                variant="highlighted"
                 @click="() => confirmPublicKey()"
               >
                 Grant Access
@@ -297,7 +297,7 @@ const Auth = {
                 v-else
                 id="login"
                 class="w-full"
-                type="highlighted"
+                variant="highlighted"
                 @click="generatePublicKey"
               >
                 Log In

--- a/frontend/src/views/omni/Auth/OIDC.vue
+++ b/frontend/src/views/omni/Auth/OIDC.vue
@@ -90,7 +90,7 @@ const copyCode = () => {
             </div>
           </div>
           <div v-else class="my-0.5 flex w-full flex-col gap-3">
-            <TButton class="w-full" type="highlighted" @click="confirmOIDCRequest">
+            <TButton class="w-full" variant="highlighted" @click="confirmOIDCRequest">
               Grant Access
             </TButton>
           </div>

--- a/frontend/src/views/omni/Clusters/ClusterEtcdBackupCheckbox.vue
+++ b/frontend/src/views/omni/Clusters/ClusterEtcdBackupCheckbox.vue
@@ -97,7 +97,7 @@ const updateBackupInterval = () => {
     >
       <TButton
         v-if="canManageBackupStore"
-        type="subtle"
+        variant="subtle"
         size="xxs"
         icon="settings"
         icon-position="left"

--- a/frontend/src/views/omni/Clusters/ClusterMenu.vue
+++ b/frontend/src/views/omni/Clusters/ClusterMenu.vue
@@ -51,8 +51,8 @@ const workersCount = computed(() => {
       </div>
       <div v-if="warning" class="text-xs text-yellow-y1">{{ warning }}</div>
     </div>
-    <TButton v-if="onReset" type="secondary" @click="onReset">Cancel</TButton>
-    <TButton icon-position="left" type="highlighted" :disabled="disabled" @click="onSubmit">
+    <TButton v-if="onReset" variant="secondary" @click="onReset">Cancel</TButton>
+    <TButton icon-position="left" variant="highlighted" :disabled="disabled" @click="onSubmit">
       {{ action }}
     </TButton>
   </div>

--- a/frontend/src/views/omni/Clusters/Clusters.vue
+++ b/frontend/src/views/omni/Clusters/Clusters.vue
@@ -101,7 +101,7 @@ const filterOptions = [
               icon="warning"
             />
           </PageHeader>
-          <TButton :disabled="!canCreateClusters" type="highlighted" @click="openClusterCreate">
+          <TButton :disabled="!canCreateClusters" variant="highlighted" @click="openClusterCreate">
             Create Cluster
           </TButton>
         </div>

--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -358,7 +358,7 @@ const filterByLabel = (e: { key: string; value?: string }) => {
           @checked-value="(value) => (state.cluster.kubernetesVersion = value)"
         />
         <TButton
-          type="primary"
+          variant="primary"
           :icon="hasConfigs ? 'settings-toggle' : 'settings'"
           @click="openPatchConfig"
         >

--- a/frontend/src/views/omni/Home/HomeGeneralInformation.vue
+++ b/frontend/src/views/omni/Home/HomeGeneralInformation.vue
@@ -138,13 +138,18 @@ const {
     <section class="flex flex-col gap-2">
       <h3 class="text-sm font-medium">CLI</h3>
 
-      <TButton type="primary" icon="document" icon-position="left" @click="downloadTalosconfig()">
+      <TButton
+        variant="primary"
+        icon="document"
+        icon-position="left"
+        @click="downloadTalosconfig()"
+      >
         Download
         <code>talosconfig</code>
       </TButton>
 
       <TButton
-        type="primary"
+        variant="primary"
         icon="talos-config"
         icon-position="left"
         @click="$router.push({ query: { modal: 'downloadTalosctlBinaries' } })"
@@ -152,13 +157,13 @@ const {
         Download talosctl
       </TButton>
 
-      <TButton type="primary" icon="document" icon-position="left" @click="downloadOmniconfig">
+      <TButton variant="primary" icon="document" icon-position="left" @click="downloadOmniconfig">
         Download
         <code>omniconfig</code>
       </TButton>
 
       <TButton
-        type="primary"
+        variant="primary"
         icon="talos-config"
         icon-position="left"
         @click="$router.push({ query: { modal: 'downloadOmnictlBinaries' } })"
@@ -170,7 +175,7 @@ const {
     <section v-if="canReadAuditLog && auditLogAvailable" class="flex flex-col gap-2">
       <h3 class="text-sm font-medium">Tools</h3>
 
-      <TButton type="primary" icon="document" icon-position="left" @click="downloadAuditLog">
+      <TButton variant="primary" icon="document" icon-position="left" @click="downloadAuditLog">
         Get audit logs
       </TButton>
     </section>

--- a/frontend/src/views/omni/Home/HomeNoAccess.vue
+++ b/frontend/src/views/omni/Home/HomeNoAccess.vue
@@ -28,13 +28,18 @@ import { downloadOmniconfig } from '@/methods'
     <p class="text-xs text-naturals-n10">At least Reader role is required</p>
 
     <div class="mt-3 flex gap-3">
-      <TButton type="primary" icon="talos-config" icon-position="left" @click="downloadOmniconfig">
+      <TButton
+        variant="primary"
+        icon="talos-config"
+        icon-position="left"
+        @click="downloadOmniconfig"
+      >
         Download
         <code>omniconfig</code>
       </TButton>
 
       <TButton
-        type="primary"
+        variant="primary"
         icon="talos-config"
         icon-position="left"
         @click="$router.push({ query: { modal: 'downloadOmnictlBinaries' } })"

--- a/frontend/src/views/omni/Home/HomeRecentClusters.vue
+++ b/frontend/src/views/omni/Home/HomeRecentClusters.vue
@@ -36,7 +36,7 @@ const { data } = useResourceWatch<ClusterStatusSpec>({
       <TButton
         icon-position="left"
         icon="clusters"
-        type="subtle"
+        variant="subtle"
         size="xs"
         @click="$router.push({ name: 'Clusters' })"
       >

--- a/frontend/src/views/omni/Home/HomeRecentMachines.vue
+++ b/frontend/src/views/omni/Home/HomeRecentMachines.vue
@@ -34,7 +34,7 @@ const { data } = useResourceWatch<MachineStatusSpec>({
       <TButton
         icon-position="left"
         icon="nodes"
-        type="subtle"
+        variant="subtle"
         size="xs"
         @click="$router.push({ name: 'Machines' })"
       >

--- a/frontend/src/views/omni/InstallationMedia/InstallationMedia.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMedia.vue
@@ -93,7 +93,7 @@ function clonePreset(preset: (typeof presets.value)[number]) {
       <PageHeader title="Installation Media" />
       <TButton
         is="router-link"
-        type="highlighted"
+        variant="highlighted"
         :to="{ name: 'InstallationMediaCreate' }"
         @click="formState = {}"
       >

--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.vue
@@ -176,7 +176,7 @@ function onSaved(name: string) {
         <TButton
           is="router-link"
           v-if="!isLastStep"
-          type="highlighted"
+          variant="highlighted"
           :disabled="!nextStep || !isStepValid"
           :to="{ name: nextStep }"
         >
@@ -186,13 +186,13 @@ function onSaved(name: string) {
         <TButton
           is="router-link"
           v-else-if="isSaved"
-          type="highlighted"
+          variant="highlighted"
           :to="{ name: 'InstallationMedia' }"
         >
           Finished
         </TButton>
 
-        <TButton v-else type="highlighted" @click="savePresetModalOpen = true">Save</TButton>
+        <TButton v-else variant="highlighted" @click="savePresetModalOpen = true">Save</TButton>
       </div>
     </div>
 

--- a/frontend/src/views/omni/InstallationMedia/SavePresetModal.vue
+++ b/frontend/src/views/omni/InstallationMedia/SavePresetModal.vue
@@ -100,7 +100,7 @@ const titleId = useId()
 
         <TButton
           :disabled="saving || !name || existingPresetLoading || !!existingPreset"
-          type="highlighted"
+          variant="highlighted"
           @click="save"
         >
           Save

--- a/frontend/src/views/omni/MachineClasses/MachineClass.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClass.vue
@@ -589,7 +589,7 @@ const submit = async () => {
       <div
         class="sticky -bottom-6 -mx-6 -my-6 flex h-16 items-center justify-end gap-2 border-t border-naturals-n5 bg-naturals-n1 px-12 py-6 text-xs"
       >
-        <TButton type="highlighted" :disabled="!canSubmit" @click="submit">
+        <TButton variant="highlighted" :disabled="!canSubmit" @click="submit">
           {{ edit ? 'Update Machine Class' : 'Create Machine Class' }}
         </TButton>
       </div>

--- a/frontend/src/views/omni/MachineClasses/MachineClasses.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClasses.vue
@@ -18,7 +18,7 @@ import MachineClassesList from '@/views/omni/MachineClasses/MachineClassesList.v
       <TButton
         is="router-link"
         :disabled="!canRemoveMachines"
-        type="highlighted"
+        variant="highlighted"
         :to="{ name: 'MachineClassCreate' }"
       >
         Create Machine Class

--- a/frontend/src/views/omni/Machines/Machines.vue
+++ b/frontend/src/views/omni/Machines/Machines.vue
@@ -170,7 +170,7 @@ function updateSelected(machine: Resource<MachineStatusLinkSpec>, v?: boolean) {
       >
         <div class="flex gap-1">
           Check the
-          <TButton type="subtle" size="xs" @click="openDocs">documentation</TButton>
+          <TButton variant="subtle" size="xs" @click="openDocs">documentation</TButton>
           on how to configure and use infrastructure providers.
         </div>
       </TAlert>
@@ -182,7 +182,7 @@ function updateSelected(machine: Resource<MachineStatusLinkSpec>, v?: boolean) {
       >
         <div class="flex gap-1">
           Download and boot the
-          <TButton is="router-link" :to="{ name: 'InstallationMedia' }" type="subtle" size="xs">
+          <TButton is="router-link" :to="{ name: 'InstallationMedia' }" variant="subtle" size="xs">
             installation media
           </TButton>
           to connect machines to your Omni instance.
@@ -244,7 +244,12 @@ function updateSelected(machine: Resource<MachineStatusLinkSpec>, v?: boolean) {
     </template>
 
     <template #extra-controls>
-      <TButton type="primary" icon="delete" :disabled="!selectedMachines.size" @click="deleteItems">
+      <TButton
+        variant="primary"
+        icon="delete"
+        :disabled="!selectedMachines.size"
+        @click="deleteItems"
+      >
         <span class="contents max-md:hidden">Delete selected</span>
       </TButton>
     </template>

--- a/frontend/src/views/omni/Machines/MachinesPending.vue
+++ b/frontend/src/views/omni/Machines/MachinesPending.vue
@@ -62,7 +62,7 @@ function rejectMachines(...ids: string[]) {
       <template #extra-controls>
         <TButton
           icon="check"
-          type="highlighted"
+          variant="highlighted"
           :disabled="!selectedMachines.size"
           @click="acceptMachines(...selectedMachines)"
         >

--- a/frontend/src/views/omni/Modals/ConfigPatchEdit.vue
+++ b/frontend/src/views/omni/Modals/ConfigPatchEdit.vue
@@ -71,7 +71,7 @@ const saveAndClose = async () => {
           rel="noopener noreferrer"
           target="_blank"
           icon="question"
-          type="subtle"
+          variant="subtle"
           size="xs"
           icon-position="left"
         >
@@ -102,7 +102,7 @@ const saveAndClose = async () => {
       />
     </div>
     <div class="flex justify-between gap-4 rounded-b bg-naturals-n3 p-4">
-      <TButton type="secondary" @click="close">Cancel</TButton>
+      <TButton variant="secondary" @click="close">Cancel</TButton>
       <TButton @click="saveAndClose">Save</TButton>
     </div>
   </div>

--- a/frontend/src/views/omni/Modals/CreateExtensions.vue
+++ b/frontend/src/views/omni/Modals/CreateExtensions.vue
@@ -100,7 +100,7 @@ const updateExtensions = (extensions?: Record<string, boolean>) => {
       />
 
       <div class="flex justify-between gap-4">
-        <TButton type="secondary" @click="close">Cancel</TButton>
+        <TButton variant="secondary" @click="close">Cancel</TButton>
         <div class="flex gap-4">
           <TButton
             icon="reset"
@@ -109,7 +109,7 @@ const updateExtensions = (extensions?: Record<string, boolean>) => {
           >
             Revert
           </TButton>
-          <TButton type="highlighted" @click="() => updateExtensions(requestedExtensions)">
+          <TButton variant="highlighted" @click="() => updateExtensions(requestedExtensions)">
             Save
           </TButton>
         </div>

--- a/frontend/src/views/omni/Modals/DownloadSupportBundle.vue
+++ b/frontend/src/views/omni/Modals/DownloadSupportBundle.vue
@@ -248,7 +248,7 @@ const { canDownloadSupportBundle } = setupClusterPermissions(
         <TButton
           class="h-9 w-32"
           :disabled="!canDownloadSupportBundle || started"
-          type="highlighted"
+          variant="highlighted"
           @click="download"
         >
           <TSpinner v-if="!status" class="h-5 w-5" />

--- a/frontend/src/views/omni/Modals/InfraProviderSetup.vue
+++ b/frontend/src/views/omni/Modals/InfraProviderSetup.vue
@@ -66,7 +66,7 @@ const close = () => {
           placeholder="examples: kubevirt, bare-metal"
         />
       </div>
-      <TButton type="highlighted" class="h-9" @click="handleCreate">Next</TButton>
+      <TButton variant="highlighted" class="h-9" @click="handleCreate">Next</TButton>
     </template>
 
     <ServiceAccountKey v-if="key" :secret-key="key" />

--- a/frontend/src/views/omni/Modals/JoinTokenCreate.vue
+++ b/frontend/src/views/omni/Modals/JoinTokenCreate.vue
@@ -104,7 +104,7 @@ const close = () => {
     </div>
 
     <TButton
-      type="highlighted"
+      variant="highlighted"
       :disabled="!canManageUsers && authType !== AuthType.SAML"
       @click="handleCreate"
     >

--- a/frontend/src/views/omni/Modals/MachineSetConfigEdit.vue
+++ b/frontend/src/views/omni/Modals/MachineSetConfigEdit.vue
@@ -114,7 +114,7 @@ const saveAndClose = async () => {
       </div>
     </div>
     <div class="flex justify-between gap-4 rounded-b bg-naturals-n3 p-4">
-      <TButton type="secondary" @click="close">Cancel</TButton>
+      <TButton variant="secondary" @click="close">Cancel</TButton>
       <TButton @click="saveAndClose">Save</TButton>
     </div>
   </div>

--- a/frontend/src/views/omni/Modals/MachineTemplateExtensions.vue
+++ b/frontend/src/views/omni/Modals/MachineTemplateExtensions.vue
@@ -64,9 +64,9 @@ const updateExtensions = (extensions?: Record<string, boolean>) => {
     <ExtensionsPicker v-model="requestedExtensions" :talos-version="talosVersion" class="flex-1" />
 
     <div class="flex justify-between gap-4">
-      <TButton type="secondary" @click="close">Cancel</TButton>
+      <TButton variant="secondary" @click="close">Cancel</TButton>
       <div class="flex gap-4">
-        <TButton type="highlighted" @click="() => updateExtensions(requestedExtensions)">
+        <TButton variant="highlighted" @click="() => updateExtensions(requestedExtensions)">
           Save
         </TButton>
       </div>

--- a/frontend/src/views/omni/Modals/MaintenanceUpdate.vue
+++ b/frontend/src/views/omni/Modals/MaintenanceUpdate.vue
@@ -153,7 +153,7 @@ const upgradeClick = async () => {
       <TButton
         class="h-9 w-32"
         :disabled="!versions || updating"
-        type="highlighted"
+        variant="highlighted"
         @click="upgradeClick"
       >
         <TSpinner v-if="!versions || updating" class="h-5 w-5" />

--- a/frontend/src/views/omni/Modals/NodeReboot.vue
+++ b/frontend/src/views/omni/Modals/NodeReboot.vue
@@ -72,7 +72,7 @@ const reboot = async () => {
       <p class="text-xs">Please confirm the action.</p>
 
       <div class="modal-buttons-box">
-        <TButton class="modal-button" type="secondary" @click="close">Cancel</TButton>
+        <TButton class="modal-button" variant="secondary" @click="close">Cancel</TButton>
         <TButton
           :disabled="!canRebootMachines || state === 'Rebooting'"
           class="modal-button"

--- a/frontend/src/views/omni/Modals/NodeShutdown.vue
+++ b/frontend/src/views/omni/Modals/NodeShutdown.vue
@@ -73,7 +73,7 @@ const shutdown = async () => {
       <p class="text-xs">Please confirm the action.</p>
 
       <div class="modal-buttons-box">
-        <TButton class="modal-button" type="secondary" @click="close">Cancel</TButton>
+        <TButton class="modal-button" variant="secondary" @click="close">Cancel</TButton>
         <TButton
           :disabled="!canRebootMachines || state === 'Shutdown in progress'"
           class="modal-button"

--- a/frontend/src/views/omni/Modals/RoleEdit.vue
+++ b/frontend/src/views/omni/Modals/RoleEdit.vue
@@ -122,7 +122,7 @@ const close = () => {
         @checked-value="(value) => (role = value)"
       />
       <TButton
-        type="highlighted"
+        variant="highlighted"
         :disabled="!canManageUsers"
         class="h-9"
         @click="

--- a/frontend/src/views/omni/Modals/ServiceAccountCreate.vue
+++ b/frontend/src/views/omni/Modals/ServiceAccountCreate.vue
@@ -96,7 +96,7 @@ const close = () => {
         />
       </div>
       <TButton
-        type="highlighted"
+        variant="highlighted"
         :disabled="!canManageUsers && authType !== AuthType.SAML"
         class="h-9"
         @click="handleCreate"

--- a/frontend/src/views/omni/Modals/ServiceAccountRenew.vue
+++ b/frontend/src/views/omni/Modals/ServiceAccountRenew.vue
@@ -68,7 +68,7 @@ const close = () => {
         class="h-full flex-1"
       />
       <TButton
-        type="highlighted"
+        variant="highlighted"
         :disabled="!canManageUsers && authType !== AuthType.SAML"
         class="h-9"
         @click="handleRenew"

--- a/frontend/src/views/omni/Modals/UntaintSingleNode.vue
+++ b/frontend/src/views/omni/Modals/UntaintSingleNode.vue
@@ -29,7 +29,7 @@ const onContinue = (untaint: boolean) => {
 
     <div class="mt-8 flex justify-end gap-2">
       <TButton class="secondary h-9 w-15" @click="onContinue(false)">No</TButton>
-      <TButton type="highlighted" class="h-9 w-15" @click="onContinue(true)">Yes</TButton>
+      <TButton variant="highlighted" class="h-9 w-15" @click="onContinue(true)">Yes</TButton>
     </div>
   </div>
 </template>

--- a/frontend/src/views/omni/Modals/UpdateExtensions.vue
+++ b/frontend/src/views/omni/Modals/UpdateExtensions.vue
@@ -190,8 +190,8 @@ const updateExtensionsConfig = async () => {
       />
 
       <div class="flex justify-between gap-4">
-        <TButton type="secondary" @click="close">Cancel</TButton>
-        <TButton type="highlighted" @click="updateExtensions">Update</TButton>
+        <TButton variant="secondary" @click="close">Cancel</TButton>
+        <TButton variant="highlighted" @click="updateExtensions">Update</TButton>
       </div>
     </div>
     <div v-else class="flex items-center justify-center">

--- a/frontend/src/views/omni/Modals/UpdateKernelArgs.vue
+++ b/frontend/src/views/omni/Modals/UpdateKernelArgs.vue
@@ -187,7 +187,7 @@ const close = () => {
       <div class="flex flex-wrap items-center gap-2">
         <TInput v-model="args" class="h-full flex-1 font-mono" placeholder="none" />
         <TButton v-if="editArgs" class="h-9 w-32" @click="() => (editArgs = false)">Cancel</TButton>
-        <TButton type="highlighted" class="h-9 w-32" @click="handleUpdateKernelArgs">
+        <TButton variant="highlighted" class="h-9 w-32" @click="handleUpdateKernelArgs">
           Update
         </TButton>
       </div>

--- a/frontend/src/views/omni/Modals/UpdateKubernetes.vue
+++ b/frontend/src/views/omni/Modals/UpdateKubernetes.vue
@@ -302,7 +302,7 @@ const upgradeClick = async () => {
         :disabled="
           !status || runningPrechecks || selectedVersion === status?.spec?.last_upgrade_version
         "
-        type="highlighted"
+        variant="highlighted"
         @click="upgradeClick"
       >
         <TSpinner v-if="runningPrechecks || !status" class="h-5 w-5" />

--- a/frontend/src/views/omni/Modals/UpdateTalos.vue
+++ b/frontend/src/views/omni/Modals/UpdateTalos.vue
@@ -151,7 +151,7 @@ const upgradeClick = async () => {
       <TButton
         class="h-9 w-32"
         :disabled="!status || selectedVersion === status?.spec?.last_upgrade_version"
-        type="highlighted"
+        variant="highlighted"
         @click="upgradeClick"
       >
         <TSpinner v-if="!status" class="h-5 w-5" />

--- a/frontend/src/views/omni/Modals/UserCreate.vue
+++ b/frontend/src/views/omni/Modals/UserCreate.vue
@@ -76,7 +76,7 @@ const close = () => {
         @checked-value="(value) => (role = value)"
       />
       <TButton
-        type="highlighted"
+        variant="highlighted"
         :disabled="!canManageUsers && authType !== AuthType.SAML"
         class="h-9 w-32"
         @click="handleUserCreate"

--- a/frontend/src/views/omni/Settings/BackupStorage.vue
+++ b/frontend/src/views/omni/Settings/BackupStorage.vue
@@ -221,7 +221,7 @@ const updateConfig = async () => {
         />
         <div class="flex gap-2 place-self-end">
           <TButton :disabled="!canManageBackupStore" @click="resetConfig">Reset</TButton>
-          <TButton :disabled="!canManageBackupStore" type="highlighted" @click="updateConfig">
+          <TButton :disabled="!canManageBackupStore" variant="highlighted" @click="updateConfig">
             Save
           </TButton>
         </div>

--- a/frontend/src/views/omni/Settings/InfraProviders.vue
+++ b/frontend/src/views/omni/Settings/InfraProviders.vue
@@ -115,7 +115,7 @@ const openRotateSecretKey = async (name: string) => {
     <div class="flex justify-end">
       <TButton
         icon-position="left"
-        type="highlighted"
+        variant="highlighted"
         :disabled="!canManageUsers"
         @click="openInfraProviderSetup"
       >

--- a/frontend/src/views/omni/Settings/JoinTokens.vue
+++ b/frontend/src/views/omni/Settings/JoinTokens.vue
@@ -124,7 +124,7 @@ const openDeleteToken = (token: string) => {
       <TButton
         icon="plus"
         icon-position="left"
-        type="highlighted"
+        variant="highlighted"
         :disabled="!canManageUsers"
         @click="openUserCreate"
       >

--- a/frontend/src/views/omni/Users/ServiceAccounts.vue
+++ b/frontend/src/views/omni/Users/ServiceAccounts.vue
@@ -49,7 +49,7 @@ const openUserCreate = () => {
       <TButton
         icon="plus"
         icon-position="left"
-        type="highlighted"
+        variant="highlighted"
         :disabled="!canManageUsers"
         @click="openUserCreate"
       >

--- a/frontend/src/views/omni/Users/Users.vue
+++ b/frontend/src/views/omni/Users/Users.vue
@@ -59,7 +59,7 @@ const openUserCreate = () => {
       <TButton
         icon="user-add"
         icon-position="left"
-        type="highlighted"
+        variant="highlighted"
         :disabled="!canManageUsers || authType === AuthType.SAML"
         @click="openUserCreate"
       >


### PR DESCRIPTION
Rename `TButton` `type` prop to `variant`, as `type` conflicts with the native HTML `button` `type` attribute.