### PR TITLE
feat: add configurable bandwidth rate limiting for SideroLink tunnel

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -207,6 +207,12 @@ func defineServiceFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, f
 	rootCmdFlagBinder.IntVar("event-sink-port", flagDescription("services.siderolink.eventSinkPort", schema), &flagConfig.Services.Siderolink.EventSinkPort)
 	rootCmdFlagBinder.IntVar("log-server-port", flagDescription("services.siderolink.logServerPort", schema), &flagConfig.Services.Siderolink.LogServerPort)
 	EnumVar(rootCmdFlagBinder, "join-tokens-mode", flagDescription("services.siderolink.joinTokensMode", schema), &flagConfig.Services.Siderolink.JoinTokensMode)
+	rootCmdFlagBinder.Uint64Var("siderolink-bandwidth-limit-mbps",
+		flagDescription("services.siderolink.bandwidthLimitMbps", schema),
+		&flagConfig.Services.Siderolink.BandwidthLimitMbps)
+	rootCmdFlagBinder.Uint64Var("siderolink-bandwidth-limit-burst-bytes",
+		flagDescription("services.siderolink.bandwidthLimitBurstBytes", schema),
+		&flagConfig.Services.Siderolink.BandwidthLimitBurstBytes)
 
 	// MachineAPI
 	for _, prefix := range []string{"siderolink", "machine"} {

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -302,6 +302,12 @@ config:
       #certFile: ""
       # KeyFile is the path to the TLS key file for the Kubernetes proxy service.
       #keyFile: ""
+      # OidcCacheBaseDir overrides the base cache directory for kubelogin in generated kubeconfigs.
+      # When empty, kubelogin uses its default (~/.kube/cache/oidc-login).
+      #oidcCacheBaseDir: ""
+      # OidcCacheIsolation isolates OIDC token caches across clusters by appending a per-context subdirectory
+      # to the cache directory in generated kubeconfigs.
+      #oidcCacheIsolation: false
     # MachineAPI contains SideroLink API service configuration.
     machineAPI:
       # -- The advertised URL for the SideroLink (Machine) API.
@@ -326,6 +332,12 @@ config:
       eventSinkPort: 8091
       # LogServerPort is the port to be used by the nodes to send their logs over SideroLink to Omni.
       #logServerPort: 8092
+      # BandwidthLimitMbps is the maximum total bandwidth in megabits per second through the SideroLink tunnel.
+      # Uses a token bucket algorithm: the rate controls sustained throughput while burst allows temporary spikes. Zero means unlimited.
+      #bandwidthLimitMbps: 0
+      # BandwidthLimitBurstBytes is the maximum number of bytes that can pass through the SideroLink tunnel in a single burst (token bucket capacity).
+      # When zero and bandwidthLimitMbps is set, defaults to one second worth of the rate.
+      #bandwidthLimitBurstBytes: 0
       # WireGuard contains WireGuard-specific configuration for the SideroLink service.
       wireGuard:
         # -- The advertised address for WireGuard connections.
@@ -429,6 +441,9 @@ config:
       #experimentalBaseParams: "_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)"
       # ExtraParams contains the extra parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. It must not start with an ampersand (&).
       #extraParams: ""
+      # PoolSize controls the maximum number of connections in the SQLite connection pool.
+      # Raising this value may improve performance under high load, at the cost of increased resource usage.
+      #poolSize: 0
     # Vault contains HashiCorp Vault storage backend configuration.
     vault:
       # -- Url is the URL of the Vault server.

--- a/hack/compose/docker-compose.yml
+++ b/hack/compose/docker-compose.yml
@@ -136,6 +136,18 @@ services:
     command: >-
       --omni-debug=${WITH_DEBUG:-false}
 
+  grafana:
+    network_mode: host
+    image: grafana/grafana:latest
+    restart: on-failure
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - grafana_data:/var/lib/grafana
+
 volumes:
   etcd:
   logs:
@@ -143,3 +155,4 @@ volumes:
   secondary-storage:
   etcd-backup:
   audit-logs:
+  grafana_data:

--- a/hack/compose/grafana/dashboards/omni-controllers.json
+++ b/hack/compose/grafana/dashboards/omni-controllers.json
@@ -1,0 +1,1551 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 78,
+      "panels": [],
+      "title": "Controllers",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 80,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_controller_crashes[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Crashes per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 88,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_controller_wakeups[$__rate_interval]))",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Wakeups per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_controller_reads[$__rate_interval]))",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Reads per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "BackupDataController",
+                  "ClusterBootstrapStatusController",
+                  "ClusterConfigVersionController",
+                  "ClusterController",
+                  "ClusterDestroyStatusController",
+                  "ClusterEndpointController",
+                  "ClusterLoadBalancerController",
+                  "ClusterMachineConfigController",
+                  "ClusterMachineConfigStatusController",
+                  "ClusterMachineController",
+                  "ClusterMachineEncryptionController",
+                  "ClusterMachineEncryptionKeyController",
+                  "ClusterMachineIdentityController",
+                  "ClusterMachineStatusController",
+                  "ClusterStatusController",
+                  "ClusterUUIDController",
+                  "ClusterWorkloadProxyController",
+                  "ControlPlaneStatusController",
+                  "EtcdBackupController",
+                  "EtcdBackupEncryptionController",
+                  "EtcdBackupOverallStatusController",
+                  "ImagePullStatusController",
+                  "InstallationMediaController",
+                  "KeyPrunerController",
+                  "KubeconfigController",
+                  "KubernetesStatusController",
+                  "KubernetesUpgradeManifestStatusController",
+                  "KubernetesUpgradeStatusController",
+                  "LoadBalancerController",
+                  "MachineConfigGenOptionsController",
+                  "MachineController",
+                  "MachineSetController",
+                  "MachineSetDestroyStatusController",
+                  "MachineSetEtcdAuditController",
+                  "MachineSetNodeController",
+                  "MachineSetStatusController",
+                  "MachineStatusController",
+                  "OngoingTaskController",
+                  "RedactedClusterMachineConfigController",
+                  "SAMLAssertionController",
+                  "SecretsController",
+                  "TalosConfigController",
+                  "TalosExtensionsController",
+                  "TalosUpgradeStatusController",
+                  "VersionsController"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_controller_writes[$__rate_interval]))",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Writes per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 92,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_controller_busy_seconds[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transform Controller Busy",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 94,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (increase(omni_runtime_controller_reconcile_cycles[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transform Controller Reconcile Loops",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 95,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (increase(omni_runtime_controller_reconcile_input_items[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transform Controller Inputs Reconciled",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 97,
+      "panels": [],
+      "title": "QControllers",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 20
+      },
+      "id": 100,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_qcontroller_crashes[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QController Errors per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 20
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_qcontroller_processed[$__rate_interval]))",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QController Processed per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 20
+      },
+      "id": 103,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (omni_runtime_qcontroller_queue_length)",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QController Queue Length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 20
+      },
+      "id": 105,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_qcontroller_requeues[$__rate_interval]))",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QController Requeued per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 29
+      },
+      "id": 107,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_qcontroller_reconcile_busy_seconds[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QController Reconcile Busy",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 29
+      },
+      "id": 109,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_qcontroller_map_busy_seconds[$__rate_interval]))",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QController Map Busy",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 29
+      },
+      "id": 111,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_qcontroller_mapped_in[$__rate_interval]))",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QController Mapped In per Second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 29
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller) (rate(omni_runtime_qcontroller_mapped_out[$__rate_interval]))",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QController Mapped Out per Second",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Omni Controllers",
+  "uid": "aSF12XcIz",
+  "version": 7,
+  "weekStart": ""
+}

--- a/hack/compose/grafana/dashboards/omni-details.json
+++ b/hack/compose/grafana/dashboards/omni-details.json
@@ -1,0 +1,2036 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 63,
+      "panels": [],
+      "title": "Details",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 59,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(omni_siderolink_received_bytes_total[$__rate_interval])",
+          "hide": false,
+          "legendFormat": "Received",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(omni_siderolink_sent_bytes_total[$__rate_interval])",
+          "hide": false,
+          "legendFormat": "Sent",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "SideroLink Traffic",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateRdYlGn",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "heatmap": {},
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 91,
+      "legend": {
+        "show": true
+      },
+      "maxDataPoints": 50,
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "10.3.3",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (le) (increase(omni_siderolink_last_handshake_seconds_bucket[$__rate_interval]))",
+          "format": "heatmap",
+          "hide": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SideroLink Last Handshake",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "transformations": [],
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "s",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "pps",
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 201,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(omni_siderolink_ratelimit_dropped_packets_total[$__rate_interval])",
+          "legendFormat": "{{direction}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rate Limit \u2014 Dropped Packets (rate/s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 65,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum by(operation, type) (rate(omni_resource_operations_total[$__rate_interval]))",
+          "legendFormat": "{{operation}} {{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Operations per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 67,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "showValue": "never",
+        "stacking": "normal",
+        "text": {},
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "omni_resource_operations_total",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Operations Totals",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "operation",
+            "rowField": "type",
+            "valueField": "Value"
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 17,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(kind) (rate(omni_resource_throughput_total[$__rate_interval]))",
+          "legendFormat": "{{kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Throughput by Operation Kind",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 17,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 105,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(type) (rate(omni_resource_throughput_total[$__rate_interval]))",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Throughput by Type",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 74,
+      "panels": [],
+      "title": "Talos/Kubernetes Workload API ",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache hits"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache misses"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 71,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(omni_talos_clientfactory_cache_size)",
+          "legendFormat": "cache size",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(omni_talos_clientfactory_active_clients)",
+          "hide": false,
+          "legendFormat": "active clients",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(rate(omni_talos_clientfactory_cache_hits_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "cache hits",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(rate(omni_talos_clientfactory_cache_misses_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "cache misses",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Talos API Client Factory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache hits"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache misses"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 72,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(omni_grpc_proxy_talos_backend_cache_size)",
+          "legendFormat": "cache size",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(omni_grpc_proxy_talos_backend_active_clients)",
+          "hide": false,
+          "legendFormat": "active clients",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(rate(omni_grpc_proxy_talos_backend_cache_hits_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "cache hits",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(rate(omni_grpc_proxy_talos_backend_cache_misses_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "cache misses",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Talos API gRPC Proxy",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache hits"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache misses"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "id": 75,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(omni_k8s_clientfactory_cache_size)",
+          "legendFormat": "cache size",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(omni_k8s_clientfactory_active_clients)",
+          "hide": false,
+          "legendFormat": "active clients",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(rate(omni_k8s_clientfactory_cache_hits_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "cache hits",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(rate(omni_k8s_clientfactory_cache_misses_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "cache misses",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Kubernetes API Client Factory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache hits"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cache misses"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "id": 76,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "sum(omni_k8sproxy_cache_size)",
+          "legendFormat": "cache size",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(rate(omni_k8sproxy_cache_hits_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "cache hits",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum(rate(omni_k8sproxy_cache_misses_total[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "cache misses",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Kubernetes API Proxy",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 69
+      },
+      "id": 103,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 25,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none",
+              "unitScale": true
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 70
+          },
+          "id": 96,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.0.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (status) (rate(omni_etcdbackup_store_uploads_total[$__rate_interval]))",
+              "legendFormat": "{{status}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Etcd Backup Uploads by Status",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 25,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none",
+              "unitScale": true
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 79
+          },
+          "id": 97,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.0.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (status) (rate(omni_etcdbackup_store_downloads_total[$__rate_interval]))",
+              "legendFormat": "{{status}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Etcd Backup Downloads by Status",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Etcd Backups",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 210,
+      "panels": [],
+      "title": "SQLite",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "id": 211,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_sqlite_db_size_bytes",
+          "legendFormat": "Total DB size",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "id": 212,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_sqlite_subsystem_size_bytes",
+          "legendFormat": "{{subsystem}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Subsystem Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 213,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_sqlite_subsystem_row_count",
+          "legendFormat": "{{subsystem}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Subsystem Row Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 79
+      },
+      "id": 214,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(omni_sqlite_cleanup_rows_deleted_total[$__rate_interval]) * 60",
+          "legendFormat": "{{subsystem}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cleanup Rows Deleted (rate/min)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Omni Details",
+  "uid": "rIe2Iu5Sk",
+  "version": 5,
+  "weekStart": ""
+}

--- a/hack/compose/grafana/provisioning/dashboards/dashboards.yml
+++ b/hack/compose/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: Omni
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/hack/compose/grafana/provisioning/datasources/prometheus.yml
+++ b/hack/compose/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://127.0.0.1:9090
+    isDefault: true
+    editable: false

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -100,6 +100,7 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/kms"
 	"github.com/siderolabs/omni/internal/pkg/machineevent"
 	"github.com/siderolabs/omni/internal/pkg/siderolink"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/ratelimit"
 	"github.com/siderolabs/omni/internal/pkg/xcontext"
 )
 
@@ -613,6 +614,25 @@ func (s *Server) runMachineAPI(ctx context.Context) error {
 	omniState := s.state.Default()
 	machineEventHandler := machineevent.NewHandler(omniState, s.logger, s.siderolinkEventsCh, s.installEventCh)
 
+	var rateLimiter *ratelimit.Limiter
+
+	if s.cfg.Services.Siderolink.GetBandwidthLimitMbps() > 0 {
+		rateLimiter = ratelimit.NewLimiter(
+			s.cfg.Services.Siderolink.GetBandwidthLimitMbps(),
+			s.cfg.Services.Siderolink.GetBandwidthLimitBurstBytes(),
+			s.logger,
+		)
+	}
+
+	if rateLimiter != nil {
+		prometheus.MustRegister(rateLimiter)
+
+		s.logger.Info("bandwidth rate limiting enabled",
+			zap.Uint64("mbps", s.cfg.Services.Siderolink.GetBandwidthLimitMbps()),
+			zap.Uint64("burst_bytes", s.cfg.Services.Siderolink.GetBandwidthLimitBurstBytes()),
+		)
+	}
+
 	slink, err := siderolink.NewManager(
 		ctx,
 		omniState,
@@ -624,6 +644,7 @@ func (s *Server) runMachineAPI(ctx context.Context) error {
 		s.logHandler,
 		machineEventHandler,
 		s.linkCounterDeltaCh,
+		rateLimiter,
 	)
 	if err != nil {
 		return err

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -1139,6 +1139,28 @@ func (s *Service) SetKeyFile(v string) {
 	s.KeyFile = &v
 }
 
+func (s *SiderolinkService) GetBandwidthLimitBurstBytes() uint64 {
+	if s == nil || s.BandwidthLimitBurstBytes == nil {
+		return *new(uint64)
+	}
+	return *s.BandwidthLimitBurstBytes
+}
+
+func (s *SiderolinkService) SetBandwidthLimitBurstBytes(v uint64) {
+	s.BandwidthLimitBurstBytes = &v
+}
+
+func (s *SiderolinkService) GetBandwidthLimitMbps() uint64 {
+	if s == nil || s.BandwidthLimitMbps == nil {
+		return *new(uint64)
+	}
+	return *s.BandwidthLimitMbps
+}
+
+func (s *SiderolinkService) SetBandwidthLimitMbps(v uint64) {
+	s.BandwidthLimitMbps = &v
+}
+
 func (s *SiderolinkService) GetDisableLastEndpoint() bool {
 	if s == nil || s.DisableLastEndpoint == nil {
 		return *new(bool)

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -315,6 +315,18 @@
         "logServerPort": {
           "description": "LogServerPort is the port to be used by the nodes to send their logs over SideroLink to Omni.",
           "type": "integer"
+        },
+        "bandwidthLimitMbps": {
+          "description": "BandwidthLimitMbps is the maximum total bandwidth in megabits per second through the SideroLink tunnel. Uses a token bucket algorithm: the rate controls sustained throughput while burst allows temporary spikes. Zero means unlimited.",
+          "type": "integer",
+          "goJSONSchema": { "type": "uint64" },
+          "minimum": 0
+        },
+        "bandwidthLimitBurstBytes": {
+          "description": "BandwidthLimitBurstBytes is the maximum number of bytes that can pass through the SideroLink tunnel in a single burst (token bucket capacity). The bucket refills continuously at the rate set by bandwidthLimitMbps. When zero and bandwidthLimitMbps is set, defaults to one second worth of the rate. For example, with bandwidthLimitMbps=10 (1.25 MB/s) and burstBytes=5000000 (5 MB), up to 5 MB can transfer instantly, then throughput settles to 1.25 MB/s.",
+          "type": "integer",
+          "goJSONSchema": { "type": "uint64" },
+          "minimum": 0
         }
       }
     },

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -614,6 +614,19 @@ type Services struct {
 }
 
 type SiderolinkService struct {
+	// BandwidthLimitBurstBytes is the maximum number of bytes that can pass through
+	// the SideroLink tunnel in a single burst (token bucket capacity). The bucket
+	// refills continuously at the rate set by bandwidthLimitMbps. When zero and
+	// bandwidthLimitMbps is set, defaults to one second worth of the rate. For
+	// example, with bandwidthLimitMbps=10 (1.25 MB/s) and burstBytes=5000000 (5 MB),
+	// up to 5 MB can transfer instantly, then throughput settles to 1.25 MB/s.
+	BandwidthLimitBurstBytes *uint64 `json:"bandwidthLimitBurstBytes,omitempty" yaml:"bandwidthLimitBurstBytes,omitempty"`
+
+	// BandwidthLimitMbps is the maximum total bandwidth in megabits per second
+	// through the SideroLink tunnel. Uses a token bucket algorithm: the rate controls
+	// sustained throughput while burst allows temporary spikes. Zero means unlimited.
+	BandwidthLimitMbps *uint64 `json:"bandwidthLimitMbps,omitempty" yaml:"bandwidthLimitMbps,omitempty"`
+
 	// DisableLastEndpoint controls whether the SideroLink service should stop using
 	// the last known endpoint of a node when it becomes unreachable via WireGuard.
 	DisableLastEndpoint *bool `json:"disableLastEndpoint,omitempty" yaml:"disableLastEndpoint,omitempty"`

--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -47,6 +47,7 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/grpcutil"
 	"github.com/siderolabs/omni/internal/pkg/logreceiver"
 	"github.com/siderolabs/omni/internal/pkg/machineevent"
+	"github.com/siderolabs/omni/internal/pkg/siderolink/ratelimit"
 	"github.com/siderolabs/omni/internal/pkg/siderolink/trustd"
 )
 
@@ -73,6 +74,7 @@ func NewManager(
 	handler *LogHandler,
 	machineEventHandler *machineevent.Handler,
 	deltaCh chan<- LinkCounterDeltas,
+	rateLimiter *ratelimit.Limiter,
 ) (*Manager, error) {
 	manager := &Manager{
 		logger:              logger,
@@ -80,6 +82,7 @@ func NewManager(
 		wgHandler:           wgHandler,
 		logHandler:          handler,
 		machineEventHandler: machineEventHandler,
+		rateLimiter:         rateLimiter,
 		metricBytesReceived: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "omni_siderolink_received_bytes_total",
 			Help: "Number of bytes received from the SideroLink interface.",
@@ -135,6 +138,8 @@ type Manager struct {
 	logHandler          *LogHandler
 	machineEventHandler *machineevent.Handler
 	provisionServer     *ProvisionHandler
+
+	rateLimiter *ratelimit.Limiter
 
 	metricBytesReceived prometheus.Counter
 	metricBytesSent     prometheus.Counter
@@ -451,14 +456,23 @@ func (manager *Manager) startWireguard(ctx context.Context, eg *errgroup.Group, 
 		allowedPeers: manager.allowedPeers,
 	}
 
+	var bind conn.Bind = wgbind.NewServerBind(manager.newBind(host), manager.virtualPrefix, manager.peerTraffic, manager.logger)
+
+	inputPacketFilters := []tun.InputPacketFilter{tun.FilterAllExceptIP(serverAddr.Addr())}
+
+	if manager.rateLimiter != nil {
+		bind = manager.rateLimiter.WrapBind(bind)
+		inputPacketFilters = append(inputPacketFilters, manager.rateLimiter.InputPacketFilter())
+	}
+
 	if err = manager.wgHandler.SetupDevice(wireguard.DeviceConfig{
-		Bind:               wgbind.NewServerBind(manager.newBind(host), manager.virtualPrefix, manager.peerTraffic, manager.logger),
+		Bind:               bind,
 		PeerHandler:        peerHandler,
 		Logger:             manager.logger,
 		ServerPrefix:       serverAddr,
 		PrivateKey:         key,
 		ListenPort:         uint16(port),
-		InputPacketFilters: []tun.InputPacketFilter{tun.FilterAllExceptIP(serverAddr.Addr())},
+		InputPacketFilters: inputPacketFilters,
 	}); err != nil {
 		return err
 	}

--- a/internal/pkg/siderolink/ratelimit/bind.go
+++ b/internal/pkg/siderolink/ratelimit/bind.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package ratelimit
+
+import (
+	"time"
+
+	"golang.zx2c4.com/wireguard/conn"
+)
+
+// rateLimitedBind wraps a conn.Bind to drop outbound packets that exceed
+// the bandwidth budget.
+type rateLimitedBind struct {
+	conn.Bind
+	limiter *Limiter
+}
+
+// Send implements conn.Bind. It drops packets that exceed the rate limit.
+func (b *rateLimitedBind) Send(bufs [][]byte, ep conn.Endpoint) error {
+	now := time.Now()
+
+	filtered := make([][]byte, 0, len(bufs))
+
+	for _, buf := range bufs {
+		if b.limiter.allow(now, len(buf), MetricLabelDirOutbound) {
+			filtered = append(filtered, buf)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return nil
+	}
+
+	return b.Bind.Send(filtered, ep)
+}

--- a/internal/pkg/siderolink/ratelimit/bind_test.go
+++ b/internal/pkg/siderolink/ratelimit/bind_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package ratelimit_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.zx2c4.com/wireguard/conn"
+
+	"github.com/siderolabs/omni/internal/pkg/siderolink/ratelimit"
+)
+
+var _ conn.Endpoint = (*mockEndpoint)(nil)
+
+type mockBind struct {
+	conn.Bind
+	sentBufs [][]byte
+}
+
+func (m *mockBind) Send(bufs [][]byte, _ conn.Endpoint) error {
+	m.sentBufs = append(m.sentBufs, bufs...)
+
+	return nil
+}
+
+type mockEndpoint struct {
+	dst string
+}
+
+func (e *mockEndpoint) ClearSrc()           {}
+func (e *mockEndpoint) SrcToString() string { return "" }
+func (e *mockEndpoint) DstToString() string { return e.dst }
+func (e *mockEndpoint) DstToBytes() []byte  { return nil }
+func (e *mockEndpoint) DstIP() netip.Addr   { return netip.MustParseAddrPort(e.dst).Addr() }
+func (e *mockEndpoint) SrcIP() netip.Addr   { return netip.Addr{} }
+
+func TestWrapBind(t *testing.T) {
+	t.Parallel()
+
+	// 1 Mbps, burst = 1500 bytes
+	limiter := ratelimit.NewLimiter(1, 1500, zaptest.NewLogger(t))
+	require.NotNil(t, limiter)
+
+	mock := &mockBind{}
+	wrapped := limiter.WrapBind(mock)
+
+	ep := &mockEndpoint{dst: "[fd00::1]:51820"}
+
+	// First packet (1200 bytes) should pass.
+	err := wrapped.Send([][]byte{make([]byte, 1200)}, ep)
+	require.NoError(t, err)
+	assert.Len(t, mock.sentBufs, 1)
+
+	// Second packet should be dropped (burst exceeded).
+	err = wrapped.Send([][]byte{make([]byte, 1200)}, ep)
+	require.NoError(t, err)
+	assert.Len(t, mock.sentBufs, 1, "second packet should be dropped")
+}
+
+func TestWrapBindPartialDrop(t *testing.T) {
+	t.Parallel()
+
+	// 1 Mbps, burst = 2000 bytes — allows ~1 packet of 1200 bytes but not 2
+	limiter := ratelimit.NewLimiter(1, 2000, zaptest.NewLogger(t))
+	require.NotNil(t, limiter)
+
+	mock := &mockBind{}
+	wrapped := limiter.WrapBind(mock)
+
+	ep := &mockEndpoint{dst: "[fd00::1]:51820"}
+
+	// Send batch of 3 packets — only first should pass
+	bufs := [][]byte{
+		make([]byte, 1200),
+		make([]byte, 1200),
+		make([]byte, 1200),
+	}
+
+	err := wrapped.Send(bufs, ep)
+	require.NoError(t, err)
+
+	assert.Len(t, mock.sentBufs, 1, "only first packet should pass within burst")
+}
+
+func TestWrapBindSharedBudget(t *testing.T) {
+	t.Parallel()
+
+	// 1 Mbps, burst = 2000 bytes — shared across all peers
+	limiter := ratelimit.NewLimiter(1, 2000, zaptest.NewLogger(t))
+	require.NotNil(t, limiter)
+
+	mock := &mockBind{}
+	wrapped := limiter.WrapBind(mock)
+
+	ep1 := &mockEndpoint{dst: "[fd00::1]:51820"}
+	ep2 := &mockEndpoint{dst: "[fd00::2]:51820"}
+
+	// First peer's packet passes (1200 bytes consumed from shared bucket).
+	err := wrapped.Send([][]byte{make([]byte, 1200)}, ep1)
+	require.NoError(t, err)
+	assert.Len(t, mock.sentBufs, 1)
+
+	// Second peer's packet dropped — shared burst exhausted.
+	err = wrapped.Send([][]byte{make([]byte, 1200)}, ep2)
+	require.NoError(t, err)
+	assert.Len(t, mock.sentBufs, 1, "second peer should be limited by shared budget")
+}

--- a/internal/pkg/siderolink/ratelimit/limiter.go
+++ b/internal/pkg/siderolink/ratelimit/limiter.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package ratelimit provides bandwidth rate limiting for the SideroLink WireGuard tunnel.
+//
+// Rate limiting is applied at two points:
+//   - Outbound: WireGuard Bind Send (packets from Omni to peers) via WrapBind
+//   - Inbound: TUN device Write (packets from peers to Omni) via InputPacketFilter
+//
+// A single token bucket is shared across all peers and both directions.
+// When the limit is exceeded, packets are dropped.
+// TCP handles this naturally via congestion control.
+//
+// Note: inbound rate limiting drops packets after they have already traversed the wire.
+// It is still useful because TCP congestion control on the sender will back off,
+// reducing sustained inbound throughput to the configured limit.
+package ratelimit
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/siderolabs/siderolink/pkg/tun"
+	"go.uber.org/zap"
+	"golang.org/x/net/ipv6"
+	"golang.org/x/time/rate"
+	"golang.zx2c4.com/wireguard/conn"
+)
+
+const (
+	MetricLabelDirInbound  = "inbound"
+	MetricLabelDirOutbound = "outbound"
+)
+
+const logDebounceInterval = time.Minute
+
+// Limiter applies bandwidth rate limiting using a single shared token bucket.
+type Limiter struct {
+	limiter        *rate.Limiter
+	droppedPackets *prometheus.CounterVec
+	logger         *zap.Logger
+	lastLogTime    atomic.Int64
+}
+
+var _ prometheus.Collector = &Limiter{}
+
+// NewLimiter creates a Limiter with the given rate limit.
+// Returns nil if mbps is 0 (unlimited).
+// When burstBytes is 0, burst defaults to one second worth of the rate.
+func NewLimiter(mbps, burstBytes uint64, logger *zap.Logger) *Limiter {
+	if mbps == 0 {
+		return nil
+	}
+
+	bytesPerSec := mbpsToByteRate(mbps)
+	burst := clampToInt(burstBytes)
+
+	if burst == 0 {
+		burst = clampToInt(bytesPerSec)
+	}
+
+	return &Limiter{
+		limiter: rate.NewLimiter(rate.Limit(bytesPerSec), burst),
+		droppedPackets: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "omni_siderolink_ratelimit_dropped_packets_total",
+			Help: "Total packets dropped by SideroLink bandwidth rate limiting.",
+		}, []string{"direction"}),
+		logger: logger,
+	}
+}
+
+// InputPacketFilter returns a tun.InputPacketFilter that rate-limits inbound packets.
+// Packets that exceed the bandwidth budget are dropped.
+func (l *Limiter) InputPacketFilter() tun.InputPacketFilter {
+	return func(header tun.PacketHeader) bool {
+		packetSize := ipv6.HeaderLen + int(header.PayloadLength)
+
+		return !l.allow(time.Now(), packetSize, MetricLabelDirInbound)
+	}
+}
+
+// WrapBind wraps a conn.Bind to rate-limit outbound packets in Send.
+func (l *Limiter) WrapBind(bind conn.Bind) conn.Bind {
+	return &rateLimitedBind{Bind: bind, limiter: l}
+}
+
+// allow checks the shared rate limit and increments the drop metric on failure.
+func (l *Limiter) allow(now time.Time, n int, direction string) bool {
+	if !l.limiter.AllowN(now, n) {
+		l.droppedPackets.WithLabelValues(direction).Inc()
+
+		if lastLog := l.lastLogTime.Load(); now.UnixNano()-lastLog >= int64(logDebounceInterval) {
+			if l.lastLogTime.CompareAndSwap(lastLog, now.UnixNano()) {
+				l.logger.Warn("SideroLink bandwidth rate limit exceeded, dropping packets", zap.String("direction", direction))
+			}
+		}
+
+		return false
+	}
+
+	return true
+}
+
+// DroppedPackets returns the dropped packets counter vec (for testing).
+func (l *Limiter) DroppedPackets() *prometheus.CounterVec { return l.droppedPackets }
+
+// Describe implements prometheus.Collector.
+func (l *Limiter) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(l, ch)
+}
+
+// Collect implements prometheus.Collector.
+func (l *Limiter) Collect(ch chan<- prometheus.Metric) {
+	l.droppedPackets.Collect(ch)
+}
+
+// mbpsToByteRate converts megabits-per-second to bytes-per-second, clamping to
+// prevent uint64 overflow on the intermediate multiplication.
+func mbpsToByteRate(mbps uint64) uint64 {
+	const maxMbps = math.MaxUint64 / 1_000_000
+
+	return min(mbps, maxMbps) * 1_000_000 / 8
+}
+
+// clampToInt safely converts a uint64 to int, clamping at math.MaxInt.
+func clampToInt(v uint64) int {
+	if v > uint64(math.MaxInt) {
+		return math.MaxInt
+	}
+
+	return int(v)
+}

--- a/internal/pkg/siderolink/ratelimit/limiter_test.go
+++ b/internal/pkg/siderolink/ratelimit/limiter_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package ratelimit_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/siderolabs/siderolink/pkg/tun"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/net/ipv6"
+
+	"github.com/siderolabs/omni/internal/pkg/siderolink/ratelimit"
+)
+
+func TestNewLimiterNil(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, ratelimit.NewLimiter(0, 0, zaptest.NewLogger(t)))
+}
+
+func TestNewLimiterNonNil(t *testing.T) {
+	t.Parallel()
+
+	assert.NotNil(t, ratelimit.NewLimiter(10, 0, zaptest.NewLogger(t)))
+}
+
+func TestLimiterMetrics(t *testing.T) {
+	t.Parallel()
+
+	// 1 Mbps with small burst so we can trigger drops easily.
+	limiter := ratelimit.NewLimiter(1, 1500, zaptest.NewLogger(t))
+	require.NotNil(t, limiter)
+
+	mock := &mockBind{}
+	wrapped := limiter.WrapBind(mock)
+
+	ep := &mockEndpoint{dst: "[fd00::1]:51820"}
+
+	// First packet passes (within burst).
+	err := wrapped.Send([][]byte{make([]byte, 1200)}, ep)
+	require.NoError(t, err)
+
+	// Second packet is dropped (burst exceeded).
+	err = wrapped.Send([][]byte{make([]byte, 1200)}, ep)
+	require.NoError(t, err)
+
+	assert.Len(t, mock.sentBufs, 1, "only first packet should have been sent")
+
+	// Verify Prometheus metrics reflect the drop.
+	assert.InDelta(t, 1, testutil.ToFloat64(limiter.DroppedPackets().WithLabelValues(ratelimit.MetricLabelDirOutbound)), 0.01)
+}
+
+func TestInputPacketFilter(t *testing.T) {
+	t.Parallel()
+
+	// 1 Mbps, burst = 1500 bytes (enough for one ~1200 byte packet).
+	limiter := ratelimit.NewLimiter(1, 1500, zaptest.NewLogger(t))
+	require.NotNil(t, limiter)
+
+	filter := limiter.InputPacketFilter()
+
+	// PayloadLength such that ipv6.HeaderLen + PayloadLength = ~1200 bytes.
+	payloadLen := uint16(1200 - ipv6.HeaderLen)
+
+	header := tun.PacketHeader{
+		SourceAddr:    netip.MustParseAddr("fd00::1"),
+		PayloadLength: payloadLen,
+	}
+
+	// First packet should be allowed (filter returns false = don't drop).
+	assert.False(t, filter(header), "first packet should be allowed")
+
+	// Second packet should be dropped (filter returns true = drop).
+	assert.True(t, filter(header), "second packet should be dropped after burst exceeded")
+
+	// Verify inbound metrics.
+	assert.InDelta(t, 1, testutil.ToFloat64(limiter.DroppedPackets().WithLabelValues(ratelimit.MetricLabelDirInbound)), 0.01)
+}
+
+func TestSharedBudgetAcrossPeers(t *testing.T) {
+	t.Parallel()
+
+	// 1 Mbps, burst = 2000 bytes — enough for one ~1200 byte packet but not two.
+	limiter := ratelimit.NewLimiter(1, 2000, zaptest.NewLogger(t))
+	require.NotNil(t, limiter)
+
+	filter := limiter.InputPacketFilter()
+	payloadLen := uint16(1200 - ipv6.HeaderLen)
+
+	h1 := tun.PacketHeader{SourceAddr: netip.MustParseAddr("fd00::1"), PayloadLength: payloadLen}
+	h2 := tun.PacketHeader{SourceAddr: netip.MustParseAddr("fd00::2"), PayloadLength: payloadLen}
+
+	// First peer's packet passes.
+	assert.False(t, filter(h1), "first packet should be allowed")
+
+	// Second peer's packet dropped — shared budget exhausted.
+	assert.True(t, filter(h2), "second packet should be dropped")
+}

--- a/internal/pkg/siderolink/siderolink_test.go
+++ b/internal/pkg/siderolink/siderolink_test.go
@@ -139,7 +139,7 @@ func (suite *SiderolinkSuite) SetupTest() {
 
 	eventHandler := machineevent.NewHandler(suite.state, zaptest.NewLogger(suite.T()), make(chan *omni.MachineStatusSnapshot), nil)
 
-	suite.manager, err = sideromanager.NewManager(suite.ctx, suite.state, wgHandler, params, zaptest.NewLogger(suite.T()), nil, eventHandler, nil)
+	suite.manager, err = sideromanager.NewManager(suite.ctx, suite.state, wgHandler, params, zaptest.NewLogger(suite.T()), nil, eventHandler, nil, nil)
 	suite.Require().NoError(err)
 
 	suite.startManager(params)


### PR DESCRIPTION
Introduce token-bucket based bandwidth rate limiting for the SideroLink WireGuard tunnel, configurable via services.siderolink.bandwidthLimitMbps and services.siderolink.bandwidthLimitBurstBytes config fields (with corresponding CLI flag fallbacks).
Rate limiting is applied in both directions: outbound via a wrapped conn.Bind and inbound via a TUN input packet filter. A shared limiter drops packets exceeding the budget, relying on TCP congestion control to throttle senders. Disabled by default (0 = unlimited).

Also adds a Grafana service to docker-compose with pre-built Omni dashboards for local development 

When all values are zero (default), rate limiting is disabled. Dropped packets are tracked via a Prometheus counter (`omni_siderolink_ratelimit_dropped_packets_total`).

Resolves: #2441
