### PR TITLE
fix(frontend): revert apexcharts tree-shaking

### DIFF
--- a/frontend/src/components/common/Charts/RadialBar.vue
+++ b/frontend/src/components/common/Charts/RadialBar.vue
@@ -5,13 +5,12 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import 'apexcharts/radialBar'
-
 import type { ApexOptions } from 'apexcharts'
-import { computed } from 'vue'
-import ApexChart from 'vue3-apexcharts/core'
+import { computed, defineAsyncComponent } from 'vue'
 
 import { getNonce } from '@/methods'
+
+const ApexChart = defineAsyncComponent(() => import('vue3-apexcharts'))
 
 interface Props {
   title: string

--- a/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
@@ -5,14 +5,11 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts" generic="T = unknown">
-import 'apexcharts/area'
-
 import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
 import type { ApexOptions } from 'apexcharts'
 import { DateTime } from 'luxon'
 import type { Ref } from 'vue'
-import { computed, ref, toRefs } from 'vue'
-import VueApexCharts from 'vue3-apexcharts/core'
+import { computed, defineAsyncComponent, ref, toRefs } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { WatchResponse } from '@/api/omni/resources/resources.pb'
@@ -22,6 +19,8 @@ import type { WatchContext, WatchEventSpec } from '@/api/watch'
 import { WatchFunc } from '@/api/watch'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import { getNonce } from '@/methods'
+
+const VueApexCharts = defineAsyncComponent(() => import('vue3-apexcharts'))
 
 type Props<T> = {
   name: string


### PR DESCRIPTION
Revert the apexcharts tree-shaking change from dependency update. As per https://github.com/apexcharts/vue3-apexcharts/issues/149 there are still some issues with it with vite for a production build. Currently on production the charts don't appear due to this.