### PR TITLE
feat: expose metrics for sqlite state and add cleanup counters

### DIFF
--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -29,6 +29,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime"
 	"github.com/siderolabs/omni/internal/backend/runtime/kubernetes"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
 	"github.com/siderolabs/omni/internal/pkg/auth"
@@ -120,6 +121,7 @@ func Run(ctx context.Context, state *omni.State, cfg *config.Params, logger *zap
 		state.Default(),
 		&cfg.Logs.Machine,
 		logger.With(logging.Component("siderolink_log_handler")),
+		siderolink.WithLogHandlerCleanupCallback(state.SQLiteMetrics().CleanupCallback(sqlite.SubsystemMachineLogs)),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to set up log handler: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/cosi-project/runtime v1.13.1-0.20251208192740-2b3357ea6788
 	github.com/cosi-project/state-etcd v0.5.3
-	github.com/cosi-project/state-sqlite v0.2.0
+	github.com/cosi-project/state-sqlite v0.3.0
 	github.com/crewjam/saml v0.5.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/emicklei/dot v1.11.0
@@ -214,6 +214,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jsimonetti/rtnetlink/v2 v2.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/cosi-project/runtime v1.13.1-0.20251208192740-2b3357ea6788 h1:h39IpNU
 github.com/cosi-project/runtime v1.13.1-0.20251208192740-2b3357ea6788/go.mod h1:/9fspODJfZrO5dQatMRgN440K8DjWP1jFSgiLX+FmQc=
 github.com/cosi-project/state-etcd v0.5.3 h1:jkXX1zFDMH6qsRjt4Ku9EqDtluhI3ghx1GuQpIwg88Q=
 github.com/cosi-project/state-etcd v0.5.3/go.mod h1:htNLQUC/dIx0twbudZ/wIr7aKLV0El7xHoGKvnuKzfk=
-github.com/cosi-project/state-sqlite v0.2.0 h1:MTgqB/ig5NNK/4VoRyrAsJVIaQhxf1veNxhOkTehYCI=
-github.com/cosi-project/state-sqlite v0.2.0/go.mod h1:V20oy2Sfxla0zZ+SJSgjV20feg2xGARlvVPL4Z4KfRo=
+github.com/cosi-project/state-sqlite v0.3.0 h1:6Qa66WaNOgRKwL/fSyn13krMGb1rXr1MGmhkFPkibt4=
+github.com/cosi-project/state-sqlite v0.3.0/go.mod h1:V20oy2Sfxla0zZ+SJSgjV20feg2xGARlvVPL4Z4KfRo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/backend/discovery/sqlitestore.go
+++ b/internal/backend/discovery/sqlitestore.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	tableName  = "discovery_service_state"
+	// TableName is the SQLite table name used by the discovery state store.
+	TableName  = "discovery_service_state"
 	idColumn   = "id"
 	dataColumn = "data"
 
@@ -55,7 +56,7 @@ func NewSQLiteStore(ctx context.Context, db *sqlitex.Pool, timeout time.Duration
 	schema := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
       %s TEXT PRIMARY KEY,
       %s BLOB
-    ) STRICT;`, tableName, idColumn, dataColumn)
+    ) STRICT;`, TableName, idColumn, dataColumn)
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -98,7 +99,7 @@ func (w *writer) Close() error {
 		return nil
 	}
 
-	query := fmt.Sprintf("INSERT INTO %s (%s, %s) VALUES ($id, $data) ON CONFLICT(%s) DO UPDATE SET %s=excluded.%s", tableName, idColumn, dataColumn, idColumn, dataColumn, dataColumn)
+	query := fmt.Sprintf("INSERT INTO %s (%s, %s) VALUES ($id, $data) ON CONFLICT(%s) DO UPDATE SET %s=excluded.%s", TableName, idColumn, dataColumn, idColumn, dataColumn, dataColumn)
 
 	ctx, cancel := context.WithTimeout(w.ctx, w.timeout)
 	defer cancel()
@@ -144,7 +145,7 @@ func (r *reader) Read(p []byte) (n int, err error) {
 	}
 
 	if r.reader == nil {
-		query := fmt.Sprintf("SELECT %s FROM %s WHERE %s = $id", dataColumn, tableName, idColumn)
+		query := fmt.Sprintf("SELECT %s FROM %s WHERE %s = $id", dataColumn, TableName, idColumn)
 
 		ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 		defer cancel()

--- a/internal/backend/runtime/omni/sqlite/metrics.go
+++ b/internal/backend/runtime/omni/sqlite/metrics.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+	zombiesqlite "zombiezen.com/go/sqlite"
+	"zombiezen.com/go/sqlite/sqlitex"
+
+	"github.com/siderolabs/omni/internal/backend/discovery"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/logstore/sqlitelog"
+)
+
+const (
+	defaultRefreshInterval = 60 * time.Second
+	queryTimeout           = 10 * time.Second
+)
+
+// Subsystem names used as label values.
+const (
+	SubsystemAuditLogs   = "audit_logs"
+	SubsystemMachineLogs = "machine_logs"
+	SubsystemDiscovery   = "discovery"
+	SubsystemState       = "state"
+)
+
+// subsystemTables maps each Omni subsystem to the SQLite tables it owns.
+// The state subsystem is handled separately via sqlState, which implements DBSize to satisfy sqlite.State.
+var subsystemTables = map[string][]string{
+	SubsystemAuditLogs:   {auditlogsqlite.TableName},
+	SubsystemMachineLogs: {sqlitelog.TableName},
+	SubsystemDiscovery:   {discovery.TableName},
+}
+
+type sqlState interface {
+	DBSize(ctx context.Context) (int64, error)
+}
+
+// Metrics implements prometheus.Collector to expose SQLite database metrics.
+type Metrics struct {
+	lastRefresh              time.Time
+	sqlState                 sqlState
+	subsystemRowCountDesc    *prometheus.Desc
+	dbSizeDesc               *prometheus.Desc
+	subsystemSizeDesc        *prometheus.Desc
+	cleanupRowsDeleted       *prometheus.CounterVec
+	db                       *sqlitex.Pool
+	logger                   *zap.Logger
+	cachedSubsystemSizes     map[string]float64
+	cachedSubsystemRowCounts map[string]float64
+	refreshInterval          time.Duration
+	cachedDBSize             float64
+	mu                       sync.Mutex
+}
+
+var _ prometheus.Collector = &Metrics{}
+
+// MetricsOption configures optional metrics behavior.
+type MetricsOption func(*Metrics)
+
+// WithRefreshInterval sets the cache refresh interval. Default is 60s.
+func WithRefreshInterval(d time.Duration) MetricsOption {
+	return func(m *Metrics) {
+		m.refreshInterval = d
+	}
+}
+
+// NewMetrics creates a *Metrics that exposes SQLite database metrics.
+// If cosiState implements sqlState, the state subsystem size is reported via its DBSize method.
+func NewMetrics(db *sqlitex.Pool, cosiState state.CoreState, logger *zap.Logger, opts ...MetricsOption) *Metrics {
+	dbSizer, ok := cosiState.(sqlState)
+	if !ok {
+		logger.Warn("COSI state does not implement sqlState, state subsystem size will not be reported")
+	}
+
+	m := &Metrics{
+		db:              db,
+		sqlState:        dbSizer,
+		logger:          logger,
+		refreshInterval: defaultRefreshInterval,
+
+		dbSizeDesc: prometheus.NewDesc(
+			"omni_sqlite_db_size_bytes",
+			"Total size of the SQLite database in bytes.",
+			nil, nil,
+		),
+		subsystemSizeDesc: prometheus.NewDesc(
+			"omni_sqlite_subsystem_size_bytes",
+			"Size of a subsystem's tables in the SQLite database in bytes.",
+			[]string{"subsystem"}, nil,
+		),
+		subsystemRowCountDesc: prometheus.NewDesc(
+			"omni_sqlite_subsystem_row_count",
+			"Total number of rows across a subsystem's tables.",
+			[]string{"subsystem"}, nil,
+		),
+		cleanupRowsDeleted: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "omni_sqlite_cleanup_rows_deleted_total",
+			Help: "Total rows deleted by cleanup.",
+		}, []string{"subsystem"}),
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+// CleanupCallback returns a callback that increments the cleanup rows deleted counter for the given subsystem.
+func (m *Metrics) CleanupCallback(subsystem string) func(int) {
+	return func(count int) {
+		if count > 0 {
+			m.cleanupRowsDeleted.WithLabelValues(subsystem).Add(float64(count))
+		}
+	}
+}
+
+// Describe implements prometheus.Collector using DescribeByCollect.
+func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(m, ch)
+}
+
+// Collect implements prometheus.Collector.
+func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if time.Since(m.lastRefresh) > m.refreshInterval {
+		m.refresh()
+	}
+
+	ch <- prometheus.MustNewConstMetric(m.dbSizeDesc, prometheus.GaugeValue, m.cachedDBSize)
+
+	for subsystem, size := range m.cachedSubsystemSizes {
+		ch <- prometheus.MustNewConstMetric(m.subsystemSizeDesc, prometheus.GaugeValue, size, subsystem)
+	}
+
+	for subsystem, count := range m.cachedSubsystemRowCounts {
+		ch <- prometheus.MustNewConstMetric(m.subsystemRowCountDesc, prometheus.GaugeValue, count, subsystem)
+	}
+
+	m.cleanupRowsDeleted.Collect(ch)
+}
+
+// refresh queries the database and updates cached values.
+// On failure, lastRefresh is still updated to avoid retrying on every scrape.
+func (m *Metrics) refresh() {
+	// Always update lastRefresh to prevent tight retry loops when the DB is unavailable.
+	defer func() { m.lastRefresh = time.Now() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer cancel()
+
+	conn, err := m.db.Take(ctx)
+	if err != nil {
+		m.logger.Warn("failed to take connection for metrics refresh", zap.Error(err))
+
+		return
+	}
+
+	defer m.db.Put(conn)
+
+	existingTables, err := m.discoverTables(conn)
+	if err != nil {
+		m.logger.Warn("failed to discover tables for metrics", zap.Error(err))
+
+		return
+	}
+
+	dbSize, err := m.queryDBSize(conn)
+	if err != nil {
+		m.logger.Warn("failed to query db size for metrics", zap.Error(err))
+
+		return
+	}
+
+	tableSizes, err := m.queryTableSizes(conn)
+	if err != nil {
+		m.logger.Warn("failed to query table sizes for metrics", zap.Error(err))
+
+		return
+	}
+
+	subsystemSizes := make(map[string]float64, len(subsystemTables)+1)
+	subsystemRowCounts := make(map[string]float64, len(subsystemTables)+1)
+
+	for subsystem, tables := range subsystemTables {
+		var totalSize float64
+
+		for _, table := range tables {
+			totalSize += tableSizes[table] // 0 if table doesn't exist in dbstat
+		}
+
+		subsystemSizes[subsystem] = totalSize
+
+		rowCount, rowCountErr := m.querySubsystemRowCount(conn, tables, existingTables)
+		if rowCountErr != nil {
+			m.logger.Warn("failed to query row count for subsystem", zap.String("subsystem", subsystem), zap.Error(rowCountErr))
+
+			return
+		}
+
+		subsystemRowCounts[subsystem] = rowCount
+	}
+
+	// State subsystem: use the COSI sqlState for size if available.
+	// Row count is not reported for the state subsystem because it uses a separate database.
+	if m.sqlState != nil {
+		stateSize, sizeErr := m.sqlState.DBSize(ctx)
+		if sizeErr != nil {
+			m.logger.Warn("failed to query state subsystem size", zap.Error(sizeErr))
+
+			return
+		}
+
+		subsystemSizes[SubsystemState] = float64(stateSize)
+	}
+
+	m.cachedDBSize = dbSize
+	m.cachedSubsystemSizes = subsystemSizes
+	m.cachedSubsystemRowCounts = subsystemRowCounts
+}
+
+func (m *Metrics) discoverTables(conn *zombiesqlite.Conn) (map[string]struct{}, error) {
+	q, err := sqlitexx.NewQuery(conn, `SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare table discovery query: %w", err)
+	}
+
+	tables := make(map[string]struct{})
+
+	if err = q.QueryAll(func(stmt *zombiesqlite.Stmt) error {
+		tables[stmt.ColumnText(0)] = struct{}{}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to query tables: %w", err)
+	}
+
+	return tables, nil
+}
+
+func (m *Metrics) queryDBSize(conn *zombiesqlite.Conn) (float64, error) {
+	q, err := sqlitexx.NewQuery(conn, `SELECT COALESCE(SUM(pgsize), 0) FROM dbstat`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare db size query: %w", err)
+	}
+
+	var size float64
+
+	if err = q.QueryRow(func(stmt *zombiesqlite.Stmt) error {
+		size = stmt.ColumnFloat(0)
+
+		return nil
+	}); err != nil {
+		return 0, fmt.Errorf("failed to query db size: %w", err)
+	}
+
+	return size, nil
+}
+
+func (m *Metrics) queryTableSizes(conn *zombiesqlite.Conn) (map[string]float64, error) {
+	q, err := sqlitexx.NewQuery(conn, `SELECT name, SUM(pgsize) FROM dbstat GROUP BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare table sizes query: %w", err)
+	}
+
+	sizes := make(map[string]float64)
+
+	if err = q.QueryAll(func(stmt *zombiesqlite.Stmt) error {
+		sizes[stmt.ColumnText(0)] = stmt.ColumnFloat(1)
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to query table sizes: %w", err)
+	}
+
+	return sizes, nil
+}
+
+// querySubsystemRowCount returns the total row count across all existing tables for a subsystem.
+func (m *Metrics) querySubsystemRowCount(conn *zombiesqlite.Conn, tables []string, existingTables map[string]struct{}) (float64, error) {
+	var total float64
+
+	for _, table := range tables {
+		if _, ok := existingTables[table]; !ok {
+			continue
+		}
+
+		// Table names come from package-level constants, so they are safe to interpolate.
+		q, err := sqlitexx.NewQuery(conn, fmt.Sprintf(`SELECT COUNT(*) FROM "%s"`, table))
+		if err != nil {
+			return 0, fmt.Errorf("failed to prepare row count query for %q: %w", table, err)
+		}
+
+		if err = q.QueryRow(func(stmt *zombiesqlite.Stmt) error {
+			total += stmt.ColumnFloat(0)
+
+			return nil
+		}); err != nil {
+			return 0, fmt.Errorf("failed to query row count for %q: %w", table, err)
+		}
+	}
+
+	return total, nil
+}

--- a/internal/backend/runtime/omni/sqlite/metrics_test.go
+++ b/internal/backend/runtime/omni/sqlite/metrics_test.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"zombiezen.com/go/sqlite/sqlitex"
+
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+func execSQL(t *testing.T, db *sqlitex.Pool, sql string) {
+	t.Helper()
+
+	conn, err := db.Take(t.Context())
+	require.NoError(t, err)
+
+	defer db.Put(conn)
+
+	require.NoError(t, sqlitex.ExecScript(conn, sql))
+}
+
+type fakeSqlState struct {
+	state.CoreState
+	size int64
+}
+
+func (f *fakeSqlState) DBSize(context.Context) (int64, error) {
+	return f.size, nil
+}
+
+func setupMetrics(t *testing.T, db *sqlitex.Pool, cosiState state.CoreState, opts ...sqlite.MetricsOption) *prometheus.Registry {
+	t.Helper()
+
+	logger := zaptest.NewLogger(t)
+	registry := prometheus.NewRegistry()
+
+	registry.MustRegister(sqlite.NewMetrics(db, cosiState, logger, opts...))
+
+	return registry
+}
+
+func TestMetricsCollect(t *testing.T) {
+	t.Parallel()
+
+	db, st := setupTestDB(t)
+
+	execSQL(t, db, `
+		CREATE TABLE machine_logs (id INTEGER PRIMARY KEY, machine_id TEXT, message TEXT);
+		INSERT INTO machine_logs (machine_id, message) VALUES ('m1', 'log1');
+		INSERT INTO machine_logs (machine_id, message) VALUES ('m1', 'log2');
+		INSERT INTO machine_logs (machine_id, message) VALUES ('m2', 'log3');
+
+		CREATE TABLE audit_logs (id INTEGER PRIMARY KEY, event TEXT);
+		INSERT INTO audit_logs (event) VALUES ('e1');
+
+		CREATE TABLE discovery_service_state (id TEXT PRIMARY KEY, data BLOB);
+		INSERT INTO discovery_service_state (id, data) VALUES ('state', x'00');
+	`)
+
+	registry := setupMetrics(t, db, &fakeSqlState{CoreState: st, size: 8192})
+
+	// Verify subsystem row counts (state has no row count since it uses sqlState).
+	expected := `
+		# HELP omni_sqlite_subsystem_row_count Total number of rows across a subsystem's tables.
+		# TYPE omni_sqlite_subsystem_row_count gauge
+		omni_sqlite_subsystem_row_count{subsystem="audit_logs"} 1
+		omni_sqlite_subsystem_row_count{subsystem="discovery"} 1
+		omni_sqlite_subsystem_row_count{subsystem="machine_logs"} 3
+	`
+	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), "omni_sqlite_subsystem_row_count"))
+
+	// Verify subsystem sizes: 3 Omni subsystems + 1 state (from sqlState).
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		if f.GetName() == "omni_sqlite_subsystem_size_bytes" {
+			assert.Len(t, f.GetMetric(), 4)
+
+			for _, m := range f.GetMetric() {
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == "subsystem" && lp.GetValue() == "state" {
+						assert.Equal(t, float64(8192), m.GetGauge().GetValue())
+					}
+				}
+			}
+		}
+
+		if f.GetName() == "omni_sqlite_db_size_bytes" {
+			require.Len(t, f.GetMetric(), 1)
+			assert.Greater(t, f.GetMetric()[0].GetGauge().GetValue(), float64(0))
+		}
+	}
+}
+
+func TestMetricsCaching(t *testing.T) {
+	t.Parallel()
+
+	db, st := setupTestDB(t)
+
+	execSQL(t, db, `
+		CREATE TABLE audit_logs (id INTEGER PRIMARY KEY, data TEXT);
+		INSERT INTO audit_logs (data) VALUES ('row1');
+	`)
+
+	registry := setupMetrics(t, db, &fakeSqlState{CoreState: st})
+
+	// First gather triggers refresh — audit_logs has 1 row.
+	expected := `
+		# HELP omni_sqlite_subsystem_row_count Total number of rows across a subsystem's tables.
+		# TYPE omni_sqlite_subsystem_row_count gauge
+		omni_sqlite_subsystem_row_count{subsystem="audit_logs"} 1
+		omni_sqlite_subsystem_row_count{subsystem="discovery"} 0
+		omni_sqlite_subsystem_row_count{subsystem="machine_logs"} 0
+	`
+	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), "omni_sqlite_subsystem_row_count"))
+
+	// Insert another row.
+	execSQL(t, db, `INSERT INTO audit_logs (data) VALUES ('row2')`)
+
+	// Second gather should return cached value (default 60s interval not elapsed).
+	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), "omni_sqlite_subsystem_row_count"))
+
+	// A new metrics instance with zero interval should see the new row.
+	registry2 := setupMetrics(t, db, &fakeSqlState{CoreState: st}, sqlite.WithRefreshInterval(0))
+
+	expected2 := `
+		# HELP omni_sqlite_subsystem_row_count Total number of rows across a subsystem's tables.
+		# TYPE omni_sqlite_subsystem_row_count gauge
+		omni_sqlite_subsystem_row_count{subsystem="audit_logs"} 2
+		omni_sqlite_subsystem_row_count{subsystem="discovery"} 0
+		omni_sqlite_subsystem_row_count{subsystem="machine_logs"} 0
+	`
+	assert.NoError(t, testutil.GatherAndCompare(registry2, strings.NewReader(expected2), "omni_sqlite_subsystem_row_count"))
+}
+
+func TestMetricsStateSubsystemUsesDBSizer(t *testing.T) {
+	t.Parallel()
+
+	db, st := setupTestDB(t)
+
+	registry := setupMetrics(t, db, &fakeSqlState{CoreState: st, size: 42000})
+
+	expected := `
+		# HELP omni_sqlite_subsystem_size_bytes Size of a subsystem's tables in the SQLite database in bytes.
+		# TYPE omni_sqlite_subsystem_size_bytes gauge
+		omni_sqlite_subsystem_size_bytes{subsystem="audit_logs"} 0
+		omni_sqlite_subsystem_size_bytes{subsystem="discovery"} 0
+		omni_sqlite_subsystem_size_bytes{subsystem="machine_logs"} 0
+		omni_sqlite_subsystem_size_bytes{subsystem="state"} 42000
+	`
+	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), "omni_sqlite_subsystem_size_bytes"))
+}
+
+func TestMetricsEmptyDB(t *testing.T) {
+	t.Parallel()
+
+	db, st := setupTestDB(t)
+
+	registry := setupMetrics(t, db, &fakeSqlState{CoreState: st})
+
+	// All Omni subsystems should report 0 rows since no tables exist.
+	expected := `
+		# HELP omni_sqlite_subsystem_row_count Total number of rows across a subsystem's tables.
+		# TYPE omni_sqlite_subsystem_row_count gauge
+		omni_sqlite_subsystem_row_count{subsystem="audit_logs"} 0
+		omni_sqlite_subsystem_row_count{subsystem="discovery"} 0
+		omni_sqlite_subsystem_row_count{subsystem="machine_logs"} 0
+	`
+	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), "omni_sqlite_subsystem_row_count"))
+}
+
+func TestCleanupCallback(t *testing.T) {
+	t.Parallel()
+
+	db, st := setupTestDB(t)
+	logger := zaptest.NewLogger(t)
+
+	m := sqlite.NewMetrics(db, &fakeSqlState{CoreState: st}, logger)
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(m)
+
+	cb := m.CleanupCallback(sqlite.SubsystemAuditLogs)
+
+	// No calls yet — counter should not appear in output (no initialized series).
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		assert.NotEqual(t, "omni_sqlite_cleanup_rows_deleted_total", f.GetName(), "counter should not appear before any callback")
+	}
+
+	// Call with 0 — should not initialize the counter.
+	cb(0)
+
+	families, err = registry.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		assert.NotEqual(t, "omni_sqlite_cleanup_rows_deleted_total", f.GetName(), "counter should not appear after cb(0)")
+	}
+
+	// Call with positive value.
+	cb(5)
+	cb(3)
+
+	expected := `
+		# HELP omni_sqlite_cleanup_rows_deleted_total Total rows deleted by cleanup.
+		# TYPE omni_sqlite_cleanup_rows_deleted_total counter
+		omni_sqlite_cleanup_rows_deleted_total{subsystem="audit_logs"} 8
+	`
+	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), "omni_sqlite_cleanup_rows_deleted_total"))
+
+	// Multiple subsystems.
+	mlCb := m.CleanupCallback(sqlite.SubsystemMachineLogs)
+	mlCb(10)
+
+	expected2 := `
+		# HELP omni_sqlite_cleanup_rows_deleted_total Total rows deleted by cleanup.
+		# TYPE omni_sqlite_cleanup_rows_deleted_total counter
+		omni_sqlite_cleanup_rows_deleted_total{subsystem="audit_logs"} 8
+		omni_sqlite_cleanup_rows_deleted_total{subsystem="machine_logs"} 10
+	`
+	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected2), "omni_sqlite_cleanup_rows_deleted_total"))
+}
+
+// setupTestDB helper handles the standard SQLite test setup.
+func setupTestDB(t *testing.T) (*sqlitex.Pool, state.State) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.db")
+	conf := config.Default().Storage.Sqlite
+	conf.SetPath(path)
+
+	db, err := sqlite.OpenDB(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	state := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	return db, state
+}


### PR DESCRIPTION
Add Prometheus metrics for SQLite database used by Omni subsystems (audit logs, machine logs, discovery, COSI state):
- omni_sqlite_db_size_bytes: total database size
- omni_sqlite_subsystem_size_bytes: per-subsystem table sizes
- omni_sqlite_subsystem_row_count: per-subsystem row counts
- omni_sqlite_cleanup_rows_deleted_total: counter tracking rows deleted by cleanup operations, labeled by subsystem (audit_logs, machine_logs)

Gauge metrics are collected via a cached refresh (default 60s interval).
Cleanup counters use a callback pattern.

Closes: #2299