### PR TITLE
feat: support custom Vault Kubernetes auth mount path

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -425,12 +425,16 @@ func defineStorageFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, f
 
 	rootCmdFlagBinder.StringVar(config.SQLiteStoragePathFlag,
 		flagDescription("storage.sqlite.path", schema), &flagConfig.Storage.Sqlite.Path)
+
 	rootCmdFlagBinder.StringVar("sqlite-storage-experimental-base-params",
 		flagDescription("storage.sqlite.experimentalBaseParams", schema), &flagConfig.Storage.Sqlite.ExperimentalBaseParams)
 
 	rootCmdFlagBinder.StringVar("sqlite-storage-extra-params",
 		flagDescription("storage.sqlite.extraParams", schema),
 		&flagConfig.Storage.Sqlite.ExtraParams)
+
+	rootCmdFlagBinder.StringVar("vault-k8s-auth-mount-path",
+		flagDescription("storage.vault.k8sAuthMountPath", schema), &flagConfig.Storage.Vault.K8SAuthMountPath)
 
 	return nil
 }

--- a/deploy/helm/v2/omni/values.yaml
+++ b/deploy/helm/v2/omni/values.yaml
@@ -421,6 +421,10 @@ config:
       # Tip: Use additionalConfigSources to load this from an existing Secret,
       # or set the VAULT_TOKEN environment variable via env/envFrom.
       token: ""
+      # K8sAuthMountPath is the mount path of the Kubernetes auth method in Vault.
+      # When not set, it defaults to "kubernetes".
+      # This is useful when Vault is running on a different cluster and has multiple Kubernetes auth mounts.
+      #k8sAuthMountPath: ""
 
 # -- Environment variables to pass to Omni.
 env: []

--- a/internal/backend/runtime/omni/state_etcd.go
+++ b/internal/backend/runtime/omni/state_etcd.go
@@ -77,7 +77,7 @@ func newEtcdPersistentState(ctx context.Context, params *config.Params, logger *
 
 	var cipher *encryption.Cipher
 
-	cipher, err = makeCipher(accountID, params.Storage.Default.Etcd, etcdState.Client(), logger, params.Storage.Vault.GetToken(), params.Storage.Vault.GetUrl()) //nolint:contextcheck
+	cipher, err = makeCipher(accountID, params.Storage.Default.Etcd, etcdState.Client(), logger, params.Storage.Vault) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -105,13 +105,13 @@ func newEtcdPersistentState(ctx context.Context, params *config.Params, logger *
 	}, nil
 }
 
-func makeCipher(name string, etcdParams config.EtcdParams, etcdClient etcd.Client, logger *zap.Logger, vaultToken, vaultURL string) (*encryption.Cipher, error) {
+func makeCipher(name string, etcdParams config.EtcdParams, etcdClient etcd.Client, logger *zap.Logger, vaultConfig config.Vault) (*encryption.Cipher, error) {
 	publicKeys, err := loadPublicKeys(etcdParams)
 	if err != nil {
 		return nil, err
 	}
 
-	loader, err := NewLoader(etcdParams.GetPrivateKeySource(), logger, vaultToken, vaultURL)
+	loader, err := NewLoader(etcdParams.GetPrivateKeySource(), logger, vaultConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -1293,6 +1293,17 @@ func (s *UserPilot) SetAppToken(v string) {
 	s.AppToken = &v
 }
 
+func (s *Vault) GetK8SAuthMountPath() string {
+	if s == nil || s.K8SAuthMountPath == nil {
+		return *new(string)
+	}
+	return *s.K8SAuthMountPath
+}
+
+func (s *Vault) SetK8SAuthMountPath(v string) {
+	s.K8SAuthMountPath = &v
+}
+
 func (s *Vault) GetToken() string {
 	if s == nil || s.Token == nil {
 		return *new(string)

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -1020,6 +1020,10 @@
         "token": {
           "description": "Token is the authentication token for the Vault server. It is read from VAULT_TOKEN env var when not set. It is recommended to be passed as env var instead of being stored in the config file.",
           "type": "string"
+        },
+        "k8sAuthMountPath": {
+          "description": "K8sAuthMountPath is the mount path of the Kubernetes auth method in Vault. When not set, it defaults to \"kubernetes\". This is useful when Vault is running on a different cluster and has multiple Kubernetes auth mounts.",
+          "type": "string"
         }
       }
     },

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -728,6 +728,11 @@ type UserPilot struct {
 }
 
 type Vault struct {
+	// K8sAuthMountPath is the mount path of the Kubernetes auth method in Vault. When
+	// not set, it defaults to "kubernetes". This is useful when Vault is running on a
+	// different cluster and has multiple Kubernetes auth mounts.
+	K8SAuthMountPath *string `json:"k8sAuthMountPath,omitempty" yaml:"k8sAuthMountPath,omitempty"`
+
 	// Token is the authentication token for the Vault server. It is read from
 	// VAULT_TOKEN env var when not set. It is recommended to be passed as env var
 	// instead of being stored in the config file.


### PR DESCRIPTION
Add a new `k8sAuthMountPath` config field under `storage.vault` and a `--vault-k8s-auth-mount-path` CLI flag. When set, it is passed as `auth.WithMountPath` to the Vault Kubernetes auth method, allowing Omni to authenticate against a Vault instance that mounts K8s auth at a non-default path (e.g., when Vault runs on a different cluster).