### PR TITLE
refactor: introduce uncached reader/writer package, fix flaky tests

### DIFF
--- a/internal/backend/kernelargs/kernelargs.go
+++ b/internal/backend/kernelargs/kernelargs.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/xslices"
@@ -171,27 +170,4 @@ func isProtected(arg string) bool {
 	}
 
 	return false
-}
-
-// GetUncached reads the KernelArgs resource with the given ID, bypassing the resource cache.
-//
-// We need this to avoid stale reads of the KernelArgs resource: there can be cases where the omni.KernelArgsInitialized annotation is present in the MachineStatus,
-// but the KernelArgs resource is not yet visible due to the resource cache, which can cause unwanted Talos upgrades through a schematic id update.
-func GetUncached(ctx context.Context, r controller.Reader, id resource.ID) (*omni.KernelArgs, error) {
-	uncachedReader, ok := r.(controller.UncachedReader)
-	if !ok {
-		return nil, fmt.Errorf("reader does not support uncached reads")
-	}
-
-	kernelArgs, err := uncachedReader.GetUncached(ctx, omni.NewKernelArgs(id).Metadata())
-	if err != nil {
-		return nil, fmt.Errorf("error getting extra kernel args configuration: %w", err)
-	}
-
-	kernelArgsTyped, ok := kernelArgs.(*omni.KernelArgs)
-	if !ok {
-		return nil, fmt.Errorf("unexpected resource type: %T", kernelArgs)
-	}
-
-	return kernelArgsTyped, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/metrics/users_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/metrics/users_test.go
@@ -35,8 +35,7 @@ func TestUserMetrics(t *testing.T) {
 	testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 		func(_ context.Context, testContext testutils.TestContext) {
 			require.NoError(t, testContext.Runtime.RegisterController(ctrl))
-		},
-		func(ctx context.Context, testContext testutils.TestContext) {
+
 			st := testContext.State
 
 			// User active 1 day ago (within both 7d and 30d windows).
@@ -96,7 +95,8 @@ func TestUserMetrics(t *testing.T) {
 				options.WithID("mysa@serviceaccount.omni.sidero.dev"),
 				options.EmptyLabel(authres.LabelIdentityTypeServiceAccount),
 			)
-
+		},
+		func(ctx context.Context, testContext testutils.TestContext) {
 			registry := prometheus.NewRegistry()
 			registry.MustRegister(ctrl)
 

--- a/internal/backend/runtime/omni/controllers/omni/redactedmachineconfig/redacted_cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/redactedmachineconfig/redacted_cluster_machine_config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 )
 
 // ControllerName is the name of Controller.
@@ -210,16 +211,7 @@ func (ctrl *Controller) reconcileRunning(ctx context.Context, r controller.Reade
 }
 
 func (ctrl *Controller) reconcileTearingDown(ctx context.Context, r controller.ReaderWriter, cmc *omni.ClusterMachineConfig) error {
-	var listFunc func(context.Context, resource.Kind, ...state.ListOption) (resource.List, error)
-
-	uncachedReader, ok := r.(controller.UncachedReader)
-	if ok {
-		listFunc = uncachedReader.ListUncached
-	} else {
-		listFunc = r.List
-	}
-
-	list, err := listFunc(ctx, omni.NewMachineConfigDiff("").Metadata(), state.WithLabelQuery(resource.LabelEqual(omni.LabelMachine, cmc.Metadata().ID())))
+	list, err := uncached.ReaderWriter(r).List(ctx, omni.NewMachineConfigDiff("").Metadata(), state.WithLabelQuery(resource.LabelEqual(omni.LabelMachine, cmc.Metadata().ID())))
 	if err != nil {
 		return fmt.Errorf("failed to list diffs for machine config %q: %w", cmc.Metadata().ID(), err)
 	}

--- a/internal/backend/runtime/omni/controllers/omni/schematic_configuration.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic_configuration.go
@@ -28,6 +28,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/kernelargs"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/set"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 )
 
 // SchematicConfigurationControllerName is the name of the SchematicConfiguration controller.
@@ -376,7 +377,11 @@ func determineKernelArgs(ctx context.Context, machineStatus *omni.MachineStatus,
 		return machineStatus.TypedSpec().Value.Schematic.KernelArgs, nil
 	}
 
-	kernelArgs, err := kernelargs.GetUncached(ctx, r, machineStatus.Metadata().ID())
+	// Read the KernelArgs resource with the given ID, bypassing the resource cache.
+	// We need this to avoid stale reads of the KernelArgs resource: there can be cases where the omni.KernelArgsInitialized annotation is present in the MachineStatus,
+	// but the KernelArgs resource is not yet visible due to the resource cache, which can cause unwanted Talos upgrades through a schematic id update.
+	kernelArgs, err := safe.ReaderGetByID[*omni.KernelArgs](ctx, uncached.Reader(r), machineStatus.Metadata().ID())
+
 	if err != nil && !state.IsNotFoundError(err) {
 		return nil, err
 	}

--- a/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status.go
@@ -33,6 +33,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/mappers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/secretrotation"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/sequence"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 )
 
 // RotationStatusControllerName is the name of the SecretRotationStatusController.
@@ -167,6 +168,29 @@ func (s *Rotator) createInitialStage(currentPhase specs.SecretRotationSpec_Phase
 		clusterSecrets := sequenceContext.Input
 		rotationStatus := sequenceContext.Output
 
+		rotateTalosCA, err := safe.ReaderGetByID[*omni.RotateTalosCA](ctx, r, clusterSecrets.Metadata().ID())
+		if err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+
+		version, _ := rotationStatus.Metadata().Annotations().Get(omni.RotateTalosCAVersion)
+		shouldRotateTalosCA := rotateTalosCA != nil && version != rotateTalosCA.Metadata().Version().String()
+
+		rotateKubernetesCA, err := safe.ReaderGetByID[*omni.RotateKubernetesCA](ctx, r, clusterSecrets.Metadata().ID())
+		if err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+
+		version, _ = rotationStatus.Metadata().Annotations().Get(omni.RotateKubernetesCAVersion)
+		shouldRotateKubernetesCA := rotateKubernetesCA != nil && version != rotateKubernetesCA.Metadata().Version().String()
+
+		// We should use an uncached reader if we need to do a rotation. This is because a rotation is a one-time operation, therefore
+		// we cannot tolerate stale reads during it - eventual consistency doesn't work for us here.
+		// We have observed a flake in the unit tests, caused by a stale read of ClusterMachineStatus resources.
+		if shouldRotateTalosCA || shouldRotateKubernetesCA {
+			r = uncached.ReaderWriter(r)
+		}
+
 		rotationStatus.TypedSpec().Value.Component = specs.SecretRotationSpec_NONE
 		rotationStatus.TypedSpec().Value.Phase = currentPhase
 		rotationStatus.TypedSpec().Value.Status = ""
@@ -220,13 +244,8 @@ func (s *Rotator) createInitialStage(currentPhase specs.SecretRotationSpec_Phase
 			return err
 		}
 
-		rotateTalosCA, err := safe.ReaderGetByID[*omni.RotateTalosCA](ctx, r, clusterSecrets.Metadata().ID())
-		if err != nil && !state.IsNotFoundError(err) {
-			return err
-		}
-
 		// This is a trigger condition to move to the next stage
-		if version, _ := rotationStatus.Metadata().Annotations().Get(omni.RotateTalosCAVersion); rotateTalosCA != nil && version != rotateTalosCA.Metadata().Version().String() {
+		if shouldRotateTalosCA {
 			logger.Info("starting rotation", zap.String("cluster", secretRotation.Metadata().ID()), zap.String("component", specs.SecretRotationSpec_TALOS_CA.String()))
 
 			return s.startCARotation(rotationStatus, cmSecretsMap, specs.SecretRotationSpec_TALOS_CA, rotateTalosCA.Metadata().Version().String(),
@@ -248,13 +267,8 @@ func (s *Rotator) createInitialStage(currentPhase specs.SecretRotationSpec_Phase
 				})
 		}
 
-		rotateKubernetesCA, err := safe.ReaderGetByID[*omni.RotateKubernetesCA](ctx, r, clusterSecrets.Metadata().ID())
-		if err != nil && !state.IsNotFoundError(err) {
-			return err
-		}
-
 		// This is a trigger condition to move to the next stage
-		if version, _ := rotationStatus.Metadata().Annotations().Get(omni.RotateKubernetesCAVersion); rotateKubernetesCA != nil && version != rotateKubernetesCA.Metadata().Version().String() {
+		if shouldRotateKubernetesCA {
 			logger.Info("starting rotation", zap.String("cluster", secretRotation.Metadata().ID()), zap.String("component", specs.SecretRotationSpec_KUBERNETES_CA.String()))
 
 			return s.startCARotation(rotationStatus, cmSecretsMap, specs.SecretRotationSpec_KUBERNETES_CA, rotateKubernetesCA.Metadata().Version().String(),
@@ -297,7 +311,7 @@ func (s *Rotator) addRotationStage(previousPhase, currentPhase specs.SecretRotat
 	sequenceContext sequence.Context[*omni.ClusterSecrets, *omni.ClusterSecretsRotationStatus],
 ) error {
 	return func(ctx context.Context, logger *zap.Logger, sequenceContext sequence.Context[*omni.ClusterSecrets, *omni.ClusterSecretsRotationStatus]) error {
-		r := sequenceContext.Runtime
+		r := uncached.ReaderWriter(sequenceContext.Runtime)
 		clusterSecrets := sequenceContext.Input
 		rotationStatus := sequenceContext.Output
 		rotationStatus.TypedSpec().Value.Phase = currentPhase
@@ -854,20 +868,5 @@ func (s *Rotator) hostnamesToString(hostnames []string) string {
 }
 
 func (s *Rotator) getSecretRotation(ctx context.Context, r controller.ReaderWriter, id resource.ID) (*omni.SecretRotation, error) {
-	uncachedReader, ok := r.(controller.UncachedReader)
-	if !ok {
-		return nil, fmt.Errorf("reader does not support uncached reads")
-	}
-
-	res, err := uncachedReader.GetUncached(ctx, omni.NewSecretRotation(id).Metadata())
-	if err != nil {
-		return nil, fmt.Errorf("error getting secret rotation: %w", err)
-	}
-
-	resTyped, ok := res.(*omni.SecretRotation)
-	if !ok {
-		return nil, fmt.Errorf("unexpected resource type: %T", res)
-	}
-
-	return resTyped, nil
+	return safe.ReaderGetByID[*omni.SecretRotation](ctx, r, id)
 }

--- a/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
@@ -1055,6 +1055,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 					)))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretsController(nil)))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)

--- a/internal/backend/runtime/omni/controllers/omni/secrets/secrets.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/secrets.go
@@ -30,6 +30,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/etcdbackup"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/etcdbackup/store"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/mappers"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 )
 
 // Controller creates omni.ClusterSecrets for each inputed omni.Cluster.
@@ -98,22 +99,12 @@ func NewSecretsController(etcdBackupStoreFactory store.Factory) *Controller {
 				// - the controller proceeds to create a new bundle
 				// t3: ImportedClusterSecrets notification wakes up the controller, but the bundle is already there, the controller does not do anything
 
-				uncachedReader, ok := r.(controller.UncachedReader)
-				if !ok {
-					return fmt.Errorf("reader does not support uncached reads")
-				}
-
-				icsRes, err := uncachedReader.GetUncached(ctx, omni.NewImportedClusterSecrets(cluster.Metadata().ID()).Metadata())
+				ics, err := safe.ReaderGetByID[*omni.ImportedClusterSecrets](ctx, uncached.Reader(r), cluster.Metadata().ID())
 				if err != nil && !state.IsNotFoundError(err) {
 					return err
 				}
 
-				if icsRes != nil {
-					ics, icsOk := icsRes.(*omni.ImportedClusterSecrets)
-					if !icsOk {
-						return fmt.Errorf("unexpected resource type: %T", icsRes)
-					}
-
+				if ics != nil {
 					var bundle *talossecrets.Bundle
 
 					bundle, err = omni.FromImportedSecretsToSecretsBundle(ics)

--- a/internal/backend/runtime/omni/controllers/uncached/uncached.go
+++ b/internal/backend/runtime/omni/controllers/uncached/uncached.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package uncached provides wrappers around controller.Reader and controller.ReaderWriter
+// that bypass the controller runtime's read cache by delegating all reads to GetUncached/ListUncached.
+package uncached
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+)
+
+type reader struct {
+	inner controller.Reader
+}
+
+func (u *reader) Get(ctx context.Context, pointer resource.Pointer, option ...state.GetOption) (resource.Resource, error) {
+	rdr, ok := u.inner.(controller.UncachedReader)
+	if !ok {
+		return nil, fmt.Errorf("reader does not support uncached reads")
+	}
+
+	return rdr.GetUncached(ctx, pointer, option...)
+}
+
+func (u *reader) List(ctx context.Context, kind resource.Kind, option ...state.ListOption) (resource.List, error) {
+	rdr, ok := u.inner.(controller.UncachedReader)
+	if !ok {
+		return resource.List{}, fmt.Errorf("reader does not support uncached reads")
+	}
+
+	return rdr.ListUncached(ctx, kind, option...)
+}
+
+func (u *reader) ContextWithTeardown(ctx context.Context, pointer resource.Pointer) (context.Context, error) {
+	return u.inner.ContextWithTeardown(ctx, pointer)
+}
+
+type readWriter struct {
+	controller.Reader
+	controller.Writer
+}
+
+// Reader wraps a controller.Reader so that all reads bypass the controller runtime cache.
+func Reader(r controller.Reader) controller.Reader {
+	return &reader{inner: r}
+}
+
+// ReaderWriter wraps a controller.ReaderWriter so that all reads bypass the controller runtime cache.
+//
+// Writes are passed through unchanged.
+func ReaderWriter(r controller.ReaderWriter) controller.ReaderWriter {
+	return &readWriter{
+		Reader: &reader{inner: r},
+		Writer: r,
+	}
+}


### PR DESCRIPTION
Introduce a new `uncached` package that provides `Reader()` and `ReaderWriter()` wrappers to bypass the COSI controller runtime read cache. Replace all manual `controller.UncachedReader` type assertion casts across the codebase with the new package, making uncached reads more ergonomic and less error-prone.

Use the new package to fix the flaky `Test_KubernetesCARotation/rotation_ongoing` test. The rotation status controller performs a one-off operation: it fires, runs through stages, and marks rotation as done. This makes it inherently vulnerable to stale reads, because further wakeups caused by delayed update notifications cannot bring the state to the desired one — the resource snapshot at the time of rotation is crucial. Replace all its read operations with uncached reads via `uncached.ReaderWriter()`.

Fix the flaky `TestUserMetrics` test by moving mock resource creation to the setup phase so the controller sees the data from its first reconcile, eliminating a race where the controller's initial reconcile would run before the test data was created.