### PR TITLE
fix: prevent unwanted upgrades of non-image-factory machines

### DIFF
--- a/client/api/omni/specs/machine_status.go
+++ b/client/api/omni/specs/machine_status.go
@@ -5,5 +5,21 @@
 package specs
 
 func (spec *MachineStatusSpec) SchematicReady() bool {
-	return spec.Schematic != nil && !spec.Schematic.InAgentMode && spec.Schematic.Id != "" && spec.Schematic.FullId != ""
+	if spec.Schematic == nil {
+		return false
+	}
+
+	if spec.Schematic.InAgentMode {
+		return false
+	}
+
+	if spec.Schematic.Invalid {
+		// If the schematic is invalid, we consider it "ready" to allow it to be allocated to a cluster.
+		// This is the case for the machines which were built bypassing image factory and with extensions in them:
+		// we mark those as invalid, as we do not know if those extensions were official (available also in image factory),
+		// but those machines still need to be usable - users should be able to create clusters with those machines.
+		return true
+	}
+
+	return spec.Schematic.Id != "" && spec.Schematic.FullId != ""
 }


### PR DESCRIPTION
This was cherry picked previously in 1.5, but it was incomplete. Bring in the missing part.

(cherry picked from commit 0906bcc23c5d2e56b52fe4c3c7826afbea73dada)