### PR TITLE
fix: prevent controller feedback loop for invalid schematic machines

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
@@ -201,16 +201,26 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 		return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("%q install image not found", machineConfig.Metadata().ID())
 	}
 
-	schematicMismatch := machineConfigStatus.TypedSpec().Value.SchematicId != rc.installImage.SchematicId
+	// If the machine has an invalid schematic (not provisioned via image factory),
+	// compare against "" instead of installImage.SchematicId, matching what upgrade() does
+	// when it encounters ErrInvalidSchematic. This prevents a feedback loop where
+	// computePendingUpdates sees a mismatch but upgrade() finds no actual upgrade needed.
+	var schematicMismatch bool
 
-	rc.compareFullSchematicID, err = kernelargs.UpdateSupported(rc.machineStatus, func() (*omni.ClusterMachineConfig, error) {
-		return machineConfig, nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine if kernel args update is supported for machine %q: %w", machineConfig.Metadata().ID(), err)
+	if rc.machineStatus.TypedSpec().Value.Schematic.Invalid {
+		schematicMismatch = machineConfigStatus.TypedSpec().Value.SchematicId != ""
+	} else {
+		schematicMismatch = machineConfigStatus.TypedSpec().Value.SchematicId != rc.installImage.SchematicId
+
+		rc.compareFullSchematicID, err = kernelargs.UpdateSupported(rc.machineStatus, func() (*omni.ClusterMachineConfig, error) {
+			return machineConfig, nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine if kernel args update is supported for machine %q: %w", machineConfig.Metadata().ID(), err)
+		}
+
+		schematicMismatch = schematicMismatch || !rc.SchematicEqual(rc.machineStatus.TypedSpec().Value.Schematic.Id, rc.machineStatus.TypedSpec().Value.Schematic.FullId, rc.installImage.SchematicId)
 	}
-
-	schematicMismatch = schematicMismatch || !rc.SchematicEqual(rc.machineStatus.TypedSpec().Value.Schematic.Id, rc.machineStatus.TypedSpec().Value.Schematic.FullId, rc.installImage.SchematicId)
 
 	talosVersionMismatch := strings.TrimLeft(rc.machineStatus.TypedSpec().Value.TalosVersion, "v") != machineConfigStatus.TypedSpec().Value.TalosVersion ||
 		machineConfigStatus.TypedSpec().Value.TalosVersion != rc.installImage.TalosVersion

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -939,7 +939,15 @@ func (ctrl *ClusterMachineConfigStatusController) computePendingUpdates(ctx cont
 			currentTalosVersion = rc.machineStatus.TypedSpec().Value.TalosVersion
 		}
 
-		shouldUpgrade = currentSchematicID != rc.installImage.SchematicId ||
+		// For invalid schematics, upgrade() treats the expected schematic as "" (empty).
+		// Match that here to prevent a feedback loop where computePendingUpdates creates
+		// MachinePendingUpdates that upgrade() then destroys in the same reconcile.
+		installSchematicID := rc.installImage.SchematicId
+		if rc.machineStatus.TypedSpec().Value.Schematic.Invalid {
+			installSchematicID = ""
+		}
+
+		shouldUpgrade = currentSchematicID != installSchematicID ||
 			currentTalosVersion != rc.installImage.TalosVersion
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/talos_upgrade_status.go
@@ -345,7 +345,7 @@ func reconcileTalosUpdateStatus(ctx context.Context, r controller.ReaderWriter,
 		}
 
 		if resourceNeedsUpdate || configStatus.TypedSpec().Value.TalosVersion != talosVersion ||
-			configStatus.TypedSpec().Value.SchematicId != schematicID {
+			(configStatus.TypedSpec().Value.SchematicId != "" && configStatus.TypedSpec().Value.SchematicId != schematicID) {
 			machinesToUpdate = append(machinesToUpdate, clusterMachineTalosVersion)
 		}
 	}


### PR DESCRIPTION
Machines with invalid schematics (not provisioned via image factory) had empty SchematicId in their ClusterMachineConfigStatus. Three places compared this against the desired schematic ID, each seeing a mismatch that the actual upgrade() function would correctly ignore, creating two independent feedback loops:

- `BuildReconciliationContext`: compared ConfigStatus.SchematicId against installImage.SchematicId, causing unnecessary upgrade() calls to the machine.
- `computePendingUpdates`: same comparison, creating/destroying MachinePendingUpdates within a single reconcile, triggering MachineSetStatusController in a loop.
- `TalosUpgradeStatusController`: compared configStatus.SchematicId against desired schematic, keeping machines in machinesToUpdate and flipping TalosUpgradeStatus to UpdatingMachineSchematics.

Fix by aligning the schematic comparison with what upgrade() does for invalid schematics: treat the expected schematic as "" (empty). For TalosUpgradeStatusController, drop the schematic check from the machinesToUpdate condition while keeping the version check to preserve upgrade progress tracking.