### PR TITLE
fix(frontend): fix multi-doc parsing when creating single node clusters

### DIFF
--- a/frontend/src/components/common/Form/JsonForm.vue
+++ b/frontend/src/components/common/Form/JsonForm.vue
@@ -22,7 +22,7 @@ import {
 import { JsonForms } from '@jsonforms/vue'
 import { vanillaRenderers } from '@jsonforms/vue-vanilla'
 import { type ErrorObject } from 'ajv'
-import yaml from 'js-yaml'
+import { dump } from 'js-yaml'
 import { computed, ref, toRefs, watch } from 'vue'
 
 import { ManagementService } from '@/api/omni/management/management.pb'
@@ -120,7 +120,7 @@ const updateErrors = async (data: unknown) => {
 
   const response = await ManagementService.ValidateJSONSchema({
     schema: jsonSchema.value,
-    data: yaml.dump(data),
+    data: dump(data),
   })
 
   errors.value =

--- a/frontend/src/states/cluster-management.ts
+++ b/frontend/src/states/cluster-management.ts
@@ -5,7 +5,7 @@
 
 // MachineSet is the state used in cluster creation flow.
 
-import yaml from 'js-yaml'
+import { loadAll } from 'js-yaml'
 import { ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -608,12 +608,12 @@ export class State {
   }
 
   private checkSchedulingEnabled(data: string) {
-    const loaded = yaml.load(data) as
-      | { cluster?: { allowSchedulingOnControlPlanes?: boolean } }
+    const loaded = loadAll(data) as
+      | { cluster?: { allowSchedulingOnControlPlanes?: boolean } }[]
       | undefined
       | null
 
-    return loaded?.cluster?.allowSchedulingOnControlPlanes
+    return loaded?.some((y) => y.cluster?.allowSchedulingOnControlPlanes)
   }
 
   private machinesOfKind(kind: string): number | string {

--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import yaml from 'js-yaml'
+import { dump } from 'js-yaml'
 import * as semver from 'semver'
 import type { Ref } from 'vue'
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
@@ -233,7 +233,7 @@ const createCluster_ = async (untaint: boolean) => {
 
   if (untaint) {
     state.value.controlPlanes().patches[PatchID.Untaint] = {
-      data: yaml.dump({
+      data: dump({
         cluster: {
           allowSchedulingOnControlPlanes: true,
         },

--- a/frontend/src/views/omni/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterMachineItem.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import yaml from 'js-yaml'
+import { dump } from 'js-yaml'
 import pluralize from 'pluralize'
 import semver from 'semver'
 import { computed, ref, watch } from 'vue'
@@ -167,7 +167,7 @@ const setInstallDisk = (value: string) => {
   }
 
   machineSetNode.value.patches[installDiskPatchID.value] = {
-    data: yaml.dump({
+    data: dump({
       machine: {
         install: {
           disk: value,

--- a/frontend/src/views/omni/MachineClasses/MachineClass.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClass.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import yaml from 'js-yaml'
+import { dump, load } from 'js-yaml'
 import type { ComputedRef, Ref } from 'vue'
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -241,8 +241,7 @@ if (props.edit) {
     if (labelsMeta) {
       initialLabels.value = {}
 
-      const l = (yaml.load(labelsMeta.value!) as { machineLabels: Record<string, string> })
-        .machineLabels
+      const l = (load(labelsMeta.value!) as { machineLabels: Record<string, string> }).machineLabels
 
       for (const key in l) {
         initialLabels.value[key] = {
@@ -256,7 +255,7 @@ if (props.edit) {
       machineClass.value?.spec.auto_provision?.provider_id &&
       machineClass.value?.spec.auto_provision?.provider_data
     ) {
-      providerConfigs.value[machineClass.value.spec.auto_provision.provider_id] = yaml.load(
+      providerConfigs.value[machineClass.value.spec.auto_provision.provider_id] = load(
         machineClass.value?.spec.auto_provision?.provider_data,
       ) as Record<string, unknown>
     }
@@ -402,7 +401,7 @@ const submit = async () => {
       machineClass.spec.auto_provision.meta_values = [
         {
           key: LabelsMeta,
-          value: yaml.dump({
+          value: dump({
             machineLabels: l,
           }),
         },
@@ -412,7 +411,7 @@ const submit = async () => {
     const providerConfig = providerConfigs.value[infraProvider.value]
 
     if (providerConfig) {
-      machineClass.spec.auto_provision.provider_data = yaml.dump(providerConfig)
+      machineClass.spec.auto_provision.provider_data = dump(providerConfig)
     }
   }
 


### PR DESCRIPTION
When creating clusters with only a single node, we do a check to see if we should ask the user whether we should allow scheduling user workloads on that node. As part of that we parse config patches to see if its already enabled there, and that parsing did not support multi-doc. Now it does.

Fixes #2333 