### PR TITLE
feat(frontend): allow embedding youtube videos

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -65,7 +65,7 @@ export default defineConfig(({ command }) => {
       "connect-src 'self' https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io",
       "font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.userpilot.io",
       "style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com",
-      'frame-src https://*.auth0.com',
+      'frame-src https://www.youtube.com/embed/ https://*.auth0.com',
       "worker-src 'self' blob:", // "worker-src blob:" only required for vite dev server
     ].join(';')
 

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -137,7 +137,7 @@ func (handler *StaticHandler) serveFile(w http.ResponseWriter, r *http.Request, 
 					";font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.userpilot.io"+
 					// We are forced to use unsafe-inline for style-src due to monaco-editor https://github.com/microsoft/monaco-editor/issues/271
 					";style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com"+
-					";frame-src https://*.auth0.com",
+					";frame-src https://www.youtube.com/embed/ https://*.auth0.com",
 			)
 
 			w.Header().Set("X-Frame-Options", "SAMEORIGIN")


### PR DESCRIPTION
Update frame-src in the CSP to allow embedding youtube videos in the frontend.


(cherry picked from commit 3d2dc7b5176a0a058eac4457df7a1a7856c81c4b)