### PR TITLE
fix(frontend): keep cluster menu visible and sticky

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -94,6 +94,7 @@ export const routes: RouteRecordRaw[] = [
           {
             path: 'create',
             name: 'ClusterCreate',
+            meta: { disablePadding: true },
             component: () => import('@/views/omni/Clusters/Management/ClusterCreate.vue'),
           },
           {
@@ -113,6 +114,7 @@ export const routes: RouteRecordRaw[] = [
               {
                 path: 'scale',
                 name: 'ClusterScale',
+                meta: { disablePadding: true },
                 component: () => import('@/views/omni/Clusters/Management/ClusterScale.vue'),
               },
               {

--- a/frontend/src/views/omni/Clusters/ClusterMenu.vue
+++ b/frontend/src/views/omni/Clusters/ClusterMenu.vue
@@ -6,11 +6,11 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import pluralize from 'pluralize'
-import { computed, toRefs } from 'vue'
+import { computed } from 'vue'
 
 import TButton from '@/components/common/Button/TButton.vue'
 
-type Props = {
+const { controlPlanes, workers } = defineProps<{
   action: string
   controlPlanes?: number | string
   workers?: number | string
@@ -18,62 +18,41 @@ type Props = {
   onReset?: () => void
   warning?: string
   disabled?: boolean
-}
-
-const props = withDefaults(defineProps<Props>(), {})
-
-const { controlPlanes, workers } = toRefs(props)
+}>()
 
 const controlPlaneCount = computed(() => {
-  if (typeof controlPlanes?.value === 'number') {
-    return `${controlPlanes.value} Control ${pluralize('Plane', controlPlanes.value as number, false)}`
+  if (typeof controlPlanes === 'number') {
+    return `${controlPlanes} Control ${pluralize('Plane', controlPlanes, false)}`
   }
 
-  return `Control Planes: ${controlPlanes?.value}`
+  return `Control Planes: ${controlPlanes}`
 })
 
 const workersCount = computed(() => {
-  if (typeof workers?.value === 'number') {
-    return `${workers.value} ${pluralize('Worker', workers.value as number, false)}`
+  if (typeof workers === 'number') {
+    return `${workers} ${pluralize('Worker', workers, false)}`
   }
 
-  return `Workers: ${workers?.value}`
+  return `Workers: ${workers}`
 })
 </script>
 
 <template>
-  <div class="menu flex items-center">
-    <div class="flex flex-1 flex-col">
-      <div class="menu-amount-box flex-1">
-        <span class="menu-amount-box-light">{{ controlPlaneCount }},</span>
-        <span class="menu-amount-box-light">{{ workersCount }}</span>
+  <div class="flex items-center gap-4">
+    <div class="flex grow flex-col">
+      <p class="text-xs text-naturals-n8">
+        <span class="text-naturals-n13">{{ controlPlaneCount }}, {{ workersCount }}</span>
         selected
-      </div>
+      </p>
+
       <div v-if="warning" class="text-xs text-yellow-y1">{{ warning }}</div>
     </div>
-    <TButton v-if="onReset" variant="secondary" @click="onReset">Cancel</TButton>
-    <TButton icon-position="left" variant="highlighted" :disabled="disabled" @click="onSubmit">
-      {{ action }}
-    </TButton>
+
+    <div class="flex shrink-0 items-center gap-2">
+      <TButton v-if="onReset" variant="secondary" @click="onReset">Cancel</TButton>
+      <TButton icon-position="left" variant="highlighted" :disabled="disabled" @click="onSubmit">
+        {{ action }}
+      </TButton>
+    </div>
   </div>
 </template>
-
-<style scoped>
-@reference "../../../index.css";
-
-.menu {
-  @apply flex gap-4;
-}
-.menu-amount-box {
-  @apply flex items-center text-xs text-naturals-n8;
-}
-.menu-amount-box-light {
-  @apply mr-1 text-naturals-n13;
-}
-.menu-buttons-box {
-  @apply flex items-center;
-}
-.menu-exit-button {
-  @apply h-6 w-6 cursor-pointer fill-current text-naturals-n7 transition-colors hover:text-naturals-n8;
-}
-</style>

--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -322,21 +322,19 @@ const list = useTemplateRef('list')
 </script>
 
 <template>
-  <div class="flex flex-col">
-    <div class="flex items-start gap-1">
-      <PageHeader title="Create Cluster" class="flex-1" />
-    </div>
-    <div class="flex flex-1 flex-col items-stretch gap-4">
-      <div class="flex h-9 w-full gap-2">
+  <div class="flex h-full flex-col pt-6">
+    <PageHeader title="Create Cluster" class="px-6" />
+
+    <div class="flex grow flex-col items-stretch gap-4 overflow-y-auto px-6 pb-6">
+      <div class="flex flex-wrap gap-2">
         <TInput
           title="Cluster Name"
-          class="h-full flex-1"
+          class="grow"
           placeholder="..."
           :model-value="state.cluster.name ?? ''"
           @update:model-value="(value) => (state.cluster.name = value)"
         />
         <TSelectList
-          class="h-full"
           title="Talos Version"
           :values="talosVersions"
           :default-value="state.cluster.talosVersion"
@@ -344,7 +342,6 @@ const list = useTemplateRef('list')
         />
         <TSelectList
           ref="kubernetesVersionSelector"
-          class="h-full"
           title="Kubernetes Version"
           :values="kubernetesVersions"
           :default-value="state.cluster.kubernetesVersion"
@@ -426,7 +423,7 @@ const list = useTemplateRef('list')
         ]"
         search
         pagination
-        class="flex-1"
+        class="h-max shrink-0"
       >
         <template #norecords>
           <TAlert v-if="!$slots.norecords" type="info" title="No Machines Available">
@@ -445,20 +442,20 @@ const list = useTemplateRef('list')
           />
         </template>
       </TList>
-      <div
-        v-if="state.controlPlanesCount !== 0"
-        class="-mx-6 -mb-6 flex h-16 items-center border-t border-naturals-n4 bg-naturals-n1 px-5 py-3"
-      >
-        <ClusterMenu
-          class="w-full"
-          :control-planes="state.controlPlanesCount"
-          :workers="state.workersCount"
-          :on-submit="createCluster"
-          :on-reset="() => reset++"
-          :disabled="!canCreateClusters"
-          action="Create Cluster"
-        />
-      </div>
+    </div>
+
+    <div
+      class="flex h-16 shrink-0 items-center border-t border-naturals-n4 bg-naturals-n1 px-5 py-3"
+    >
+      <ClusterMenu
+        class="w-full"
+        :control-planes="state.controlPlanesCount"
+        :workers="state.workersCount"
+        :on-submit="createCluster"
+        :on-reset="() => reset++"
+        :disabled="!canCreateClusters || !state.controlPlanesCount"
+        action="Create Cluster"
+      />
     </div>
   </div>
 </template>

--- a/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
@@ -129,10 +129,12 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-3">
-    <PageHeader :title="`Add Machines to Cluster ${$route.params.cluster}`" />
-    <ManagedByTemplatesWarning :resource="currentCluster" />
-    <template v-if="existingResources.length > 0">
+  <div class="flex h-full flex-col gap-3 pt-6">
+    <PageHeader :title="`Add Machines to Cluster ${$route.params.cluster}`" class="px-6" />
+
+    <div v-if="existingResources.length > 0" class="grow overflow-y-auto px-6 pb-6">
+      <ManagedByTemplatesWarning :resource="currentCluster" />
+
       <div class="text-naturals-n13">Machine Sets</div>
       <MachineSets />
       <div class="text-naturals-n13">Available Machines</div>
@@ -176,21 +178,24 @@ onMounted(async () => {
           />
         </template>
       </Watch>
-      <div
-        class="-mx-6 -mb-6 flex h-16 items-center border-t border-naturals-n4 bg-naturals-n1 px-5 py-3"
-      >
-        <ClusterMenu
-          class="w-full"
-          :control-planes="state.controlPlanesCount"
-          :workers="state.workersCount"
-          :on-submit="scaleCluster"
-          action="Update"
-          :warning="quorumWarning"
-        />
-      </div>
-    </template>
+    </div>
+
     <div v-else class="flex flex-1 items-center justify-center">
       <TSpinner class="h-6 w-6" />
+    </div>
+
+    <div
+      class="flex h-16 shrink-0 items-center border-t border-naturals-n4 bg-naturals-n1 px-5 py-3"
+    >
+      <ClusterMenu
+        class="w-full"
+        :control-planes="state.controlPlanesCount"
+        :workers="state.workersCount"
+        :on-submit="scaleCluster"
+        :disabled="!existingResources.length"
+        action="Update"
+        :warning="quorumWarning"
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
During cluster scaling and creation, keep the cluster menu visible and sticky at the bottom