### PR TITLE
test: use envsubst in tests and do small improvements

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -55,14 +55,14 @@ PARTIAL_CONFIG_SCHEMATIC_ID=$(prepare_partial_config)
 KERNEL_ARGS_SCHEMATIC_ID=$(prepare_kernel_args_schematic)
 
 # Create machines.
-if [ "${CREATE_QEMU_MACHINES:-true}" == "true" ]; then
-  create_machines name=test-partial-config count=${PARTIAL_CONFIG_MACHINES} cidr=172.20.0.0/24 secure_boot=false uki=true use_partial_config=true talos_version="${TALOS_VERSION}" \
+if [[ "${CREATE_QEMU_MACHINES:-true}" == "true" ]]; then
+  create_machines name=test-partial-config count="${PARTIAL_CONFIG_MACHINES}" cidr=172.20.0.0/24 secure_boot=false uki=true use_partial_config=true talos_version="${TALOS_VERSION}" \
     kernel_args_schematic_id="${KERNEL_ARGS_SCHEMATIC_ID}" partial_config_schematic_id="${PARTIAL_CONFIG_SCHEMATIC_ID}"
-  create_machines name=test-kernel-args count=${KERNEL_ARGS_MACHINES} cidr=172.21.0.0/24 secure_boot=false uki=true use_partial_config=false talos_version="${TALOS_VERSION}" \
+  create_machines name=test-kernel-args count="${KERNEL_ARGS_MACHINES}" cidr=172.21.0.0/24 secure_boot=false uki=true use_partial_config=false talos_version="${TALOS_VERSION}" \
     kernel_args_schematic_id="${KERNEL_ARGS_SCHEMATIC_ID}" partial_config_schematic_id="${PARTIAL_CONFIG_SCHEMATIC_ID}"
-  create_machines name=test-secure-boot count=${SECURE_BOOT_MACHINES} cidr=172.22.0.0/24 secure_boot=true uki=true use_partial_config=false talos_version="${TALOS_VERSION}" \
+  create_machines name=test-secure-boot count="${SECURE_BOOT_MACHINES}" cidr=172.22.0.0/24 secure_boot=true uki=true use_partial_config=false talos_version="${TALOS_VERSION}" \
     kernel_args_schematic_id="${KERNEL_ARGS_SCHEMATIC_ID}" partial_config_schematic_id="${PARTIAL_CONFIG_SCHEMATIC_ID}"
-  create_machines name=test-non-uki count=${NON_UKI_MACHINES} cidr=172.23.0.0/24 secure_boot=false uki=false use_partial_config=false talos_version="${TALOS_VERSION}" \
+  create_machines name=test-non-uki count="${NON_UKI_MACHINES}" cidr=172.23.0.0/24 secure_boot=false uki=false use_partial_config=false talos_version="${TALOS_VERSION}" \
     kernel_args_schematic_id="${KERNEL_ARGS_SCHEMATIC_ID}" partial_config_schematic_id="${PARTIAL_CONFIG_SCHEMATIC_ID}"
 fi
 

--- a/hack/test/e2e-talemu.sh
+++ b/hack/test/e2e-talemu.sh
@@ -14,9 +14,9 @@ TALEMU_INFRA_PROVIDER_IMAGE=ghcr.io/siderolabs/talemu-infra-provider:latest
 TALEMU_CONTAINER_NAME=talemu
 
 function cleanup() {
-  docker stop ${TALEMU_CONTAINER_NAME} || true
-  docker logs ${TALEMU_CONTAINER_NAME} &>"$TEST_OUTPUTS_DIR/${TALEMU_CONTAINER_NAME}.log" || true
-  docker rm -f ${TALEMU_CONTAINER_NAME} || true
+  docker stop "${TALEMU_CONTAINER_NAME}" || true
+  docker logs "${TALEMU_CONTAINER_NAME}" &>"${TEST_OUTPUTS_DIR}/${TALEMU_CONTAINER_NAME}.log" || true
+  docker rm -f "${TALEMU_CONTAINER_NAME}" || true
 
   common_cleanup
   vault_cleanup
@@ -45,7 +45,7 @@ docker run --name "${TALEMU_CONTAINER_NAME}" \
   -it -d \
   "${TALEMU_INFRA_PROVIDER_IMAGE}" \
   --create-service-account \
-  --omni-api-endpoint="https://$LOCAL_IP:8099"
+  --omni-api-endpoint="https://${LOCAL_IP}:8099"
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
   nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \

--- a/hack/test/freeze-a-vm.sh
+++ b/hack/test/freeze-a-vm.sh
@@ -7,16 +7,9 @@
 
 set -eoux pipefail
 
-dir=""
+source ./hack/test/vm-common.sh
 
-# find the cluster machine $1 belongs to
-for d in "${HOME}"/.talos/clusters/*; do
-  if [ -e "${d}/machine-$1.monitor" ]; then
-    dir="${d}"
-
-    break
-  fi
-done
+dir=$(find_machine_dir "$1")
 
 # freeze the VM $1
-echo "s" | socat - "unix-connect:${dir}/machine-$1.monitor"
+echo "s" | socat - "unix-connect:${dir}/machine-${1}.monitor"

--- a/hack/test/integration-qemu.sh
+++ b/hack/test/integration-qemu.sh
@@ -10,13 +10,13 @@ set -eoux pipefail
 # Load common functions and variables.
 source ./hack/test/common.sh
 
-QEMU_TALOS_VERSION=${TALOS_VERSION}
-WITH_QEMU_TALOS_VERSION_OVERRIDE=${WITH_QEMU_TALOS_VERSION_OVERRIDE:-false}
-if [[ $WITH_QEMU_TALOS_VERSION_OVERRIDE == "true" ]]; then
-  QEMU_TALOS_VERSION=$STABLE_TALOS_VERSION
+QEMU_TALOS_VERSION="${TALOS_VERSION}"
+WITH_QEMU_TALOS_VERSION_OVERRIDE="${WITH_QEMU_TALOS_VERSION_OVERRIDE:-false}"
+if [[ "${WITH_QEMU_TALOS_VERSION_OVERRIDE}" == "true" ]]; then
+  QEMU_TALOS_VERSION="${STABLE_TALOS_VERSION}"
 fi
 
-ENABLE_SECUREBOOT=${ENABLE_SECUREBOOT:-false}
+ENABLE_SECUREBOOT="${ENABLE_SECUREBOOT:-false}"
 
 # Machine Counts: 10 machines in total
 TOTAL_MACHINES=10
@@ -68,23 +68,23 @@ PARTIAL_CONFIG_SCHEMATIC_ID=$(prepare_partial_config)
 KERNEL_ARGS_SCHEMATIC_ID=$(prepare_kernel_args_schematic)
 
 # Create machines.
-if [ "${CREATE_QEMU_MACHINES:-true}" == "true" ]; then
-  create_machines name=test-partial-config count=${PARTIAL_CONFIG_MACHINES} cidr=172.20.0.0/24 secure_boot=false uki=true use_partial_config=true talos_version="${QEMU_TALOS_VERSION}" \
+if [[ "${CREATE_QEMU_MACHINES:-true}" == "true" ]]; then
+  create_machines name=test-partial-config count="${PARTIAL_CONFIG_MACHINES}" cidr=172.20.0.0/24 secure_boot=false uki=true use_partial_config=true talos_version="${QEMU_TALOS_VERSION}" \
     kernel_args_schematic_id="${KERNEL_ARGS_SCHEMATIC_ID}" partial_config_schematic_id="${PARTIAL_CONFIG_SCHEMATIC_ID}"
-  create_machines name=test-kernel-args count=${KERNEL_ARGS_MACHINES} cidr=172.21.0.0/24 secure_boot=false uki=true use_partial_config=false talos_version="${QEMU_TALOS_VERSION}" \
+  create_machines name=test-kernel-args count="${KERNEL_ARGS_MACHINES}" cidr=172.21.0.0/24 secure_boot=false uki=true use_partial_config=false talos_version="${QEMU_TALOS_VERSION}" \
     kernel_args_schematic_id="${KERNEL_ARGS_SCHEMATIC_ID}" partial_config_schematic_id="${PARTIAL_CONFIG_SCHEMATIC_ID}"
-  create_machines name=test-secure-boot count=${SECURE_BOOT_MACHINES} cidr=172.22.0.0/24 secure_boot=true uki=true use_partial_config=false talos_version="${QEMU_TALOS_VERSION}" \
+  create_machines name=test-secure-boot count="${SECURE_BOOT_MACHINES}" cidr=172.22.0.0/24 secure_boot=true uki=true use_partial_config=false talos_version="${QEMU_TALOS_VERSION}" \
     kernel_args_schematic_id="${KERNEL_ARGS_SCHEMATIC_ID}" partial_config_schematic_id="${PARTIAL_CONFIG_SCHEMATIC_ID}"
-  create_machines name=test-non-uki count=${NON_UKI_MACHINES} cidr=172.23.0.0/24 secure_boot=false uki=false use_partial_config=false talos_version="${QEMU_TALOS_VERSION}" \
+  create_machines name=test-non-uki count="${NON_UKI_MACHINES}" cidr=172.23.0.0/24 secure_boot=false uki=false use_partial_config=false talos_version="${QEMU_TALOS_VERSION}" \
     kernel_args_schematic_id="${KERNEL_ARGS_SCHEMATIC_ID}" partial_config_schematic_id="${PARTIAL_CONFIG_SCHEMATIC_ID}"
 fi
 
 # Create a Talos cluster to be imported.
-if [ "${CREATE_TALOS_CLUSTER:-false}" == "true" ]; then
+if [[ "${CREATE_TALOS_CLUSTER:-false}" == "true" ]]; then
   create_talos_cluster name=test-cluster-import cp_count=3 wk_count=3 cidr=172.28.0.0/24 talos_version="${QEMU_TALOS_VERSION}"
 fi
 
-if [ -n "$ANOTHER_OMNI_VERSION" ] && [ -n "$INTEGRATION_PREPARE_TEST_ARGS" ]; then
+if [[ -n "$ANOTHER_OMNI_VERSION" && -n "$INTEGRATION_PREPARE_TEST_ARGS" ]]; then
   docker run \
     --cap-add=NET_ADMIN \
     --device=/dev/net/tun \
@@ -103,7 +103,7 @@ if [ -n "$ANOTHER_OMNI_VERSION" ] && [ -n "$INTEGRATION_PREPARE_TEST_ARGS" ]; th
     --omni.kubernetes-version="${KUBERNETES_VERSION}" \
     --omni.another-kubernetes-version="${ANOTHER_KUBERNETES_VERSION}" \
     --omni.omnictl-path=/_out/omnictl-linux-amd64 \
-    --omni.expected-machines=${TOTAL_MACHINES} \
+    --omni.expected-machines="${TOTAL_MACHINES}" \
     --omni.embedded \
     --omni.config-path=/config.yaml \
     --omni.output-dir=/outputs \
@@ -115,26 +115,25 @@ if [ -n "$ANOTHER_OMNI_VERSION" ] && [ -n "$INTEGRATION_PREPARE_TEST_ARGS" ]; th
     ${INTEGRATION_PREPARE_TEST_ARGS:-}
 fi
 
-# shellcheck disable=SC2068
 # Run the integration test.
-SIDEROLINK_DEV_JOIN_TOKEN=${JOIN_TOKEN} \
+SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
   SSL_CERT_DIR=hack/certs:/etc/ssl/certs \
-  "${ARTIFACTS}"/integration-test-linux-amd64 \
+  "${ARTIFACTS}/integration-test-linux-amd64" \
   --omni.talos-version="${TALOS_VERSION}" \
   --omni.stable-talos-version="${STABLE_TALOS_VERSION}" \
   --omni.kubernetes-version="${KUBERNETES_VERSION}" \
   --omni.another-kubernetes-version="${ANOTHER_KUBERNETES_VERSION}" \
-  --omni.omnictl-path="${ARTIFACTS}"/omnictl-linux-amd64 \
-  --omni.expected-machines=${TOTAL_MACHINES} \
+  --omni.omnictl-path="${ARTIFACTS}/omnictl-linux-amd64" \
+  --omni.expected-machines="${TOTAL_MACHINES}" \
   --omni.embedded \
   --omni.config-path="${OMNI_CONFIG}" \
   --omni.output-dir="${TEST_OUTPUTS_DIR}" \
   --omni.log-output="${TEST_OUTPUTS_DIR}/omni-integration.log" \
   --omni.sleep-after-failure="${SLEEP_AFTER_FAILURE}" \
   --test.failfast \
-  --test.coverprofile="${ARTIFACTS}"/coverage-integration.txt \
+  --test.coverprofile="${ARTIFACTS}/coverage-integration.txt" \
   --test.v \
-  ${IMPORTED_CLUSTER_ARGS[@]:-} \
+  "${IMPORTED_CLUSTER_ARGS[@]}" \
   ${INTEGRATION_TEST_ARGS:-}
 
 # No cleanup here, as it runs in the CI as a container in a pod.

--- a/hack/test/integration-talemu.sh
+++ b/hack/test/integration-talemu.sh
@@ -15,12 +15,12 @@ TALEMU_CONTAINER_NAME=talemu
 PROMETHEUS_CONTAINER_NAME=talemu-prom
 
 function cleanup() {
-  docker stop ${TALEMU_CONTAINER_NAME} || true
-  docker logs ${TALEMU_CONTAINER_NAME} &>"$TEST_OUTPUTS_DIR/${TALEMU_CONTAINER_NAME}.log" || true
-  docker rm -f ${TALEMU_CONTAINER_NAME} || true
+  docker stop "${TALEMU_CONTAINER_NAME}" || true
+  docker logs "${TALEMU_CONTAINER_NAME}" &>"${TEST_OUTPUTS_DIR}/${TALEMU_CONTAINER_NAME}.log" || true
+  docker rm -f "${TALEMU_CONTAINER_NAME}" || true
 
-  docker stop ${PROMETHEUS_CONTAINER_NAME} || true
-  docker rm -f ${PROMETHEUS_CONTAINER_NAME} || true
+  docker stop "${PROMETHEUS_CONTAINER_NAME}" || true
+  docker rm -f "${PROMETHEUS_CONTAINER_NAME}" || true
 
   common_cleanup
   vault_cleanup
@@ -43,7 +43,7 @@ prepare_minio access_key="access" secret_key="secret123"
 
 prepare_omni_config
 
-docker run --name ${PROMETHEUS_CONTAINER_NAME} \
+docker run --name "${PROMETHEUS_CONTAINER_NAME}" \
   --network host -p "9090:9090" \
   -v "$(pwd)/hack/compose/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml" \
   -it --rm -d prom/prometheus
@@ -54,16 +54,16 @@ docker run --name "${TALEMU_CONTAINER_NAME}" \
   -it -d \
   "${TALEMU_INFRA_PROVIDER_IMAGE}" \
   --create-service-account \
-  --omni-api-endpoint="https://$LOCAL_IP:8099"
+  --omni-api-endpoint="https://${LOCAL_IP}:8099"
 
-SIDEROLINK_DEV_JOIN_TOKEN=${JOIN_TOKEN} \
+SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
   SSL_CERT_DIR=hack/certs:/etc/ssl/certs \
-  "${ARTIFACTS}"/integration-test-linux-amd64 \
+  "${ARTIFACTS}/integration-test-linux-amd64" \
   --omni.talos-version="${TALOS_VERSION}" \
   --omni.stable-talos-version="${STABLE_TALOS_VERSION}" \
   --omni.kubernetes-version="${KUBERNETES_VERSION}" \
   --omni.another-kubernetes-version="${ANOTHER_KUBERNETES_VERSION}" \
-  --omni.omnictl-path=${ARTIFACTS}/omnictl-linux-amd64 \
+  --omni.omnictl-path="${ARTIFACTS}/omnictl-linux-amd64" \
   --omni.expected-machines=30 \
   --omni.provision-config-file=hack/test/provisionconfig.yaml \
   --omni.run-stats-check \
@@ -72,7 +72,7 @@ SIDEROLINK_DEV_JOIN_TOKEN=${JOIN_TOKEN} \
   --omni.output-dir="${TEST_OUTPUTS_DIR}" \
   --omni.log-output="${TEST_OUTPUTS_DIR}/omni-emulator.log" \
   --omni.sleep-after-failure="${SLEEP_AFTER_FAILURE}" \
-  --test.coverprofile="${ARTIFACTS}"/coverage-emulator.txt \
+  --test.coverprofile="${ARTIFACTS}/coverage-emulator.txt" \
   --test.timeout 10m \
   --test.parallel 10 \
   --test.failfast \

--- a/hack/test/restart-a-vm.sh
+++ b/hack/test/restart-a-vm.sh
@@ -7,16 +7,9 @@
 
 set -eoux pipefail
 
-dir=""
+source ./hack/test/vm-common.sh
 
-# find the cluster machine $1 belongs to
-for d in "${HOME}"/.talos/clusters/*; do
-  if [ -e "${d}/machine-$1.monitor" ]; then
-    dir="${d}"
-
-    break
-  fi
-done
+dir=$(find_machine_dir "$1")
 
 # restart the VM $1
-echo "q" | socat - "unix-connect:${dir}/machine-$1.monitor"
+echo "q" | socat - "unix-connect:${dir}/machine-${1}.monitor"

--- a/hack/test/templates/kernel-args-schematic.yaml
+++ b/hack/test/templates/kernel-args-schematic.yaml
@@ -1,0 +1,11 @@
+customization:
+  meta: [{ key: 42, value: test-1 }, { key: 41, value: test-2 }]
+  extraKernelArgs:
+    - siderolink.api=grpc://${WIREGUARD_IP}:8090?jointoken=${JOIN_TOKEN}
+    - talos.events.sink=[fdae:41e4:649b:9303::1]:8091
+    - talos.logging.kernel=tcp://[fdae:41e4:649b:9303::1]:8092
+    - console=tty0
+    - console=ttyS0
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/hello-world-service

--- a/hack/test/templates/omni-config.yaml
+++ b/hack/test/templates/omni-config.yaml
@@ -1,0 +1,64 @@
+services:
+  api:
+    endpoint: 0.0.0.0:8099
+    advertisedURL: ${BASE_URL}
+    certFile: hack/certs/localhost.pem
+    keyFile: hack/certs/localhost-key.pem
+  metrics:
+    endpoint: 0.0.0.0:2122
+  kubernetesProxy:
+    endpoint: localhost:8095
+  siderolink:
+    wireGuard:
+      endpoint: ${LOCAL_IP}:50180
+      advertisedEndpoint: ${LOCAL_IP}:50180
+    joinTokensMode: strict
+    eventSinkPort: 8091
+  machineAPI:
+    endpoint: 0.0.0.0:8090
+    advertisedURL: grpc://${LOCAL_IP}:8090
+  workloadProxy:
+    enabled: true
+    subdomain: proxy-us
+    stopLBsAfter: 15s # use a short duration to test turning lazy LBs on/off
+auth:
+  auth0:
+    enabled: true
+    clientID: ${AUTH0_CLIENT_ID}
+    domain: ${AUTH0_DOMAIN}
+    initialUsers:
+      - ${AUTH_USERNAME}
+etcdBackup:
+  s3Enabled: true
+${REGISTRY_MIRROR_CONFIG}
+storage:
+  vault:
+    url: ${VAULT_ADDR}
+    token: ${VAULT_TOKEN}
+  sqlite:
+    path: ${TEST_OUTPUTS_DIR}/sqlite.db
+  default:
+    kind: etcd
+    etcd:
+      endpoints:
+        - http://localhost:2379
+      dialKeepAliveTime: 30s
+      dialKeepAliveTimeout: 5s
+      caFile: etcd/ca.crt
+      certFile: etcd/client.crt
+      keyFile: etcd/client.key
+      embedded: true
+      privateKeySource: "vault://secret/omni-private-key"
+      publicKeyFiles:
+        - internal/backend/runtime/omni/testdata/pgp/new_key.public
+      embeddedUnsafeFsync: true
+      embeddedDBPath: ${ARTIFACTS}/etcd/
+logs:
+  audit:
+    enabled: true
+features:
+  enableTalosPreReleaseVersions: ${ENABLE_TALOS_PRERELEASE_VERSIONS}
+  enableConfigDataCompression: true
+  enableBreakGlassConfigs: true
+  enableClusterImport: true
+  disableControllerRuntimeCache: false

--- a/hack/test/templates/partial-config-schematic.yaml
+++ b/hack/test/templates/partial-config-schematic.yaml
@@ -1,0 +1,9 @@
+customization:
+  meta: [{ key: 42, value: test-1 }, { key: 41, value: test-2 }]
+  extraKernelArgs:
+    - talos.config=http://${WIREGUARD_IP}:${PARTIAL_CONFIG_PORT}/config.yaml
+    - console=tty0
+    - console=ttyS0
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/hello-world-service

--- a/hack/test/templates/partial-machine-config.yaml
+++ b/hack/test/templates/partial-machine-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1alpha1
+kind: SideroLinkConfig
+apiUrl: grpc://${LOCAL_IP}:8090?jointoken=${JOIN_TOKEN}
+---
+apiVersion: v1alpha1
+kind: EventSinkConfig
+endpoint: '[fdae:41e4:649b:9303::1]:8091'
+---
+apiVersion: v1alpha1
+kind: KmsgLogConfig
+name: omni-kmsg
+url: 'tcp://[fdae:41e4:649b:9303::1]:8092'

--- a/hack/test/templates/talos-image-schematic.yaml
+++ b/hack/test/templates/talos-image-schematic.yaml
@@ -1,0 +1,8 @@
+customization:
+  meta: [{ key: 42, value: test-1 }, { key: 41, value: test-2 }]
+  extraKernelArgs:
+    - console=tty0
+    - console=ttyS0
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/hello-world-service

--- a/hack/test/vm-common.sh
+++ b/hack/test/vm-common.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 Sidero Labs, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+
+# Find the cluster directory containing the given machine.
+# Usage: dir=$(find_machine_dir "$machine_name")
+find_machine_dir() {
+  local machine="$1"
+
+  for d in "${HOME}/.talos/clusters"/*; do
+    if [[ -e "${d}/machine-${machine}.monitor" ]]; then
+      echo "${d}"
+      return
+    fi
+  done
+
+  echo "Error: machine '${machine}' not found" >&2
+  return 1
+}

--- a/hack/test/wipe-a-vm.sh
+++ b/hack/test/wipe-a-vm.sh
@@ -7,21 +7,14 @@
 
 set -eoux pipefail
 
-dir=""
+source ./hack/test/vm-common.sh
 
-# find the cluster machine $1 belongs to
-for d in "${HOME}"/.talos/clusters/*; do
-  if [ -e "${d}/machine-$1.monitor" ]; then
-    dir="${d}"
-
-    break
-  fi
-done
+dir=$(find_machine_dir "$1")
 
 # wipe the VM $1
-echo "s" | socat - "unix-connect:${dir}/machine-$1.monitor"
+echo "s" | socat - "unix-connect:${dir}/machine-${1}.monitor"
 
-disk="${dir}/machine-$1-0.disk"
+disk="${dir}/machine-${1}-0.disk"
 
 size=$(du -bs "${disk}" | cut -f1)
 
@@ -29,4 +22,4 @@ rm "${disk}"
 
 truncate -s "${size}" "${disk}"
 
-echo "q" | socat - "unix-connect:${dir}/machine-$1.monitor"
+echo "q" | socat - "unix-connect:${dir}/machine-${1}.monitor"


### PR DESCRIPTION
Now that we have envsubst in the build container, we can simplify our scripts a bit.

Also do other cosmetic improvements in the test scripts.