### PR TITLE
fix: use single shared etcd backup store factory

### DIFF
--- a/internal/backend/grpc/configs_test.go
+++ b/internal/backend/grpc/configs_test.go
@@ -58,7 +58,8 @@ func TestGenerateConfigs(t *testing.T) {
 	defer cancel()
 
 	logger := zaptest.NewLogger(t)
-	st := omniruntime.NewTestState(logger)
+	st, err := omniruntime.NewTestState(logger)
+	require.NoError(t, err)
 
 	kubernetesRuntime, err := kubernetes.New(st.Default(), "", "", "")
 	require.NoError(t, err)

--- a/internal/backend/grpc/grpc_test.go
+++ b/internal/backend/grpc/grpc_test.go
@@ -75,7 +75,9 @@ func (suite *GrpcSuite) SetupTest() {
 
 	logger := zaptest.NewLogger(suite.T())
 
-	st := omniruntime.NewTestState(logger)
+	st, err := omniruntime.NewTestState(logger)
+	suite.Require().NoError(err)
+
 	suite.state = st.Default()
 
 	clientFactory := talos.NewClientFactory(suite.state, logger)

--- a/internal/backend/grpc/router/talos_backend_test.go
+++ b/internal/backend/grpc/router/talos_backend_test.go
@@ -55,7 +55,8 @@ func TestTalosBackendRoles(t *testing.T) {
 	g, ctx := errgroup.WithContext(ctx)
 
 	logger := zaptest.NewLogger(t)
-	st := omniruntime.NewTestState(logger)
+	st, err := omniruntime.NewTestState(logger)
+	require.NoError(t, err)
 
 	grpcProxy, err := makeGRPCProxy(ctx, proxyEndpoint, serverEndpoint, st.Default())
 	require.NoError(t, err)
@@ -83,7 +84,8 @@ func TestNodeResolution(t *testing.T) {
 	}
 
 	logger := zaptest.NewLogger(t)
-	st := omniruntime.NewTestState(logger)
+	st, err := omniruntime.NewTestState(logger)
+	require.NoError(t, err)
 
 	noOpVerifier := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		return handler(ctx, req)

--- a/internal/backend/runtime/omni/export_test.go
+++ b/internal/backend/runtime/omni/export_test.go
@@ -16,10 +16,16 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
-func NewMockState(st state.State) *State {
+func NewMockState(st state.State) (*State, error) {
+	storeFactory, err := store.NewStoreFactory(config.EtcdBackup{})
+	if err != nil {
+		return nil, err
+	}
+
 	return &State{
 		defaultState: st,
-	}
+		storeFactory: storeFactory,
+	}, nil
 }
 
 func NewEtcdPersistentState(ctx context.Context, params *config.Params, logger *zap.Logger) (*PersistentState, error) {

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -110,10 +110,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		return nil, err
 	}
 
-	storeFactory, err := store.NewStoreFactory(cfg.EtcdBackup)
-	if err != nil {
-		return nil, err
-	}
+	storeFactory := st.StoreFactory()
 
 	powerStageEventsCh := make(chan *omni.MachineStatusSnapshot)
 	powerStageWatcher := powerstage.NewWatcher(defaultState, powerStageEventsCh, logger.With(logging.Component("power_stage_watcher")), powerstage.WatcherOptions{})

--- a/internal/backend/runtime/omni/omni_test.go
+++ b/internal/backend/runtime/omni/omni_test.go
@@ -91,8 +91,11 @@ func (suite *OmniRuntimeSuite) SetupTest() {
 	kubernetesRuntime, err := kubernetes.New(resourceState, "", "", "")
 	suite.Require().NoError(err)
 
+	mockState, err := omniruntime.NewMockState(resourceState)
+	suite.Require().NoError(err)
+
 	suite.runtime, err = omniruntime.NewRuntime(config.Default(), clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
-		omniruntime.NewMockState(resourceState), prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
+		mockState, prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)))
 
 	suite.Require().NoError(err)
 

--- a/internal/backend/runtime/omni/talosconfig_test.go
+++ b/internal/backend/runtime/omni/talosconfig_test.go
@@ -35,7 +35,9 @@ func TestOperatorTalosconfig(t *testing.T) {
 	defer cancel()
 
 	logger := zaptest.NewLogger(t)
-	st := omniruntime.NewTestState(logger)
+	st, err := omniruntime.NewTestState(logger)
+	require.NoError(t, err)
+
 	clientFactory := talos.NewClientFactory(st.Default(), logger)
 	dnsService := dns.NewService(st.Default(), logger)
 	discoveryClientCache := &discoveryClientCacheMock{}


### PR DESCRIPTION
The etcd backup store factory was being created twice: once in NewState (for the external.State serving backup list queries) and once in NewRuntime (for backup controllers). Only the latter had Start() called, so the external.State factory never received EtcdBackupS3Conf events and its store was never initialized.

This caused "s3 store is not initialized" errors when listing EtcdBackup resources through the API, e.g., during cluster creation from an etcd backup.
