### PR TITLE
fix: properly generate upgrade diffs for the imported cluster

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_status.go
@@ -173,7 +173,8 @@ func NewClusterStatusController(embeddedDiscoveryServiceEnabled bool) *ClusterSt
 				case phases[specs.MachineSetPhase_ScalingDown] > 0 || phases[specs.MachineSetPhase_Destroying] > 0:
 					// at least one scaling down
 					phase = specs.ClusterStatusSpec_SCALING_DOWN
-				case phases[specs.MachineSetPhase_Running] > 0 || phases[specs.MachineSetPhase_Reconfiguring] > 0:
+				case phases[specs.MachineSetPhase_Running] > 0 || phases[specs.MachineSetPhase_Reconfiguring] > 0 ||
+					phases[specs.MachineSetPhase_Upgrading] > 0:
 					// some running/reconfiguration
 					phase = specs.ClusterStatusSpec_RUNNING
 				}


### PR DESCRIPTION
Imported cluster doesn't have schematic/talos version in the cluster machine config status resource. So fall back to the MachineStatus schematic info instead.

Also change the ClusterStatus controller to treat Upgrading machines as running.