### PR TITLE
feat: allow resetting node unique tokens

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -1876,6 +1876,86 @@ func (x *CreateJoinTokenResponse) GetId() string {
 	return ""
 }
 
+type ResetNodeUniqueTokenRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResetNodeUniqueTokenRequest) Reset() {
+	*x = ResetNodeUniqueTokenRequest{}
+	mi := &file_omni_management_management_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResetNodeUniqueTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResetNodeUniqueTokenRequest) ProtoMessage() {}
+
+func (x *ResetNodeUniqueTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResetNodeUniqueTokenRequest.ProtoReflect.Descriptor instead.
+func (*ResetNodeUniqueTokenRequest) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *ResetNodeUniqueTokenRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type ResetNodeUniqueTokenResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResetNodeUniqueTokenResponse) Reset() {
+	*x = ResetNodeUniqueTokenResponse{}
+	mi := &file_omni_management_management_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResetNodeUniqueTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResetNodeUniqueTokenResponse) ProtoMessage() {}
+
+func (x *ResetNodeUniqueTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResetNodeUniqueTokenResponse.ProtoReflect.Descriptor instead.
+func (*ResetNodeUniqueTokenResponse) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{33}
+}
+
 type ListServiceAccountsResponse_ServiceAccount struct {
 	state         protoimpl.MessageState                                     `protogen:"open.v1"`
 	Name          string                                                     `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -1887,7 +1967,7 @@ type ListServiceAccountsResponse_ServiceAccount struct {
 
 func (x *ListServiceAccountsResponse_ServiceAccount) Reset() {
 	*x = ListServiceAccountsResponse_ServiceAccount{}
-	mi := &file_omni_management_management_proto_msgTypes[32]
+	mi := &file_omni_management_management_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1899,7 +1979,7 @@ func (x *ListServiceAccountsResponse_ServiceAccount) String() string {
 func (*ListServiceAccountsResponse_ServiceAccount) ProtoMessage() {}
 
 func (x *ListServiceAccountsResponse_ServiceAccount) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[32]
+	mi := &file_omni_management_management_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1947,7 +2027,7 @@ type ListServiceAccountsResponse_ServiceAccount_PgpPublicKey struct {
 
 func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) Reset() {
 	*x = ListServiceAccountsResponse_ServiceAccount_PgpPublicKey{}
-	mi := &file_omni_management_management_proto_msgTypes[33]
+	mi := &file_omni_management_management_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1959,7 +2039,7 @@ func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) String() strin
 func (*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) ProtoMessage() {}
 
 func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[33]
+	mi := &file_omni_management_management_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2007,7 +2087,7 @@ type CreateSchematicRequest_Overlay struct {
 
 func (x *CreateSchematicRequest_Overlay) Reset() {
 	*x = CreateSchematicRequest_Overlay{}
-	mi := &file_omni_management_management_proto_msgTypes[34]
+	mi := &file_omni_management_management_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2019,7 +2099,7 @@ func (x *CreateSchematicRequest_Overlay) String() string {
 func (*CreateSchematicRequest_Overlay) ProtoMessage() {}
 
 func (x *CreateSchematicRequest_Overlay) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[34]
+	mi := &file_omni_management_management_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2069,7 +2149,7 @@ type GetSupportBundleResponse_Progress struct {
 
 func (x *GetSupportBundleResponse_Progress) Reset() {
 	*x = GetSupportBundleResponse_Progress{}
-	mi := &file_omni_management_management_proto_msgTypes[36]
+	mi := &file_omni_management_management_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2081,7 +2161,7 @@ func (x *GetSupportBundleResponse_Progress) String() string {
 func (*GetSupportBundleResponse_Progress) ProtoMessage() {}
 
 func (x *GetSupportBundleResponse_Progress) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[36]
+	mi := &file_omni_management_management_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2144,7 +2224,7 @@ type ValidateJsonSchemaResponse_Error struct {
 
 func (x *ValidateJsonSchemaResponse_Error) Reset() {
 	*x = ValidateJsonSchemaResponse_Error{}
-	mi := &file_omni_management_management_proto_msgTypes[37]
+	mi := &file_omni_management_management_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2156,7 +2236,7 @@ func (x *ValidateJsonSchemaResponse_Error) String() string {
 func (*ValidateJsonSchemaResponse_Error) ProtoMessage() {}
 
 func (x *ValidateJsonSchemaResponse_Error) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[37]
+	mi := &file_omni_management_management_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2364,12 +2444,15 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12C\n" +
 	"\x0fexpiration_time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x0eexpirationTime\")\n" +
 	"\x17CreateJoinTokenResponse\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id*O\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"-\n" +
+	"\x1bResetNodeUniqueTokenRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\x1e\n" +
+	"\x1cResetNodeUniqueTokenResponse*O\n" +
 	"\x13SchematicBootloader\x12\r\n" +
 	"\tBOOT_AUTO\x10\x00\x12\r\n" +
 	"\tBOOT_DUAL\x10\x01\x12\v\n" +
 	"\aBOOT_SD\x10\x02\x12\r\n" +
-	"\tBOOT_GRUB\x10\x032\x9c\r\n" +
+	"\tBOOT_GRUB\x10\x032\x87\x0e\n" +
 	"\x11ManagementService\x12K\n" +
 	"\n" +
 	"Kubeconfig\x12\x1d.management.KubeconfigRequest\x1a\x1e.management.KubeconfigResponse\x12N\n" +
@@ -2390,7 +2473,8 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\fReadAuditLog\x12\x1f.management.ReadAuditLogRequest\x1a .management.ReadAuditLogResponse0\x01\x12c\n" +
 	"\x12MaintenanceUpgrade\x12%.management.MaintenanceUpgradeRequest\x1a&.management.MaintenanceUpgradeResponse\x12i\n" +
 	"\x14GetMachineJoinConfig\x12'.management.GetMachineJoinConfigRequest\x1a(.management.GetMachineJoinConfigResponse\x12Z\n" +
-	"\x0fCreateJoinToken\x12\".management.CreateJoinTokenRequest\x1a#.management.CreateJoinTokenResponseB7Z5github.com/siderolabs/omni/client/api/omni/managementb\x06proto3"
+	"\x0fCreateJoinToken\x12\".management.CreateJoinTokenRequest\x1a#.management.CreateJoinTokenResponse\x12i\n" +
+	"\x14ResetNodeUniqueToken\x12'.management.ResetNodeUniqueTokenRequest\x1a(.management.ResetNodeUniqueTokenResponseB7Z5github.com/siderolabs/omni/client/api/omni/managementb\x06proto3"
 
 var (
 	file_omni_management_management_proto_rawDescOnce sync.Once
@@ -2405,7 +2489,7 @@ func file_omni_management_management_proto_rawDescGZIP() []byte {
 }
 
 var file_omni_management_management_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_omni_management_management_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_omni_management_management_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_omni_management_management_proto_goTypes = []any{
 	(SchematicBootloader)(0),                                        // 0: management.SchematicBootloader
 	(KubernetesSyncManifestResponse_ResponseType)(0),                // 1: management.KubernetesSyncManifestResponse.ResponseType
@@ -2442,40 +2526,42 @@ var file_omni_management_management_proto_goTypes = []any{
 	(*GenJoinTokenResponse)(nil),                                    // 32: management.GenJoinTokenResponse
 	(*CreateJoinTokenRequest)(nil),                                  // 33: management.CreateJoinTokenRequest
 	(*CreateJoinTokenResponse)(nil),                                 // 34: management.CreateJoinTokenResponse
-	(*ListServiceAccountsResponse_ServiceAccount)(nil),              // 35: management.ListServiceAccountsResponse.ServiceAccount
-	(*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey)(nil), // 36: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	(*CreateSchematicRequest_Overlay)(nil),                          // 37: management.CreateSchematicRequest.Overlay
-	nil,                                                             // 38: management.CreateSchematicRequest.MetaValuesEntry
-	(*GetSupportBundleResponse_Progress)(nil),                       // 39: management.GetSupportBundleResponse.Progress
-	(*ValidateJsonSchemaResponse_Error)(nil),                        // 40: management.ValidateJsonSchemaResponse.Error
-	(*durationpb.Duration)(nil),                                     // 41: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                                   // 42: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                                           // 43: google.protobuf.Empty
-	(*common.Data)(nil),                                             // 44: common.Data
+	(*ResetNodeUniqueTokenRequest)(nil),                             // 35: management.ResetNodeUniqueTokenRequest
+	(*ResetNodeUniqueTokenResponse)(nil),                            // 36: management.ResetNodeUniqueTokenResponse
+	(*ListServiceAccountsResponse_ServiceAccount)(nil),              // 37: management.ListServiceAccountsResponse.ServiceAccount
+	(*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey)(nil), // 38: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
+	(*CreateSchematicRequest_Overlay)(nil),                          // 39: management.CreateSchematicRequest.Overlay
+	nil,                                                             // 40: management.CreateSchematicRequest.MetaValuesEntry
+	(*GetSupportBundleResponse_Progress)(nil),                       // 41: management.GetSupportBundleResponse.Progress
+	(*ValidateJsonSchemaResponse_Error)(nil),                        // 42: management.ValidateJsonSchemaResponse.Error
+	(*durationpb.Duration)(nil),                                     // 43: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                                   // 44: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                                           // 45: google.protobuf.Empty
+	(*common.Data)(nil),                                             // 46: common.Data
 }
 var file_omni_management_management_proto_depIdxs = []int32{
-	35, // 0: management.ListServiceAccountsResponse.service_accounts:type_name -> management.ListServiceAccountsResponse.ServiceAccount
-	41, // 1: management.KubeconfigRequest.service_account_ttl:type_name -> google.protobuf.Duration
+	37, // 0: management.ListServiceAccountsResponse.service_accounts:type_name -> management.ListServiceAccountsResponse.ServiceAccount
+	43, // 1: management.KubeconfigRequest.service_account_ttl:type_name -> google.protobuf.Duration
 	1,  // 2: management.KubernetesSyncManifestResponse.response_type:type_name -> management.KubernetesSyncManifestResponse.ResponseType
-	38, // 3: management.CreateSchematicRequest.meta_values:type_name -> management.CreateSchematicRequest.MetaValuesEntry
+	40, // 3: management.CreateSchematicRequest.meta_values:type_name -> management.CreateSchematicRequest.MetaValuesEntry
 	2,  // 4: management.CreateSchematicRequest.siderolink_grpc_tunnel_mode:type_name -> management.CreateSchematicRequest.SiderolinkGRPCTunnelMode
-	37, // 5: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
+	39, // 5: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
 	0,  // 6: management.CreateSchematicRequest.bootloader:type_name -> management.SchematicBootloader
-	39, // 7: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
-	40, // 8: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	42, // 9: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
-	36, // 10: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	42, // 11: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
-	40, // 12: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	41, // 7: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
+	42, // 8: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	44, // 9: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
+	38, // 10: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
+	44, // 11: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
+	42, // 12: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
 	15, // 13: management.ManagementService.Kubeconfig:input_type -> management.KubeconfigRequest
 	8,  // 14: management.ManagementService.Talosconfig:input_type -> management.TalosconfigRequest
-	43, // 15: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
+	45, // 15: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
 	6,  // 16: management.ManagementService.MachineLogs:input_type -> management.MachineLogsRequest
 	7,  // 17: management.ManagementService.ValidateConfig:input_type -> management.ValidateConfigRequest
 	26, // 18: management.ManagementService.ValidateJSONSchema:input_type -> management.ValidateJsonSchemaRequest
 	9,  // 19: management.ManagementService.CreateServiceAccount:input_type -> management.CreateServiceAccountRequest
 	11, // 20: management.ManagementService.RenewServiceAccount:input_type -> management.RenewServiceAccountRequest
-	43, // 21: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
+	45, // 21: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
 	13, // 22: management.ManagementService.DestroyServiceAccount:input_type -> management.DestroyServiceAccountRequest
 	16, // 23: management.ManagementService.KubernetesUpgradePreChecks:input_type -> management.KubernetesUpgradePreChecksRequest
 	18, // 24: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
@@ -2485,26 +2571,28 @@ var file_omni_management_management_proto_depIdxs = []int32{
 	28, // 28: management.ManagementService.MaintenanceUpgrade:input_type -> management.MaintenanceUpgradeRequest
 	30, // 29: management.ManagementService.GetMachineJoinConfig:input_type -> management.GetMachineJoinConfigRequest
 	33, // 30: management.ManagementService.CreateJoinToken:input_type -> management.CreateJoinTokenRequest
-	3,  // 31: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
-	4,  // 32: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
-	5,  // 33: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
-	44, // 34: management.ManagementService.MachineLogs:output_type -> common.Data
-	43, // 35: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
-	27, // 36: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
-	10, // 37: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
-	12, // 38: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
-	14, // 39: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
-	43, // 40: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
-	17, // 41: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
-	19, // 42: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
-	21, // 43: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
-	23, // 44: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
-	25, // 45: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
-	29, // 46: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
-	31, // 47: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
-	34, // 48: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
-	31, // [31:49] is the sub-list for method output_type
-	13, // [13:31] is the sub-list for method input_type
+	35, // 31: management.ManagementService.ResetNodeUniqueToken:input_type -> management.ResetNodeUniqueTokenRequest
+	3,  // 32: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
+	4,  // 33: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
+	5,  // 34: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
+	46, // 35: management.ManagementService.MachineLogs:output_type -> common.Data
+	45, // 36: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
+	27, // 37: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
+	10, // 38: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
+	12, // 39: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
+	14, // 40: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
+	45, // 41: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
+	17, // 42: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
+	19, // 43: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
+	21, // 44: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
+	23, // 45: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
+	25, // 46: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
+	29, // 47: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
+	31, // 48: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
+	34, // 49: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
+	36, // 50: management.ManagementService.ResetNodeUniqueToken:output_type -> management.ResetNodeUniqueTokenResponse
+	32, // [32:51] is the sub-list for method output_type
+	13, // [13:32] is the sub-list for method input_type
 	13, // [13:13] is the sub-list for extension type_name
 	13, // [13:13] is the sub-list for extension extendee
 	0,  // [0:13] is the sub-list for field type_name
@@ -2521,7 +2609,7 @@ func file_omni_management_management_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_omni_management_management_proto_rawDesc), len(file_omni_management_management_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   38,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/client/api/omni/management/management.pb.gw.go
+++ b/client/api/omni/management/management.pb.gw.go
@@ -506,6 +506,33 @@ func local_request_ManagementService_CreateJoinToken_0(ctx context.Context, mars
 	return msg, metadata, err
 }
 
+func request_ManagementService_ResetNodeUniqueToken_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ResetNodeUniqueTokenRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ResetNodeUniqueToken(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ManagementService_ResetNodeUniqueToken_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ResetNodeUniqueTokenRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ResetNodeUniqueToken(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterManagementServiceHandlerServer registers the http handlers for service ManagementService to "mux".
 // UnaryRPC     :call ManagementServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -819,6 +846,26 @@ func RegisterManagementServiceHandlerServer(ctx context.Context, mux *runtime.Se
 			return
 		}
 		forward_ManagementService_CreateJoinToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_ResetNodeUniqueToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/ResetNodeUniqueToken", runtime.WithHTTPPathPattern("/management.ManagementService/ResetNodeUniqueToken"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ManagementService_ResetNodeUniqueToken_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_ResetNodeUniqueToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -1166,6 +1213,23 @@ func RegisterManagementServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_ManagementService_CreateJoinToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_ResetNodeUniqueToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/ResetNodeUniqueToken", runtime.WithHTTPPathPattern("/management.ManagementService/ResetNodeUniqueToken"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ManagementService_ResetNodeUniqueToken_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_ResetNodeUniqueToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1188,6 +1252,7 @@ var (
 	pattern_ManagementService_MaintenanceUpgrade_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "MaintenanceUpgrade"}, ""))
 	pattern_ManagementService_GetMachineJoinConfig_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "GetMachineJoinConfig"}, ""))
 	pattern_ManagementService_CreateJoinToken_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "CreateJoinToken"}, ""))
+	pattern_ManagementService_ResetNodeUniqueToken_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "ResetNodeUniqueToken"}, ""))
 )
 
 var (
@@ -1209,4 +1274,5 @@ var (
 	forward_ManagementService_MaintenanceUpgrade_0         = runtime.ForwardResponseMessage
 	forward_ManagementService_GetMachineJoinConfig_0       = runtime.ForwardResponseMessage
 	forward_ManagementService_CreateJoinToken_0            = runtime.ForwardResponseMessage
+	forward_ManagementService_ResetNodeUniqueToken_0       = runtime.ForwardResponseMessage
 )

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -238,6 +238,12 @@ message CreateJoinTokenResponse {
   string id = 1;
 }
 
+message ResetNodeUniqueTokenRequest {
+  string id = 1;
+}
+
+message ResetNodeUniqueTokenResponse {}
+
 service ManagementService {
   rpc Kubeconfig(KubeconfigRequest) returns (KubeconfigResponse);
   rpc Talosconfig(TalosconfigRequest) returns (TalosconfigResponse);
@@ -257,4 +263,5 @@ service ManagementService {
   rpc MaintenanceUpgrade(MaintenanceUpgradeRequest) returns (MaintenanceUpgradeResponse);
   rpc GetMachineJoinConfig(GetMachineJoinConfigRequest) returns (GetMachineJoinConfigResponse);
   rpc CreateJoinToken(CreateJoinTokenRequest) returns (CreateJoinTokenResponse);
+  rpc ResetNodeUniqueToken(ResetNodeUniqueTokenRequest) returns (ResetNodeUniqueTokenResponse);
 }

--- a/client/api/omni/management/management_grpc.pb.go
+++ b/client/api/omni/management/management_grpc.pb.go
@@ -40,6 +40,7 @@ const (
 	ManagementService_MaintenanceUpgrade_FullMethodName         = "/management.ManagementService/MaintenanceUpgrade"
 	ManagementService_GetMachineJoinConfig_FullMethodName       = "/management.ManagementService/GetMachineJoinConfig"
 	ManagementService_CreateJoinToken_FullMethodName            = "/management.ManagementService/CreateJoinToken"
+	ManagementService_ResetNodeUniqueToken_FullMethodName       = "/management.ManagementService/ResetNodeUniqueToken"
 )
 
 // ManagementServiceClient is the client API for ManagementService service.
@@ -64,6 +65,7 @@ type ManagementServiceClient interface {
 	MaintenanceUpgrade(ctx context.Context, in *MaintenanceUpgradeRequest, opts ...grpc.CallOption) (*MaintenanceUpgradeResponse, error)
 	GetMachineJoinConfig(ctx context.Context, in *GetMachineJoinConfigRequest, opts ...grpc.CallOption) (*GetMachineJoinConfigResponse, error)
 	CreateJoinToken(ctx context.Context, in *CreateJoinTokenRequest, opts ...grpc.CallOption) (*CreateJoinTokenResponse, error)
+	ResetNodeUniqueToken(ctx context.Context, in *ResetNodeUniqueTokenRequest, opts ...grpc.CallOption) (*ResetNodeUniqueTokenResponse, error)
 }
 
 type managementServiceClient struct {
@@ -290,6 +292,16 @@ func (c *managementServiceClient) CreateJoinToken(ctx context.Context, in *Creat
 	return out, nil
 }
 
+func (c *managementServiceClient) ResetNodeUniqueToken(ctx context.Context, in *ResetNodeUniqueTokenRequest, opts ...grpc.CallOption) (*ResetNodeUniqueTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ResetNodeUniqueTokenResponse)
+	err := c.cc.Invoke(ctx, ManagementService_ResetNodeUniqueToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ManagementServiceServer is the server API for ManagementService service.
 // All implementations must embed UnimplementedManagementServiceServer
 // for forward compatibility.
@@ -312,6 +324,7 @@ type ManagementServiceServer interface {
 	MaintenanceUpgrade(context.Context, *MaintenanceUpgradeRequest) (*MaintenanceUpgradeResponse, error)
 	GetMachineJoinConfig(context.Context, *GetMachineJoinConfigRequest) (*GetMachineJoinConfigResponse, error)
 	CreateJoinToken(context.Context, *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error)
+	ResetNodeUniqueToken(context.Context, *ResetNodeUniqueTokenRequest) (*ResetNodeUniqueTokenResponse, error)
 	mustEmbedUnimplementedManagementServiceServer()
 }
 
@@ -375,6 +388,9 @@ func (UnimplementedManagementServiceServer) GetMachineJoinConfig(context.Context
 }
 func (UnimplementedManagementServiceServer) CreateJoinToken(context.Context, *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateJoinToken not implemented")
+}
+func (UnimplementedManagementServiceServer) ResetNodeUniqueToken(context.Context, *ResetNodeUniqueTokenRequest) (*ResetNodeUniqueTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ResetNodeUniqueToken not implemented")
 }
 func (UnimplementedManagementServiceServer) mustEmbedUnimplementedManagementServiceServer() {}
 func (UnimplementedManagementServiceServer) testEmbeddedByValue()                           {}
@@ -693,6 +709,24 @@ func _ManagementService_CreateJoinToken_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ManagementService_ResetNodeUniqueToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResetNodeUniqueTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).ResetNodeUniqueToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_ResetNodeUniqueToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).ResetNodeUniqueToken(ctx, req.(*ResetNodeUniqueTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ManagementService_ServiceDesc is the grpc.ServiceDesc for ManagementService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -755,6 +789,10 @@ var ManagementService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreateJoinToken",
 			Handler:    _ManagementService_CreateJoinToken_Handler,
+		},
+		{
+			MethodName: "ResetNodeUniqueToken",
+			Handler:    _ManagementService_ResetNodeUniqueToken_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -771,6 +771,39 @@ func (m *CreateJoinTokenResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *ResetNodeUniqueTokenRequest) CloneVT() *ResetNodeUniqueTokenRequest {
+	if m == nil {
+		return (*ResetNodeUniqueTokenRequest)(nil)
+	}
+	r := new(ResetNodeUniqueTokenRequest)
+	r.Id = m.Id
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ResetNodeUniqueTokenRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ResetNodeUniqueTokenResponse) CloneVT() *ResetNodeUniqueTokenResponse {
+	if m == nil {
+		return (*ResetNodeUniqueTokenResponse)(nil)
+	}
+	r := new(ResetNodeUniqueTokenResponse)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ResetNodeUniqueTokenResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *KubeconfigResponse) EqualVT(that *KubeconfigResponse) bool {
 	if this == that {
 		return true
@@ -1702,6 +1735,41 @@ func (this *CreateJoinTokenResponse) EqualVT(that *CreateJoinTokenResponse) bool
 
 func (this *CreateJoinTokenResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*CreateJoinTokenResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ResetNodeUniqueTokenRequest) EqualVT(that *ResetNodeUniqueTokenRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Id != that.Id {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ResetNodeUniqueTokenRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ResetNodeUniqueTokenRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ResetNodeUniqueTokenResponse) EqualVT(that *ResetNodeUniqueTokenResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ResetNodeUniqueTokenResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ResetNodeUniqueTokenResponse)
 	if !ok {
 		return false
 	}
@@ -3600,6 +3668,79 @@ func (m *CreateJoinTokenResponse) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
+func (m *ResetNodeUniqueTokenRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ResetNodeUniqueTokenRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ResetNodeUniqueTokenRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ResetNodeUniqueTokenResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ResetNodeUniqueTokenResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ResetNodeUniqueTokenResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *KubeconfigResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -4308,6 +4449,30 @@ func (m *CreateJoinTokenResponse) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ResetNodeUniqueTokenRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ResetNodeUniqueTokenResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
 	n += len(m.unknownFields)
 	return n
 }
@@ -8796,6 +8961,140 @@ func (m *CreateJoinTokenResponse) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Id = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ResetNodeUniqueTokenRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ResetNodeUniqueTokenRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ResetNodeUniqueTokenRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ResetNodeUniqueTokenResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ResetNodeUniqueTokenResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ResetNodeUniqueTokenResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/client/management/management.go
+++ b/client/pkg/client/management/management.go
@@ -249,6 +249,15 @@ func (client *Client) ReadAuditLog(ctx context.Context, start, end string) iter.
 	}
 }
 
+// ResetNodeUniqueToken resets the node unique token for the machine, which forces the machine to get a new one on next startup.
+func (client *Client) ResetNodeUniqueToken(ctx context.Context, machineID string) error {
+	_, err := client.conn.ResetNodeUniqueToken(ctx, &management.ResetNodeUniqueTokenRequest{
+		Id: machineID,
+	})
+
+	return err
+}
+
 // LogReader is a log client reader which implements io.Reader.
 type LogReader struct {
 	ctx    context.Context //nolint:containedctx

--- a/client/pkg/omnictl/configure/machine.go
+++ b/client/pkg/omnictl/configure/machine.go
@@ -28,6 +28,7 @@ const (
 
 var machineCmdFlags struct {
 	siderolinkConnection siderolinkConnection
+	resetNodeUniqueToken bool
 }
 
 var delayNotice = fmt.Sprintf("It will take around %s for the machine to reconnect back in the new mode.\n", wireguard.PeerDownInterval)
@@ -40,66 +41,78 @@ var machineCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return access.WithClient(func(ctx context.Context, client *client.Client) error {
 			for _, id := range args {
-
-				if machineCmdFlags.siderolinkConnection == "" {
-					fmt.Println("nothing to do: no flags specified")
-
-					return nil
+				if machineCmdFlags.siderolinkConnection != "" {
+					if err := updateSideroLinkConnectionMode(ctx, client, id); err != nil {
+						return fmt.Errorf("failed to update SideroLink connection mode for machine %s: %w", id, err)
+					}
 				}
 
-				_, err := safe.ReaderGetByID[*omni.Machine](ctx, client.Omni().State(), id)
-				if err != nil {
-					if state.IsNotFoundError(err) {
-						return fmt.Errorf("machine with id %s doesn't exist", id)
+				if machineCmdFlags.resetNodeUniqueToken {
+					err := client.Management().ResetNodeUniqueToken(ctx, id)
+					if err != nil {
+						return fmt.Errorf("failed to reset node unique token for machine %s: %w", id, err)
 					}
 
-					return err
+					fmt.Printf("reset node unique token for machine %s\n", id)
 				}
-
-				config := siderolink.NewGRPCTunnelConfig(id)
-
-				switch string(machineCmdFlags.siderolinkConnection) {
-				case siderolinkConnectionModeUDP:
-					return safe.StateModify(ctx, client.Omni().State(), config, func(res *siderolink.GRPCTunnelConfig) error {
-						if !res.TypedSpec().Value.Enabled {
-							return nil
-						}
-
-						res.TypedSpec().Value.Enabled = false
-
-						fmt.Printf("disabled gRPC tunnel mode for machine %s\n%s", id, delayNotice)
-
-						return nil
-					})
-				case siderolinkConnectionModeTunnel:
-					return safe.StateModify(ctx, client.Omni().State(), config, func(res *siderolink.GRPCTunnelConfig) error {
-						if res.TypedSpec().Value.Enabled {
-							return nil
-						}
-
-						res.TypedSpec().Value.Enabled = true
-
-						fmt.Printf("enabled gRPC tunnel mode for machine %s\n%s", id, delayNotice)
-
-						return nil
-					})
-
-				case siderolinkConnectionModeAuto:
-					err = client.Omni().State().TeardownAndDestroy(ctx, config.Metadata())
-					if err != nil && !state.IsNotFoundError(err) {
-						return err
-					}
-
-					fmt.Printf("deleted grpc tunnel config for the machine %s\n%s", id, delayNotice)
-				}
-
-				fmt.Println("WARNING: the changes won't be applied until the machine is restarted")
 			}
 
 			return nil
 		})
 	},
 	Args: cobra.MinimumNArgs(1),
+}
+
+func updateSideroLinkConnectionMode(ctx context.Context, client *client.Client, id string) error {
+	_, err := safe.ReaderGetByID[*omni.Machine](ctx, client.Omni().State(), id)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return fmt.Errorf("machine with id %s doesn't exist", id)
+		}
+
+		return err
+	}
+
+	config := siderolink.NewGRPCTunnelConfig(id)
+
+	switch string(machineCmdFlags.siderolinkConnection) {
+	case siderolinkConnectionModeUDP:
+		return safe.StateModify(ctx, client.Omni().State(), config, func(res *siderolink.GRPCTunnelConfig) error {
+			if !res.TypedSpec().Value.Enabled {
+				return nil
+			}
+
+			res.TypedSpec().Value.Enabled = false
+
+			fmt.Printf("disabled gRPC tunnel mode for machine %s\n%s", id, delayNotice)
+
+			return nil
+		})
+	case siderolinkConnectionModeTunnel:
+		return safe.StateModify(ctx, client.Omni().State(), config, func(res *siderolink.GRPCTunnelConfig) error {
+			if res.TypedSpec().Value.Enabled {
+				return nil
+			}
+
+			res.TypedSpec().Value.Enabled = true
+
+			fmt.Printf("enabled gRPC tunnel mode for machine %s\n%s", id, delayNotice)
+
+			return nil
+		})
+
+	case siderolinkConnectionModeAuto:
+		err = client.Omni().State().TeardownAndDestroy(ctx, config.Metadata())
+		if err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+
+		fmt.Printf("deleted grpc tunnel config for the machine %s\n%s", id, delayNotice)
+	}
+
+	fmt.Println("WARNING: the changes won't be applied until the machine is restarted")
+
+	return nil
 }
 
 type siderolinkConnection string
@@ -129,6 +142,7 @@ func (s *siderolinkConnection) String() string {
 
 func init() {
 	machineCmd.Flags().Var(&machineCmdFlags.siderolinkConnection, "siderolink-connection", "configure SideroLink connection mode")
+	machineCmd.Flags().BoolVar(&machineCmdFlags.resetNodeUniqueToken, "reset-node-unique-token", false, "reset the node unique token for the machine")
 
 	configureCmd.AddCommand(machineCmd)
 }

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -225,6 +225,13 @@ export type CreateJoinTokenResponse = {
   id?: string
 }
 
+export type ResetNodeUniqueTokenRequest = {
+  id?: string
+}
+
+export type ResetNodeUniqueTokenResponse = {
+}
+
 export class ManagementService {
   static Kubeconfig(req: KubeconfigRequest, ...options: fm.fetchOption[]): Promise<KubeconfigResponse> {
     return fm.fetchReq<KubeconfigRequest, KubeconfigResponse>("POST", `/management.ManagementService/Kubeconfig`, req, ...options)
@@ -279,5 +286,8 @@ export class ManagementService {
   }
   static CreateJoinToken(req: CreateJoinTokenRequest, ...options: fm.fetchOption[]): Promise<CreateJoinTokenResponse> {
     return fm.fetchReq<CreateJoinTokenRequest, CreateJoinTokenResponse>("POST", `/management.ManagementService/CreateJoinToken`, req, ...options)
+  }
+  static ResetNodeUniqueToken(req: ResetNodeUniqueTokenRequest, ...options: fm.fetchOption[]): Promise<ResetNodeUniqueTokenResponse> {
+    return fm.fetchReq<ResetNodeUniqueTokenRequest, ResetNodeUniqueTokenResponse>("POST", `/management.ManagementService/ResetNodeUniqueToken`, req, ...options)
   }
 }

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -824,6 +824,28 @@ func (s *managementServer) CreateJoinToken(ctx context.Context, request *managem
 	}, nil
 }
 
+func (s *managementServer) ResetNodeUniqueToken(ctx context.Context, request *management.ResetNodeUniqueTokenRequest) (*management.ResetNodeUniqueTokenResponse, error) {
+	_, err := auth.CheckGRPC(ctx, auth.WithRole(role.Admin))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = safe.StateGetByID[*omnires.MachineStatus](ctx, s.omniState, request.Id)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil, status.Error(codes.NotFound, "machine not found")
+		}
+
+		return nil, fmt.Errorf("failed to get machine status: %w", err)
+	}
+
+	if err = s.omniState.TeardownAndDestroy(actor.MarkContextAsInternalActor(ctx), siderolinkres.NewNodeUniqueToken(request.Id).Metadata()); err != nil {
+		return nil, fmt.Errorf("failed to teardown and destroy node unique token: %w", err)
+	}
+
+	return &management.ResetNodeUniqueTokenResponse{}, nil
+}
+
 func parseTime(date string, fallback time.Time) (time.Time, error) {
 	if date == "" {
 		return fallback, nil


### PR DESCRIPTION
This allows token rotation and disaster recovery if the token gets rejected by Omni.

Introduced the new CLI command for that:

```
omnictl configure machine <id> --reset-node-unique-token
```


(cherry picked from commit 47fb4dd792b7201f1cbb2a3710da03c3b11d5972)