### PR TITLE
test: add embedded etcd smoke test to helm e2e

### DIFF
--- a/deploy/helm/omni/Chart.yaml
+++ b/deploy/helm/omni/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: omni
 description: A helm chart to deploy Omni on a Kubernetes cluster
 type: application
-version: 2.1.0
-appVersion: "v1.5.2"
+version: 2.1.1
+appVersion: "v1.5.3"
 home: https://www.siderolabs.com/omni/
 sources:
   - https://github.com/siderolabs/omni

--- a/deploy/helm/omni/README.md
+++ b/deploy/helm/omni/README.md
@@ -1,6 +1,6 @@
 # Omni Helm Chart (v2)
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat) ![AppVersion: v1.5.2](https://img.shields.io/badge/AppVersion-v1.5.2-informational?style=flat)
+![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat) ![AppVersion: v1.5.3](https://img.shields.io/badge/AppVersion-v1.5.3-informational?style=flat)
 
 A Helm chart to deploy [Omni](https://omni.siderolabs.com) on a Kubernetes cluster.
 

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -91,10 +91,6 @@ registries:
       REGISTRY_MIRROR_CONFIG+="    - ${registry}=http://${addr}:5000"
       REGISTRY_MIRROR_CONFIG+=$'\n'
     done
-  else
-    # use the value from the environment, if present
-    REGISTRY_MIRROR_FLAGS=("${REGISTRY_MIRROR_FLAGS:-}")
-    REGISTRY_MIRROR_CONFIG="${REGISTRY_MIRROR_CONFIG:-}"
   fi
 }
 

--- a/hack/test/helm/templates/omni-external-etcd-values.yaml
+++ b/hack/test/helm/templates/omni-external-etcd-values.yaml
@@ -1,0 +1,20 @@
+config:
+  storage:
+    default:
+      etcd:
+        embedded: false
+        endpoints:
+          - https://etcd.etcd.svc.cluster.local:2379
+        caFile: /etcd-client-certs/ca.crt
+        certFile: /etcd-client-certs/client.crt
+        keyFile: /etcd-client-certs/client.key
+
+extraVolumes:
+  - name: etcd-client-certs
+    secret:
+      secretName: etcd-client-certs
+
+extraVolumeMounts:
+  - name: etcd-client-certs
+    mountPath: /etcd-client-certs
+    readOnly: true

--- a/hack/test/helm/templates/omni-values.yaml
+++ b/hack/test/helm/templates/omni-values.yaml
@@ -43,15 +43,6 @@ config:
       - ${AUTH0_TEST_USERNAME}
   registries:
     mirrors: ${REGISTRY_MIRRORS_JSON}
-  storage:
-    default:
-      etcd:
-        embedded: false
-        endpoints:
-          - https://etcd.etcd.svc.cluster.local:2379
-        caFile: /etcd-client-certs/ca.crt
-        certFile: /etcd-client-certs/client.crt
-        keyFile: /etcd-client-certs/client.key
   services:
     api:
       advertisedURL: https://omni.example.org
@@ -93,16 +84,6 @@ ingress:
   # because connecting machines use the node IP directly and cannot resolve domain names.
   siderolinkApi:
     enabled: false
-
-extraVolumes:
-  - name: etcd-client-certs
-    secret:
-      secretName: etcd-client-certs
-
-extraVolumeMounts:
-  - name: etcd-client-certs
-    mountPath: /etcd-client-certs
-    readOnly: true
 
 # Traefik IngressRoute for workload proxy wildcard domain.
 # Uses the default TLS store (which has the wildcard cert covering *.omni-workload.example.org).


### PR DESCRIPTION
Add a two-phase approach to the helm e2e test: first install Omni with embedded etcd and run a smoke test (omnictl get defaultjointoken), then uninstall and reinstall with external etcd for the full integration suite.

Other changes:
- Extract reusable extract_sa_key function
- Split helm values into base + external etcd overlay to remove duplication
- Move helm test values to hack/test/helm/templates/ and drop .envsubst suffix
- Fix empty string arg bug in configure_registry_mirrors (remove dead else branch)