### PR TITLE
fix(frontend): fix unintented icon button size overrides

### DIFF
--- a/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
+++ b/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
@@ -133,7 +133,6 @@ const updateLock = async () => {
       >
         <IconButton
           :icon="locked ? (lockedUpdate ? 'locked-toggle' : 'locked') : 'unlocked'"
-          class="mt-0.5 h-4 w-4"
           @click.stop="updateLock"
         />
       </Tooltip>

--- a/frontend/src/views/cluster/Config/Patches.vue
+++ b/frontend/src/views/cluster/Config/Patches.vue
@@ -299,7 +299,7 @@ const openPatchCreate = () => {
               <IconButton
                 :disabled="!canManageConfigPatches"
                 icon="delete"
-                class="absolute top-0 right-3 bottom-0 m-auto h-4 w-4"
+                class="absolute top-0 right-3 bottom-0 m-auto"
                 @click.stop="
                   () => {
                     $router.push({ query: { modal: 'configPatchDestroy', id: item.id } })

--- a/frontend/src/views/omni/MachineClasses/MachineClass.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClass.vue
@@ -463,7 +463,7 @@ const submit = async () => {
               </div>
               <div v-if="i !== conditions.length - 1">OR</div>
             </template>
-            <IconButton icon="plus" class="h-full" @click="addCondition" />
+            <IconButton icon="plus" @click="addCondition" />
           </div>
           <div class="flex flex-col gap-1 text-xs">
             <p>


### PR DESCRIPTION
In #2359 `IconButton` was updated to use `cn` to allow class overrides, and some places that were failing to override the size were now overriding the size. They were not meant to however, so removed their sizes.