### PR TITLE
fix(frontend): reset support bundle state on close

### DIFF
--- a/frontend/src/views/cluster/Overview/components/OverviewRightPanel/DownloadSupportBundleModal.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewRightPanel/DownloadSupportBundleModal.vue
@@ -67,19 +67,23 @@ const closeText = computed(() => {
   return done.value ? 'Close' : 'Cancel'
 })
 
-watchEffect(() => {
-  // Reset the modal when opening
-  if (open.value) {
-    sourceToProgress.value = {}
-    expanded.value = {}
-    done.value = false
-  }
-})
-
 let abortController: AbortController
 
 onUnmounted(() => {
   abortController?.abort()
+})
+
+watchEffect(() => {
+  if (!open.value) {
+    abortController?.abort()
+    return
+  }
+
+  // Reset the modal when opening
+  sourceToProgress.value = {}
+  expanded.value = {}
+  downloading.value = false
+  done.value = false
 })
 
 const download = async () => {


### PR DESCRIPTION
When closing the download support bundle modal, cancel any in-progress downloads and properly reset the modal's state.