### PR TITLE
fix: add required SQLite storage path flag to compose.yaml

### DIFF
--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -7,6 +7,7 @@ services:
       - /dev/net/tun
     volumes:
       - ${ETCD_VOLUME_PATH}:/_out/etcd
+      - ${SQLITE_STORAGE_PATH}:/_out/secondary-storage
       - ${ETCD_ENCRYPTION_KEY}:/omni.asc
       - ${TLS_CERT}:/tls.crt
       - ${TLS_KEY}:/tls.key
@@ -16,6 +17,7 @@ services:
     command: >
       --account-id=${OMNI_ACCOUNT_UUID} 
       --name=${NAME} 
+      --sqlite-storage-path=/_out/secondary-storage/sqlite.db
       --cert=/tls.crt
       --key=/tls.key
       --machine-api-cert=/tls.crt

--- a/deploy/compose/env.template
+++ b/deploy/compose/env.template
@@ -8,6 +8,7 @@ EVENT_SINK_PORT=8091
 TLS_CERT=/etc/letsencrypt/live/${OMNI_DOMAIN_NAME}/fullchain.pem
 TLS_KEY=/etc/letsencrypt/live/${OMNI_DOMAIN_NAME}/privkey.pem
 ETCD_VOLUME_PATH=/etc/etcd/
+SQLITE_STORAGE_PATH=/var/lib/omni/secondary-storage
 ETCD_ENCRYPTION_KEY=${PWD}/omni.asc
 
 ## Binding

--- a/hack/generate-certs/main.go
+++ b/hack/generate-certs/main.go
@@ -255,6 +255,7 @@ const composeTemplate = `version: '3.8'
 services:
   omni:
     command: >-
+      --sqlite-storage-path=/_out/secondary-storage/sqlite.db
       --siderolink-wireguard-advertised-addr 172.20.0.1:50180
       --siderolink-wireguard-bind-addr='0.0.0.0:50180'
       --private-key-source vault://secret/omni-private-key


### PR DESCRIPTION
Add the required flag `--sqlite-storage-path`.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>

Closes #2297 