### PR TITLE
fix(frontend): truncate machine classes in cluster list

### DIFF
--- a/frontend/src/components/common/Button/TButton.vue
+++ b/frontend/src/components/common/Button/TButton.vue
@@ -98,12 +98,13 @@ const dynamicProps = computed(() => {
       )
     "
   >
-    <span v-if="$slots.default" class="whitespace-nowrap">
+    <span v-if="$slots.default" class="truncate">
       <slot />
     </span>
     <TIcon
       v-if="icon"
       :icon="icon"
+      class="shrink-0"
       :class="[
         size === 'xxs' ? 'size-3' : 'size-4',
         {

--- a/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
+++ b/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
@@ -91,7 +91,7 @@ const updateLock = async () => {
     @click="openNodeInfo"
   >
     <div class="col-span-2 ml-6 flex items-center gap-2">
-      <TIcon :icon="icon" class="h-4 w-4" />
+      <TIcon :icon="icon" class="size-4 shrink-0" />
       <RouterLink
         :to="{
           name: 'NodeOverview',

--- a/frontend/src/views/cluster/ClusterMachines/MachineRequest.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineRequest.vue
@@ -47,9 +47,9 @@ const stage = computed(() => {
       <IconHeaderDropdownLoading
         v-if="stage !== TCommonStatuses.PROVISIONED"
         active
-        class="size-4"
+        class="size-4 shrink-0"
       />
-      <TIcon v-else icon="cloud-connection" class="size-4" />
+      <TIcon v-else icon="cloud-connection" class="size-4 shrink-0" />
       {{ requestStatus.metadata.id }}
     </div>
 

--- a/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
+++ b/frontend/src/views/cluster/ClusterMachines/MachineSet.vue
@@ -183,7 +183,7 @@ function isMachineSetScalable(
     <AccordionHeader class="col-span-full grid grid-cols-subgrid items-center p-2 pr-4 text-xs">
       <AccordionTrigger
         :id="sectionHeadingId"
-        class="group/accordion flex items-stretch gap-0.5 truncate text-left"
+        class="group/accordion flex shrink-0 items-stretch gap-0.5 truncate text-left"
       >
         <div class="flex shrink-0 items-center rounded-l bg-naturals-n4 px-0.5">
           <TIcon
@@ -193,9 +193,9 @@ function isMachineSetScalable(
           />
         </div>
 
-        <div class="flex items-center gap-1 rounded-r bg-naturals-n4 px-2 py-1.5">
+        <div class="flex min-w-0 items-center gap-1 rounded-r bg-naturals-n4 px-2 py-1.5">
           <TIcon icon="server-stack" class="size-4 shrink-0" aria-hidden="true" />
-          <span class="flex-1 truncate">
+          <span class="grow truncate">
             {{ machineSetTitle(clusterID, machineSetId) }}
           </span>
         </div>
@@ -217,7 +217,7 @@ function isMachineSetScalable(
       <TButton
         v-if="isMachineSetScalable(machineSet)"
         size="sm"
-        class="justify-self-start text-xs"
+        class="max-w-full justify-self-start overflow-hidden text-xs"
         variant="primary"
         icon="edit"
         @click="scaleMachinesModalOpen = true"


### PR DESCRIPTION
When machine class names get too long in cluster list, truncate them

<img width="441" height="149" alt="image" src="https://github.com/user-attachments/assets/46c00338-6604-49a6-9f80-35f4cc13fe8b" />
