### PR TITLE
feat: update machinery doc links

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/siderolabs/image-factory v1.0.0
 	github.com/siderolabs/proto-codec v0.1.3
 	github.com/siderolabs/siderolink v0.3.15
-	github.com/siderolabs/talos v1.13.0-alpha.0.0.20260126150111-859d3f03c444
-	github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.0.0.20260126150111-859d3f03c444
+	github.com/siderolabs/talos v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3
+	github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/xlab/treeprint v1.2.0

--- a/client/go.sum
+++ b/client/go.sum
@@ -210,10 +210,10 @@ github.com/siderolabs/protoenc v0.2.4 h1:D3Fpn2nQSQOhl8ZlAxijZAf7K6F8CM1uZq0afIG
 github.com/siderolabs/protoenc v0.2.4/go.mod h1:i5XLHjfv5vyi7LhQrSEo19HCA+lYtDd7CWxsoWp9XE8=
 github.com/siderolabs/siderolink v0.3.15 h1:WSsgKQGJY/ObIKjTcYYGEaGfRMyox+r/Ft+9lIgJqOI=
 github.com/siderolabs/siderolink v0.3.15/go.mod h1:iWdlsHji90zotgDg4+a2zJL2ZMNJckQ8/VwqR39ThBM=
-github.com/siderolabs/talos v1.13.0-alpha.0.0.20260126150111-859d3f03c444 h1:CnnZT+60dT5GJBE4tDXfi0rN2ggxxcFjDYnx7HrsKCA=
-github.com/siderolabs/talos v1.13.0-alpha.0.0.20260126150111-859d3f03c444/go.mod h1:cXu7s85WHRXox3UJLgDTtedV+KZc0wIPrFMecc9PzpA=
-github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.0.0.20260126150111-859d3f03c444 h1:DFa2KULjaHiRvIRXK5Mojmr5TxgjismLcKPLcw3kt6g=
-github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.0.0.20260126150111-859d3f03c444/go.mod h1:QKitWcS6eF4RnOUK7mJZEUwUTVi34hNKw4t4BFNpCoM=
+github.com/siderolabs/talos v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3 h1:SXKyyQ76pUSHDNfZkwfXFJjVEjxIgrLSHzoovZHq2lc=
+github.com/siderolabs/talos v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3/go.mod h1:qOz9COzDsTohBYUAS3GWJttiUe6qhABYvw4g7TvUxjU=
+github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3 h1:ejFpLb7XgRordk94Zn3KxC9dq1cj9oqxjceCU810xPQ=
+github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3/go.mod h1:QKitWcS6eF4RnOUK7mJZEUwUTVi34hNKw4t4BFNpCoM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/frontend/src/methods/index.spec.ts
+++ b/frontend/src/methods/index.spec.ts
@@ -8,29 +8,10 @@ import { test } from 'vitest'
 
 import { DefaultTalosVersion } from '@/api/resources'
 
-import { getDocsLink, getLegacyDocsLink, majorMinorVersion } from '.'
+import { getDocsLink, majorMinorVersion } from '.'
 
 const { major, minor } = parse(DefaultTalosVersion, false, true)
 const defaultVersion = `${major}.${minor}`
-
-test.each`
-  path            | options                       | expected
-  ${undefined}    | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}`}
-  ${'/hello/123'} | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}/hello/123`}
-  ${'hello/123'}  | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}/hello/123`}
-  ${'/hello'}     | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}/hello`}
-  ${'123'}        | ${undefined}                  | ${`https://talos.dev/v${defaultVersion}/123`}
-  ${'/hello/123'} | ${{}}                         | ${`https://talos.dev/v${defaultVersion}/hello/123`}
-  ${'hello/123'}  | ${{}}                         | ${`https://talos.dev/v${defaultVersion}/hello/123`}
-  ${'/hello'}     | ${{}}                         | ${`https://talos.dev/v${defaultVersion}/hello`}
-  ${'123'}        | ${{}}                         | ${`https://talos.dev/v${defaultVersion}/123`}
-  ${'/hello/123'} | ${{ talosVersion: '1.11.3' }} | ${'https://talos.dev/v1.11/hello/123'}
-  ${'hello/123'}  | ${{ talosVersion: '1.10.0' }} | ${'https://talos.dev/v1.10/hello/123'}
-  ${'/hello'}     | ${{ talosVersion: '1.9' }}    | ${'https://talos.dev/v1.9/hello'}
-  ${'123'}        | ${{ talosVersion: '1' }}      | ${'https://talos.dev/v1.0/123'}
-`('getDocsLink: $type - $path - $options returns $expected', ({ path, options, expected }) => {
-  expect(getLegacyDocsLink(path, options)).toBe(expected)
-})
 
 test.each`
   type       | path            | options                       | expected

--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -240,21 +240,6 @@ export const downloadMachineJoinConfig = async (
 
 type DocsType = 'talos' | 'omni' | 'k8s'
 
-/**
- * @deprecated Update links to use getDocsLink instead where possible.
- */
-export function getLegacyDocsLink(path?: string, options?: { talosVersion?: string }) {
-  const parts = ['https://talos.dev']
-
-  parts.push(`v${majorMinorVersion(options?.talosVersion || DefaultTalosVersion)}`)
-
-  if (path) {
-    parts.push(path.replace(/^\//, ''))
-  }
-
-  return parts.join('/')
-}
-
 export function getDocsLink(
   type: 'talos',
   path?: string,

--- a/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/CloudProvider.vue
@@ -14,7 +14,7 @@ import { CloudPlatformConfigType, VirtualNamespace } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
-import { getLegacyDocsLink } from '@/methods'
+import { getDocsLink } from '@/methods'
 import { useResourceList } from '@/methods/useResourceList'
 import type { FormState } from '@/views/omni/InstallationMedia/useFormState'
 
@@ -39,7 +39,11 @@ const platforms = computed(() =>
       ...p,
       spec: {
         ...p.spec,
-        documentation: p.spec.documentation && getLegacyDocsLink(p.spec.documentation),
+        documentation:
+          p.spec.documentation &&
+          getDocsLink('talos', p.spec.documentation, {
+            talosVersion: formState.value.talosVersion,
+          }),
       },
     })),
 )

--- a/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/Confirmation.vue
@@ -28,7 +28,7 @@ import TIcon from '@/components/common/Icon/TIcon.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 import TAlert from '@/components/TAlert.vue'
-import { getDocsLink, getLegacyDocsLink, majorMinorVersion } from '@/methods'
+import { getDocsLink, majorMinorVersion } from '@/methods'
 import { useFeatures } from '@/methods/features'
 import { useDownloadImage } from '@/methods/useDownloadImage'
 import { useResourceGet } from '@/methods/useResourceGet'
@@ -257,7 +257,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', `/getting-started/what's-new-in-talos`, {
-              talosVersion: formState.talosVersion!,
+              talosVersion: formState.talosVersion,
             })
           "
           target="_blank"
@@ -272,7 +272,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', '/getting-started/support-matrix', {
-              talosVersion: formState.talosVersion!,
+              talosVersion: formState.talosVersion,
             })
           "
           target="_blank"
@@ -286,7 +286,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', '/getting-started/getting-started', {
-              talosVersion: formState.talosVersion!,
+              talosVersion: formState.talosVersion,
             })
           "
           target="_blank"
@@ -303,7 +303,7 @@ const installerImage = computed(() =>
             getDocsLink(
               'talos',
               '/platform-specific-installations/bare-metal-platforms/network-config',
-              { talosVersion: formState.talosVersion! },
+              { talosVersion: formState.talosVersion },
             )
           "
           target="_blank"
@@ -316,8 +316,8 @@ const installerImage = computed(() =>
         <a
           class="link-primary"
           :href="
-            getLegacyDocsLink(selectedPlatform.spec.documentation, {
-              talosVersion: formState.talosVersion!,
+            getDocsLink('talos', selectedPlatform.spec.documentation, {
+              talosVersion: formState.talosVersion,
             })
           "
           target="_blank"
@@ -330,8 +330,8 @@ const installerImage = computed(() =>
         <a
           class="link-primary"
           :href="
-            getLegacyDocsLink(selectedSBC.spec.documentation, {
-              talosVersion: formState.talosVersion!,
+            getDocsLink('talos', selectedSBC.spec.documentation, {
+              talosVersion: formState.talosVersion,
             })
           "
           target="_blank"
@@ -348,7 +348,7 @@ const installerImage = computed(() =>
             getDocsLink(
               'talos',
               '/platform-specific-installations/bare-metal-platforms/secureboot',
-              { talosVersion: formState.talosVersion! },
+              { talosVersion: formState.talosVersion },
             )
           "
           target="_blank"
@@ -363,7 +363,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', '/getting-started/prodnotes', {
-              talosVersion: formState.talosVersion!,
+              talosVersion: formState.talosVersion,
             })
           "
           target="_blank"
@@ -378,7 +378,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', '/troubleshooting/troubleshooting', {
-              talosVersion: formState.talosVersion!,
+              talosVersion: formState.talosVersion,
             })
           "
           target="_blank"

--- a/frontend/src/views/omni/InstallationMedia/Steps/SBCType.vue
+++ b/frontend/src/views/omni/InstallationMedia/Steps/SBCType.vue
@@ -14,7 +14,7 @@ import { SBCConfigType, VirtualNamespace } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import RadioGroup from '@/components/common/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/common/Radio/RadioGroupOption.vue'
-import { getLegacyDocsLink } from '@/methods'
+import { getDocsLink } from '@/methods'
 import { useResourceList } from '@/methods/useResourceList'
 import type { FormState } from '@/views/omni/InstallationMedia/useFormState'
 
@@ -39,7 +39,11 @@ const SBCs = computed(() =>
       ...sbc,
       spec: {
         ...sbc.spec,
-        documentation: sbc.spec.documentation && getLegacyDocsLink(sbc.spec.documentation),
+        documentation:
+          sbc.spec.documentation &&
+          getDocsLink('talos', sbc.spec.documentation, {
+            talosVersion: formState.value.talosVersion,
+          }),
       },
     })),
 )

--- a/go.mod
+++ b/go.mod
@@ -84,8 +84,8 @@ require (
 	github.com/siderolabs/omni/client v1.4.7
 	github.com/siderolabs/proto-codec v0.1.3
 	github.com/siderolabs/siderolink v0.3.15
-	github.com/siderolabs/talos v1.13.0-alpha.0.0.20260126150111-859d3f03c444
-	github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.0.0.20260126150111-859d3f03c444
+	github.com/siderolabs/talos v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3
+	github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3
 	github.com/siderolabs/tcpproxy v0.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -498,10 +498,10 @@ github.com/siderolabs/protoenc v0.2.4 h1:D3Fpn2nQSQOhl8ZlAxijZAf7K6F8CM1uZq0afIG
 github.com/siderolabs/protoenc v0.2.4/go.mod h1:i5XLHjfv5vyi7LhQrSEo19HCA+lYtDd7CWxsoWp9XE8=
 github.com/siderolabs/siderolink v0.3.15 h1:WSsgKQGJY/ObIKjTcYYGEaGfRMyox+r/Ft+9lIgJqOI=
 github.com/siderolabs/siderolink v0.3.15/go.mod h1:iWdlsHji90zotgDg4+a2zJL2ZMNJckQ8/VwqR39ThBM=
-github.com/siderolabs/talos v1.13.0-alpha.0.0.20260126150111-859d3f03c444 h1:CnnZT+60dT5GJBE4tDXfi0rN2ggxxcFjDYnx7HrsKCA=
-github.com/siderolabs/talos v1.13.0-alpha.0.0.20260126150111-859d3f03c444/go.mod h1:cXu7s85WHRXox3UJLgDTtedV+KZc0wIPrFMecc9PzpA=
-github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.0.0.20260126150111-859d3f03c444 h1:DFa2KULjaHiRvIRXK5Mojmr5TxgjismLcKPLcw3kt6g=
-github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.0.0.20260126150111-859d3f03c444/go.mod h1:QKitWcS6eF4RnOUK7mJZEUwUTVi34hNKw4t4BFNpCoM=
+github.com/siderolabs/talos v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3 h1:SXKyyQ76pUSHDNfZkwfXFJjVEjxIgrLSHzoovZHq2lc=
+github.com/siderolabs/talos v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3/go.mod h1:qOz9COzDsTohBYUAS3GWJttiUe6qhABYvw4g7TvUxjU=
+github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3 h1:ejFpLb7XgRordk94Zn3KxC9dq1cj9oqxjceCU810xPQ=
+github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.1.0.20260210134859-406b8c83c9b3/go.mod h1:QKitWcS6eF4RnOUK7mJZEUwUTVi34hNKw4t4BFNpCoM=
 github.com/siderolabs/tcpproxy v0.1.0 h1:IbkS9vRhjMOscc1US3M5P1RnsGKFgB6U5IzUk+4WkKA=
 github.com/siderolabs/tcpproxy v0.1.0/go.mod h1:onn6CPPj/w1UNqQ0U97oRPF0CqbrgEApYCw4P9IiCW8=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/internal/backend/runtime/omni/controllers/omni/image/client.go
+++ b/internal/backend/runtime/omni/controllers/omni/image/client.go
@@ -40,6 +40,7 @@ func (c *TalosImageClient) ListImagesOnNode(ctx context.Context, cluster, node s
 
 	nodeAddress := c.NodeResolver.Resolve(cluster, node).GetAddress()
 
+	//nolint:staticcheck
 	imageListStream, err := talosCli.ImageList(client.WithNode(ctx, nodeAddress), common.ContainerdNamespace_NS_CRI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list images: %w", err)
@@ -77,6 +78,7 @@ func (c *TalosImageClient) PullImageToNode(ctx context.Context, cluster, node, i
 		return fmt.Errorf("failed to resolve node %q", node)
 	}
 
+	//nolint:staticcheck
 	if err = talosCli.ImagePull(client.WithNode(ctx, nodeAddress), common.ContainerdNamespace_NS_CRI, image); err != nil {
 		return fmt.Errorf("failed to pull image %s: %w", image, err)
 	}


### PR DESCRIPTION
Bump Talos version and update machinery doc links to point to docs.siderolabs.com.

Closes #1956