### PR TITLE
feat: add ManagementService gRPC endpoints for user operations

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -1956,6 +1956,242 @@ func (*ResetNodeUniqueTokenResponse) Descriptor() ([]byte, []int) {
 	return file_omni_management_management_proto_rawDescGZIP(), []int{33}
 }
 
+type CreateUserRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Email         string                 `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty"`
+	Role          string                 `protobuf:"bytes,2,opt,name=role,proto3" json:"role,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateUserRequest) Reset() {
+	*x = CreateUserRequest{}
+	mi := &file_omni_management_management_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateUserRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateUserRequest) ProtoMessage() {}
+
+func (x *CreateUserRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateUserRequest.ProtoReflect.Descriptor instead.
+func (*CreateUserRequest) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *CreateUserRequest) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+func (x *CreateUserRequest) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+type CreateUserResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateUserResponse) Reset() {
+	*x = CreateUserResponse{}
+	mi := &file_omni_management_management_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateUserResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateUserResponse) ProtoMessage() {}
+
+func (x *CreateUserResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateUserResponse.ProtoReflect.Descriptor instead.
+func (*CreateUserResponse) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *CreateUserResponse) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+type UpdateUserRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Email         string                 `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty"`
+	Role          string                 `protobuf:"bytes,2,opt,name=role,proto3" json:"role,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateUserRequest) Reset() {
+	*x = UpdateUserRequest{}
+	mi := &file_omni_management_management_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateUserRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateUserRequest) ProtoMessage() {}
+
+func (x *UpdateUserRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateUserRequest.ProtoReflect.Descriptor instead.
+func (*UpdateUserRequest) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *UpdateUserRequest) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+func (x *UpdateUserRequest) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+type DestroyUserRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Email         string                 `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DestroyUserRequest) Reset() {
+	*x = DestroyUserRequest{}
+	mi := &file_omni_management_management_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DestroyUserRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DestroyUserRequest) ProtoMessage() {}
+
+func (x *DestroyUserRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DestroyUserRequest.ProtoReflect.Descriptor instead.
+func (*DestroyUserRequest) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *DestroyUserRequest) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+type ListUsersResponse struct {
+	state         protoimpl.MessageState    `protogen:"open.v1"`
+	Users         []*ListUsersResponse_User `protobuf:"bytes,1,rep,name=users,proto3" json:"users,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListUsersResponse) Reset() {
+	*x = ListUsersResponse{}
+	mi := &file_omni_management_management_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListUsersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListUsersResponse) ProtoMessage() {}
+
+func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListUsersResponse.ProtoReflect.Descriptor instead.
+func (*ListUsersResponse) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *ListUsersResponse) GetUsers() []*ListUsersResponse_User {
+	if x != nil {
+		return x.Users
+	}
+	return nil
+}
+
 type ListServiceAccountsResponse_ServiceAccount struct {
 	state         protoimpl.MessageState                                     `protogen:"open.v1"`
 	Name          string                                                     `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -1967,7 +2203,7 @@ type ListServiceAccountsResponse_ServiceAccount struct {
 
 func (x *ListServiceAccountsResponse_ServiceAccount) Reset() {
 	*x = ListServiceAccountsResponse_ServiceAccount{}
-	mi := &file_omni_management_management_proto_msgTypes[34]
+	mi := &file_omni_management_management_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1979,7 +2215,7 @@ func (x *ListServiceAccountsResponse_ServiceAccount) String() string {
 func (*ListServiceAccountsResponse_ServiceAccount) ProtoMessage() {}
 
 func (x *ListServiceAccountsResponse_ServiceAccount) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[34]
+	mi := &file_omni_management_management_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2027,7 +2263,7 @@ type ListServiceAccountsResponse_ServiceAccount_PgpPublicKey struct {
 
 func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) Reset() {
 	*x = ListServiceAccountsResponse_ServiceAccount_PgpPublicKey{}
-	mi := &file_omni_management_management_proto_msgTypes[35]
+	mi := &file_omni_management_management_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2039,7 +2275,7 @@ func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) String() strin
 func (*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) ProtoMessage() {}
 
 func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[35]
+	mi := &file_omni_management_management_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2087,7 +2323,7 @@ type CreateSchematicRequest_Overlay struct {
 
 func (x *CreateSchematicRequest_Overlay) Reset() {
 	*x = CreateSchematicRequest_Overlay{}
-	mi := &file_omni_management_management_proto_msgTypes[36]
+	mi := &file_omni_management_management_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2099,7 +2335,7 @@ func (x *CreateSchematicRequest_Overlay) String() string {
 func (*CreateSchematicRequest_Overlay) ProtoMessage() {}
 
 func (x *CreateSchematicRequest_Overlay) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[36]
+	mi := &file_omni_management_management_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2149,7 +2385,7 @@ type GetSupportBundleResponse_Progress struct {
 
 func (x *GetSupportBundleResponse_Progress) Reset() {
 	*x = GetSupportBundleResponse_Progress{}
-	mi := &file_omni_management_management_proto_msgTypes[38]
+	mi := &file_omni_management_management_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2161,7 +2397,7 @@ func (x *GetSupportBundleResponse_Progress) String() string {
 func (*GetSupportBundleResponse_Progress) ProtoMessage() {}
 
 func (x *GetSupportBundleResponse_Progress) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[38]
+	mi := &file_omni_management_management_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2224,7 +2460,7 @@ type ValidateJsonSchemaResponse_Error struct {
 
 func (x *ValidateJsonSchemaResponse_Error) Reset() {
 	*x = ValidateJsonSchemaResponse_Error{}
-	mi := &file_omni_management_management_proto_msgTypes[39]
+	mi := &file_omni_management_management_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2236,7 +2472,7 @@ func (x *ValidateJsonSchemaResponse_Error) String() string {
 func (*ValidateJsonSchemaResponse_Error) ProtoMessage() {}
 
 func (x *ValidateJsonSchemaResponse_Error) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[39]
+	mi := &file_omni_management_management_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2278,6 +2514,74 @@ func (x *ValidateJsonSchemaResponse_Error) GetCause() string {
 		return x.Cause
 	}
 	return ""
+}
+
+type ListUsersResponse_User struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Email         string                 `protobuf:"bytes,2,opt,name=email,proto3" json:"email,omitempty"`
+	Role          string                 `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
+	SamlLabels    map[string]string      `protobuf:"bytes,4,rep,name=saml_labels,json=samlLabels,proto3" json:"saml_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListUsersResponse_User) Reset() {
+	*x = ListUsersResponse_User{}
+	mi := &file_omni_management_management_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListUsersResponse_User) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListUsersResponse_User) ProtoMessage() {}
+
+func (x *ListUsersResponse_User) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListUsersResponse_User.ProtoReflect.Descriptor instead.
+func (*ListUsersResponse_User) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{38, 0}
+}
+
+func (x *ListUsersResponse_User) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ListUsersResponse_User) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+func (x *ListUsersResponse_User) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+func (x *ListUsersResponse_User) GetSamlLabels() map[string]string {
+	if x != nil {
+		return x.SamlLabels
+	}
+	return nil
 }
 
 var File_omni_management_management_proto protoreflect.FileDescriptor
@@ -2447,12 +2751,33 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"-\n" +
 	"\x1bResetNodeUniqueTokenRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"\x1e\n" +
-	"\x1cResetNodeUniqueTokenResponse*O\n" +
+	"\x1cResetNodeUniqueTokenResponse\"=\n" +
+	"\x11CreateUserRequest\x12\x14\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\x12\x12\n" +
+	"\x04role\x18\x02 \x01(\tR\x04role\"-\n" +
+	"\x12CreateUserResponse\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\"=\n" +
+	"\x11UpdateUserRequest\x12\x14\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\x12\x12\n" +
+	"\x04role\x18\x02 \x01(\tR\x04role\"*\n" +
+	"\x12DestroyUserRequest\x12\x14\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\"\xa4\x02\n" +
+	"\x11ListUsersResponse\x128\n" +
+	"\x05users\x18\x01 \x03(\v2\".management.ListUsersResponse.UserR\x05users\x1a\xd4\x01\n" +
+	"\x04User\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05email\x18\x02 \x01(\tR\x05email\x12\x12\n" +
+	"\x04role\x18\x03 \x01(\tR\x04role\x12S\n" +
+	"\vsaml_labels\x18\x04 \x03(\v22.management.ListUsersResponse.User.SamlLabelsEntryR\n" +
+	"samlLabels\x1a=\n" +
+	"\x0fSamlLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*O\n" +
 	"\x13SchematicBootloader\x12\r\n" +
 	"\tBOOT_AUTO\x10\x00\x12\r\n" +
 	"\tBOOT_DUAL\x10\x01\x12\v\n" +
 	"\aBOOT_SD\x10\x02\x12\r\n" +
-	"\tBOOT_GRUB\x10\x032\x87\x0e\n" +
+	"\tBOOT_GRUB\x10\x032\xa4\x10\n" +
 	"\x11ManagementService\x12K\n" +
 	"\n" +
 	"Kubeconfig\x12\x1d.management.KubeconfigRequest\x1a\x1e.management.KubeconfigResponse\x12N\n" +
@@ -2474,7 +2799,13 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x12MaintenanceUpgrade\x12%.management.MaintenanceUpgradeRequest\x1a&.management.MaintenanceUpgradeResponse\x12i\n" +
 	"\x14GetMachineJoinConfig\x12'.management.GetMachineJoinConfigRequest\x1a(.management.GetMachineJoinConfigResponse\x12Z\n" +
 	"\x0fCreateJoinToken\x12\".management.CreateJoinTokenRequest\x1a#.management.CreateJoinTokenResponse\x12i\n" +
-	"\x14ResetNodeUniqueToken\x12'.management.ResetNodeUniqueTokenRequest\x1a(.management.ResetNodeUniqueTokenResponseB7Z5github.com/siderolabs/omni/client/api/omni/managementb\x06proto3"
+	"\x14ResetNodeUniqueToken\x12'.management.ResetNodeUniqueTokenRequest\x1a(.management.ResetNodeUniqueTokenResponse\x12K\n" +
+	"\n" +
+	"CreateUser\x12\x1d.management.CreateUserRequest\x1a\x1e.management.CreateUserResponse\x12B\n" +
+	"\tListUsers\x12\x16.google.protobuf.Empty\x1a\x1d.management.ListUsersResponse\x12C\n" +
+	"\n" +
+	"UpdateUser\x12\x1d.management.UpdateUserRequest\x1a\x16.google.protobuf.Empty\x12E\n" +
+	"\vDestroyUser\x12\x1e.management.DestroyUserRequest\x1a\x16.google.protobuf.EmptyB7Z5github.com/siderolabs/omni/client/api/omni/managementb\x06proto3"
 
 var (
 	file_omni_management_management_proto_rawDescOnce sync.Once
@@ -2489,7 +2820,7 @@ func file_omni_management_management_proto_rawDescGZIP() []byte {
 }
 
 var file_omni_management_management_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_omni_management_management_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_omni_management_management_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_omni_management_management_proto_goTypes = []any{
 	(SchematicBootloader)(0),                                        // 0: management.SchematicBootloader
 	(KubernetesSyncManifestResponse_ResponseType)(0),                // 1: management.KubernetesSyncManifestResponse.ResponseType
@@ -2528,74 +2859,91 @@ var file_omni_management_management_proto_goTypes = []any{
 	(*CreateJoinTokenResponse)(nil),                                 // 34: management.CreateJoinTokenResponse
 	(*ResetNodeUniqueTokenRequest)(nil),                             // 35: management.ResetNodeUniqueTokenRequest
 	(*ResetNodeUniqueTokenResponse)(nil),                            // 36: management.ResetNodeUniqueTokenResponse
-	(*ListServiceAccountsResponse_ServiceAccount)(nil),              // 37: management.ListServiceAccountsResponse.ServiceAccount
-	(*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey)(nil), // 38: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	(*CreateSchematicRequest_Overlay)(nil),                          // 39: management.CreateSchematicRequest.Overlay
-	nil,                                                             // 40: management.CreateSchematicRequest.MetaValuesEntry
-	(*GetSupportBundleResponse_Progress)(nil),                       // 41: management.GetSupportBundleResponse.Progress
-	(*ValidateJsonSchemaResponse_Error)(nil),                        // 42: management.ValidateJsonSchemaResponse.Error
-	(*durationpb.Duration)(nil),                                     // 43: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                                   // 44: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                                           // 45: google.protobuf.Empty
-	(*common.Data)(nil),                                             // 46: common.Data
+	(*CreateUserRequest)(nil),                                       // 37: management.CreateUserRequest
+	(*CreateUserResponse)(nil),                                      // 38: management.CreateUserResponse
+	(*UpdateUserRequest)(nil),                                       // 39: management.UpdateUserRequest
+	(*DestroyUserRequest)(nil),                                      // 40: management.DestroyUserRequest
+	(*ListUsersResponse)(nil),                                       // 41: management.ListUsersResponse
+	(*ListServiceAccountsResponse_ServiceAccount)(nil),              // 42: management.ListServiceAccountsResponse.ServiceAccount
+	(*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey)(nil), // 43: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
+	(*CreateSchematicRequest_Overlay)(nil),                          // 44: management.CreateSchematicRequest.Overlay
+	nil,                                                             // 45: management.CreateSchematicRequest.MetaValuesEntry
+	(*GetSupportBundleResponse_Progress)(nil),                       // 46: management.GetSupportBundleResponse.Progress
+	(*ValidateJsonSchemaResponse_Error)(nil),                        // 47: management.ValidateJsonSchemaResponse.Error
+	(*ListUsersResponse_User)(nil),                                  // 48: management.ListUsersResponse.User
+	nil,                                                             // 49: management.ListUsersResponse.User.SamlLabelsEntry
+	(*durationpb.Duration)(nil),                                     // 50: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                                   // 51: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                                           // 52: google.protobuf.Empty
+	(*common.Data)(nil),                                             // 53: common.Data
 }
 var file_omni_management_management_proto_depIdxs = []int32{
-	37, // 0: management.ListServiceAccountsResponse.service_accounts:type_name -> management.ListServiceAccountsResponse.ServiceAccount
-	43, // 1: management.KubeconfigRequest.service_account_ttl:type_name -> google.protobuf.Duration
+	42, // 0: management.ListServiceAccountsResponse.service_accounts:type_name -> management.ListServiceAccountsResponse.ServiceAccount
+	50, // 1: management.KubeconfigRequest.service_account_ttl:type_name -> google.protobuf.Duration
 	1,  // 2: management.KubernetesSyncManifestResponse.response_type:type_name -> management.KubernetesSyncManifestResponse.ResponseType
-	40, // 3: management.CreateSchematicRequest.meta_values:type_name -> management.CreateSchematicRequest.MetaValuesEntry
+	45, // 3: management.CreateSchematicRequest.meta_values:type_name -> management.CreateSchematicRequest.MetaValuesEntry
 	2,  // 4: management.CreateSchematicRequest.siderolink_grpc_tunnel_mode:type_name -> management.CreateSchematicRequest.SiderolinkGRPCTunnelMode
-	39, // 5: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
+	44, // 5: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
 	0,  // 6: management.CreateSchematicRequest.bootloader:type_name -> management.SchematicBootloader
-	41, // 7: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
-	42, // 8: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	44, // 9: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
-	38, // 10: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	44, // 11: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
-	42, // 12: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	15, // 13: management.ManagementService.Kubeconfig:input_type -> management.KubeconfigRequest
-	8,  // 14: management.ManagementService.Talosconfig:input_type -> management.TalosconfigRequest
-	45, // 15: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
-	6,  // 16: management.ManagementService.MachineLogs:input_type -> management.MachineLogsRequest
-	7,  // 17: management.ManagementService.ValidateConfig:input_type -> management.ValidateConfigRequest
-	26, // 18: management.ManagementService.ValidateJSONSchema:input_type -> management.ValidateJsonSchemaRequest
-	9,  // 19: management.ManagementService.CreateServiceAccount:input_type -> management.CreateServiceAccountRequest
-	11, // 20: management.ManagementService.RenewServiceAccount:input_type -> management.RenewServiceAccountRequest
-	45, // 21: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
-	13, // 22: management.ManagementService.DestroyServiceAccount:input_type -> management.DestroyServiceAccountRequest
-	16, // 23: management.ManagementService.KubernetesUpgradePreChecks:input_type -> management.KubernetesUpgradePreChecksRequest
-	18, // 24: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
-	20, // 25: management.ManagementService.CreateSchematic:input_type -> management.CreateSchematicRequest
-	22, // 26: management.ManagementService.GetSupportBundle:input_type -> management.GetSupportBundleRequest
-	24, // 27: management.ManagementService.ReadAuditLog:input_type -> management.ReadAuditLogRequest
-	28, // 28: management.ManagementService.MaintenanceUpgrade:input_type -> management.MaintenanceUpgradeRequest
-	30, // 29: management.ManagementService.GetMachineJoinConfig:input_type -> management.GetMachineJoinConfigRequest
-	33, // 30: management.ManagementService.CreateJoinToken:input_type -> management.CreateJoinTokenRequest
-	35, // 31: management.ManagementService.ResetNodeUniqueToken:input_type -> management.ResetNodeUniqueTokenRequest
-	3,  // 32: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
-	4,  // 33: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
-	5,  // 34: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
-	46, // 35: management.ManagementService.MachineLogs:output_type -> common.Data
-	45, // 36: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
-	27, // 37: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
-	10, // 38: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
-	12, // 39: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
-	14, // 40: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
-	45, // 41: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
-	17, // 42: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
-	19, // 43: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
-	21, // 44: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
-	23, // 45: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
-	25, // 46: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
-	29, // 47: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
-	31, // 48: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
-	34, // 49: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
-	36, // 50: management.ManagementService.ResetNodeUniqueToken:output_type -> management.ResetNodeUniqueTokenResponse
-	32, // [32:51] is the sub-list for method output_type
-	13, // [13:32] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	46, // 7: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
+	47, // 8: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	51, // 9: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
+	48, // 10: management.ListUsersResponse.users:type_name -> management.ListUsersResponse.User
+	43, // 11: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
+	51, // 12: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
+	47, // 13: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	49, // 14: management.ListUsersResponse.User.saml_labels:type_name -> management.ListUsersResponse.User.SamlLabelsEntry
+	15, // 15: management.ManagementService.Kubeconfig:input_type -> management.KubeconfigRequest
+	8,  // 16: management.ManagementService.Talosconfig:input_type -> management.TalosconfigRequest
+	52, // 17: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
+	6,  // 18: management.ManagementService.MachineLogs:input_type -> management.MachineLogsRequest
+	7,  // 19: management.ManagementService.ValidateConfig:input_type -> management.ValidateConfigRequest
+	26, // 20: management.ManagementService.ValidateJSONSchema:input_type -> management.ValidateJsonSchemaRequest
+	9,  // 21: management.ManagementService.CreateServiceAccount:input_type -> management.CreateServiceAccountRequest
+	11, // 22: management.ManagementService.RenewServiceAccount:input_type -> management.RenewServiceAccountRequest
+	52, // 23: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
+	13, // 24: management.ManagementService.DestroyServiceAccount:input_type -> management.DestroyServiceAccountRequest
+	16, // 25: management.ManagementService.KubernetesUpgradePreChecks:input_type -> management.KubernetesUpgradePreChecksRequest
+	18, // 26: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
+	20, // 27: management.ManagementService.CreateSchematic:input_type -> management.CreateSchematicRequest
+	22, // 28: management.ManagementService.GetSupportBundle:input_type -> management.GetSupportBundleRequest
+	24, // 29: management.ManagementService.ReadAuditLog:input_type -> management.ReadAuditLogRequest
+	28, // 30: management.ManagementService.MaintenanceUpgrade:input_type -> management.MaintenanceUpgradeRequest
+	30, // 31: management.ManagementService.GetMachineJoinConfig:input_type -> management.GetMachineJoinConfigRequest
+	33, // 32: management.ManagementService.CreateJoinToken:input_type -> management.CreateJoinTokenRequest
+	35, // 33: management.ManagementService.ResetNodeUniqueToken:input_type -> management.ResetNodeUniqueTokenRequest
+	37, // 34: management.ManagementService.CreateUser:input_type -> management.CreateUserRequest
+	52, // 35: management.ManagementService.ListUsers:input_type -> google.protobuf.Empty
+	39, // 36: management.ManagementService.UpdateUser:input_type -> management.UpdateUserRequest
+	40, // 37: management.ManagementService.DestroyUser:input_type -> management.DestroyUserRequest
+	3,  // 38: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
+	4,  // 39: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
+	5,  // 40: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
+	53, // 41: management.ManagementService.MachineLogs:output_type -> common.Data
+	52, // 42: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
+	27, // 43: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
+	10, // 44: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
+	12, // 45: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
+	14, // 46: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
+	52, // 47: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
+	17, // 48: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
+	19, // 49: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
+	21, // 50: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
+	23, // 51: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
+	25, // 52: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
+	29, // 53: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
+	31, // 54: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
+	34, // 55: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
+	36, // 56: management.ManagementService.ResetNodeUniqueToken:output_type -> management.ResetNodeUniqueTokenResponse
+	38, // 57: management.ManagementService.CreateUser:output_type -> management.CreateUserResponse
+	41, // 58: management.ManagementService.ListUsers:output_type -> management.ListUsersResponse
+	52, // 59: management.ManagementService.UpdateUser:output_type -> google.protobuf.Empty
+	52, // 60: management.ManagementService.DestroyUser:output_type -> google.protobuf.Empty
+	38, // [38:61] is the sub-list for method output_type
+	15, // [15:38] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_omni_management_management_proto_init() }
@@ -2609,7 +2957,7 @@ func file_omni_management_management_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_omni_management_management_proto_rawDesc), len(file_omni_management_management_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   40,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/client/api/omni/management/management.pb.gw.go
+++ b/client/api/omni/management/management.pb.gw.go
@@ -533,6 +533,114 @@ func local_request_ManagementService_ResetNodeUniqueToken_0(ctx context.Context,
 	return msg, metadata, err
 }
 
+func request_ManagementService_CreateUser_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateUserRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.CreateUser(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ManagementService_CreateUser_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateUserRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.CreateUser(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ManagementService_ListUsers_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq emptypb.Empty
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListUsers(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ManagementService_ListUsers_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq emptypb.Empty
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListUsers(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ManagementService_UpdateUser_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq UpdateUserRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.UpdateUser(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ManagementService_UpdateUser_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq UpdateUserRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.UpdateUser(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ManagementService_DestroyUser_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DestroyUserRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.DestroyUser(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ManagementService_DestroyUser_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DestroyUserRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.DestroyUser(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterManagementServiceHandlerServer registers the http handlers for service ManagementService to "mux".
 // UnaryRPC     :call ManagementServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -866,6 +974,86 @@ func RegisterManagementServiceHandlerServer(ctx context.Context, mux *runtime.Se
 			return
 		}
 		forward_ManagementService_ResetNodeUniqueToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_CreateUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/CreateUser", runtime.WithHTTPPathPattern("/management.ManagementService/CreateUser"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ManagementService_CreateUser_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_CreateUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_ListUsers_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/ListUsers", runtime.WithHTTPPathPattern("/management.ManagementService/ListUsers"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ManagementService_ListUsers_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_ListUsers_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_UpdateUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/UpdateUser", runtime.WithHTTPPathPattern("/management.ManagementService/UpdateUser"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ManagementService_UpdateUser_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_UpdateUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_DestroyUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/DestroyUser", runtime.WithHTTPPathPattern("/management.ManagementService/DestroyUser"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ManagementService_DestroyUser_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_DestroyUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -1230,6 +1418,74 @@ func RegisterManagementServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_ManagementService_ResetNodeUniqueToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_CreateUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/CreateUser", runtime.WithHTTPPathPattern("/management.ManagementService/CreateUser"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ManagementService_CreateUser_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_CreateUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_ListUsers_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/ListUsers", runtime.WithHTTPPathPattern("/management.ManagementService/ListUsers"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ManagementService_ListUsers_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_ListUsers_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_UpdateUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/UpdateUser", runtime.WithHTTPPathPattern("/management.ManagementService/UpdateUser"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ManagementService_UpdateUser_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_UpdateUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_DestroyUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/DestroyUser", runtime.WithHTTPPathPattern("/management.ManagementService/DestroyUser"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ManagementService_DestroyUser_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_DestroyUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1253,6 +1509,10 @@ var (
 	pattern_ManagementService_GetMachineJoinConfig_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "GetMachineJoinConfig"}, ""))
 	pattern_ManagementService_CreateJoinToken_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "CreateJoinToken"}, ""))
 	pattern_ManagementService_ResetNodeUniqueToken_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "ResetNodeUniqueToken"}, ""))
+	pattern_ManagementService_CreateUser_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "CreateUser"}, ""))
+	pattern_ManagementService_ListUsers_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "ListUsers"}, ""))
+	pattern_ManagementService_UpdateUser_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "UpdateUser"}, ""))
+	pattern_ManagementService_DestroyUser_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "DestroyUser"}, ""))
 )
 
 var (
@@ -1275,4 +1535,8 @@ var (
 	forward_ManagementService_GetMachineJoinConfig_0       = runtime.ForwardResponseMessage
 	forward_ManagementService_CreateJoinToken_0            = runtime.ForwardResponseMessage
 	forward_ManagementService_ResetNodeUniqueToken_0       = runtime.ForwardResponseMessage
+	forward_ManagementService_CreateUser_0                 = runtime.ForwardResponseMessage
+	forward_ManagementService_ListUsers_0                  = runtime.ForwardResponseMessage
+	forward_ManagementService_UpdateUser_0                 = runtime.ForwardResponseMessage
+	forward_ManagementService_DestroyUser_0                = runtime.ForwardResponseMessage
 )

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -244,6 +244,35 @@ message ResetNodeUniqueTokenRequest {
 
 message ResetNodeUniqueTokenResponse {}
 
+message CreateUserRequest {
+  string email = 1;
+  string role = 2;
+}
+
+message CreateUserResponse {
+  string user_id = 1;
+}
+
+message UpdateUserRequest {
+  string email = 1;
+  string role = 2;
+}
+
+message DestroyUserRequest {
+  string email = 1;
+}
+
+message ListUsersResponse {
+  message User {
+    string id = 1;
+    string email = 2;
+    string role = 3;
+    map<string, string> saml_labels = 4;
+  }
+
+  repeated User users = 1;
+}
+
 service ManagementService {
   rpc Kubeconfig(KubeconfigRequest) returns (KubeconfigResponse);
   rpc Talosconfig(TalosconfigRequest) returns (TalosconfigResponse);
@@ -264,4 +293,8 @@ service ManagementService {
   rpc GetMachineJoinConfig(GetMachineJoinConfigRequest) returns (GetMachineJoinConfigResponse);
   rpc CreateJoinToken(CreateJoinTokenRequest) returns (CreateJoinTokenResponse);
   rpc ResetNodeUniqueToken(ResetNodeUniqueTokenRequest) returns (ResetNodeUniqueTokenResponse);
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+  rpc ListUsers(google.protobuf.Empty) returns (ListUsersResponse);
+  rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
+  rpc DestroyUser(DestroyUserRequest) returns (google.protobuf.Empty);
 }

--- a/client/api/omni/management/management_grpc.pb.go
+++ b/client/api/omni/management/management_grpc.pb.go
@@ -41,6 +41,10 @@ const (
 	ManagementService_GetMachineJoinConfig_FullMethodName       = "/management.ManagementService/GetMachineJoinConfig"
 	ManagementService_CreateJoinToken_FullMethodName            = "/management.ManagementService/CreateJoinToken"
 	ManagementService_ResetNodeUniqueToken_FullMethodName       = "/management.ManagementService/ResetNodeUniqueToken"
+	ManagementService_CreateUser_FullMethodName                 = "/management.ManagementService/CreateUser"
+	ManagementService_ListUsers_FullMethodName                  = "/management.ManagementService/ListUsers"
+	ManagementService_UpdateUser_FullMethodName                 = "/management.ManagementService/UpdateUser"
+	ManagementService_DestroyUser_FullMethodName                = "/management.ManagementService/DestroyUser"
 )
 
 // ManagementServiceClient is the client API for ManagementService service.
@@ -66,6 +70,10 @@ type ManagementServiceClient interface {
 	GetMachineJoinConfig(ctx context.Context, in *GetMachineJoinConfigRequest, opts ...grpc.CallOption) (*GetMachineJoinConfigResponse, error)
 	CreateJoinToken(ctx context.Context, in *CreateJoinTokenRequest, opts ...grpc.CallOption) (*CreateJoinTokenResponse, error)
 	ResetNodeUniqueToken(ctx context.Context, in *ResetNodeUniqueTokenRequest, opts ...grpc.CallOption) (*ResetNodeUniqueTokenResponse, error)
+	CreateUser(ctx context.Context, in *CreateUserRequest, opts ...grpc.CallOption) (*CreateUserResponse, error)
+	ListUsers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListUsersResponse, error)
+	UpdateUser(ctx context.Context, in *UpdateUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	DestroyUser(ctx context.Context, in *DestroyUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
 type managementServiceClient struct {
@@ -302,6 +310,46 @@ func (c *managementServiceClient) ResetNodeUniqueToken(ctx context.Context, in *
 	return out, nil
 }
 
+func (c *managementServiceClient) CreateUser(ctx context.Context, in *CreateUserRequest, opts ...grpc.CallOption) (*CreateUserResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateUserResponse)
+	err := c.cc.Invoke(ctx, ManagementService_CreateUser_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *managementServiceClient) ListUsers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListUsersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListUsersResponse)
+	err := c.cc.Invoke(ctx, ManagementService_ListUsers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *managementServiceClient) UpdateUser(ctx context.Context, in *UpdateUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, ManagementService_UpdateUser_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *managementServiceClient) DestroyUser(ctx context.Context, in *DestroyUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, ManagementService_DestroyUser_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ManagementServiceServer is the server API for ManagementService service.
 // All implementations must embed UnimplementedManagementServiceServer
 // for forward compatibility.
@@ -325,6 +373,10 @@ type ManagementServiceServer interface {
 	GetMachineJoinConfig(context.Context, *GetMachineJoinConfigRequest) (*GetMachineJoinConfigResponse, error)
 	CreateJoinToken(context.Context, *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error)
 	ResetNodeUniqueToken(context.Context, *ResetNodeUniqueTokenRequest) (*ResetNodeUniqueTokenResponse, error)
+	CreateUser(context.Context, *CreateUserRequest) (*CreateUserResponse, error)
+	ListUsers(context.Context, *emptypb.Empty) (*ListUsersResponse, error)
+	UpdateUser(context.Context, *UpdateUserRequest) (*emptypb.Empty, error)
+	DestroyUser(context.Context, *DestroyUserRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedManagementServiceServer()
 }
 
@@ -391,6 +443,18 @@ func (UnimplementedManagementServiceServer) CreateJoinToken(context.Context, *Cr
 }
 func (UnimplementedManagementServiceServer) ResetNodeUniqueToken(context.Context, *ResetNodeUniqueTokenRequest) (*ResetNodeUniqueTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ResetNodeUniqueToken not implemented")
+}
+func (UnimplementedManagementServiceServer) CreateUser(context.Context, *CreateUserRequest) (*CreateUserResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateUser not implemented")
+}
+func (UnimplementedManagementServiceServer) ListUsers(context.Context, *emptypb.Empty) (*ListUsersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListUsers not implemented")
+}
+func (UnimplementedManagementServiceServer) UpdateUser(context.Context, *UpdateUserRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateUser not implemented")
+}
+func (UnimplementedManagementServiceServer) DestroyUser(context.Context, *DestroyUserRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method DestroyUser not implemented")
 }
 func (UnimplementedManagementServiceServer) mustEmbedUnimplementedManagementServiceServer() {}
 func (UnimplementedManagementServiceServer) testEmbeddedByValue()                           {}
@@ -727,6 +791,78 @@ func _ManagementService_ResetNodeUniqueToken_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ManagementService_CreateUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateUserRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).CreateUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_CreateUser_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).CreateUser(ctx, req.(*CreateUserRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ManagementService_ListUsers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(emptypb.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).ListUsers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_ListUsers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).ListUsers(ctx, req.(*emptypb.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ManagementService_UpdateUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateUserRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).UpdateUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_UpdateUser_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).UpdateUser(ctx, req.(*UpdateUserRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ManagementService_DestroyUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DestroyUserRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).DestroyUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_DestroyUser_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).DestroyUser(ctx, req.(*DestroyUserRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ManagementService_ServiceDesc is the grpc.ServiceDesc for ManagementService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -793,6 +929,22 @@ var ManagementService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ResetNodeUniqueToken",
 			Handler:    _ManagementService_ResetNodeUniqueToken_Handler,
+		},
+		{
+			MethodName: "CreateUser",
+			Handler:    _ManagementService_CreateUser_Handler,
+		},
+		{
+			MethodName: "ListUsers",
+			Handler:    _ManagementService_ListUsers_Handler,
+		},
+		{
+			MethodName: "UpdateUser",
+			Handler:    _ManagementService_UpdateUser_Handler,
+		},
+		{
+			MethodName: "DestroyUser",
+			Handler:    _ManagementService_DestroyUser_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -804,6 +804,125 @@ func (m *ResetNodeUniqueTokenResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *CreateUserRequest) CloneVT() *CreateUserRequest {
+	if m == nil {
+		return (*CreateUserRequest)(nil)
+	}
+	r := new(CreateUserRequest)
+	r.Email = m.Email
+	r.Role = m.Role
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateUserRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *CreateUserResponse) CloneVT() *CreateUserResponse {
+	if m == nil {
+		return (*CreateUserResponse)(nil)
+	}
+	r := new(CreateUserResponse)
+	r.UserId = m.UserId
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateUserResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *UpdateUserRequest) CloneVT() *UpdateUserRequest {
+	if m == nil {
+		return (*UpdateUserRequest)(nil)
+	}
+	r := new(UpdateUserRequest)
+	r.Email = m.Email
+	r.Role = m.Role
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *UpdateUserRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *DestroyUserRequest) CloneVT() *DestroyUserRequest {
+	if m == nil {
+		return (*DestroyUserRequest)(nil)
+	}
+	r := new(DestroyUserRequest)
+	r.Email = m.Email
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DestroyUserRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ListUsersResponse_User) CloneVT() *ListUsersResponse_User {
+	if m == nil {
+		return (*ListUsersResponse_User)(nil)
+	}
+	r := new(ListUsersResponse_User)
+	r.Id = m.Id
+	r.Email = m.Email
+	r.Role = m.Role
+	if rhs := m.SamlLabels; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.SamlLabels = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ListUsersResponse_User) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ListUsersResponse) CloneVT() *ListUsersResponse {
+	if m == nil {
+		return (*ListUsersResponse)(nil)
+	}
+	r := new(ListUsersResponse)
+	if rhs := m.Users; rhs != nil {
+		tmpContainer := make([]*ListUsersResponse_User, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Users = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ListUsersResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *KubeconfigResponse) EqualVT(that *KubeconfigResponse) bool {
 	if this == that {
 		return true
@@ -1770,6 +1889,158 @@ func (this *ResetNodeUniqueTokenResponse) EqualVT(that *ResetNodeUniqueTokenResp
 
 func (this *ResetNodeUniqueTokenResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*ResetNodeUniqueTokenResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *CreateUserRequest) EqualVT(that *CreateUserRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Email != that.Email {
+		return false
+	}
+	if this.Role != that.Role {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateUserRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateUserRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *CreateUserResponse) EqualVT(that *CreateUserResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.UserId != that.UserId {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateUserResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateUserResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *UpdateUserRequest) EqualVT(that *UpdateUserRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Email != that.Email {
+		return false
+	}
+	if this.Role != that.Role {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *UpdateUserRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*UpdateUserRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *DestroyUserRequest) EqualVT(that *DestroyUserRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Email != that.Email {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *DestroyUserRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DestroyUserRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ListUsersResponse_User) EqualVT(that *ListUsersResponse_User) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Id != that.Id {
+		return false
+	}
+	if this.Email != that.Email {
+		return false
+	}
+	if this.Role != that.Role {
+		return false
+	}
+	if len(this.SamlLabels) != len(that.SamlLabels) {
+		return false
+	}
+	for i, vx := range this.SamlLabels {
+		vy, ok := that.SamlLabels[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ListUsersResponse_User) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ListUsersResponse_User)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ListUsersResponse) EqualVT(that *ListUsersResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if len(this.Users) != len(that.Users) {
+		return false
+	}
+	for i, vx := range this.Users {
+		vy := that.Users[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ListUsersResponse_User{}
+			}
+			if q == nil {
+				q = &ListUsersResponse_User{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ListUsersResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ListUsersResponse)
 	if !ok {
 		return false
 	}
@@ -3741,6 +4012,298 @@ func (m *ResetNodeUniqueTokenResponse) MarshalToSizedBufferVT(dAtA []byte) (int,
 	return len(dAtA) - i, nil
 }
 
+func (m *CreateUserRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateUserRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateUserRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Role) > 0 {
+		i -= len(m.Role)
+		copy(dAtA[i:], m.Role)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Role)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Email) > 0 {
+		i -= len(m.Email)
+		copy(dAtA[i:], m.Email)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Email)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *CreateUserResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateUserResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateUserResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.UserId) > 0 {
+		i -= len(m.UserId)
+		copy(dAtA[i:], m.UserId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.UserId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *UpdateUserRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *UpdateUserRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *UpdateUserRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Role) > 0 {
+		i -= len(m.Role)
+		copy(dAtA[i:], m.Role)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Role)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Email) > 0 {
+		i -= len(m.Email)
+		copy(dAtA[i:], m.Email)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Email)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DestroyUserRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DestroyUserRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DestroyUserRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Email) > 0 {
+		i -= len(m.Email)
+		copy(dAtA[i:], m.Email)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Email)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ListUsersResponse_User) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListUsersResponse_User) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ListUsersResponse_User) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.SamlLabels) > 0 {
+		for k := range m.SamlLabels {
+			v := m.SamlLabels[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.Role) > 0 {
+		i -= len(m.Role)
+		copy(dAtA[i:], m.Role)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Role)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Email) > 0 {
+		i -= len(m.Email)
+		copy(dAtA[i:], m.Email)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Email)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ListUsersResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ListUsersResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ListUsersResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Users) > 0 {
+		for iNdEx := len(m.Users) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Users[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *KubeconfigResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -4473,6 +5036,116 @@ func (m *ResetNodeUniqueTokenResponse) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *CreateUserRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Email)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Role)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *CreateUserResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.UserId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *UpdateUserRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Email)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Role)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DestroyUserRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Email)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ListUsersResponse_User) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Email)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Role)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.SamlLabels) > 0 {
+		for k, v := range m.SamlLabels {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ListUsersResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Users) > 0 {
+		for _, e := range m.Users {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -9095,6 +9768,761 @@ func (m *ResetNodeUniqueTokenResponse) UnmarshalVT(dAtA []byte) error {
 			return fmt.Errorf("proto: ResetNodeUniqueTokenResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateUserRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateUserRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateUserRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Email", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Email = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Role", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Role = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateUserResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateUserResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateUserResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UserId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UserId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *UpdateUserRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: UpdateUserRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: UpdateUserRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Email", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Email = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Role", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Role = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DestroyUserRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DestroyUserRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DestroyUserRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Email", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Email = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListUsersResponse_User) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListUsersResponse_User: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListUsersResponse_User: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Email", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Email = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Role", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Role = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SamlLabels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SamlLabels == nil {
+				m.SamlLabels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.SamlLabels[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListUsersResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListUsersResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListUsersResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Users", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Users = append(m.Users, &ListUsersResponse_User{})
+			if err := m.Users[len(m.Users)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/client/management/management.go
+++ b/client/pkg/client/management/management.go
@@ -186,6 +186,48 @@ func (client *Client) DestroyServiceAccount(ctx context.Context, name string) er
 	return err
 }
 
+// CreateUser creates a user and returns the user ID.
+func (client *Client) CreateUser(ctx context.Context, email, role string) (string, error) {
+	resp, err := client.conn.CreateUser(ctx, &management.CreateUserRequest{
+		Email: email,
+		Role:  role,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.UserId, nil
+}
+
+// ListUsers lists all users.
+func (client *Client) ListUsers(ctx context.Context) ([]*management.ListUsersResponse_User, error) {
+	response, err := client.conn.ListUsers(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, err
+	}
+
+	return response.GetUsers(), nil
+}
+
+// UpdateUser updates the role of the user with the given email.
+func (client *Client) UpdateUser(ctx context.Context, email, role string) error {
+	_, err := client.conn.UpdateUser(ctx, &management.UpdateUserRequest{
+		Email: email,
+		Role:  role,
+	})
+
+	return err
+}
+
+// DestroyUser deletes a user.
+func (client *Client) DestroyUser(ctx context.Context, email string) error {
+	_, err := client.conn.DestroyUser(ctx, &management.DestroyUserRequest{
+		Email: email,
+	})
+
+	return err
+}
+
 // GetSupportBundle generates support bundle on Omni server and returns it to the client.
 func (client *Client) GetSupportBundle(ctx context.Context, cluster string, progress chan *management.GetSupportBundleResponse_Progress) ([]byte, error) {
 	if progress != nil {

--- a/client/pkg/omnictl/user/list.go
+++ b/client/pkg/omnictl/user/list.go
@@ -12,13 +12,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/cosi-project/runtime/pkg/resource"
-	"github.com/cosi-project/runtime/pkg/safe"
-	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/omni/client/pkg/client"
-	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omnictl/internal/access"
 )
 
@@ -35,75 +31,43 @@ var listCmd = &cobra.Command{
 }
 
 func listUsers(ctx context.Context, client *client.Client) error {
-	identities, err := safe.ReaderListAll[*auth.Identity](ctx, client.Omni().State(), state.WithLabelQuery(
-		resource.LabelExists(auth.LabelIdentityTypeServiceAccount, resource.NotMatches),
-	))
+	users, err := client.Management().ListUsers(ctx)
 	if err != nil {
 		return err
 	}
-
-	type user struct {
-		id     string
-		email  string
-		role   string
-		labels string
-	}
-
-	users, err := safe.ReaderListAll[*auth.User](ctx, client.Omni().State())
-	if err != nil {
-		return err
-	}
-
-	userList := safe.ToSlice(identities, func(identity *auth.Identity) user {
-		res := user{
-			id:    identity.TypedSpec().Value.UserId,
-			email: identity.Metadata().ID(),
-		}
-
-		u, found := users.Find(func(user *auth.User) bool {
-			return user.Metadata().ID() == identity.TypedSpec().Value.UserId
-		})
-		if !found {
-			return res
-		}
-
-		res.role = u.TypedSpec().Value.Role
-
-		allLabels := identity.Metadata().Labels().Raw()
-
-		samlLabels := make([]string, 0, len(allLabels))
-
-		for key, value := range allLabels {
-			if !strings.HasPrefix(key, auth.SAMLLabelPrefix) {
-				continue
-			}
-
-			samlLabels = append(samlLabels, strings.TrimPrefix(key, auth.SAMLLabelPrefix)+"="+value)
-		}
-
-		slices.Sort(samlLabels)
-
-		res.labels = strings.Join(samlLabels, ", ")
-
-		return res
-	})
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	defer w.Flush() //nolint:errcheck
 
-	_, err = fmt.Fprintln(w, "ID\tEMAIL\tROLE\tLABELS")
-	if err != nil {
+	if _, err = fmt.Fprintln(w, "ID\tEMAIL\tROLE\tLABELS"); err != nil {
 		return err
 	}
 
-	for _, user := range userList {
-		_, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", user.id, user.email, user.role, user.labels)
-		if err != nil {
+	for _, user := range users {
+		labels := formatSAMLLabels(user.SamlLabels)
+
+		if _, err = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", user.Id, user.Email, user.Role, labels); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func formatSAMLLabels(labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+
+	result := make([]string, 0, len(labels))
+
+	for key, value := range labels {
+		result = append(result, key+"="+value)
+	}
+
+	slices.Sort(result)
+
+	return strings.Join(result, ", ")
 }
 
 func init() {

--- a/client/pkg/omnictl/user/set_role.go
+++ b/client/pkg/omnictl/user/set_role.go
@@ -7,11 +7,9 @@ package user
 import (
 	"context"
 
-	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/spf13/cobra"
 
 	"github.com/siderolabs/omni/client/pkg/client"
-	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omnictl/internal/access"
 )
 
@@ -33,24 +31,7 @@ var setRoleCmd = &cobra.Command{
 
 func setUserRole(email string) func(ctx context.Context, client *client.Client) error {
 	return func(ctx context.Context, client *client.Client) error {
-		identity, err := safe.ReaderGetByID[*auth.Identity](ctx, client.Omni().State(), email)
-		if err != nil {
-			return err
-		}
-
-		_, err = safe.StateUpdateWithConflicts(ctx, client.Omni().State(),
-			auth.NewUser(identity.TypedSpec().Value.UserId).Metadata(),
-			func(user *auth.User) error {
-				user.TypedSpec().Value.Role = setRoleCmdFlags.role
-
-				return nil
-			},
-		)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return client.Management().UpdateUser(ctx, email, setRoleCmdFlags.role)
 	}
 }
 

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -232,6 +232,35 @@ export type ResetNodeUniqueTokenRequest = {
 export type ResetNodeUniqueTokenResponse = {
 }
 
+export type CreateUserRequest = {
+  email?: string
+  role?: string
+}
+
+export type CreateUserResponse = {
+  user_id?: string
+}
+
+export type UpdateUserRequest = {
+  email?: string
+  role?: string
+}
+
+export type DestroyUserRequest = {
+  email?: string
+}
+
+export type ListUsersResponseUser = {
+  id?: string
+  email?: string
+  role?: string
+  saml_labels?: {[key: string]: string}
+}
+
+export type ListUsersResponse = {
+  users?: ListUsersResponseUser[]
+}
+
 export class ManagementService {
   static Kubeconfig(req: KubeconfigRequest, ...options: fm.fetchOption[]): Promise<KubeconfigResponse> {
     return fm.fetchReq<KubeconfigRequest, KubeconfigResponse>("POST", `/management.ManagementService/Kubeconfig`, req, ...options)
@@ -289,5 +318,17 @@ export class ManagementService {
   }
   static ResetNodeUniqueToken(req: ResetNodeUniqueTokenRequest, ...options: fm.fetchOption[]): Promise<ResetNodeUniqueTokenResponse> {
     return fm.fetchReq<ResetNodeUniqueTokenRequest, ResetNodeUniqueTokenResponse>("POST", `/management.ManagementService/ResetNodeUniqueToken`, req, ...options)
+  }
+  static CreateUser(req: CreateUserRequest, ...options: fm.fetchOption[]): Promise<CreateUserResponse> {
+    return fm.fetchReq<CreateUserRequest, CreateUserResponse>("POST", `/management.ManagementService/CreateUser`, req, ...options)
+  }
+  static ListUsers(req: GoogleProtobufEmpty.Empty, ...options: fm.fetchOption[]): Promise<ListUsersResponse> {
+    return fm.fetchReq<GoogleProtobufEmpty.Empty, ListUsersResponse>("POST", `/management.ManagementService/ListUsers`, req, ...options)
+  }
+  static UpdateUser(req: UpdateUserRequest, ...options: fm.fetchOption[]): Promise<GoogleProtobufEmpty.Empty> {
+    return fm.fetchReq<UpdateUserRequest, GoogleProtobufEmpty.Empty>("POST", `/management.ManagementService/UpdateUser`, req, ...options)
+  }
+  static DestroyUser(req: DestroyUserRequest, ...options: fm.fetchOption[]): Promise<GoogleProtobufEmpty.Empty> {
+    return fm.fetchReq<DestroyUserRequest, GoogleProtobufEmpty.Empty>("POST", `/management.ManagementService/DestroyUser`, req, ...options)
   }
 }

--- a/frontend/src/methods/user.ts
+++ b/frontend/src/methods/user.ts
@@ -4,95 +4,15 @@
 // included in the LICENSE file.
 
 import { enums, generateKey } from 'openpgp/lightweight'
-import { v4 as uuidv4 } from 'uuid'
 
-import { Runtime } from '@/api/common/omni.pb'
-import { Code } from '@/api/google/rpc/code.pb'
-import type { Resource } from '@/api/grpc'
-import { ResourceService } from '@/api/grpc'
 import { ManagementService } from '@/api/omni/management/management.pb'
-import type { UserSpec } from '@/api/omni/specs/auth.pb'
-import type { IdentitySpec } from '@/api/omni/specs/auth.pb'
-import { withRuntime } from '@/api/options'
 import {
-  DefaultNamespace,
-  IdentityType,
   InfraProviderServiceAccountDomain,
-  LabelIdentityUserID,
   RoleInfraProvider,
   ServiceAccountDomain,
-  UserType,
 } from '@/api/resources'
 
 import { isoNow } from './time'
-
-export const createUser = async (email: string, role: string) => {
-  const user: Resource<UserSpec> = {
-    metadata: {
-      id: uuidv4(),
-      namespace: DefaultNamespace,
-      type: UserType,
-    },
-    spec: {
-      role: role,
-    },
-  }
-
-  const identity: Resource<IdentitySpec> = {
-    metadata: {
-      id: email.toLowerCase(),
-      namespace: DefaultNamespace,
-      type: IdentityType,
-      labels: {
-        [LabelIdentityUserID]: user.metadata.id as string,
-      },
-    },
-    spec: {
-      user_id: user.metadata.id as string,
-    },
-  }
-
-  let identityExists = true
-  try {
-    await ResourceService.Get(
-      {
-        id: identity.metadata.id,
-        namespace: DefaultNamespace,
-        type: identity.metadata.type,
-      },
-      withRuntime(Runtime.Omni),
-    )
-  } catch (e) {
-    if (e.code !== Code.NOT_FOUND) {
-      throw e
-    }
-
-    identityExists = false
-  }
-
-  if (identityExists) {
-    throw new Error(`The email ${identity.metadata.id} is already in use`)
-  }
-
-  await ResourceService.Create(user, withRuntime(Runtime.Omni))
-
-  await ResourceService.Create(identity, withRuntime(Runtime.Omni))
-}
-
-export const updateRole = async (userID: string, role: string) => {
-  const user = await ResourceService.Get(
-    {
-      id: userID,
-      namespace: DefaultNamespace,
-      type: UserType,
-    },
-    withRuntime(Runtime.Omni),
-  )
-
-  user.spec.role = role
-
-  await ResourceService.Update(user, undefined, withRuntime(Runtime.Omni))
-}
 
 export const createJoinToken = async (name: string, expirationDays?: number) => {
   let expirationTime: string | undefined

--- a/frontend/src/views/omni/Modals/RoleEdit.vue
+++ b/frontend/src/views/omni/Modals/RoleEdit.vue
@@ -11,6 +11,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { type Resource, ResourceService } from '@/api/grpc'
+import { ManagementService } from '@/api/omni/management/management.pb'
 import type { IdentitySpec, UserSpec } from '@/api/omni/specs/auth.pb'
 import { withRuntime } from '@/api/options'
 import {
@@ -25,7 +26,6 @@ import {
 import TButton from '@/components/common/Button/TButton.vue'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
 import { canManageUsers } from '@/methods/auth'
-import { updateRole } from '@/methods/user'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showSuccess } from '@/notification'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
@@ -82,7 +82,7 @@ const handleRoleUpdate = async () => {
   }
 
   try {
-    await updateRole(userID.value, role.value)
+    await ManagementService.UpdateUser({ email: id as string, role: role.value })
   } catch (e) {
     showError(`Failed to Update ${object}`, e.message)
 

--- a/frontend/src/views/omni/Modals/UserCreate.vue
+++ b/frontend/src/views/omni/Modals/UserCreate.vue
@@ -9,13 +9,13 @@ import type { Ref } from 'vue'
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 
+import { ManagementService } from '@/api/omni/management/management.pb'
 import { RoleAdmin, RoleNone, RoleOperator, RoleReader } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import { AuthType, authType } from '@/methods'
 import { canManageUsers } from '@/methods/auth'
-import { createUser } from '@/methods/user'
 import { showError, showSuccess } from '@/notification'
 import CloseButton from '@/views/omni/Modals/CloseButton.vue'
 
@@ -34,7 +34,7 @@ const handleUserCreate = async () => {
   }
 
   try {
-    await createUser(identity.value, role.value)
+    await ManagementService.CreateUser({ email: identity.value, role: role.value })
   } catch (e) {
     showError('Failed to Create User', e.message)
 

--- a/internal/backend/grpc/grpc.go
+++ b/internal/backend/grpc/grpc.go
@@ -91,7 +91,7 @@ func MakeServiceServers(
 			provider: oidcProvider,
 		},
 		newManagementServer(
-			state,
+			omniRuntime.ValidatedState(),
 			jwtSigningKeyProvider,
 			logHandler,
 			logger.With(logging.Component("management_server")),

--- a/internal/backend/grpc/user.go
+++ b/internal/backend/grpc/user.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/siderolabs/omni/client/api/omni/management"
+	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/role"
+	"github.com/siderolabs/omni/internal/pkg/auth/user"
+)
+
+func (s *managementServer) CreateUser(ctx context.Context, req *management.CreateUserRequest) (*management.CreateUserResponse, error) {
+	if _, err := s.authCheckGRPC(ctx, auth.WithRole(role.Admin)); err != nil {
+		return nil, err
+	}
+
+	userID, err := user.Create(ctx, s.omniState, req.Email, req.Role)
+	if err != nil {
+		return nil, wrapError(err)
+	}
+
+	return &management.CreateUserResponse{UserId: userID}, nil
+}
+
+func (s *managementServer) UpdateUser(ctx context.Context, req *management.UpdateUserRequest) (*emptypb.Empty, error) {
+	checkResult, err := s.authCheckGRPC(ctx, auth.WithRole(role.Admin))
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.EqualFold(checkResult.Identity, req.Email) {
+		return nil, status.Error(codes.InvalidArgument, "updating your own role is not allowed")
+	}
+
+	if err := user.Update(ctx, s.omniState, req.Email, req.Role); err != nil {
+		return nil, wrapError(err)
+	}
+
+	return &emptypb.Empty{}, nil
+}
+
+func (s *managementServer) ListUsers(ctx context.Context, _ *emptypb.Empty) (*management.ListUsersResponse, error) {
+	if _, err := s.authCheckGRPC(ctx, auth.WithRole(role.Admin)); err != nil {
+		return nil, err
+	}
+
+	identities, err := safe.StateListAll[*authres.Identity](ctx, s.omniState, state.WithLabelQuery(
+		resource.LabelExists(authres.LabelIdentityTypeServiceAccount, resource.NotMatches),
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	users, err := safe.StateListAll[*authres.User](ctx, s.omniState)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*management.ListUsersResponse_User, 0, identities.Len())
+
+	for identity := range identities.All() {
+		u := &management.ListUsersResponse_User{
+			Id:    identity.TypedSpec().Value.UserId,
+			Email: identity.Metadata().ID(),
+		}
+
+		foundUser, found := users.Find(func(usr *authres.User) bool {
+			return usr.Metadata().ID() == identity.TypedSpec().Value.UserId
+		})
+		if found {
+			u.Role = foundUser.TypedSpec().Value.Role
+		}
+
+		samlLabels := map[string]string{}
+
+		for key, value := range identity.Metadata().Labels().Raw() {
+			if !strings.HasPrefix(key, authres.SAMLLabelPrefix) {
+				continue
+			}
+
+			samlLabels[strings.TrimPrefix(key, authres.SAMLLabelPrefix)] = value
+		}
+
+		if len(samlLabels) > 0 {
+			u.SamlLabels = samlLabels
+		}
+
+		result = append(result, u)
+	}
+
+	return &management.ListUsersResponse{Users: result}, nil
+}
+
+func (s *managementServer) DestroyUser(ctx context.Context, req *management.DestroyUserRequest) (*emptypb.Empty, error) {
+	checkResult, err := s.authCheckGRPC(ctx, auth.WithRole(role.Admin))
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.EqualFold(checkResult.Identity, req.Email) {
+		return nil, status.Error(codes.InvalidArgument, "destroying your own account is not allowed")
+	}
+
+	err = user.Destroy(ctx, s.omniState, req.Email)
+
+	switch {
+	case state.IsNotFoundError(err):
+		return nil, status.Errorf(codes.NotFound, "user %q not found", req.Email)
+	case errors.Is(err, user.ErrIsServiceAccount):
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	case err != nil:
+		return nil, wrapError(err)
+	}
+
+	return &emptypb.Empty{}, nil
+}

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -334,7 +334,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		clusterValidationOptions(defaultState, cfg.EtcdBackup, cfg.Services.EmbeddedDiscoveryService),
 		relationLabelsValidationOptions(),
 		accessPolicyValidationOptions(),
-		authorizationValidationOptions(defaultState, cfg.Auth.Saml.GetEnabled()),
+		authorizationValidationOptions(defaultState),
 		roleValidationOptions(),
 		machineSetNodeValidationOptions(defaultState),
 		machineSetValidationOptions(defaultState, storeFactory),
@@ -634,6 +634,11 @@ func (r *Runtime) Delete(ctx context.Context, setters ...runtime.QueryOption) er
 	}
 
 	return r.state.TeardownAndDestroy(ctx, md)
+}
+
+// ValidatedState returns the validated runtime state.
+func (r *Runtime) ValidatedState() state.State { //nolint:ireturn
+	return r.state
 }
 
 // CachedState returns runtime cached state.

--- a/internal/integration/suites_test.go
+++ b/internal/integration/suites_test.go
@@ -1196,6 +1196,11 @@ Test authorization on accessing Omni API, some tests run without a cluster, some
 			AssertServiceAccountAPIFlow(t.Context(), options.omniClient),
 		)
 
+		t.Run(
+			"UserManagementAPIShouldWork",
+			AssertUserManagementAPIFlow(t.Context(), options.omniClient),
+		)
+
 		clientFactory := newTestClientFactory(omniEndpoint, options.omniClient)
 		t.Cleanup(func() {
 			clientFactory.close() //nolint:errcheck

--- a/internal/pkg/auth/user/user.go
+++ b/internal/pkg/auth/user/user.go
@@ -8,9 +8,11 @@ package user
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/google/uuid"
@@ -18,8 +20,12 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
+
+// ErrIsServiceAccount is returned when an operation is attempted on a service account identity.
+var ErrIsServiceAccount = errors.New("identity is a service account, not a user")
 
 // EnsureInitialResources creates the auth.User and auth.Identity resources if they are not present.
 func EnsureInitialResources(ctx context.Context, st state.State, logger *zap.Logger, initialUsers []string) error {
@@ -45,8 +51,107 @@ func EnsureInitialResources(ctx context.Context, st state.State, logger *zap.Log
 	return multiErr
 }
 
+// Create creates a new user with the given email and role.
+// It returns the user ID. It fails if a user with the given email already exists.
+func Create(ctx context.Context, st state.State, email, userRole string) (string, error) {
+	email = strings.ToLower(email)
+
+	parsedRole, err := role.Parse(userRole)
+	if err != nil {
+		return "", err
+	}
+
+	ctx = actor.MarkContextAsInternalActor(ctx)
+
+	_, err = st.Get(ctx, auth.NewIdentity(email).Metadata())
+	if err == nil {
+		return "", fmt.Errorf("user with email %q already exists", email)
+	}
+
+	if !state.IsNotFoundError(err) {
+		return "", err
+	}
+
+	return createIdentityAndUser(ctx, st, email, parsedRole)
+}
+
+// Update updates the role of the user with the given email.
+func Update(ctx context.Context, st state.State, email, userRole string) error {
+	email = strings.ToLower(email)
+
+	parsedRole, err := role.Parse(userRole)
+	if err != nil {
+		return err
+	}
+
+	ctx = actor.MarkContextAsInternalActor(ctx)
+
+	identity, err := safe.StateGet[*auth.Identity](ctx, st, auth.NewIdentity(email).Metadata())
+	if err != nil {
+		return err
+	}
+
+	_, err = safe.StateUpdateWithConflicts(ctx, st,
+		auth.NewUser(identity.TypedSpec().Value.UserId).Metadata(),
+		func(user *auth.User) error {
+			user.TypedSpec().Value.Role = string(parsedRole)
+
+			return nil
+		},
+	)
+
+	return err
+}
+
+// Destroy destroys the user with the given email, cleaning up Identity and User resources.
+func Destroy(ctx context.Context, st state.State, email string) error {
+	email = strings.ToLower(email)
+
+	ctx = actor.MarkContextAsInternalActor(ctx)
+
+	identity, err := safe.StateGet[*auth.Identity](ctx, st, auth.NewIdentity(email).Metadata())
+	if err != nil {
+		return err
+	}
+
+	// Ensure this is not a service account.
+	_, isServiceAccount := identity.Metadata().Labels().Get(auth.LabelIdentityTypeServiceAccount)
+	if isServiceAccount {
+		return fmt.Errorf("identity %q: %w", email, ErrIsServiceAccount)
+	}
+
+	// Destroy public keys associated with the user.
+	pubKeys, err := st.List(
+		ctx,
+		auth.NewPublicKey("").Metadata(),
+		state.WithLabelQuery(resource.LabelEqual(auth.LabelPublicKeyUserID, identity.TypedSpec().Value.UserId)),
+	)
+	if err != nil {
+		return err
+	}
+
+	var destroyErr error
+
+	for _, pubKey := range pubKeys.Items {
+		if err = st.TeardownAndDestroy(ctx, pubKey.Metadata()); err != nil && !state.IsNotFoundError(err) {
+			destroyErr = multierror.Append(destroyErr, err)
+		}
+	}
+
+	if err = st.TeardownAndDestroy(ctx, identity.Metadata()); err != nil && !state.IsNotFoundError(err) {
+		destroyErr = multierror.Append(destroyErr, err)
+	}
+
+	if err = st.TeardownAndDestroy(ctx, auth.NewUser(identity.TypedSpec().Value.UserId).Metadata()); err != nil && !state.IsNotFoundError(err) {
+		destroyErr = multierror.Append(destroyErr, err)
+	}
+
+	return destroyErr
+}
+
 // Ensure creates the auth.User and auth.Identity resources with the given role if they are not already present.
-func Ensure(ctx context.Context, st state.State, email string, role role.Role, updateRole bool) error {
+// If the user already exists and updateRole is true, it updates the role.
+func Ensure(ctx context.Context, st state.State, email string, r role.Role, updateRole bool) error {
 	email = strings.ToLower(email)
 
 	identity, err := safe.StateGet[*auth.Identity](ctx, st, auth.NewIdentity(email).Metadata())
@@ -55,34 +160,45 @@ func Ensure(ctx context.Context, st state.State, email string, role role.Role, u
 			return err
 		}
 
-		newUserID := uuid.New().String()
+		// User does not exist, create it.
+		_, createErr := createIdentityAndUser(ctx, st, email, r)
 
-		identity = auth.NewIdentity(email)
-		identity.TypedSpec().Value.UserId = newUserID
-		identity.Metadata().Labels().Set(auth.LabelIdentityUserID, newUserID)
-
-		err = st.Create(ctx, identity)
-		if err != nil {
-			return fmt.Errorf("failed to create Identity resource %s: %w", identity.Metadata().ID(), err)
-		}
+		return createErr
 	}
 
-	user := auth.NewUser(identity.TypedSpec().Value.UserId)
-
-	user.TypedSpec().Value.Role = string(role)
-
-	if updateRole {
-		return safe.StateModify(ctx, st, user, func(res *auth.User) error {
-			res.TypedSpec().Value = user.TypedSpec().Value
-
-			return nil
-		})
+	// User already exists.
+	if !updateRole {
+		return nil
 	}
 
-	err = st.Create(ctx, user)
-	if err != nil && !state.IsConflictError(err) {
-		return err
+	return safe.StateModify(ctx, st, auth.NewUser(identity.TypedSpec().Value.UserId), func(res *auth.User) error {
+		res.TypedSpec().Value.Role = string(r)
+
+		return nil
+	})
+}
+
+// createIdentityAndUser creates the Identity and User resources for a new user.
+// It cleans up the Identity if User creation fails.
+func createIdentityAndUser(ctx context.Context, st state.State, email string, r role.Role) (string, error) {
+	newUserID := uuid.NewString()
+
+	identity := auth.NewIdentity(email)
+	identity.TypedSpec().Value.UserId = newUserID
+	identity.Metadata().Labels().Set(auth.LabelIdentityUserID, newUserID)
+
+	if err := st.Create(ctx, identity); err != nil {
+		return "", fmt.Errorf("failed to create Identity resource %s: %w", identity.Metadata().ID(), err)
 	}
 
-	return nil
+	user := auth.NewUser(newUserID)
+	user.TypedSpec().Value.Role = string(r)
+
+	if err := st.Create(ctx, user); err != nil {
+		_ = st.Destroy(ctx, identity.Metadata()) //nolint:errcheck // best-effort cleanup
+
+		return "", err
+	}
+
+	return newUserID, nil
 }


### PR DESCRIPTION
Migrate user create, list, update, and destroy operations from direct resource manipulation to dedicated ManagementService gRPC endpoints, matching the existing service account pattern.
Direct Identity/User resource mutations are now restricted, and the CLI, frontend, and client library are updated to use the new endpoints.
