### PR TITLE
test: fix flaky unit tests

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/etcdbackup/crypt/encrypt_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/etcdbackup/crypt/encrypt_test.go
@@ -331,6 +331,8 @@ type backupBlocker struct {
 func (e *backupBlocker) Upload(ctx context.Context, _ etcdbackup.Description, r io.Reader) error {
 	if e.block {
 		<-ctx.Done()
+
+		return ctx.Err()
 	}
 
 	_, err := io.Copy(io.Discard, r)

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_node_audit.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_node_audit.go
@@ -59,7 +59,7 @@ func NewKubernetesNodeAuditController(getKubernetesClientFunc GetKubernetesClien
 				status, err := safe.ReaderGetByID[*omni.KubernetesStatus](ctx, r, nodes.Metadata().ID())
 				if err != nil {
 					if state.IsNotFoundError(err) {
-						return nil
+						return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("kubernetes status not found, skipping")
 					}
 
 					return fmt.Errorf("failed to get kubernetes status: %w", err)

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -500,7 +500,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 	t.Run("generationErrorPropagation", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*5)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{}, addControllers, func(ctx context.Context, testContext testutils.TestContext) {
@@ -532,7 +532,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 	t.Run("applyLocked", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*5)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{}, addControllers,
@@ -615,7 +615,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 	t.Run("gracefulConfigRollout", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*5)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{}, addControllers,

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -232,13 +232,6 @@ func (ms *machineService) Version(context.Context, *emptypb.Empty) (*machine.Ver
 	}, nil
 }
 
-func (ms *machineService) setServiceList(value *machine.ServiceListResponse) {
-	ms.lock.Lock()
-	defer ms.lock.Unlock()
-
-	ms.serviceList = value
-}
-
 func (ms *machineService) ServiceList(context.Context, *emptypb.Empty) (*machine.ServiceListResponse, error) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()

--- a/internal/backend/runtime/omni/controllers/omni/secrets/talosconfig_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/talosconfig_test.go
@@ -127,7 +127,7 @@ func Test_Talosconfig(t *testing.T) {
 	t.Run("rotate secret", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*20)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{}, addControllers,

--- a/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status_test.go
@@ -199,7 +199,7 @@ func TestTalosUpgradeStatus(t *testing.T) {
 	t.Run("reconcile", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(ctx, t, testutils.TestOptions{},

--- a/internal/backend/runtime/omni/controllers/testutils/machine_service.go
+++ b/internal/backend/runtime/omni/controllers/testutils/machine_service.go
@@ -422,7 +422,25 @@ func (ms *MachineServiceMock) Version(ctx context.Context, _ *emptypb.Empty) (*m
 	}, nil
 }
 
-func (ms *MachineServiceMock) GetServiceList(value *machine.ServiceListResponse) {
+func (ms *MachineServiceMock) SetEtcdMembers(value *machine.EtcdMemberListResponse) {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	ms.etcdMembers = value
+}
+
+func (ms *MachineServiceMock) GetEtcdMemberCount() int {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	if ms.etcdMembers == nil || len(ms.etcdMembers.Messages) == 0 {
+		return 0
+	}
+
+	return len(ms.etcdMembers.Messages[0].Members)
+}
+
+func (ms *MachineServiceMock) SetServiceList(value *machine.ServiceListResponse) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 

--- a/internal/pkg/siderolink/siderolink_test.go
+++ b/internal/pkg/siderolink/siderolink_test.go
@@ -202,7 +202,7 @@ func (suite *SiderolinkSuite) startManager(params sideromanager.Params) {
 }
 
 func (suite *SiderolinkSuite) TestNodes() {
-	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*2)
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
 	defer cancel()
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{
@@ -229,6 +229,14 @@ func (suite *SiderolinkSuite) TestNodes() {
 
 		joinToken = r.TypedSpec().Value.TokenId
 	})
+
+	// Wait for JoinTokenStatusController to reconcile the token into an ACTIVE JoinTokenStatus,
+	// otherwise the provision handler will reject the request as the token status doesn't exist yet.
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{joinToken},
+		func(r *siderolink.JoinTokenStatus, assertion *assert.Assertions) {
+			assertion.Equal(specs.JoinTokenStatusSpec_ACTIVE, r.TypedSpec().Value.State)
+		},
+	)
 
 	conn, err := grpc.NewClient(suite.address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	suite.Require().NoError(err)
@@ -336,7 +344,7 @@ func (suite *SiderolinkSuite) TestNodeWithSeveralAdvertisedIPs() {
 }
 
 func (suite *SiderolinkSuite) TestVirtualNodes() {
-	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*2)
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
 	defer cancel()
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{
@@ -363,6 +371,14 @@ func (suite *SiderolinkSuite) TestVirtualNodes() {
 
 		joinToken = r.TypedSpec().Value.TokenId
 	})
+
+	// Wait for JoinTokenStatusController to reconcile the token into an ACTIVE JoinTokenStatus,
+	// otherwise the provision handler will reject the request as the token status doesn't exist yet.
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{joinToken},
+		func(r *siderolink.JoinTokenStatus, assertion *assert.Assertions) {
+			assertion.Equal(specs.JoinTokenStatusSpec_ACTIVE, r.TypedSpec().Value.State)
+		},
+	)
 
 	conn, err := grpc.NewClient(suite.address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	suite.Require().NoError(err)


### PR DESCRIPTION
Fix several flaky unit tests:
  * Fix infra provider cleanup test using wrong service account identity ID (prefix+id instead of id+suffix).
  * Fix cluster bootstrap status test using separate time.Now() calls for backup upload and snapshot lookup, causing mismatched snapshot names when even 1 second elapsed.
  * Increase context timeouts for machineconfig status and talosconfig tests to prevent deadline exceeded under load.
  * Fix siderolink tests by increasing timeouts and waiting for JoinTokenStatus to be ACTIVE before provisioning.
  * Replace time.Sleep with EventuallyWithT polling in stripe metrics reporter test to avoid flaky timing.
  * Make kubernetes_node_audit mock thread-safe with mutex, deduplicate deletions, remove incorrect assertNoResource (qtransform creates output even with SkipReconcileTag).
  * Fix encrypt (crypt) blocked upload mock to return ctx.Err() immediately, preventing race between context cancellation and io.Copy on small payloads.
  * Fix cluster_status break glass test to trigger reconcile via Cluster input update after modifying ClusterStatus output, since qtransform only watches inputs.
  * Fix machine_set_status cluster locks test by moving sleep between lock and MachineSetNode destruction so pending reconciles drain before state changes.
  * Fix infra_provider_cleanup test to create Link and InfraMachineStatus before controller registration, avoiding race where teardown fires before watch events reach the controller cache.
  * Use inmem state with history options in NewTestState to prevent watch event loss.
  * Use inmem state with history options in testutils.WithRuntime to prevent watch event loss.
  * Refactor machine_set_etcd_audit from testify.Suite to testutils.WithRuntime + rmock pattern with per-test isolated runtimes.

Fixes: #2328
