### PR TITLE
fix(frontend): prevent -1 stats on home page

### DIFF
--- a/frontend/src/views/omni/Home/HomeClustersChart.vue
+++ b/frontend/src/views/omni/Home/HomeClustersChart.vue
@@ -37,7 +37,7 @@ const counts = computed(() => {
   const scalingUpCount = spec?.phases?.[ClusterStatusSpecPhase.SCALING_UP] ?? 0
 
   return {
-    healthyCount: runningCount - notReadyCount,
+    healthyCount: Math.max(runningCount - notReadyCount, 0),
     unhealthyCount: notReadyCount,
     scalingUpCount,
     scalingDownCount,

--- a/frontend/src/views/omni/Home/HomeMachinesChart.vue
+++ b/frontend/src/views/omni/Home/HomeMachinesChart.vue
@@ -39,9 +39,9 @@ const counts = computed(() => {
     totalCount: registeredCount + pendingCount,
     connectedCount,
     pendingCount,
-    notConnectedCount: registeredCount - connectedCount,
+    notConnectedCount: Math.max(registeredCount - connectedCount, 0),
     inClusterCount: allocatedCount,
-    freeMachineCount: registeredCount - allocatedCount,
+    freeMachineCount: Math.max(registeredCount - allocatedCount, 0),
   }
 })
 </script>


### PR DESCRIPTION
Clamp values to prevent -1 stats on home page, in event of unusual data.