### PR TITLE
feat(frontend): reintroduce apexcharts tree-shaking

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@vueuse/components": "^14.2.1",
         "@vueuse/core": "^14.2.1",
         "@vueuse/integrations": "^14.2.1",
-        "apexcharts": "^5.10.1",
+        "apexcharts": "^5.10.3",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "fetch-intercept": "^2.4.0",
@@ -4251,9 +4251,9 @@
       }
     },
     "node_modules/apexcharts": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.10.1.tgz",
-      "integrity": "sha512-BpKKRopNm5cziXmA1igmCKiJ02I2g/I4vBtjhB6/50FrrY2IH5csvCzzqiIuFCB+P+2p0MgLAGOJPKOUvXO63w==",
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.10.3.tgz",
+      "integrity": "sha512-wwvkSLsodNOc/rHo5MJsn3GPM4Krc5Gs0zKX4Lfzq4LohcTbyKylYUGEqJFmXXxGR7yLbZQz31sB5RTqT5mv1g==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@yr/monotone-cubic-spline": "^1.0.3"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "@vueuse/components": "^14.2.1",
     "@vueuse/core": "^14.2.1",
     "@vueuse/integrations": "^14.2.1",
-    "apexcharts": "^5.10.1",
+    "apexcharts": "^5.10.3",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "fetch-intercept": "^2.4.0",

--- a/frontend/src/components/common/Charts/RadialBar.vue
+++ b/frontend/src/components/common/Charts/RadialBar.vue
@@ -5,12 +5,13 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import 'apexcharts/radialBar'
+
 import type { ApexOptions } from 'apexcharts'
-import { computed, defineAsyncComponent } from 'vue'
+import { computed } from 'vue'
+import ApexChart from 'vue3-apexcharts/core'
 
 import { getNonce } from '@/methods'
-
-const ApexChart = defineAsyncComponent(() => import('vue3-apexcharts'))
 
 interface Props {
   title: string

--- a/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
@@ -5,11 +5,14 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts" generic="T = unknown">
+import 'apexcharts/area'
+
 import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
 import type { ApexOptions } from 'apexcharts'
 import { DateTime } from 'luxon'
 import type { Ref } from 'vue'
-import { computed, defineAsyncComponent, ref, toRefs } from 'vue'
+import { computed, ref, toRefs } from 'vue'
+import VueApexCharts from 'vue3-apexcharts/core'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { WatchResponse } from '@/api/omni/resources/resources.pb'
@@ -19,8 +22,6 @@ import type { WatchContext, WatchEventSpec } from '@/api/watch'
 import { WatchFunc } from '@/api/watch'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import { getNonce } from '@/methods'
-
-const VueApexCharts = defineAsyncComponent(() => import('vue3-apexcharts'))
 
 type Props<T> = {
   name: string


### PR DESCRIPTION
Reintroduce apexcharts tree-shaking following their [fixes](https://github.com/apexcharts/apexcharts.js/releases/tag/v5.10.2) from 5.10.2. This will reduce the bundle impact of apexcharts quite a bit, around 700kb.