### PR TITLE
feat: add global size-based cleanup for machine log storage

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -314,6 +314,7 @@ func defineLogsFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flag
 	rootCmdFlagBinder.DurationVar("machine-log-cleanup-interval", flagDescription("logs.machine.storage.cleanupInterval", schema), &flagConfig.Logs.Machine.Storage.CleanupInterval)
 	rootCmdFlagBinder.DurationVar("machine-log-cleanup-older-than", flagDescription("logs.machine.storage.cleanupOlderThan", schema), &flagConfig.Logs.Machine.Storage.CleanupOlderThan)
 	rootCmdFlagBinder.IntVar("machine-log-max-lines-per-machine", flagDescription("logs.machine.storage.maxLinesPerMachine", schema), &flagConfig.Logs.Machine.Storage.MaxLinesPerMachine)
+	rootCmdFlagBinder.Uint64Var("machine-log-max-size", flagDescription("logs.machine.storage.maxSize", schema), &flagConfig.Logs.Machine.Storage.MaxSize)
 	rootCmdFlagBinder.Float64Var("machine-log-cleanup-probability",
 		flagDescription("logs.machine.storage.cleanupProbability", schema), &flagConfig.Logs.Machine.Storage.CleanupProbability)
 

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -181,6 +181,13 @@ config:
       #enabled: true
       # SqliteTimeout is the timeout for SQLite operations used for audit logs storage.
       #sqliteTimeout: 30s
+      # RetentionPeriod is the duration after which audit logs are considered old and eligible for cleanup.
+      #retentionPeriod: 720h
+      # MaxSize is the maximum allowed size (in bytes) of the audit logs.
+      # When exceeded, the oldest entries are removed. 0 means unlimited.
+      #maxSize: 0
+      # CleanupProbability is the probability of triggering size-based cleanup on each audit log write.
+      #cleanupProbability: 0.01
     # Machine contains machine logs configuration.
     machine:
       # -- Storage contains configuration for machine logs storage.
@@ -195,6 +202,9 @@ config:
         #maxLinesPerMachine: 5000
         # CleanupProbability is the probability of triggering the cleanup on each log write.
         #cleanupProbability: 0.01
+        # MaxSize is the maximum allowed size (in bytes) of the machine logs.
+        # When exceeded, the oldest entries are removed globally across all machines. 0 means unlimited.
+        #maxSize: 0
     # -- ResourceLogger contains resource logger configuration.
     resourceLogger:
       # LogLevel is the logging level used by the resource logger.

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -798,6 +798,17 @@ func (s *LogsMachineStorage) SetMaxLinesPerMachine(v int) {
 	s.MaxLinesPerMachine = &v
 }
 
+func (s *LogsMachineStorage) GetMaxSize() uint64 {
+	if s == nil || s.MaxSize == nil {
+		return *new(uint64)
+	}
+	return *s.MaxSize
+}
+
+func (s *LogsMachineStorage) SetMaxSize(v uint64) {
+	s.MaxSize = &v
+}
+
 func (s *LogsMachineStorage) GetSqliteTimeout() time.Duration {
 	if s == nil || s.SqliteTimeout == nil {
 		return *new(time.Duration)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -149,6 +149,7 @@ func Default() *Params {
 	p.Logs.Machine.Storage.SetCleanupInterval(30 * time.Minute)
 	p.Logs.Machine.Storage.SetCleanupOlderThan(24 * 30 * time.Hour)
 	p.Logs.Machine.Storage.SetMaxLinesPerMachine(5000)
+	p.Logs.Machine.Storage.SetMaxSize(0) // 0 means unlimited
 	p.Logs.Machine.Storage.SetCleanupProbability(0.01)
 
 	p.Storage.Sqlite.SetExperimentalBaseParams("_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)")

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -847,6 +847,14 @@
           "description": "MaxLinesPerMachine is the maximum number of log lines to keep per machine.",
           "type": "integer"
         },
+        "maxSize": {
+          "description": "MaxSize is the maximum allowed size (in bytes) of the machine logs table. When exceeded, the oldest entries are removed globally across all machines. 0 means unlimited.",
+          "type": "integer",
+          "minimum": 0,
+          "goJSONSchema": {
+            "type": "uint64"
+          }
+        },
         "cleanupProbability": {
           "description": "CleanupProbability is the probability of triggering the cleanup on each log write for that machine.",
           "type": "number"

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -381,6 +381,11 @@ type LogsMachineStorage struct {
 	// MaxLinesPerMachine is the maximum number of log lines to keep per machine.
 	MaxLinesPerMachine *int `json:"maxLinesPerMachine,omitempty" yaml:"maxLinesPerMachine,omitempty"`
 
+	// MaxSize is the maximum allowed size (in bytes) of the machine logs table. When
+	// exceeded, the oldest entries are removed globally across all machines. 0 means
+	// unlimited.
+	MaxSize *uint64 `json:"maxSize,omitempty" yaml:"maxSize,omitempty"`
+
 	// SqliteTimeout is the timeout for SQLite operations used for machine logs
 	// storage.
 	SqliteTimeout *time.Duration `json:"sqliteTimeout,omitempty" yaml:"sqliteTimeout,omitempty"`


### PR DESCRIPTION
Add a --machine-log-max-size flag (config: logs.machine.storage.maxSize) that caps the total byte size of the machine logs SQLite table. When exceeded, the oldest entries are deleted globally across all machines. Defaults to 0 (unlimited).

Closes: #2341
