### PR TITLE
test: fix flaky link cleanup test

### DIFF
--- a/internal/backend/runtime/omni/controllers/cleanup/id.go
+++ b/internal/backend/runtime/omni/controllers/cleanup/id.go
@@ -33,7 +33,9 @@ func (h *SameIDHandler[I, O]) FinalizerRemoval(ctx context.Context, r controller
 		resource.VersionUndefined,
 	)
 
-	res, err := r.Get(ctx, md)
+	// Use GetUncached to bypass the controller runtime cache. A cached miss here would cause the handler to skip cleanup permanently (the finalizer gets removed
+	// and the orphaned resource is never retried).
+	res, err := r.GetUncached(ctx, md)
 	if err != nil {
 		if state.IsNotFoundError(err) {
 			return nil
@@ -99,7 +101,9 @@ func IDHandleFunc[I, O generic.ResourceWithRD](getIDFunc GetIDFunc[I], blockIfOw
 			resource.VersionUndefined,
 		)
 
-		res, err := r.Get(ctx, md)
+		// Use GetUncached to bypass the controller runtime cache. A cached miss here would cause the handler to skip cleanup permanently (the finalizer gets removed
+		// and the orphaned resource is never retried).
+		res, err := r.GetUncached(ctx, md)
 		if err != nil {
 			if state.IsNotFoundError(err) {
 				return nil

--- a/internal/backend/runtime/omni/controllers/omni/link_cleanup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/link_cleanup_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller/runtime"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,7 +32,7 @@ func TestLinkCleanup(t *testing.T) {
 
 	controller := omni.NewLinkCleanupController()
 
-	st := state.WrapCore(namespaced.NewState(inmem.Build))
+	st := state.WrapCore(namespaced.NewState(omniruntime.TestStateBuilder()))
 	logger := zaptest.NewLogger(t)
 
 	rt, err := runtime.NewRuntime(st, logger, omniruntime.RuntimeCacheOptions()...)


### PR DESCRIPTION
Use GetUncached to bypass controller runtime cache in cleanup controllers.
