### PR TITLE
feat: implement saml logout flow

### DIFF
--- a/internal/backend/saml/saml.go
+++ b/internal/backend/saml/saml.go
@@ -8,10 +8,13 @@ package saml
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/crewjam/saml"
@@ -23,6 +26,16 @@ import (
 	"github.com/siderolabs/omni/internal/backend/logging"
 	"github.com/siderolabs/omni/internal/backend/monitoring"
 )
+
+// NameIDCookieName is the cookie used to store the SAML session data for SLO.
+const NameIDCookieName = "saml_name_id"
+
+// sloSessionData holds the SAML assertion fields needed to build a LogoutRequest.
+type sloSessionData struct {
+	NameID       string `json:"n"`
+	Format       string `json:"f,omitempty"`
+	SessionIndex string `json:"s,omitempty"`
+}
 
 // NewHandler creates new SAML handler.
 func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.Logger, apiURL string) (*samlsp.Middleware, error) {
@@ -39,7 +52,7 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 	opts := samlsp.Options{
 		URL:               *rootURL,
 		IDPMetadata:       idpMetadata,
-		LogoutBindings:    []string{saml.HTTPPostBinding},
+		LogoutBindings:    []string{saml.HTTPRedirectBinding, saml.HTTPPostBinding},
 		AllowIDPInitiated: true,
 	}
 
@@ -55,7 +68,7 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 	m := &samlsp.Middleware{
 		ServiceProvider: serviceProvider,
 		ResponseBinding: saml.HTTPPostBinding,
-		OnError:         createErrorHandler(logger),
+		OnError:         createErrorHandler(logger, apiURL),
 		Session: NewSessionProvider(
 			state,
 			requestTracker,
@@ -69,15 +82,15 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 	return m, nil
 }
 
-// RegisterHandlers adds login and logout handlers.
-func RegisterHandlers(saml *samlsp.Middleware, mux *http.ServeMux, logger *zap.Logger) {
+// RegisterHandlers adds SAML handlers for ACS, metadata, and SLO.
+func RegisterHandlers(m *samlsp.Middleware, mux *http.ServeMux, logger *zap.Logger, advertisedURL string) {
 	logger = logger.With(zap.String("handler", "saml"))
 
-	md := http.HandlerFunc(saml.ServeMetadata)
+	md := http.HandlerFunc(m.ServeMetadata)
 	promLabel := prometheus.Labels{"handler": "saml"}
 
 	mux.Handle("/saml/", monitoring.NewHandler(
-		logging.NewHandler(saml, logger),
+		logging.NewHandler(m, logger),
 		promLabel,
 	))
 
@@ -85,6 +98,116 @@ func RegisterHandlers(saml *samlsp.Middleware, mux *http.ServeMux, logger *zap.L
 		logging.NewHandler(md, logger),
 		promLabel,
 	))
+
+	mux.Handle("/saml/slo", monitoring.NewHandler(
+		logging.NewHandler(createSLOHandler(m, advertisedURL, logger), logger),
+		promLabel,
+	))
+}
+
+// CreateLogoutHandler returns an HTTP handler that performs SAML Single Logout.
+// It reads the NameID, format, and session index from a cookie set during login,
+// builds a LogoutRequest, and redirects to the IdP's SLO endpoint. If the IdP
+// has no SLO endpoint or no cookie is present, it falls back to a local-only logout.
+func CreateLogoutHandler(m *samlsp.Middleware, advertisedURL string, logger *zap.Logger) http.HandlerFunc {
+	logger = logger.With(logging.Component("saml_logout"))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, ok := readNameIDCookie(r)
+
+		deleteNameIDCookie(w)
+
+		if !ok {
+			logger.Debug("no SAML SLO cookie, skipping SLO")
+
+			http.Redirect(w, r, advertisedURL, http.StatusSeeOther)
+
+			return
+		}
+
+		sloURL := m.ServiceProvider.GetSLOBindingLocation(saml.HTTPRedirectBinding)
+		if sloURL == "" {
+			logger.Debug("IdP does not advertise SLO redirect endpoint, skipping SLO")
+
+			http.Redirect(w, r, advertisedURL, http.StatusSeeOther)
+
+			return
+		}
+
+		req, err := m.ServiceProvider.MakeLogoutRequest(sloURL, data.NameID)
+		if err != nil {
+			logger.Error("failed to build SAML logout request", zap.Error(err))
+
+			http.Redirect(w, r, advertisedURL, http.StatusSeeOther)
+
+			return
+		}
+
+		if data.Format != "" && req.NameID != nil {
+			req.NameID.Format = data.Format
+		}
+
+		if data.SessionIndex != "" {
+			req.SessionIndex = &saml.SessionIndex{Value: data.SessionIndex}
+		}
+
+		// Note: for HTTP-Redirect binding the IdP ignores embedded XML signatures.
+		// MakeLogoutRequest may have added one, but it's harmless — the IdP validates
+		// the query-string signature (SigAlg + Signature params), not the XML body signature.
+		// We intentionally skip re-signing after modifying Format/SessionIndex.
+		// See SAML 2.0 Bindings, §3.4.4.1 (HTTP-Redirect DEFLATE Encoding), which
+		// defines signatures over the URL query parameters, not the XML payload.
+
+		redirectURL := req.Redirect(advertisedURL)
+
+		http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+	}
+}
+
+func createSLOHandler(m *samlsp.Middleware, advertisedURL string, logger *zap.Logger) http.HandlerFunc {
+	logger = logger.With(logging.Component("saml_slo"))
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := m.ServiceProvider.ValidateLogoutResponseRequest(r); err != nil {
+			logger.Warn("invalid SAML logout response", zap.Error(err))
+		}
+
+		deleteNameIDCookie(w)
+
+		http.Redirect(w, r, advertisedURL, http.StatusSeeOther)
+	}
+}
+
+// deleteNameIDCookie instructs the browser to remove the SLO cookie by setting MaxAge=-1.
+func deleteNameIDCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     NameIDCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func readNameIDCookie(r *http.Request) (sloSessionData, bool) {
+	cookie, err := r.Cookie(NameIDCookieName)
+	if err != nil || cookie.Value == "" {
+		return sloSessionData{}, false
+	}
+
+	raw, err := base64.URLEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return sloSessionData{}, false
+	}
+
+	var data sloSessionData
+	if err := json.Unmarshal(raw, &data); err != nil || data.NameID == "" {
+		return sloSessionData{}, false
+	}
+
+	return data, true
 }
 
 func readMetadata(cfg *specs.AuthConfigSpec_SAML) (*saml.EntityDescriptor, error) {
@@ -106,12 +229,32 @@ func readMetadata(cfg *specs.AuthConfigSpec_SAML) (*saml.EntityDescriptor, error
 	return samlsp.ParseMetadata(data)
 }
 
-func createErrorHandler(logger *zap.Logger) func(http.ResponseWriter, *http.Request, error) {
+func createErrorHandler(logger *zap.Logger, advertisedURL string) func(http.ResponseWriter, *http.Request, error) {
 	logger = logger.With(logging.Component("saml"))
 
 	return func(w http.ResponseWriter, r *http.Request, err error) {
 		var invalidSAML *saml.InvalidResponseError
 		if errors.As(err, &invalidSAML) {
+			// When the IdP sends a LogoutResponse to the ACS endpoint (e.g., because the
+			// IdP's SAML client has no dedicated SLO URL configured), the ACS handler fails
+			// to parse it as a login Response. Treat this as a completed logout.
+			//
+			// NOTE: this relies on the crewjam/saml library including "LogoutResponse" in the
+			// error message when it encounters a LogoutResponse instead of an expected Response.
+			// There is no structured way to detect this; if the library changes its error format,
+			// this detection may need updating.
+			if strings.Contains(invalidSAML.PrivateErr.Error(), "LogoutResponse") {
+				logger.Info("received LogoutResponse on ACS endpoint, treating as logout",
+					zap.Error(invalidSAML.PrivateErr),
+				)
+
+				deleteNameIDCookie(w)
+
+				http.Redirect(w, r, advertisedURL, http.StatusSeeOther)
+
+				return
+			}
+
 			logger.Warn("received invalid saml response",
 				zap.String("response", invalidSAML.Response),
 				zap.Time("now", invalidSAML.Now),

--- a/internal/backend/saml/saml_test.go
+++ b/internal/backend/saml/saml_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package saml_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	omnisaml "github.com/siderolabs/omni/internal/backend/saml"
+)
+
+const (
+	testAdvertisedURL = "https://omni.example.com"
+	testIDPSLOURL     = "https://idp.example.com/saml"
+)
+
+// makeSLOCookie builds a saml_name_id cookie value the same way CreateSession does.
+func makeSLOCookie(t *testing.T, nameID, format, sessionIndex string) *http.Cookie {
+	t.Helper()
+
+	data := map[string]string{"n": nameID}
+
+	if format != "" {
+		data["f"] = format
+	}
+
+	if sessionIndex != "" {
+		data["s"] = sessionIndex
+	}
+
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	return &http.Cookie{
+		Name:  omnisaml.NameIDCookieName,
+		Value: base64.URLEncoding.EncodeToString(raw),
+	}
+}
+
+func newMiddleware(t *testing.T, sloEndpoint string) *samlsp.Middleware {
+	t.Helper()
+
+	rootURL, err := url.Parse("https://omni.example.com")
+	require.NoError(t, err)
+
+	metadataURL := rootURL.JoinPath("saml", "metadata")
+	acsURL := rootURL.JoinPath("saml", "acs")
+	sloURL := rootURL.JoinPath("saml", "slo")
+
+	sp := saml.ServiceProvider{
+		MetadataURL: *metadataURL,
+		AcsURL:      *acsURL,
+		SloURL:      *sloURL,
+		IDPMetadata: &saml.EntityDescriptor{
+			EntityID: "https://idp.example.com",
+		},
+	}
+
+	if sloEndpoint != "" {
+		sp.IDPMetadata.IDPSSODescriptors = []saml.IDPSSODescriptor{
+			{
+				SSODescriptor: saml.SSODescriptor{
+					SingleLogoutServices: []saml.Endpoint{
+						{
+							Binding:  saml.HTTPRedirectBinding,
+							Location: sloEndpoint,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return &samlsp.Middleware{ServiceProvider: sp}
+}
+
+func TestCreateLogoutHandler_NoCookie(t *testing.T) {
+	handler := omnisaml.CreateLogoutHandler(newMiddleware(t, testIDPSLOURL), testAdvertisedURL, zaptest.NewLogger(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/logout", nil)
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	assert.Equal(t, testAdvertisedURL, resp.Header.Get("Location"))
+
+	assertNameIDCookieCleared(t, resp)
+}
+
+func TestCreateLogoutHandler_NoSLOEndpoint(t *testing.T) {
+	handler := omnisaml.CreateLogoutHandler(newMiddleware(t, ""), testAdvertisedURL, zaptest.NewLogger(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/logout", nil)
+	req.AddCookie(makeSLOCookie(t, "user@example.com", "", ""))
+
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	assert.Equal(t, testAdvertisedURL, resp.Header.Get("Location"))
+
+	assertNameIDCookieCleared(t, resp)
+}
+
+func TestCreateLogoutHandler_RedirectsToSLO(t *testing.T) {
+	handler := omnisaml.CreateLogoutHandler(newMiddleware(t, testIDPSLOURL), testAdvertisedURL, zaptest.NewLogger(t))
+
+	req := httptest.NewRequest(http.MethodGet, "/logout", nil)
+	req.AddCookie(makeSLOCookie(t, "user@example.com", "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", "_session123"))
+
+	rec := httptest.NewRecorder()
+
+	handler(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusFound, resp.StatusCode)
+
+	location := resp.Header.Get("Location")
+	redirectURL, err := url.Parse(location)
+	require.NoError(t, err)
+
+	assert.Equal(t, "idp.example.com", redirectURL.Host)
+	assert.Equal(t, "/saml", redirectURL.Path)
+	assert.NotEmpty(t, redirectURL.Query().Get("SAMLRequest"))
+	assert.Equal(t, testAdvertisedURL, redirectURL.Query().Get("RelayState"))
+
+	assertNameIDCookieCleared(t, resp)
+}
+
+func TestCreateLogoutHandler_InvalidCookieValue(t *testing.T) {
+	handler := omnisaml.CreateLogoutHandler(newMiddleware(t, testIDPSLOURL), testAdvertisedURL, zaptest.NewLogger(t))
+
+	for _, tt := range []struct {
+		name        string
+		cookieValue string
+	}{
+		{name: "empty value", cookieValue: ""},
+		{name: "invalid base64", cookieValue: "%%%not-base64%%%"},
+		{name: "invalid json", cookieValue: base64.URLEncoding.EncodeToString([]byte("{broken"))},
+		{name: "missing name_id", cookieValue: base64.URLEncoding.EncodeToString([]byte(`{"f":"fmt"}`))},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/logout", nil)
+			req.AddCookie(&http.Cookie{Name: omnisaml.NameIDCookieName, Value: tt.cookieValue})
+
+			rec := httptest.NewRecorder()
+
+			handler(rec, req)
+
+			resp := rec.Result()
+			defer resp.Body.Close() //nolint:errcheck
+
+			assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
+			assert.Equal(t, testAdvertisedURL, resp.Header.Get("Location"))
+
+			assertNameIDCookieCleared(t, resp)
+		})
+	}
+}
+
+func TestSLOHandler_InvalidResponse_ClearsCookieAndRedirects(t *testing.T) {
+	m := newMiddleware(t, testIDPSLOURL)
+	mux := http.NewServeMux()
+
+	omnisaml.RegisterHandlers(m, mux, zaptest.NewLogger(t), testAdvertisedURL)
+
+	// Provide a minimal (invalid) SAMLResponse so ValidateLogoutResponseRequest
+	// does not panic on a nil XML document. The handler logs the validation error
+	// and proceeds to clear the cookie and redirect.
+	samlResponse := base64.StdEncoding.EncodeToString([]byte(`<samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_fake" Version="2.0"/>`))
+
+	req := httptest.NewRequest(http.MethodPost, "/saml/slo", strings.NewReader("SAMLResponse="+url.QueryEscape(samlResponse)))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(makeSLOCookie(t, "user@example.com", "", ""))
+
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	assert.Equal(t, testAdvertisedURL, resp.Header.Get("Location"))
+
+	assertNameIDCookieCleared(t, resp)
+}
+
+func TestSLOHandler_NoCookie(t *testing.T) {
+	m := newMiddleware(t, testIDPSLOURL)
+	mux := http.NewServeMux()
+
+	omnisaml.RegisterHandlers(m, mux, zaptest.NewLogger(t), testAdvertisedURL)
+
+	samlResponse := base64.StdEncoding.EncodeToString([]byte(`<samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_fake" Version="2.0"/>`))
+
+	req := httptest.NewRequest(http.MethodPost, "/saml/slo", strings.NewReader("SAMLResponse="+url.QueryEscape(samlResponse)))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close() //nolint:errcheck
+
+	// Should still redirect and clear the cookie even without a prior cookie.
+	assert.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	assert.Equal(t, testAdvertisedURL, resp.Header.Get("Location"))
+
+	assertNameIDCookieCleared(t, resp)
+}
+
+func assertNameIDCookieCleared(t *testing.T, resp *http.Response) {
+	t.Helper()
+
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == omnisaml.NameIDCookieName {
+			assert.Equal(t, "", cookie.Value)
+			assert.Equal(t, -1, cookie.MaxAge)
+
+			return
+		}
+	}
+
+	t.Error("expected saml_name_id cookie to be set (cleared) in response")
+}

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -911,12 +911,12 @@ func registerAuthHandlers(mux *http.ServeMux, samlHandler *samlsp.Middleware, oi
 
 	switch {
 	case samlHandler != nil:
-		saml.RegisterHandlers(samlHandler, mux, logger)
+		advertisedURL := cfg.Services.Api.GetAdvertisedURL()
+
+		saml.RegisterHandlers(samlHandler, mux, logger, advertisedURL)
 
 		loginHandler = samlHandler.HandleStartAuthFlow
-		logoutHandler = func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, cfg.Services.Api.GetAdvertisedURL(), http.StatusSeeOther)
-		}
+		logoutHandler = saml.CreateLogoutHandler(samlHandler, advertisedURL, logger)
 	case oidcProvider != nil:
 		handler, err := oidc.NewOIDCHandler(cfg.Services.Api.GetAdvertisedURL(), cfg.Auth.Oidc, oidcProvider)
 		if err != nil {


### PR DESCRIPTION
Implement SAML Single Logout flow with HTTP-Redirect binding.
Tested with Keycloak and Microsoft Entra ID
