### PR TITLE
refactor(frontend): create pagecontainer component to manage padding

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -42,7 +42,7 @@ const darkThemeEnabled = computed(() => {
 </script>
 
 <template>
-  <main class="flex h-screen flex-col" :class="{ dark: darkThemeEnabled }">
+  <div class="flex h-screen flex-col" :class="{ dark: darkThemeEnabled }">
     <UserConsent
       v-if="trackingFeatureEnabled && trackingPending"
       @decline="disableTracking"
@@ -79,14 +79,13 @@ const darkThemeEnabled = computed(() => {
         class="relative flex grow flex-col gap-4 overflow-auto"
         :class="{
           'max-md:pointer-events-none max-md:select-none': isSidebarOpen,
-          'p-6': !$route.meta.disablePadding,
         }"
       >
         <TSuspended v-if="suspended" />
         <RouterView />
       </div>
     </div>
-  </main>
+  </div>
 
   <TModal />
 </template>

--- a/frontend/src/components/common/PageContainer/PageContainer.vue
+++ b/frontend/src/components/common/PageContainer/PageContainer.vue
@@ -1,0 +1,24 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+
+import { cn } from '@/methods/utils'
+
+interface Props extends /* @vue-ignore */ HTMLAttributes {
+  disablePadding?: boolean
+  class?: HTMLAttributes['class']
+}
+
+const { class: className } = defineProps<Props>()
+</script>
+
+<template>
+  <main :class="cn({ 'px-4 py-2 md:px-6 md:py-4': !disablePadding }, className)">
+    <slot></slot>
+  </main>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -94,7 +94,6 @@ export const routes: RouteRecordRaw[] = [
           {
             path: 'create',
             name: 'ClusterCreate',
-            meta: { disablePadding: true },
             component: () => import('@/views/omni/Clusters/Management/ClusterCreate.vue'),
           },
           {
@@ -114,7 +113,6 @@ export const routes: RouteRecordRaw[] = [
               {
                 path: 'scale',
                 name: 'ClusterScale',
-                meta: { disablePadding: true },
                 component: () => import('@/views/omni/Clusters/Management/ClusterScale.vue'),
               },
               {
@@ -153,7 +151,6 @@ export const routes: RouteRecordRaw[] = [
                   {
                     path: '',
                     name: 'NodeDetails',
-                    meta: { disablePadding: true },
                     component: () => import('@/views/cluster/Nodes/NodeDetails.vue'),
                     children: [
                       {
@@ -271,7 +268,6 @@ export const routes: RouteRecordRaw[] = [
                 path: 'create',
                 name: 'InstallationMediaCreate',
                 redirect: { name: 'InstallationMediaCreateEntry' },
-                meta: { disablePadding: true },
                 component: () =>
                   import('@/views/omni/InstallationMedia/InstallationMediaCreate.vue'),
                 children: [

--- a/frontend/src/types/vue-router.d.ts
+++ b/frontend/src/types/vue-router.d.ts
@@ -7,6 +7,5 @@ import 'vue-router'
 declare module 'vue-router' {
   interface RouteMeta {
     title?: string
-    disablePadding?: boolean
   }
 }

--- a/frontend/src/views/cluster/Backups/Backups.vue
+++ b/frontend/src/views/cluster/Backups/Backups.vue
@@ -17,6 +17,7 @@ import { withRuntime } from '@/api/options'
 import { ClusterUUIDType, DefaultNamespace } from '@/api/resources'
 import IconButton from '@/components/common/Button/IconButton.vue'
 import TButton from '@/components/common/Button/TButton.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import { setupBackupStatus } from '@/methods'
 import { triggerEtcdBackup } from '@/methods/cluster'
@@ -57,7 +58,7 @@ const runEtcdBackup = async () => {
 </script>
 
 <template>
-  <div class="flex flex-col">
+  <PageContainer class="flex flex-col">
     <div class="flex items-start gap-1">
       <PageHeader title="Control Plane Backups" class="flex-1" />
       <div class="flex items-center gap-1 text-xs">
@@ -75,5 +76,5 @@ const runEtcdBackup = async () => {
       </div>
     </div>
     <BackupsList class="mb-6" />
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/ClusterScoped.vue
+++ b/frontend/src/views/cluster/ClusterScoped.vue
@@ -12,6 +12,7 @@ import { Runtime } from '@/api/common/omni.pb'
 import { EventType } from '@/api/omni/resources/resources.pb'
 import type { ClusterSpec } from '@/api/omni/specs/omni.pb'
 import { ClusterType, DefaultNamespace } from '@/api/resources'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TAlert from '@/components/TAlert.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
@@ -38,16 +39,9 @@ const { data: cluster } = useResourceWatch<ClusterSpec>(
 
 <template>
   <RouterView v-if="cluster" :current-cluster="cluster" />
-  <div
-    v-else-if="bootstrapped"
-    class="font-sm flex-1"
-    :class="{
-      // Need to re-enable padding for this case, if a child disabled it
-      'p-6': $route.meta.disablePadding,
-    }"
-  >
+  <PageContainer v-else-if="bootstrapped" class="font-sm flex-1">
     <TAlert title="Cluster Not Found" type="error">
       Cluster {{ route.params.cluster as string }} does not exist.
     </TAlert>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Config/ClusterPatches.vue
+++ b/frontend/src/views/cluster/Config/ClusterPatches.vue
@@ -7,6 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import type { Resource } from '@/api/grpc'
 import type { ClusterSpec } from '@/api/omni/specs/omni.pb'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 
 import Patches from './Patches.vue'
@@ -17,10 +18,10 @@ defineProps<{
 </script>
 
 <template>
-  <div class="flex flex-col gap-2 overflow-y-auto">
+  <PageContainer class="flex flex-col gap-2 overflow-y-auto">
     <div class="flex items-start">
       <PageHeader class="flex-1" :title="`Cluster ${$route.params.cluster} Config Patches`" />
     </div>
     <Patches :cluster="currentCluster" />
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Config/PatchEdit.vue
+++ b/frontend/src/views/cluster/Config/PatchEdit.vue
@@ -42,6 +42,7 @@ import {
 } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
@@ -494,8 +495,8 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="relative -mx-6 -mb-6 flex flex-1 flex-col overflow-hidden" :style="{ width: 'auto' }">
-    <div class="flex flex-1 flex-col overflow-hidden px-6 pb-16">
+  <div class="flex h-full flex-col">
+    <PageContainer class="flex grow flex-col overflow-hidden">
       <PageHeader :title="title" :subtitle="subtitle" :notes="notes" />
       <ManagedByTemplatesWarning :resource="currentCluster" />
       <div v-if="state === State.NotExists" class="mb-4 flex items-center gap-3">
@@ -518,7 +519,7 @@ onMounted(async () => {
           </template>
         </Tooltip>
       </div>
-      <div class="font-sm mb-7 flex-1 overflow-y-hidden rounded bg-naturals-n1 px-2 py-3">
+      <div class="font-sm flex-1 overflow-y-hidden rounded bg-naturals-n1 px-2 py-3">
         <div v-if="!ready" class="flex h-full w-full items-center justify-center">
           <TSpinner class="h-6 w-6" />
         </div>
@@ -532,9 +533,9 @@ onMounted(async () => {
           @editor-did-mount="editorDidMount"
         />
       </div>
-    </div>
+    </PageContainer>
     <div
-      class="absolute right-0 bottom-0 left-0 flex h-16 items-center gap-4 border-t border-naturals-n4 bg-naturals-n1 px-5 py-3"
+      class="flex h-16 shrink-0 items-center gap-4 border-t border-naturals-n4 bg-naturals-n1 px-5 py-3"
     >
       <TButton class="secondary" @click="() => $router.push({ name: patchListPage })">Back</TButton>
       <div class="flex-1" />

--- a/frontend/src/views/cluster/Manifest/Sync.vue
+++ b/frontend/src/views/cluster/Manifest/Sync.vue
@@ -23,6 +23,7 @@ import {
 import { withContext } from '@/api/options'
 import TButton from '@/components/common/Button/TButton.vue'
 import TListItem from '@/components/common/List/TListItem.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
@@ -173,7 +174,7 @@ setupSyncStream()
 </script>
 
 <template>
-  <div class="flex flex-col gap-2">
+  <PageContainer class="flex flex-col gap-2">
     <div class="flex items-start">
       <PageHeader class="flex-1" :title="title" />
       <TButton variant="highlighted" :disabled="applyChangesDisabled" @click="applyChanges">
@@ -236,7 +237,7 @@ setupSyncStream()
         </template>
       </TListItem>
     </div>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/cluster/Nodes/NodeConfig.vue
+++ b/frontend/src/views/cluster/Nodes/NodeConfig.vue
@@ -11,6 +11,7 @@ import { useRoute } from 'vue-router'
 import { Runtime } from '@/api/common/omni.pb'
 import type { ClusterSpec, RedactedClusterMachineConfigSpec } from '@/api/omni/specs/omni.pb'
 import { ClusterType, DefaultNamespace, RedactedClusterMachineConfigType } from '@/api/resources'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const CodeEditor = defineAsyncComponent(
@@ -41,10 +42,11 @@ const config = computed(() => configResource.value?.spec.data ?? '')
 </script>
 
 <template>
-  <CodeEditor
-    v-model:value="config"
-    :options="{ readOnly: true }"
-    :talos-version="cluster?.spec.talos_version"
-    class="py-4"
-  />
+  <PageContainer class="h-full">
+    <CodeEditor
+      v-model:value="config"
+      :options="{ readOnly: true }"
+      :talos-version="cluster?.spec.talos_version"
+    />
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Nodes/NodeConfigDiffs.vue
+++ b/frontend/src/views/cluster/Nodes/NodeConfigDiffs.vue
@@ -12,6 +12,7 @@ import { Runtime } from '@/api/common/omni.pb'
 import type { MachineConfigDiffSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, LabelMachine, MachineConfigDiffType } from '@/api/resources'
 import DiffRenderer from '@/components/common/DiffRenderer/DiffRenderer.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import { formatISO } from '@/methods/time'
@@ -40,7 +41,7 @@ const combinedDiff = computed(() =>
 </script>
 
 <template>
-  <div class="h-full py-4">
+  <PageContainer class="h-full">
     <template v-if="!diffsLoading">
       <TAlert v-if="!combinedDiff" type="info" title="No Records">
         No previously applied config diffs found for this machine
@@ -50,5 +51,5 @@ const combinedDiff = computed(() =>
     </template>
 
     <TSpinner v-else class="mx-auto my-8 size-6" />
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Nodes/NodeDetails.vue
+++ b/frontend/src/views/cluster/Nodes/NodeDetails.vue
@@ -82,7 +82,6 @@ const routes = computed(() => {
           v-for="{ name, to } in routes"
           :key="name"
           class="grow overflow-y-auto"
-          :class="{ 'px-4 md:px-6': to.name !== 'NodeExtensions' }"
           :value="to.name"
         >
           <RouterView />

--- a/frontend/src/views/cluster/Nodes/NodeDevices.vue
+++ b/frontend/src/views/cluster/Nodes/NodeDevices.vue
@@ -74,6 +74,7 @@ import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
 import { TalosHardwareNamespace, TalosPCIDeviceType } from '@/api/resources'
 import TIcon, { type IconType } from '@/components/common/Icon/TIcon.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import { getContext } from '@/context'
@@ -138,7 +139,7 @@ function isLastChild(item?: DeviceTreeItem) {
 </script>
 
 <template>
-  <div class="h-full py-4">
+  <PageContainer class="h-full">
     <TSpinner v-if="loading" class="size-4" />
     <TAlert v-else-if="err" type="error" title="Error">{{ err }}</TAlert>
     <TAlert v-else-if="!devices.length" type="info" title="No Records">
@@ -212,5 +213,5 @@ function isLastChild(item?: DeviceTreeItem) {
         </TreeItem>
       </TreeVirtualizer>
     </TreeRoot>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Nodes/NodeDisks.vue
+++ b/frontend/src/views/cluster/Nodes/NodeDisks.vue
@@ -64,6 +64,7 @@ import {
 } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import TIcon from '@/components/common/Icon/TIcon.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import { getContext } from '@/context'
@@ -123,7 +124,7 @@ const organizedDisks = computed(() =>
 </script>
 
 <template>
-  <div class="space-y-4 py-4">
+  <PageContainer class="space-y-4">
     <TSpinner v-if="loading" class="mx-auto size-6" />
 
     <TAlert v-else-if="!organizedDisks.length" type="info" title="No Records">
@@ -177,5 +178,5 @@ const organizedDisks = computed(() =>
         <DiskPartitionTable v-if="diskInfo.partitions.length" :partitions="diskInfo.partitions" />
       </div>
     </section>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Nodes/NodeExtensions.vue
+++ b/frontend/src/views/cluster/Nodes/NodeExtensions.vue
@@ -32,6 +32,7 @@ import Watch from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TListItem from '@/components/common/List/TListItem.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import TAlert from '@/components/TAlert.vue'
@@ -169,7 +170,7 @@ const openExtensionsUpdate = () => {
 
 <template>
   <div class="flex h-full flex-col">
-    <div class="flex grow flex-col gap-4 overflow-y-auto px-4 py-4 md:px-6">
+    <PageContainer class="flex grow flex-col gap-4 overflow-y-auto">
       <TInput v-model="searchString" icon="search" />
       <div class="flex flex-1 flex-col overflow-y-auto">
         <template v-if="ready && extensionsState.length > 0">
@@ -226,7 +227,7 @@ const openExtensionsUpdate = () => {
           <TAlert title="No Extensions Found" type="info" />
         </div>
       </div>
-    </div>
+    </PageContainer>
 
     <div
       class="flex h-16 shrink-0 items-center justify-end border-t border-naturals-n5 bg-naturals-n1 px-12"

--- a/frontend/src/views/cluster/Nodes/NodeLogs.vue
+++ b/frontend/src/views/cluster/Nodes/NodeLogs.vue
@@ -15,6 +15,7 @@ import { withContext, withRuntime } from '@/api/options'
 import type { LogsRequest } from '@/api/talos/machine/machine.pb'
 import { MachineService } from '@/api/talos/machine/machine.pb'
 import LogViewer from '@/components/common/LogViewer/LogViewer.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import TAlert from '@/components/TAlert.vue'
 import { getContext } from '@/context'
@@ -136,7 +137,7 @@ const err = computed(() => {
 </script>
 
 <template>
-  <div class="logs py-4">
+  <PageContainer class="logs">
     <MachineLogsContainer
       v-if="$route.params.service === 'machine'"
       :machine-id="route.params.machine as string"
@@ -161,7 +162,7 @@ const err = computed(() => {
         :without-date="!parsers[$route.params.service as string]"
       />
     </div>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/cluster/Nodes/NodeMonitor.vue
+++ b/frontend/src/views/cluster/Nodes/NodeMonitor.vue
@@ -18,6 +18,7 @@ import {
   TalosPerfNamespace,
 } from '@/api/resources'
 import { MachineService, type ProcessInfo } from '@/api/talos/machine/machine.pb'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import { getContext } from '@/context'
 import { formatBytes } from '@/methods'
 import NodesMonitorChart from '@/views/cluster/Nodes/components/NodesMonitorChart.vue'
@@ -231,7 +232,7 @@ const sortBy = (id: keyof Proc) => {
 </script>
 
 <template>
-  <div class="monitor py-4">
+  <PageContainer class="monitor">
     <div class="monitor-charts-box">
       <div class="monitor-charts-wrapper">
         <div class="monitor-chart">
@@ -357,7 +358,7 @@ const sortBy = (id: keyof Proc) => {
         </div>
       </div>
     </div>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/cluster/Nodes/NodeOverview.vue
+++ b/frontend/src/views/cluster/Nodes/NodeOverview.vue
@@ -37,6 +37,7 @@ import { MachineService } from '@/api/talos/machine/machine.pb'
 import TGroupAnimation from '@/components/common/Animation/TGroupAnimation.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import TListItem from '@/components/common/List/TListItem.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TStatus from '@/components/common/Status/TStatus.vue'
 import Tag from '@/components/common/Tag/Tag.vue'
 import TAlert from '@/components/TAlert.vue'
@@ -280,7 +281,7 @@ const servicesSectionHeadingId = useId()
 </script>
 
 <template>
-  <div class="overview py-4">
+  <PageContainer class="overview">
     <TAlert
       v-if="clusterMachineStatus?.spec?.last_config_error && !alertDismissed"
       :dismiss="{ name: 'Dismiss', action: () => (alertDismissed = true) }"
@@ -476,7 +477,7 @@ const servicesSectionHeadingId = useId()
         </TListItem>
       </TGroupAnimation>
     </section>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/cluster/Nodes/NodePatches.vue
+++ b/frontend/src/views/cluster/Nodes/NodePatches.vue
@@ -10,6 +10,7 @@ import { useRoute } from 'vue-router'
 import { Runtime } from '@/api/common/omni.pb'
 import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, MachineStatusType } from '@/api/resources'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import Patches from '@/views/cluster/Config/Patches.vue'
 
@@ -26,5 +27,7 @@ const { data: machine } = useResourceWatch<MachineStatusSpec>(() => ({
 </script>
 
 <template>
-  <Patches v-if="machine" :machine class="py-4" />
+  <PageContainer>
+    <Patches v-if="machine" :machine />
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Nodes/NodePendingUpdates.vue
+++ b/frontend/src/views/cluster/Nodes/NodePendingUpdates.vue
@@ -12,6 +12,7 @@ import { Runtime } from '@/api/common/omni.pb'
 import type { MachinePendingUpdatesSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, MachinePendingUpdatesType } from '@/api/resources'
 import DiffRenderer from '@/components/common/DiffRenderer/DiffRenderer.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
@@ -31,7 +32,7 @@ const { data, loading } = useResourceWatch<MachinePendingUpdatesSpec>(() => ({
 </script>
 
 <template>
-  <div class="flex flex-col gap-4 py-4">
+  <PageContainer class="flex flex-col gap-4">
     <template v-if="!loading">
       <TAlert v-if="!data?.spec.config_diff" type="info" title="No Records">
         No pending config updates found for this machine
@@ -41,5 +42,5 @@ const { data, loading } = useResourceWatch<MachinePendingUpdatesSpec>(() => ({
     </template>
 
     <TSpinner v-else class="mx-auto my-8 size-6" />
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Nodes/NodesList.vue
+++ b/frontend/src/views/cluster/Nodes/NodesList.vue
@@ -22,6 +22,7 @@ import {
 } from '@/api/resources'
 import TGroupAnimation from '@/components/common/Animation/TGroupAnimation.vue'
 import TList from '@/components/common/List/TList.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import { getContext } from '@/context'
 import NodesItem from '@/views/cluster/Nodes/components/NodesItem.vue'
@@ -66,7 +67,7 @@ const opts = [
 </script>
 
 <template>
-  <div class="flex w-full flex-col gap-4">
+  <PageContainer class="flex w-full flex-col gap-4">
     <PageHeader title="All Nodes" />
     <TList :opts="opts" search pagination>
       <template #default="{ items, searchQuery }">
@@ -89,7 +90,7 @@ const opts = [
         </div>
       </template>
     </TList>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/cluster/Overview/Overview.vue
+++ b/frontend/src/views/cluster/Overview/Overview.vue
@@ -7,6 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import type { Resource } from '@/api/grpc'
 import type { ClusterSpec } from '@/api/omni/specs/omni.pb'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import OverviewContent from '@/views/cluster/Overview/components/OverviewContent.vue'
 
@@ -18,8 +19,8 @@ defineProps<Props>()
 </script>
 
 <template>
-  <div>
+  <PageContainer>
     <PageHeader :title="$route.params.cluster as string" />
     <OverviewContent :current-cluster="currentCluster" />
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/cluster/Pods/TPods.vue
+++ b/frontend/src/views/cluster/Pods/TPods.vue
@@ -10,6 +10,7 @@ import { computed, ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { kubernetes } from '@/api/resources'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TPagination from '@/components/common/Pagination/TPagination.vue'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
@@ -53,7 +54,7 @@ const filteredItems = computed(() =>
 </script>
 
 <template>
-  <div class="flex flex-col">
+  <PageContainer class="flex flex-col">
     <PageHeader title="All Pods" />
 
     <TSpinner v-if="loading" class="size-6 self-center" />
@@ -93,5 +94,5 @@ const filteredItems = computed(() =>
         </template>
       </TPagination>
     </div>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/common/BadRequest.vue
+++ b/frontend/src/views/common/BadRequest.vue
@@ -4,13 +4,17 @@ Copyright (c) 2026 Sidero Labs, Inc.
 Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
+<script setup lang="ts">
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
+</script>
+
 <template>
-  <div class="flex h-full items-center justify-center">
+  <PageContainer class="flex h-full items-center justify-center">
     <div class="flex flex-col items-center">
       <div class="code">400</div>
       <div class="text-center text-xl">Bad Request</div>
     </div>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/common/Forbidden.vue
+++ b/frontend/src/views/common/Forbidden.vue
@@ -4,15 +4,17 @@ Copyright (c) 2026 Sidero Labs, Inc.
 Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
+</script>
 
 <template>
-  <div class="flex h-full items-center justify-center">
+  <PageContainer class="flex h-full items-center justify-center">
     <div class="flex flex-col items-center">
       <div class="code">403</div>
       <div class="text-center text-xl">Access Denied</div>
     </div>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/common/PageNotFound.vue
+++ b/frontend/src/views/common/PageNotFound.vue
@@ -6,16 +6,17 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import TButton from '@/components/common/Button/TButton.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 </script>
 
 <template>
-  <div class="flex h-full items-center justify-center">
+  <PageContainer class="flex h-full items-center justify-center">
     <div class="flex flex-col items-center">
       <div class="code">404</div>
       <div class="text-center text-xl">Page not found</div>
       <TButton class="mt-4" @click="() => $router.push({ path: '/' })">Go Back</TButton>
     </div>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/omni/Auth/Authenticate.vue
+++ b/frontend/src/views/omni/Auth/Authenticate.vue
@@ -31,6 +31,7 @@ import {
 } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import UserInfo from '@/components/common/UserInfo/UserInfo.vue'
 import { AuthType, authType } from '@/methods'
@@ -258,7 +259,7 @@ watch(
 </script>
 
 <template>
-  <div class="flex h-full items-center justify-center">
+  <PageContainer class="flex h-full items-center justify-center">
     <div class="flex flex-col gap-2 rounded-md bg-naturals-n3 px-8 py-8 drop-shadow-md">
       <div class="flex items-center gap-4">
         <TIcon icon="key" class="fill-color h-6 w-6" />
@@ -310,5 +311,5 @@ watch(
         </div>
       </div>
     </div>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/Auth/OIDC.vue
+++ b/frontend/src/views/omni/Auth/OIDC.vue
@@ -12,6 +12,7 @@ import { useRoute } from 'vue-router'
 import { OIDCService } from '@/api/omni/oidc/oidc.pb'
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import UserInfo from '@/components/common/UserInfo/UserInfo.vue'
 import { useIdentity } from '@/methods/identity'
 import { showError } from '@/notification'
@@ -50,7 +51,7 @@ const copyCode = () => {
 </script>
 
 <template>
-  <div class="flex h-full items-center justify-center">
+  <PageContainer class="flex h-full items-center justify-center">
     <div class="flex flex-col gap-2 rounded-md bg-naturals-n3 px-8 py-8 drop-shadow-md">
       <div class="flex items-center gap-4">
         <TIcon icon="kubernetes" class="fill-color h-6 w-6" />
@@ -97,7 +98,7 @@ const copyCode = () => {
         </div>
       </template>
     </div>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/omni/Clusters/Clusters.vue
+++ b/frontend/src/views/omni/Clusters/Clusters.vue
@@ -21,6 +21,7 @@ import {
 import { itemID, type WatchOptions } from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
 import TList from '@/components/common/List/TList.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
 import TAlert from '@/components/TAlert.vue'
@@ -72,7 +73,7 @@ const filterOptions = [
 </script>
 
 <template>
-  <div>
+  <PageContainer>
     <TList
       :opts="watchOpts"
       search
@@ -159,5 +160,5 @@ const filterOptions = [
         </div>
       </template>
     </TList>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterCreate.vue
@@ -33,6 +33,7 @@ import WatchResource, { itemID } from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TList from '@/components/common/List/TList.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TSelectList from '@/components/common/SelectList/TSelectList.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
@@ -323,7 +324,7 @@ const list = useTemplateRef('list')
 </script>
 
 <template>
-  <div class="flex h-full flex-col pt-6">
+  <PageContainer disable-padding class="flex h-full flex-col pt-6">
     <PageHeader title="Create Cluster" class="px-6" />
 
     <div class="flex grow flex-col items-stretch gap-4 overflow-y-auto px-6 pb-6">
@@ -460,5 +461,5 @@ const list = useTemplateRef('list')
         action="Create Cluster"
       />
     </div>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
+++ b/frontend/src/views/omni/Clusters/Management/ClusterScale.vue
@@ -25,6 +25,7 @@ import {
   MachineStatusType,
 } from '@/api/resources'
 import { itemID } from '@/api/watch'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import Watch from '@/components/common/Watch/Watch.vue'
@@ -129,7 +130,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="flex h-full flex-col gap-3 pt-6">
+  <PageContainer disable-padding class="flex h-full flex-col gap-3 pt-6">
     <PageHeader :title="`Add Machines to Cluster ${$route.params.cluster}`" class="px-6" />
 
     <div v-if="existingResources.length > 0" class="grow overflow-y-auto px-6 pb-6">
@@ -197,5 +198,5 @@ onMounted(async () => {
         :warning="quorumWarning"
       />
     </div>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/Home/Home.vue
+++ b/frontend/src/views/omni/Home/Home.vue
@@ -8,6 +8,7 @@ included in the LICENSE file.
 import { computed } from 'vue'
 
 import { RoleNone } from '@/api/resources'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import { currentUser } from '@/methods/auth'
 import HomeContent from '@/views/omni/Home/HomeContent.vue'
 import HomeNoAccess from '@/views/omni/Home/HomeNoAccess.vue'
@@ -20,6 +21,8 @@ const hasRoleNone = computed(() => {
 </script>
 
 <template>
-  <HomeNoAccess v-if="hasRoleNone" />
-  <HomeContent v-else />
+  <PageContainer>
+    <HomeNoAccess v-if="hasRoleNone" />
+    <HomeContent v-else />
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/InstallationMedia/InstallationMedia.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMedia.vue
@@ -17,6 +17,7 @@ import { DefaultNamespace, InstallationMediaConfigType } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import IconButton from '@/components/common/Button/IconButton.vue'
 import TButton from '@/components/common/Button/TButton.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TableCell from '@/components/common/Table/TableCell.vue'
@@ -86,7 +87,7 @@ function clonePreset(preset: (typeof presets.value)[number]) {
 </script>
 
 <template>
-  <div class="flex h-full flex-col gap-6">
+  <PageContainer class="flex h-full flex-col gap-6">
     <TSpinner v-if="presetsLoading" class="size-8 self-center" />
 
     <div class="flex items-start justify-between gap-1">
@@ -191,5 +192,5 @@ function clonePreset(preset: (typeof presets.value)[number]) {
       :open="downloadPresetModalOpen"
       @close="downloadPresetModalOpen = false"
     />
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaCreate.vue
@@ -40,6 +40,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import TButton from '@/components/common/Button/TButton.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import Stepper from '@/components/common/Stepper/Stepper.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 import { showSuccess } from '@/notification'
@@ -134,7 +135,7 @@ function onSaved(name: string) {
 </script>
 
 <template>
-  <div class="flex h-full flex-col">
+  <PageContainer disable-padding class="flex h-full flex-col">
     <div class="flex grow flex-col gap-6 overflow-auto p-6">
       <h1 class="shrink-0 text-xl font-medium text-naturals-n14">Create New Media</h1>
       <RouterView v-model="formState" />
@@ -202,5 +203,5 @@ function onSaved(name: string) {
       @close="savePresetModalOpen = false"
       @saved="onSaved"
     />
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/InstallationMedia/InstallationMediaReview.vue
+++ b/frontend/src/views/omni/InstallationMedia/InstallationMediaReview.vue
@@ -10,6 +10,7 @@ import { useRoute } from 'vue-router'
 import { Runtime } from '@/api/common/omni.pb'
 import type { InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, InstallationMediaConfigType } from '@/api/resources'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
@@ -35,7 +36,7 @@ const {
 </script>
 
 <template>
-  <div>
+  <PageContainer>
     <PageHeader :title="`Previously saved preset &quot;${route.params.presetId}&quot;`" />
     <TSpinner v-if="presetLoading" class="mx-auto size-8" />
 
@@ -49,5 +50,5 @@ const {
       <code>InstallationMediaConfigType</code>
       {{ route.params.presetId }} does not exist
     </TAlert>
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/MachineClasses/MachineClass.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClass.vue
@@ -32,6 +32,7 @@ import TButton from '@/components/common/Button/TButton.vue'
 import TButtonGroup from '@/components/common/Button/TButtonGroup.vue'
 import TIcon from '@/components/common/Icon/TIcon.vue'
 import type { LabelSelectItem } from '@/components/common/Labels/Labels.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
@@ -406,163 +407,165 @@ const submit = async () => {
 </script>
 
 <template>
-  <div class="flex h-full flex-col gap-4">
-    <div class="flex items-start gap-1">
+  <PageContainer disable-padding class="flex h-full flex-col overflow-hidden">
+    <div class="grow overflow-auto p-6">
       <PageHeader
-        :title="`${machineClassEditId ? 'Edit Machine Class' : 'Create Machine Class'}`"
-        class="flex-1"
+        :title="`${machineClassEditId ? 'Edit' : 'Create'} Machine Class`"
         :subtitle="machineClassEditId ? `name: ${machineClassEditId}` : ''"
       />
-    </div>
-    <div v-if="loading" class="flex flex-1 items-center justify-center">
-      <TSpinner class="h-6 w-6" />
-    </div>
-    <TAlert v-else-if="notFound" title="Not Found" type="error">
-      The
-      <code>MachineClass</code>
-      {{ machineClassEditId }} does not exist
-    </TAlert>
-    <template v-else>
-      <div class="flex flex-col gap-2">
-        <TInput
-          v-if="!machineClassEditId"
-          v-model.trim="machineClassName"
-          title="Machine Class Name"
-        />
-        <div v-if="infraProviders.length > 0" class="flex items-center gap-2 text-xs">
-          <span>Machine Class Type:</span>
-          <TButtonGroup v-model="machineClassMode" :options="machineClassModeOptions" />
-        </div>
-        <template v-if="machineClassMode === MachineClassMode.Manual">
-          <div class="text-naturals-n13">Conditions</div>
-          <div class="flex flex-wrap items-center gap-2">
-            <template v-for="(_, i) in conditions" :key="i">
-              <div
-                class="flex gap-0.5 rounded-md border border-transparent transition-colors focus-within:border-naturals-n8"
-              >
+
+      <TSpinner v-if="loading" class="mx-auto size-6" />
+
+      <TAlert v-else-if="notFound" title="Not Found" type="error">
+        The
+        <code>MachineClass</code>
+        {{ machineClassEditId }} does not exist
+      </TAlert>
+
+      <template v-else>
+        <div class="flex flex-col gap-2">
+          <TInput
+            v-if="!machineClassEditId"
+            v-model.trim="machineClassName"
+            title="Machine Class Name"
+          />
+          <div v-if="infraProviders.length > 0" class="flex items-center gap-2 text-xs">
+            <span>Machine Class Type:</span>
+            <TButtonGroup v-model="machineClassMode" :options="machineClassModeOptions" />
+          </div>
+          <template v-if="machineClassMode === MachineClassMode.Manual">
+            <div class="text-naturals-n13">Conditions</div>
+            <div class="flex flex-wrap items-center gap-2">
+              <template v-for="(_, i) in conditions" :key="i">
                 <div
-                  class="flex cursor-pointer items-center rounded-l-md bg-naturals-n3 px-2 transition-colors hover:bg-naturals-n7 hover:text-naturals-n14"
-                  @click="deleteCondition(i)"
+                  class="flex gap-0.5 rounded-md border border-transparent transition-colors focus-within:border-naturals-n8"
                 >
-                  <TIcon icon="delete" class="h-4 w-4" />
+                  <div
+                    class="flex cursor-pointer items-center rounded-l-md bg-naturals-n3 px-2 transition-colors hover:bg-naturals-n7 hover:text-naturals-n14"
+                    @click="deleteCondition(i)"
+                  >
+                    <TIcon icon="delete" class="h-4 w-4" />
+                  </div>
+                  <span
+                    ref="conditionElements"
+                    role="textbox"
+                    style="min-width: 28px"
+                    spellcheck="false"
+                    class="rounded-r-md bg-naturals-n3 px-2 py-1 font-mono text-sm whitespace-pre text-naturals-n14"
+                    contenteditable
+                    @focus="lastFocused = i"
+                    @keyup="(event) => updateContent(i, event)"
+                    @keydown.enter.prevent="addCondition"
+                    @keydown.backspace="(event) => handleBackspace(event, i)"
+                  >
+                    {{ conditions[i] }}
+                  </span>
                 </div>
-                <span
-                  ref="conditionElements"
-                  role="textbox"
-                  style="min-width: 28px"
-                  spellcheck="false"
-                  class="rounded-r-md bg-naturals-n3 px-2 py-1 font-mono text-sm whitespace-pre text-naturals-n14"
-                  contenteditable
-                  @focus="lastFocused = i"
-                  @keyup="(event) => updateContent(i, event)"
-                  @keydown.enter.prevent="addCondition"
-                  @keydown.backspace="(event) => handleBackspace(event, i)"
-                >
-                  {{ conditions[i] }}
-                </span>
-              </div>
-              <div v-if="i !== conditions.length - 1">OR</div>
-            </template>
-            <IconButton icon="plus" @click="addCondition" />
-          </div>
-          <div class="flex flex-col gap-1 text-xs">
-            <p>
-              Click or type a node label to match nodes with those labels. Multiple labels in the
-              same condition, joined by
-              <code>,</code>
-              will only match nodes that match all labels. i.e. Logical
-              <code>AND</code>
-              operator.
-            </p>
-            <p>
-              Separate conditions are matched using
-              <code>OR</code>
-              .
-            </p>
-            <p>
-              Allowed operators are
-              <code>&gt;</code>
-              ,
-              <code>&gt;=</code>
-              ,
-              <code>&lt;</code>
-              ,
-              <code>&lt;=</code>
-              ,
-              <code>=</code>
-              ,
-              <code>==</code>
-              ,
-              <code>!=</code>
-              ,
-              <code>in</code>
-              ,
-              <code>notin</code>
-              . e.g.
-              <code>omni.sidero.dev/cluster in (talos,talos-default)</code>
-            </p>
-            <p>
-              Excluding a label can be done by prepending
-              <code>!</code>
-              to the label key, example:
-              <code>!omni.sidero.dev/available</code>
-              .
-            </p>
-          </div>
-        </template>
-        <template v-else>
-          <ProviderConfig v-model:infra-provider="infraProvider" />
-        </template>
-      </div>
-      <div class="mb-6 flex flex-1 flex-col gap-2">
-        <div v-if="machineClassMode === MachineClassMode.Manual">
-          <div class="text-naturals-n13">Matches</div>
-
-          <div v-if="machinesLoading" class="flex size-full items-center justify-center">
-            <TSpinner class="size-6" />
-          </div>
-
-          <TAlert v-else-if="machinesErr" title="Failed to Fetch Data" type="error">
-            {{ machinesErr }}
-          </TAlert>
-
-          <TAlert v-else-if="!machines.length" type="info" title="No Records">
-            No entries of the requested resource type are found on the server.
-          </TAlert>
-
-          <MachineMatchItem
-            v-for="item in machines"
-            :key="itemID(item)"
-            :machine="item"
-            @filter-labels="copyLabel"
-          />
+                <div v-if="i !== conditions.length - 1">OR</div>
+              </template>
+              <IconButton icon="plus" @click="addCondition" />
+            </div>
+            <div class="flex flex-col gap-1 text-xs">
+              <p>
+                Click or type a node label to match nodes with those labels. Multiple labels in the
+                same condition, joined by
+                <code>,</code>
+                will only match nodes that match all labels. i.e. Logical
+                <code>AND</code>
+                operator.
+              </p>
+              <p>
+                Separate conditions are matched using
+                <code>OR</code>
+                .
+              </p>
+              <p>
+                Allowed operators are
+                <code>&gt;</code>
+                ,
+                <code>&gt;=</code>
+                ,
+                <code>&lt;</code>
+                ,
+                <code>&lt;=</code>
+                ,
+                <code>=</code>
+                ,
+                <code>==</code>
+                ,
+                <code>!=</code>
+                ,
+                <code>in</code>
+                ,
+                <code>notin</code>
+                . e.g.
+                <code>omni.sidero.dev/cluster in (talos,talos-default)</code>
+              </p>
+              <p>
+                Excluding a label can be done by prepending
+                <code>!</code>
+                to the label key, example:
+                <code>!omni.sidero.dev/available</code>
+                .
+              </p>
+            </div>
+          </template>
+          <template v-else>
+            <ProviderConfig v-model:infra-provider="infraProvider" />
+          </template>
         </div>
-        <template v-else>
-          <MachineTemplate
-            v-if="infraProvider"
-            :key="infraProvider"
-            v-model:kernel-arguments="kernelArguments"
-            v-model:grpc-tunnel="grpcTunnelMode"
-            v-model:initial-labels="initialLabels"
-            :infra-provider="infraProvider"
-            :provider-config="providerConfigs[infraProvider] || {}"
-            @update:provider-config="
-              (value) => {
-                providerConfigs[infraProvider!] = value
-              }
-            "
-          />
-        </template>
-      </div>
-      <div
-        class="sticky -bottom-6 -mx-6 -my-6 flex h-16 items-center justify-end gap-2 border-t border-naturals-n5 bg-naturals-n1 px-12 py-6 text-xs"
-      >
-        <TButton variant="highlighted" :disabled="!canSubmit" @click="submit">
-          {{ machineClassEditId ? 'Update Machine Class' : 'Create Machine Class' }}
-        </TButton>
-      </div>
-    </template>
-  </div>
+
+        <div class="flex flex-1 flex-col gap-2">
+          <div v-if="machineClassMode === MachineClassMode.Manual">
+            <div class="text-naturals-n13">Matches</div>
+
+            <div v-if="machinesLoading" class="flex size-full items-center justify-center">
+              <TSpinner class="size-6" />
+            </div>
+
+            <TAlert v-else-if="machinesErr" title="Failed to Fetch Data" type="error">
+              {{ machinesErr }}
+            </TAlert>
+
+            <TAlert v-else-if="!machines.length" type="info" title="No Records">
+              No entries of the requested resource type are found on the server.
+            </TAlert>
+
+            <MachineMatchItem
+              v-for="item in machines"
+              :key="itemID(item)"
+              :machine="item"
+              @filter-labels="copyLabel"
+            />
+          </div>
+          <template v-else>
+            <MachineTemplate
+              v-if="infraProvider"
+              :key="infraProvider"
+              v-model:kernel-arguments="kernelArguments"
+              v-model:grpc-tunnel="grpcTunnelMode"
+              v-model:initial-labels="initialLabels"
+              :infra-provider="infraProvider"
+              :provider-config="providerConfigs[infraProvider] || {}"
+              @update:provider-config="
+                (value) => {
+                  providerConfigs[infraProvider!] = value
+                }
+              "
+            />
+          </template>
+        </div>
+      </template>
+    </div>
+
+    <div
+      class="flex h-16 items-center justify-end gap-2 border-t border-naturals-n5 bg-naturals-n1 px-12 py-6 text-xs"
+    >
+      <TButton variant="highlighted" :disabled="!canSubmit" @click="submit">
+        {{ machineClassEditId ? 'Update Machine Class' : 'Create Machine Class' }}
+      </TButton>
+    </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/omni/MachineClasses/MachineClasses.vue
+++ b/frontend/src/views/omni/MachineClasses/MachineClasses.vue
@@ -16,6 +16,7 @@ import IconButton from '@/components/common/Button/IconButton.vue'
 import TButton from '@/components/common/Button/TButton.vue'
 import TList from '@/components/common/List/TList.vue'
 import TListItem from '@/components/common/List/TListItem.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import Tag from '@/components/common/Tag/Tag.vue'
 import TAlert from '@/components/TAlert.vue'
@@ -39,7 +40,7 @@ const openMachineClassDestroy = (id: string) => {
 </script>
 
 <template>
-  <div class="flex h-full flex-col">
+  <PageContainer class="flex h-full flex-col">
     <div class="flex items-start gap-1">
       <PageHeader title="Machine Classes" class="flex-1" />
       <TButton
@@ -102,7 +103,7 @@ const openMachineClassDestroy = (id: string) => {
         </TListItem>
       </template>
     </TList>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/omni/Machines/Machine.vue
+++ b/frontend/src/views/omni/Machines/Machine.vue
@@ -57,12 +57,14 @@ const hasMatchingTab = computed(() =>
 </script>
 
 <template>
-  <div class="flex h-full flex-col gap-4">
-    <div class="flex h-9 justify-between">
-      <PageHeader :title="machineName" />
-    </div>
+  <div class="flex h-full flex-col pt-6">
+    <PageHeader :title="machineName" class="px-4 md:px-6" />
 
-    <Tabs :model-value="$route.name?.toString()" :class="{ grow: hasMatchingTab }">
+    <Tabs
+      :model-value="$route.name?.toString()"
+      :class="{ grow: hasMatchingTab }"
+      tabs-list-class="px-4 md:px-6"
+    >
       <template #triggers>
         <TabButton v-for="{ name, to } in routes" :key="name" :as="RouterLink" :value="to.name" :to>
           {{ name }}
@@ -70,7 +72,7 @@ const hasMatchingTab = computed(() =>
       </template>
 
       <template #contents>
-        <TabContent v-for="{ name, to } in routes" :key="name" class="mt-4 grow" :value="to.name">
+        <TabContent v-for="{ name, to } in routes" :key="name" class="grow" :value="to.name">
           <RouterView class="h-full" />
         </TabContent>
       </template>

--- a/frontend/src/views/omni/Machines/MachineLogs.vue
+++ b/frontend/src/views/omni/Machines/MachineLogs.vue
@@ -5,9 +5,12 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import MachineLogsContainer from '@/views/omni/Machines/MachineLogsContainer.vue'
 </script>
 
 <template>
-  <MachineLogsContainer />
+  <PageContainer>
+    <MachineLogsContainer class="h-full" />
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/Machines/MachinePatches.vue
+++ b/frontend/src/views/omni/Machines/MachinePatches.vue
@@ -10,6 +10,7 @@ import { useRoute } from 'vue-router'
 import { Runtime } from '@/api/common/omni.pb'
 import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, MachineStatusType } from '@/api/resources'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import Patches from '@/views/cluster/Config/Patches.vue'
 
@@ -26,5 +27,7 @@ const { data: machine } = useResourceWatch<MachineStatusSpec>(() => ({
 </script>
 
 <template>
-  <Patches v-if="machine" :machine />
+  <PageContainer>
+    <Patches v-if="machine" :machine />
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/Machines/Machines.vue
+++ b/frontend/src/views/omni/Machines/Machines.vue
@@ -30,6 +30,7 @@ import {
 } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
 import TList from '@/components/common/List/TList.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
 import TAlert from '@/components/TAlert.vue'
@@ -148,136 +149,149 @@ function updateSelected(machine: Resource<MachineStatusLinkSpec>, v?: boolean) {
 </script>
 
 <template>
-  <TList
-    :opts="{
-      runtime: Runtime.Omni,
-      resource: {
-        type: MachineStatusLinkType,
-        namespace: MetricsNamespace,
-      },
-      selectors,
-      selectUsingOR: true,
-    }"
-    search
-    pagination
-    :sort-options="sortOptions"
-    :filter-value="filterValue"
-  >
-    <template #norecords>
-      <TAlert
-        v-if="filter === MachineFilterOption.Managed && infraProviderStatuses.length === 0"
-        type="info"
-        title="No Infrastructure Providers Connected"
-      >
-        <div class="flex gap-1">
-          Check the
-          <TButton variant="subtle" size="xs" @click="openDocs">documentation</TButton>
-          on how to configure and use infrastructure providers.
+  <PageContainer class="h-full">
+    <TList
+      :opts="{
+        runtime: Runtime.Omni,
+        resource: {
+          type: MachineStatusLinkType,
+          namespace: MetricsNamespace,
+        },
+        selectors,
+        selectUsingOR: true,
+      }"
+      search
+      pagination
+      :sort-options="sortOptions"
+      :filter-value="filterValue"
+    >
+      <template #norecords>
+        <TAlert
+          v-if="filter === MachineFilterOption.Managed && infraProviderStatuses.length === 0"
+          type="info"
+          title="No Infrastructure Providers Connected"
+        >
+          <div class="flex gap-1">
+            Check the
+            <TButton variant="subtle" size="xs" @click="openDocs">documentation</TButton>
+            on how to configure and use infrastructure providers.
+          </div>
+        </TAlert>
+
+        <TAlert
+          v-else-if="filter === MachineFilterOption.Manual"
+          type="info"
+          title="No Machines Found"
+        >
+          <div class="flex gap-1">
+            Download and boot the
+            <TButton
+              is="router-link"
+              :to="{ name: 'InstallationMedia' }"
+              variant="subtle"
+              size="xs"
+            >
+              installation media
+            </TButton>
+            to connect machines to your Omni instance.
+          </div>
+        </TAlert>
+
+        <TAlert v-else type="info" title="No Machines Found">
+          <div class="flex gap-1">
+            No entries of the requested resource type are found on the server.
+          </div>
+        </TAlert>
+
+        <AddingMachinesTutorial class="mt-4" />
+      </template>
+
+      <template #header="{ itemsCount, filtered }">
+        <div v-if="!filter" class="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <h1 class="text-xl font-medium text-naturals-n14 max-md:basis-full">Machines</h1>
+
+          <StatsItem title="Total" :value="itemsCount" icon="nodes" />
+
+          <template v-if="!filtered">
+            <StatsItem
+              title="Allocated"
+              :value="machineStatusMetrics?.spec.allocated_machines_count ?? 0"
+              icon="arrow-right-square"
+            />
+
+            <StatsItem
+              title="Capacity"
+              :value="`${getCapacity(machineStatusMetrics)}%`"
+              icon="box"
+            />
+          </template>
         </div>
-      </TAlert>
 
-      <TAlert
-        v-else-if="filter === MachineFilterOption.Manual"
-        type="info"
-        title="No Machines Found"
+        <PageHeader
+          v-else-if="filter === MachineFilterOption.Manual"
+          title="Manually Joined Machines"
+        />
+
+        <PageHeader
+          v-else-if="filter === MachineFilterOption.Managed"
+          title="Machines Managed by the Infrastructure Providers"
+        />
+
+        <PageHeader
+          v-else-if="$route.params.provider"
+          :title="`Machines Managed by the Infrastructure Provider ${$route.params.provider}`"
+        />
+      </template>
+
+      <template #input>
+        <LabelsInput
+          v-model:filter-labels="filterLabels"
+          v-model:filter-value="filterValue"
+          :completions-resource="{
+            id: MachineStatusType,
+            type: LabelsCompletionType,
+            namespace: VirtualNamespace,
+          }"
+          class="w-full"
+          placeholder="Search ..."
+        />
+      </template>
+
+      <template #extra-controls>
+        <TButton
+          variant="primary"
+          icon="delete"
+          :disabled="!selectedMachines.size"
+          @click="deleteItems"
+        >
+          <span class="contents max-md:hidden">Delete selected</span>
+        </TButton>
+      </template>
+
+      <template
+        #default="{ items, searchQuery, sidePanelOpen, sidePanelSelectedItemId, openPanel }"
       >
-        <div class="flex gap-1">
-          Download and boot the
-          <TButton is="router-link" :to="{ name: 'InstallationMedia' }" variant="subtle" size="xs">
-            installation media
-          </TButton>
-          to connect machines to your Omni instance.
-        </div>
-      </TAlert>
+        <MachineItem
+          v-for="item in items"
+          :key="item.metadata.id"
+          :machine="item"
+          :search-query="searchQuery"
+          :panel-open="sidePanelOpen && item.metadata.id === sidePanelSelectedItemId"
+          :selected="selectedMachines.has(item.metadata.id ?? '')"
+          @update:selected="(v) => updateSelected(item, v)"
+          @open-panel="openPanel(item.metadata.id ?? '')"
+          @filter-labels="(label) => addLabel(filterLabels, label)"
+        />
+      </template>
 
-      <TAlert v-else type="info" title="No Machines Found">
-        <div class="flex gap-1">
-          No entries of the requested resource type are found on the server.
-        </div>
-      </TAlert>
-
-      <AddingMachinesTutorial class="mt-4" />
-    </template>
-
-    <template #header="{ itemsCount, filtered }">
-      <div v-if="!filter" class="flex flex-wrap items-center gap-x-6 gap-y-2">
-        <h1 class="text-xl font-medium text-naturals-n14 max-md:basis-full">Machines</h1>
-
-        <StatsItem title="Total" :value="itemsCount" icon="nodes" />
-
-        <template v-if="!filtered">
-          <StatsItem
-            title="Allocated"
-            :value="machineStatusMetrics?.spec.allocated_machines_count ?? 0"
-            icon="arrow-right-square"
-          />
-
-          <StatsItem title="Capacity" :value="`${getCapacity(machineStatusMetrics)}%`" icon="box" />
-        </template>
-      </div>
-
-      <PageHeader
-        v-else-if="filter === MachineFilterOption.Manual"
-        title="Manually Joined Machines"
-      />
-
-      <PageHeader
-        v-else-if="filter === MachineFilterOption.Managed"
-        title="Machines Managed by the Infrastructure Providers"
-      />
-
-      <PageHeader
-        v-else-if="$route.params.provider"
-        :title="`Machines Managed by the Infrastructure Provider ${$route.params.provider}`"
-      />
-    </template>
-
-    <template #input>
-      <LabelsInput
-        v-model:filter-labels="filterLabels"
-        v-model:filter-value="filterValue"
-        :completions-resource="{
-          id: MachineStatusType,
-          type: LabelsCompletionType,
-          namespace: VirtualNamespace,
-        }"
-        class="w-full"
-        placeholder="Search ..."
-      />
-    </template>
-
-    <template #extra-controls>
-      <TButton
-        variant="primary"
-        icon="delete"
-        :disabled="!selectedMachines.size"
-        @click="deleteItems"
-      >
-        <span class="contents max-md:hidden">Delete selected</span>
-      </TButton>
-    </template>
-
-    <template #default="{ items, searchQuery, sidePanelOpen, sidePanelSelectedItemId, openPanel }">
-      <MachineItem
-        v-for="item in items"
-        :key="item.metadata.id"
-        :machine="item"
-        :search-query="searchQuery"
-        :panel-open="sidePanelOpen && item.metadata.id === sidePanelSelectedItemId"
-        :selected="selectedMachines.has(item.metadata.id ?? '')"
-        @update:selected="(v) => updateSelected(item, v)"
-        @open-panel="openPanel(item.metadata.id ?? '')"
-        @filter-labels="(label) => addLabel(filterLabels, label)"
-      />
-    </template>
-
-    <template #sidePanel="{ items, searchQuery, sidePanelSelectedItemId, closePanel }">
-      <MachineDetailsPanel
-        :machine="items.find((i) => i.metadata.id === sidePanelSelectedItemId)"
-        :search-query="searchQuery"
-        class="h-full"
-        @close="closePanel"
-      />
-    </template>
-  </TList>
+      <template #sidePanel="{ items, searchQuery, sidePanelSelectedItemId, closePanel }">
+        <MachineDetailsPanel
+          :machine="items.find((i) => i.metadata.id === sidePanelSelectedItemId)"
+          :search-query="searchQuery"
+          class="h-full"
+          @close="closePanel"
+        />
+      </template>
+    </TList>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/Machines/MachinesPending.vue
+++ b/frontend/src/views/omni/Machines/MachinesPending.vue
@@ -14,6 +14,7 @@ import { itemID } from '@/api/watch'
 import TButton from '@/components/common/Button/TButton.vue'
 import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import TList from '@/components/common/List/TList.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import StatsItem from '@/components/common/Stats/StatsItem.vue'
 import TableCell from '@/components/common/Table/TableCell.vue'
@@ -33,7 +34,7 @@ const unrejectModalOpen = ref(false)
 </script>
 
 <template>
-  <div>
+  <PageContainer>
     <TList
       :opts="{
         runtime: Runtime.Omni,
@@ -166,5 +167,5 @@ const unrejectModalOpen = ref(false)
       :machines="Array.from(selectedMachines)"
       @confirmed="selectedMachines.clear()"
     />
-  </div>
+  </PageContainer>
 </template>

--- a/frontend/src/views/omni/Settings/JoinTokens.vue
+++ b/frontend/src/views/omni/Settings/JoinTokens.vue
@@ -25,6 +25,7 @@ import TActionsBoxItem from '@/components/common/ActionsBox/TActionsBoxItem.vue'
 import TButton from '@/components/common/Button/TButton.vue'
 import TList from '@/components/common/List/TList.vue'
 import TListItem from '@/components/common/List/TListItem.vue'
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import TStatus from '@/components/common/Status/TStatus.vue'
 import { TCommonStatuses } from '@/constants'
@@ -116,7 +117,7 @@ const openDeleteToken = (token: string) => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-2">
+  <PageContainer class="flex flex-col gap-2">
     <div class="flex items-start gap-1">
       <PageHeader title="Machine Join Tokens" class="flex-1" />
     </div>
@@ -217,7 +218,7 @@ const openDeleteToken = (token: string) => {
         </TListItem>
       </template>
     </TList>
-  </div>
+  </PageContainer>
 </template>
 
 <style scoped>

--- a/frontend/src/views/omni/Settings/Settings.vue
+++ b/frontend/src/views/omni/Settings/Settings.vue
@@ -7,6 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import type { Component } from 'vue'
 
+import PageContainer from '@/components/common/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 
 type Props = {
@@ -17,10 +18,10 @@ defineProps<Props>()
 </script>
 
 <template>
-  <div class="flex h-full flex-col gap-4">
+  <PageContainer class="flex h-full flex-col gap-4">
     <div class="flex items-start gap-1">
       <PageHeader title="Settings" class="flex-1" :subtitle="$route.meta.title" />
     </div>
     <RouterView class="grow" />
-  </div>
+  </PageContainer>
 </template>


### PR DESCRIPTION
When a child of ClusterScoped disables padding, ClusterScoped itself loses its padding. However, it needs padding itself for its error flow. As pages have differing layout requirements, I am dropping the default padding and instead introducing the `PageContainer` component for padding. Components can then selectively opt in/out of padding, without having to go through the router. 