### PR TITLE
fix(frontend): correct config patch routing for cluster machines

### DIFF
--- a/frontend/src/views/cluster/Config/PatchEdit.vue
+++ b/frontend/src/views/cluster/Config/PatchEdit.vue
@@ -315,7 +315,7 @@ const patchTypes = computed(() => {
   }
 
   if (machine.value?.metadata.labels?.[LabelCluster] ?? route.params.machine) {
-    return [PatchType.Machine, PatchType.ClusterMachine]
+    return [PatchType.ClusterMachine, PatchType.Machine]
   }
 
   return undefined

--- a/frontend/src/views/cluster/Config/Patches.vue
+++ b/frontend/src/views/cluster/Config/Patches.vue
@@ -119,6 +119,20 @@ interface RouteItem {
   description?: string
 }
 
+type PatchEditRouteName = 'ClusterPatchEdit' | 'ClusterMachinePatchEdit' | 'MachinePatchEdit'
+
+const patchEditRouteName = computed<PatchEditRouteName>(() => {
+  if (cluster) {
+    return 'ClusterPatchEdit'
+  }
+
+  if (route.params.cluster) {
+    return 'ClusterMachinePatchEdit'
+  }
+
+  return 'MachinePatchEdit'
+})
+
 const patchTypeCluster = 'Cluster'
 
 const routes = computed(() => {
@@ -145,13 +159,11 @@ const routes = computed(() => {
       return
     }
 
-    const patchEditPage = route.params.cluster ? 'ClusterMachinePatchEdit' : 'MachinePatchEdit'
-
     const r = {
       name: (item.metadata.annotations || {})[ConfigPatchName] || item.metadata.id!,
       icon: 'document',
       route: {
-        name: machine ? patchEditPage : 'ClusterPatchEdit',
+        name: patchEditRouteName.value,
         params: { patch: item.metadata.id! },
       },
       id: item.metadata.id!,
@@ -240,7 +252,7 @@ const openPatchCreate = () => {
   }
 
   router.push({
-    name: cluster ? 'ClusterPatchEdit' : 'MachinePatchEdit',
+    name: patchEditRouteName.value,
     params: {
       patch: `500-${uuidv4()}`,
     },


### PR DESCRIPTION
Patch creation from a cluster machine page navigated to the standalone machine patch editor instead of the cluster machine one. Also fixed the patch target selector defaulting to Machine instead of Cluster Machine.
