### PR TITLE
feat: add configuration options for audit log cleanup

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -585,6 +585,7 @@ spec:
       copy:
         - frontend/
         - internal/backend/runtime/omni/controllers/omni/
+        - internal/pkg/config/
   vtProtobufEnabled: true
   specs:
     - source: client/api/common/omni.proto

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-01-30T12:27:48Z by kres dc032d7.
+# Generated on 2026-02-10T13:20:54Z by kres f3ab59e.
 
 ARG JS_TOOLCHAIN
 ARG TOOLCHAIN=scratch
@@ -379,6 +379,7 @@ FROM scratch AS generate
 COPY --from=proto-compile /client/api/ /client/api/
 COPY --from=go-generate-0 /src/frontend frontend
 COPY --from=go-generate-0 /src/internal/backend/runtime/omni/controllers/omni internal/backend/runtime/omni/controllers/omni
+COPY --from=go-generate-0 /src/internal/pkg/config internal/pkg/config
 COPY --from=embed-abbrev-generate /src/internal/version internal/version
 
 # builds acompat-linux-amd64

--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -340,6 +340,9 @@ func defineLogsFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flag
 	rootCmdFlagBinder.StringVar("log-resource-updates-log-level", flagDescription("logs.resourceLogger.logLevel", schema), &flagConfig.Logs.ResourceLogger.LogLevel)
 	rootCmdFlagBinder.BoolVar("audit-log-enabled", flagDescription("logs.audit.enabled", schema), &flagConfig.Logs.Audit.Enabled)
 	rootCmdFlagBinder.DurationVar("audit-log-sqlite-timeout", flagDescription("logs.audit.sqliteTimeout", schema), &flagConfig.Logs.Audit.SqliteTimeout)
+	rootCmdFlagBinder.DurationVar("audit-log-retention-period", flagDescription("logs.audit.retentionPeriod", schema), &flagConfig.Logs.Audit.RetentionPeriod)
+	rootCmdFlagBinder.Uint64Var("audit-log-max-size", flagDescription("logs.audit.maxSize", schema), &flagConfig.Logs.Audit.MaxSize)
+	rootCmdFlagBinder.Float64Var("audit-log-cleanup-probability", flagDescription("logs.audit.cleanupProbability", schema), &flagConfig.Logs.Audit.CleanupProbability)
 	rootCmdFlagBinder.BoolVar("enable-stripe-reporting", flagDescription("logs.stripe.enabled", schema), &flagConfig.Logs.Stripe.Enabled)
 	rootCmdFlagBinder.Uint32Var("stripe-minimum-commit", flagDescription("logs.stripe.minCommit", schema), &flagConfig.Logs.Stripe.MinCommit)
 

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"path/filepath"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	zombiesqlite "zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
@@ -132,6 +134,236 @@ func TestRemove(t *testing.T) {
 	events := readAllEvents(t, rdr)
 	require.Len(t, events, 1)
 	assert.Equal(t, times[2].UnixMilli(), events[0].TimeMillis)
+}
+
+func TestRemoveByRetentionPeriod(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+	store, _ := setupStore(ctx, t, logger)
+
+	now := time.Now()
+	retentionPeriod := 7 * 24 * time.Hour // 7 days
+
+	// Write events at various ages relative to now.
+	eventTimes := []time.Time{
+		now.Add(-30 * 24 * time.Hour),        // 30 days ago — should be removed
+		now.Add(-14 * 24 * time.Hour),        // 14 days ago — should be removed
+		now.Add(-7*24*time.Hour - time.Hour), // 7 days + 1 hour ago — should be removed
+		now.Add(-6 * 24 * time.Hour),         // 6 days ago — should remain
+		now.Add(-1 * 24 * time.Hour),         // 1 day ago — should remain
+		now.Add(-1 * time.Hour),              // 1 hour ago — should remain
+	}
+
+	for i, ts := range eventTimes {
+		evt := auditlog.Event{
+			Type:       "retention-test",
+			TimeMillis: ts.UnixMilli(),
+			Data:       &auditlog.Data{Session: auditlog.Session{UserID: fmt.Sprintf("user-%d", i)}},
+		}
+		require.NoError(t, store.Write(ctx, evt))
+	}
+
+	// Simulate RunCleanup: remove from epoch to (now - retentionPeriod).
+	err := store.Remove(ctx, time.Unix(0, 0), now.Add(-retentionPeriod))
+	require.NoError(t, err)
+
+	// Verify only the 3 recent events remain.
+	rdr, err := store.Reader(ctx, time.Time{}, now.Add(time.Hour))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, rdr.Close())
+	})
+
+	events := readAllEvents(t, rdr)
+	require.Len(t, events, 3)
+
+	// The remaining events should be the 3 newest, ordered by time.
+	assert.Equal(t, eventTimes[3].UnixMilli(), events[0].TimeMillis)
+	assert.Equal(t, eventTimes[4].UnixMilli(), events[1].TimeMillis)
+	assert.Equal(t, eventTimes[5].UnixMilli(), events[2].TimeMillis)
+}
+
+func TestRemoveByMaxSize(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+
+	// First, create a store without size limit to populate data and measure table size.
+	seedStore, db := setupStore(ctx, t, logger)
+
+	fakeEventCount := 50
+	fakeTimeMillis := func(i int) int64 { return int64(i) * 1000 }
+
+	// Write 50 events with known data.
+	for i := range fakeEventCount {
+		evt := auditlog.Event{
+			Type:       "size-test",
+			TimeMillis: fakeTimeMillis(i),
+			Data: &auditlog.Data{
+				Session: auditlog.Session{
+					UserID: fmt.Sprintf("user-%d", i),
+					Email:  fmt.Sprintf("user-%d@example.com", i),
+				},
+			},
+		}
+		require.NoError(t, seedStore.Write(ctx, evt))
+	}
+
+	// Get the current table size from dbstat.
+	conn, err := db.Take(ctx)
+	require.NoError(t, err)
+
+	var tableSize int64
+
+	err = sqlitex.ExecuteTransient(conn, "SELECT SUM(pgsize) FROM dbstat WHERE name = 'audit_logs'", &sqlitex.ExecOptions{
+		ResultFunc: func(stmt *zombiesqlite.Stmt) error {
+			tableSize = stmt.ColumnInt64(0)
+
+			return nil
+		},
+	})
+	require.NoError(t, err)
+
+	db.Put(conn)
+
+	require.Greater(t, tableSize, int64(0), "table size should be > 0 after writing events")
+
+	// Create a new store on the same DB with maxSize=half, probability=1.0 to always trigger cleanup.
+	maxSize := uint64(tableSize / 2)
+
+	sizedStore, err := auditlogsqlite.NewStore(ctx, db, 5*time.Second, maxSize, 1.0, logger)
+	require.NoError(t, err)
+
+	// Write one more event to trigger cleanup.
+	require.NoError(t, sizedStore.Write(ctx, auditlog.Event{
+		Type:       "size-test-trigger",
+		TimeMillis: fakeTimeMillis(fakeEventCount),
+		Data:       &auditlog.Data{},
+	}))
+
+	// Verify some events were deleted.
+	rdr, err := sizedStore.Reader(ctx, time.Time{}, time.Now().Add(24*time.Hour))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, rdr.Close())
+	})
+
+	events := readAllEvents(t, rdr)
+	assert.Less(t, len(events), fakeEventCount, "some events should have been deleted")
+	assert.Greater(t, len(events), 0, "not all events should be deleted")
+
+	// Verify that the remaining events are the newest ones (oldest were deleted).
+	for i, evt := range events {
+		if i > 0 {
+			assert.Greater(t, evt.TimeMillis, events[i-1].TimeMillis, "remaining events should be ordered by time")
+		}
+	}
+
+	// The last event should be the newest one.
+	assert.Equal(t, fakeTimeMillis(fakeEventCount), events[len(events)-1].TimeMillis)
+}
+
+func TestRemoveByMaxSizeUnlimited(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+
+	// maxSize=0 means unlimited, probability=1.0 to ensure the check runs on every write.
+	store, _ := setupStoreWithOpts(ctx, t, logger, 0, 1.0)
+
+	// Write a few events (timestamps start at 1000ms to avoid matching time-based deletion range).
+	for i := range 5 {
+		evt := auditlog.Event{
+			Type:       "unlimited-test",
+			TimeMillis: int64(i+1) * 1000,
+			Data:       &auditlog.Data{},
+		}
+		require.NoError(t, store.Write(ctx, evt))
+	}
+
+	rdr, err := store.Reader(ctx, time.Time{}, time.Now().Add(24*time.Hour))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, rdr.Close())
+	})
+
+	events := readAllEvents(t, rdr)
+	assert.Len(t, events, 5, "all events should remain when maxSize is 0")
+}
+
+func TestRemoveByMaxSizeBatchCap(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+
+	// Seed 1500 events into a store with no size limit.
+	seedStore, db := setupStore(ctx, t, logger)
+
+	const totalEvents = 1500
+
+	for i := range totalEvents {
+		evt := auditlog.Event{
+			Type:       "batch-cap-test",
+			TimeMillis: int64(i) * 1000,
+			Data: &auditlog.Data{
+				Session: auditlog.Session{
+					UserID: fmt.Sprintf("user-%d", i),
+					Email:  fmt.Sprintf("user-%d@example.com", i),
+				},
+			},
+		}
+		require.NoError(t, seedStore.Write(ctx, evt))
+	}
+
+	// Create a new store on the same DB with maxSize=1 (effectively 0) and probability=1.0.
+	// This means all rows exceed the limit, but the batch cap (1000) should prevent
+	// deleting them all in a single cleanup pass.
+	sizedStore, err := auditlogsqlite.NewStore(ctx, db, 5*time.Second, 1, 1.0, logger)
+	require.NoError(t, err)
+
+	// Write one event to trigger a single cleanup pass.
+	require.NoError(t, sizedStore.Write(ctx, auditlog.Event{
+		Type:       "batch-cap-trigger",
+		TimeMillis: int64(totalEvents) * 1000,
+		Data:       &auditlog.Data{},
+	}))
+
+	// Count remaining rows. The batch cap is 1000, so roughly 1000 should have been
+	// deleted, leaving ~501 rows (1500 - 1000 + 1 trigger event).
+	rdr, err := sizedStore.Reader(ctx, time.Time{}, time.Now().Add(24*time.Hour))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, rdr.Close())
+	})
+
+	events := readAllEvents(t, rdr)
+
+	// The cap prevents deleting everything at once: at least 400 rows must survive.
+	assert.Greater(t, len(events), 400, "batch cap should prevent deleting all excess rows in one pass")
+	// But some rows should have been deleted.
+	assert.Less(t, len(events), totalEvents, "some events should have been deleted")
+
+	// Verify remaining events are the newest (oldest were deleted first).
+	for i := range len(events) - 1 {
+		assert.Greater(t, events[i+1].TimeMillis, events[i].TimeMillis, "remaining events should be ordered by time")
+	}
 }
 
 func TestReaderParameters(t *testing.T) {
@@ -302,7 +534,11 @@ func TestExtractedColumns(t *testing.T) {
 	}
 }
 
-func setupStore(ctx context.Context, t *testing.T, _ *zap.Logger) (*auditlogsqlite.Store, *sqlitex.Pool) {
+func setupStore(ctx context.Context, t *testing.T, logger *zap.Logger) (*auditlogsqlite.Store, *sqlitex.Pool) {
+	return setupStoreWithOpts(ctx, t, logger, 0, 0)
+}
+
+func setupStoreWithOpts(ctx context.Context, t *testing.T, logger *zap.Logger, maxSize uint64, cleanupProbability float64) (*auditlogsqlite.Store, *sqlitex.Pool) {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "test.db")
@@ -317,7 +553,7 @@ func setupStore(ctx context.Context, t *testing.T, _ *zap.Logger) (*auditlogsqli
 		require.NoError(t, db.Close())
 	})
 
-	store, err := auditlogsqlite.NewStore(ctx, db, 5*time.Second)
+	store, err := auditlogsqlite.NewStore(ctx, db, 5*time.Second, maxSize, cleanupProbability, logger)
 	require.NoError(t, err)
 
 	return store, db

--- a/internal/backend/runtime/omni/audit/logger.go
+++ b/internal/backend/runtime/omni/audit/logger.go
@@ -30,7 +30,7 @@ func initLogger(ctx context.Context, config config.LogsAudit, db *sqlitex.Pool, 
 		return &nopLogger{}, nil
 	}
 
-	dbAuditLogger, err := auditlogsqlite.NewStore(ctx, db, config.GetSqliteTimeout())
+	dbAuditLogger, err := auditlogsqlite.NewStore(ctx, db, config.GetSqliteTimeout(), config.GetMaxSize(), config.GetCleanupProbability(), logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create sqlite audit logger: %w", err)
 	}

--- a/internal/backend/runtime/omni/audit/logger_test.go
+++ b/internal/backend/runtime/omni/audit/logger_test.go
@@ -132,7 +132,7 @@ func TestMigrateSkipIfHasData(t *testing.T) {
 	})
 
 	// Pre-populate DB using internal store to simulate existing state
-	sqliteStore, err := auditlogsqlite.NewStore(ctx, db, 5*time.Second)
+	sqliteStore, err := auditlogsqlite.NewStore(ctx, db, 5*time.Second, 0, 0, logger)
 	require.NoError(t, err)
 
 	dbEvt := auditlog.MakeEvent("create", "db.resource", "test-id", &auditlog.Data{Session: auditlog.Session{UserID: "db-user"}})

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -710,6 +710,17 @@ func (s *LocalResourceService) SetPort(v int) {
 	s.Port = &v
 }
 
+func (s *LogsAudit) GetCleanupProbability() float64 {
+	if s == nil || s.CleanupProbability == nil {
+		return *new(float64)
+	}
+	return *s.CleanupProbability
+}
+
+func (s *LogsAudit) SetCleanupProbability(v float64) {
+	s.CleanupProbability = &v
+}
+
 func (s *LogsAudit) GetEnabled() bool {
 	if s == nil || s.Enabled == nil {
 		return *new(bool)
@@ -721,6 +732,17 @@ func (s *LogsAudit) SetEnabled(v bool) {
 	s.Enabled = &v
 }
 
+func (s *LogsAudit) GetMaxSize() uint64 {
+	if s == nil || s.MaxSize == nil {
+		return *new(uint64)
+	}
+	return *s.MaxSize
+}
+
+func (s *LogsAudit) SetMaxSize(v uint64) {
+	s.MaxSize = &v
+}
+
 func (s *LogsAudit) GetPath() string {
 	if s == nil || s.Path == nil {
 		return *new(string)
@@ -730,6 +752,17 @@ func (s *LogsAudit) GetPath() string {
 
 func (s *LogsAudit) SetPath(v string) {
 	s.Path = &v
+}
+
+func (s *LogsAudit) GetRetentionPeriod() time.Duration {
+	if s == nil || s.RetentionPeriod == nil {
+		return *new(time.Duration)
+	}
+	return *s.RetentionPeriod
+}
+
+func (s *LogsAudit) SetRetentionPeriod(v time.Duration) {
+	s.RetentionPeriod = &v
 }
 
 func (s *LogsAudit) GetSqliteTimeout() time.Duration {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -140,6 +140,9 @@ func Default() *Params {
 	p.Logs.Audit.SetEnabled(true)
 	p.Logs.Audit.SetPath("_out/audit")
 	p.Logs.Audit.SetSqliteTimeout(30 * time.Second)
+	p.Logs.Audit.SetRetentionPeriod(24 * 30 * time.Hour)
+	p.Logs.Audit.SetMaxSize(0)
+	p.Logs.Audit.SetCleanupProbability(0.01)
 
 	p.Logs.ResourceLogger.SetLogLevel(zapcore.InfoLevel.String())
 	p.Logs.ResourceLogger.Types = common.UserManagedResourceTypes

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -921,6 +921,26 @@
           "goJSONSchema": {
             "type": "time.Duration"
           }
+        },
+        "retentionPeriod": {
+          "description": "RetentionPeriod is the duration after which audit logs are considered old and eligible for cleanup.",
+          "type": "string",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "goJSONSchema": {
+            "type": "time.Duration"
+          }
+        },
+        "maxSize": {
+          "description": "MaxSize is the maximum allowed size (in bytes) of the audit logs. When exceeded, the oldest entries are removed. 0 means unlimited.",
+          "type": "integer",
+          "minimum": 0,
+          "goJSONSchema": {
+            "type": "uint64"
+          }
+        },
+        "cleanupProbability": {
+          "description": "CleanupProbability is the probability of triggering size-based cleanup on each audit log write. When triggered, a best-effort cleanup removes a bounded batch of the oldest rows to reduce the table size toward maxSize; multiple cleanups may be required for the table to fall below maxSize. 0 disables size-based cleanup.",
+          "type": "number"
         }
       }
     },

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -344,13 +344,28 @@ type Logs struct {
 }
 
 type LogsAudit struct {
+	// CleanupProbability is the probability of triggering size-based cleanup on each
+	// audit log write. When triggered, a best-effort cleanup removes a bounded batch
+	// of the oldest rows to reduce the table size toward maxSize; multiple cleanups
+	// may be required for the table to fall below maxSize. 0 disables size-based
+	// cleanup.
+	CleanupProbability *float64 `json:"cleanupProbability,omitempty" yaml:"cleanupProbability,omitempty"`
+
 	// Enabled controls whether audit logging is enabled.
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	// MaxSize is the maximum allowed size (in bytes) of the audit logs. When
+	// exceeded, the oldest entries are removed. 0 means unlimited.
+	MaxSize *uint64 `json:"maxSize,omitempty" yaml:"maxSize,omitempty"`
 
 	// Path is the path where audit logs are stored. DEPRECATED: they are now stored
 	// in SQLite, and this parameter exists for the migration purposes only, and will
 	// be removed.
 	Path *string `json:"path,omitempty" yaml:"path,omitempty"`
+
+	// RetentionPeriod is the duration after which audit logs are considered old and
+	// eligible for cleanup.
+	RetentionPeriod *time.Duration `json:"retentionPeriod,omitempty" yaml:"retentionPeriod,omitempty"`
 
 	// SqliteTimeout is the timeout for SQLite operations used for audit logs storage.
 	SqliteTimeout *time.Duration `json:"sqliteTimeout,omitempty" yaml:"sqliteTimeout,omitempty"`


### PR DESCRIPTION
Add retentionPeriod, maxSize, and cleanupProbability config fields to audit logs. Retention was previously hardcoded to 30 days. Size-based cleanup runs probabilistically on each Write (default 1%), deleting oldest rows when the table exceeds maxSize.

Closes: #2264
Fixes: #2294
