### PR TITLE
test: fix flaky nature of ca rotation tests

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
@@ -120,6 +120,7 @@ func Test_TalosCARotation(t *testing.T) {
 						&fakeRemoteGeneratorFactory{testContext.State},
 						&fakeKubernetesClientFactory{},
 					)))
+				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretsController(nil)))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},
@@ -774,6 +775,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 						&fakeRemoteGeneratorFactory{testContext.State},
 						&fakeKubernetesClientFactory{},
 					)))
+				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretsController(nil)))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
 			},


### PR DESCRIPTION
SecretRotationStatusController needs SecretsController to be present and active for it's lifecycle. Without it we were only depending on events for MachinePendingUpdates resource. This does not reflect the full picture and depending on the order of events received, SecretRotationStatusController might not wake up to do final reconciliation to finalize the rotation, leading to flakiness. Having SecretsController present for the test will fix this issue.
