### PR TITLE
refactor(frontend): add type checking for context inclusion

### DIFF
--- a/frontend/src/api/watch.ts
+++ b/frontend/src/api/watch.ts
@@ -176,9 +176,7 @@ export type WatchContext = {
 
 export type WatchOptions = WatchOptionsSingle | WatchOptionsMulti
 
-interface WatchOptionsBase {
-  runtime: Runtime
-  context?: WatchContext
+interface WatchOptionsCommon {
   selectors?: string[]
   selectUsingOR?: boolean
   tailEvents?: number
@@ -193,11 +191,17 @@ interface WatchOptionsBase {
   skip?: boolean
 }
 
-export interface WatchOptionsSingle extends WatchOptionsBase {
+type WatchOptionsBase = WatchOptionsCommon &
+  (
+    | { runtime: Runtime.Omni; context?: never }
+    | { runtime: Exclude<Runtime, Runtime.Omni>; context: WatchContext }
+  )
+
+export type WatchOptionsSingle = WatchOptionsBase & {
   resource: Metadata & { id: string }
 }
 
-export interface WatchOptionsMulti extends WatchOptionsBase {
+export type WatchOptionsMulti = WatchOptionsBase & {
   resource: Omit<Metadata, 'id'>
 }
 

--- a/frontend/src/methods/useResourceGet.ts
+++ b/frontend/src/methods/useResourceGet.ts
@@ -11,13 +11,17 @@ import type { GetRequest } from '@/api/omni/resources/resources.pb'
 import { withAbortController, withContext, withRuntime, withSelectors } from '@/api/options'
 import type { WatchContext } from '@/api/watch'
 
-export interface GetOptions {
+interface GetOptionsCommon {
   resource: GetRequest
-  runtime: Runtime
-  context?: WatchContext
   selectors?: string[]
   skip?: boolean
 }
+
+export type GetOptions = GetOptionsCommon &
+  (
+    | { runtime: Runtime.Omni; context?: never }
+    | { runtime: Exclude<Runtime, Runtime.Omni>; context: WatchContext }
+  )
 
 export function useResourceGet<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<GetOptions>,

--- a/frontend/src/methods/useResourceList.ts
+++ b/frontend/src/methods/useResourceList.ts
@@ -11,13 +11,17 @@ import type { ListRequest } from '@/api/omni/resources/resources.pb'
 import { withAbortController, withContext, withRuntime, withSelectors } from '@/api/options'
 import type { WatchContext } from '@/api/watch'
 
-export interface ListOptions {
+interface ListOptionsCommon {
   resource: ListRequest
-  runtime: Runtime
-  context?: WatchContext
   selectors?: string[]
   skip?: boolean
 }
+
+export type ListOptions = ListOptionsCommon &
+  (
+    | { runtime: Runtime.Omni; context?: never }
+    | { runtime: Exclude<Runtime, Runtime.Omni>; context: WatchContext }
+  )
 
 export function useResourceList<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<ListOptions>,

--- a/frontend/src/methods/useResourceWatch.spec.ts
+++ b/frontend/src/methods/useResourceWatch.spec.ts
@@ -86,7 +86,7 @@ describe('useResourceWatch', () => {
     const { pushEvents } = createWatchStreamMock({ skipBootstrap: true })
 
     const options = ref({
-      runtime: Runtime.Omni,
+      runtime: Runtime.Omni as const,
       resource: { namespace: 'default', type: 'custom.sidero.dev/Resource' },
       skip: true,
     })

--- a/frontend/src/views/cluster/Backups/BackupsList.vue
+++ b/frontend/src/views/cluster/Backups/BackupsList.vue
@@ -47,7 +47,7 @@ const watchStatusOpts = computed(() => {
       id: route.params.cluster as string,
     },
     runtime: Runtime.Omni,
-  }
+  } as const
 })
 
 const watchOverallStatusOpts = computed(() => {
@@ -58,7 +58,7 @@ const watchOverallStatusOpts = computed(() => {
       id: EtcdBackupOverallStatusID,
     },
     runtime: Runtime.Omni,
-  }
+  } as const
 })
 
 const watchOpts = computed(() => {
@@ -69,7 +69,7 @@ const watchOpts = computed(() => {
     },
     runtime: Runtime.Omni,
     selectors: [`${LabelCluster}=${route.params.cluster}`],
-  }
+  } as const
 })
 
 const docsLink = getDocsLink('omni', '/how-to-guides/etcd-backups#s3-configuration')

--- a/frontend/src/views/cluster/ClusterScoped.vue
+++ b/frontend/src/views/cluster/ClusterScoped.vue
@@ -13,13 +13,11 @@ import { EventType } from '@/api/omni/resources/resources.pb'
 import type { ClusterSpec } from '@/api/omni/specs/omni.pb'
 import { ClusterType, DefaultNamespace } from '@/api/resources'
 import TAlert from '@/components/TAlert.vue'
-import { getContext } from '@/context'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const bootstrapped = ref(false)
 
 const route = useRoute()
-const context = getContext(route)
 
 const { data: cluster } = useResourceWatch<ClusterSpec>(
   () => ({
@@ -29,7 +27,6 @@ const { data: cluster } = useResourceWatch<ClusterSpec>(
       namespace: DefaultNamespace,
       id: route.params.cluster as string,
     },
-    context,
   }),
   (message) => {
     if (message.event?.event_type === EventType.BOOTSTRAPPED) {

--- a/frontend/src/views/cluster/Nodes/NodeConfig.vue
+++ b/frontend/src/views/cluster/Nodes/NodeConfig.vue
@@ -11,7 +11,6 @@ import { useRoute } from 'vue-router'
 import { Runtime } from '@/api/common/omni.pb'
 import type { ClusterSpec, RedactedClusterMachineConfigSpec } from '@/api/omni/specs/omni.pb'
 import { ClusterType, DefaultNamespace, RedactedClusterMachineConfigType } from '@/api/resources'
-import { getContext } from '@/context'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const CodeEditor = defineAsyncComponent(
@@ -19,7 +18,6 @@ const CodeEditor = defineAsyncComponent(
 )
 
 const route = useRoute()
-const context = getContext(route)
 
 const { data: configResource } = useResourceWatch<RedactedClusterMachineConfigSpec>(() => ({
   runtime: Runtime.Omni,
@@ -28,7 +26,6 @@ const { data: configResource } = useResourceWatch<RedactedClusterMachineConfigSp
     namespace: DefaultNamespace,
     id: route.params.machine as string,
   },
-  context,
 }))
 
 const { data: cluster } = useResourceWatch<ClusterSpec>(() => ({

--- a/frontend/src/views/cluster/Nodes/NodeOverview.vue
+++ b/frontend/src/views/cluster/Nodes/NodeOverview.vue
@@ -194,7 +194,6 @@ const { data: machineStatus } = useResourceWatch<MachineStatusLinkSpec>(() => ({
     type: MachineStatusLinkType,
     namespace: MetricsNamespace,
   },
-  context,
 }))
 
 const { data: clusterMachineStatus } = useResourceWatch<ClusterMachineStatusSpec>(() => ({

--- a/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
@@ -12,7 +12,7 @@ import type { Ref } from 'vue'
 import { computed, defineAsyncComponent, ref, toRefs } from 'vue'
 import type { VueApexChartsComponentProps } from 'vue3-apexcharts'
 
-import type { Runtime } from '@/api/common/omni.pb'
+import { Runtime } from '@/api/common/omni.pb'
 import type { WatchResponse } from '@/api/omni/resources/resources.pb'
 import { EventType } from '@/api/omni/resources/resources.pb'
 import type { Metadata } from '@/api/v1alpha1/resource.pb'
@@ -152,12 +152,22 @@ const handlePoint = (message: WatchResponse, spec: WatchEventSpec) => {
 
 const w = new WatchFunc(handlePoint)
 
-w.setup({
-  resource: resource.value,
-  runtime: runtime.value,
-  tailEvents: tailEvents.value,
-  context: context?.value,
-})
+w.setup(
+  runtime.value === Runtime.Omni
+    ? {
+        resource: resource.value,
+        runtime: runtime.value,
+        tailEvents: tailEvents.value,
+      }
+    : context.value
+      ? {
+          resource: resource.value,
+          runtime: runtime.value,
+          tailEvents: tailEvents.value,
+          context: context.value,
+        }
+      : undefined,
+)
 
 const options = computed(() => {
   return {


### PR DESCRIPTION
Add type checking so that context is always included for Talos/K8s resource requests, and omitted for omni ones.