### PR TITLE
feat(frontend): replace mount status data with volume status data

### DIFF
--- a/client/pkg/constants/talos.go
+++ b/client/pkg/constants/talos.go
@@ -44,6 +44,8 @@ const (
 	_ = runtime.MountStatusType
 	// tsgen:TalosMachineStatusType
 	_ = runtime.MachineStatusType
+	// tsgen:TalosVolumeStatusType
+	_ = block.VolumeStatusType
 
 	// Resource ids.
 	// tsgen:TalosNodenameID

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -52,6 +52,7 @@ export const TalosPCIDeviceType = "PCIDevices.hardware.talos.dev";
 export const TalosNodeAddressType = "NodeAddresses.net.talos.dev";
 export const TalosMountStatusType = "MountStatuses.runtime.talos.dev";
 export const TalosMachineStatusType = "MachineStatuses.runtime.talos.dev";
+export const TalosVolumeStatusType = "VolumeStatuses.block.talos.dev";
 export const TalosNodenameID = "nodename";
 export const TalosAddressRoutedNoK8s = "routed-no-k8s";
 export const TalosCPUID = "latest";

--- a/frontend/src/views/cluster/Nodes/NodeDisks.stories.ts
+++ b/frontend/src/views/cluster/Nodes/NodeDisks.stories.ts
@@ -8,14 +8,14 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import {
   TalosDiscoveredVolumeType,
   TalosDiskType,
-  TalosMountStatusType,
   TalosRuntimeNamespace,
+  TalosVolumeStatusType,
 } from '@/api/resources'
 
 import NodeDisks, {
   type TalosDiscoveredVolumeSpec,
   type TalosDiskSpec,
-  type TalosMountStatusSpec,
+  type TalosVolumeStatusSpec,
 } from './NodeDisks.vue'
 
 const meta: Meta<typeof NodeDisks> = {
@@ -142,23 +142,61 @@ export const WithData = {
           ],
         }).handler,
 
-        createWatchStreamHandler<TalosMountStatusSpec>({
+        createWatchStreamHandler<TalosVolumeStatusSpec>({
           expectedOptions: {
             namespace: TalosRuntimeNamespace,
-            type: TalosMountStatusType,
+            type: TalosVolumeStatusType,
           },
           initialResources: [
             {
               metadata: {
-                id: '/dev/vda4',
+                id: 'EPHEMERAL',
                 namespace: TalosRuntimeNamespace,
-                type: TalosMountStatusType,
+                type: TalosVolumeStatusType,
               },
               spec: {
-                encrypted: true,
-                filesystemType: 'xfs',
-                source: '/dev/vda4',
-                target: '/var',
+                filesystem: 'xfs',
+                location: '/dev/vda4',
+                mountLocation: '/dev/vda4',
+                mountSpec: {
+                  fileMode: 493,
+                  projectQuotaSupport: true,
+                  selinuxLabel: 'system_u:object_r:ephemeral_t:s0',
+                  targetPath: '/var',
+                },
+                parentLocation: '/dev/vda',
+                partitionIndex: 4,
+                phase: 'ready',
+                prettySize: '4.1 GB',
+                size: 4131389440,
+                type: 'partition',
+              },
+            },
+            {
+              metadata: {
+                id: 'u-mydata2',
+                namespace: TalosRuntimeNamespace,
+                type: TalosVolumeStatusType,
+              },
+              spec: {
+                configuredEncryptionKeys: ['static'],
+                encryptionProvider: 'luks2',
+                encryptionSlot: 0,
+                filesystem: 'xfs',
+                location: '/dev/vda3',
+                mountLocation: '/dev/dm-0',
+                mountSpec: {
+                  fileMode: 493,
+                  projectQuotaSupport: false,
+                  selinuxLabel: 'system_u:object_r:ephemeral_t:s0',
+                  targetPath: 'mydata2',
+                },
+                parentLocation: '/dev/vda',
+                partitionIndex: 3,
+                phase: 'ready',
+                prettySize: '104 MB',
+                size: 104857600,
+                type: 'partition',
               },
             },
           ],

--- a/frontend/src/views/cluster/Nodes/NodeDisks.vue
+++ b/frontend/src/views/cluster/Nodes/NodeDisks.vue
@@ -44,11 +44,38 @@ export interface TalosDiscoveredVolumeSpec {
   uuid?: string
 }
 
-export interface TalosMountStatusSpec {
-  encrypted?: boolean
-  filesystemType?: string
-  source?: string
-  target?: string
+export interface TalosVolumeStatusMountSpec {
+  fileMode?: number
+  gid?: number
+  parentId?: string
+  projectQuotaSupport?: boolean
+  recursiveRelabel?: boolean
+  selinuxLabel?: string
+  targetPath?: string
+  uid?: number
+}
+
+export interface TalosVolumeStatusSpec {
+  mountSpec?: TalosVolumeStatusMountSpec
+  phase?: string
+  type?: string
+  parentID?: string
+  symlink?: {
+    force?: boolean
+    symlinkTargetPath?: string
+  }
+  configuredEncryptionKeys?: string[]
+  encryptionProvider?: string
+  encryptionSlot?: number
+  filesystem?: string
+  location?: string
+  mountLocation?: string
+  parentLocation?: string
+  partitionIndex?: number
+  partitionUUID?: string
+  prettySize?: string
+  size?: number
+  uuid?: string
 }
 </script>
 
@@ -59,8 +86,8 @@ import { Runtime } from '@/api/common/omni.pb'
 import {
   TalosDiscoveredVolumeType,
   TalosDiskType,
-  TalosMountStatusType,
   TalosRuntimeNamespace,
+  TalosVolumeStatusType,
 } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import TIcon from '@/components/common/Icon/TIcon.vue'
@@ -94,16 +121,19 @@ const { data: volumes, loading: volumesLoading } = useResourceWatch<TalosDiscove
   }),
 )
 
-const { data: mounts, loading: mountsLoading } = useResourceWatch<TalosMountStatusSpec>(() => ({
-  resource: {
-    namespace: TalosRuntimeNamespace,
-    type: TalosMountStatusType,
-  },
-  runtime: Runtime.Talos,
-  context,
-}))
+const { data: volumeStatuses, loading: volumeStatusesLoading } =
+  useResourceWatch<TalosVolumeStatusSpec>(() => ({
+    resource: {
+      namespace: TalosRuntimeNamespace,
+      type: TalosVolumeStatusType,
+    },
+    runtime: Runtime.Talos,
+    context,
+  }))
 
-const loading = computed(() => disksLoading.value || volumesLoading.value || mountsLoading.value)
+const loading = computed(
+  () => disksLoading.value || volumesLoading.value || volumeStatusesLoading.value,
+)
 
 const organizedDisks = computed(() =>
   disks.value
@@ -114,7 +144,7 @@ const organizedDisks = computed(() =>
         .filter((v) => v.spec.parent === disk.metadata.id)
         .map((v) => ({
           volume: v,
-          mount: mounts.value.find((m) => m.spec.source === v.spec.dev_path),
+          volumeStatus: volumeStatuses.value.find((m) => m.spec.location === v.spec.dev_path),
         }))
         .sort(
           (a, b) => (a.volume.spec.partition_index || 0) - (b.volume.spec.partition_index || 0),

--- a/frontend/src/views/cluster/Nodes/components/DiskPartitionTable.vue
+++ b/frontend/src/views/cluster/Nodes/components/DiskPartitionTable.vue
@@ -13,13 +13,13 @@ import TableRoot from '@/components/common/Table/TableRoot.vue'
 import TableRow from '@/components/common/Table/TableRow.vue'
 import type {
   TalosDiscoveredVolumeSpec,
-  TalosMountStatusSpec,
+  TalosVolumeStatusSpec,
 } from '@/views/cluster/Nodes/NodeDisks.vue'
 
 defineProps<{
   partitions: {
     volume: Resource<TalosDiscoveredVolumeSpec>
-    mount?: Resource<TalosMountStatusSpec>
+    volumeStatus?: Resource<TalosVolumeStatusSpec>
   }[]
 }>()
 
@@ -37,15 +37,15 @@ const getFilesystemIcon = (fsType?: string): IconType => {
   return 'document'
 }
 
-const isEncrypted = (item?: Resource<TalosMountStatusSpec>) => {
-  if (item?.spec.encrypted === undefined) {
+const isEncrypted = (item?: Resource<TalosVolumeStatusSpec>) => {
+  if (!item) {
     return Encryption.Unknown
   }
 
-  return item.spec.encrypted ? Encryption.Enabled : Encryption.Disabled
+  return item.spec.encryptionProvider ? Encryption.Enabled : Encryption.Disabled
 }
 
-const getEncryptionClass = (item?: Resource<TalosMountStatusSpec>) => {
+const getEncryptionClass = (item?: Resource<TalosVolumeStatusSpec>) => {
   switch (isEncrypted(item)) {
     case Encryption.Disabled:
       return 'text-red-r1'
@@ -56,7 +56,7 @@ const getEncryptionClass = (item?: Resource<TalosMountStatusSpec>) => {
   }
 }
 
-const getEncryptionIcon = (item?: Resource<TalosMountStatusSpec>): IconType => {
+const getEncryptionIcon = (item?: Resource<TalosVolumeStatusSpec>): IconType => {
   switch (isEncrypted(item)) {
     case Encryption.Disabled:
       return 'unlocked'
@@ -83,7 +83,7 @@ const getEncryptionIcon = (item?: Resource<TalosMountStatusSpec>): IconType => {
 
       <template #body>
         <TableRow
-          v-for="{ mount, volume } in partitions"
+          v-for="{ volume, volumeStatus } in partitions"
           :key="itemID(volume)"
           :aria-labelledby="`volume-${volume.metadata.id}-title`"
           class="whitespace-nowrap"
@@ -91,7 +91,7 @@ const getEncryptionIcon = (item?: Resource<TalosMountStatusSpec>): IconType => {
           <TableCell>
             <div class="flex items-center gap-2">
               <TIcon
-                :icon="getFilesystemIcon(volume.spec.name)"
+                :icon="getFilesystemIcon(volume.spec.name || volumeStatus?.spec.filesystem)"
                 class="size-4 shrink-0 text-naturals-n14"
               />
 
@@ -110,15 +110,17 @@ const getEncryptionIcon = (item?: Resource<TalosMountStatusSpec>): IconType => {
             </div>
           </TableCell>
 
-          <TableCell class="font-medium">{{ volume.spec.name || 'N/A' }}</TableCell>
+          <TableCell class="font-medium">
+            {{ volume.spec.name || volumeStatus?.spec.filesystem || 'N/A' }}
+          </TableCell>
 
           <TableCell>
             <span
               class="inline-flex items-center gap-1 rounded bg-naturals-n4 px-1.5 py-0.75"
-              :class="getEncryptionClass(mount)"
+              :class="getEncryptionClass(volumeStatus)"
             >
-              <TIcon :icon="getEncryptionIcon(mount)" class="size-3" aria-hidden />
-              <span class="text-xs/none">{{ isEncrypted(mount) }}</span>
+              <TIcon :icon="getEncryptionIcon(volumeStatus)" class="size-3" aria-hidden />
+              <span class="text-xs/none">{{ isEncrypted(volumeStatus) }}</span>
             </span>
           </TableCell>
 


### PR DESCRIPTION
For NodeDisks, query VolumeStatuses instead of MountStatuses to get better information about encryption and filesystem.

<img width="1068" height="906" alt="image" src="https://github.com/user-attachments/assets/f7925f25-71aa-4294-a539-8ed947857fc9" />
