### PR TITLE
feat: warn about non-factory machines on extensions and kernel args

### DIFF
--- a/frontend/src/views/cluster/Nodes/NodeExtensions.vue
+++ b/frontend/src/views/cluster/Nodes/NodeExtensions.vue
@@ -15,6 +15,7 @@ import type {
   ExtensionsConfigurationSpec,
   MachineExtensionsSpec,
   MachineExtensionsStatusSpec,
+  MachineStatusSpec,
 } from '@/api/omni/specs/omni.pb'
 import { MachineExtensionsStatusSpecItemPhase } from '@/api/omni/specs/omni.pb'
 import {
@@ -26,6 +27,7 @@ import {
   LabelMachineSet,
   MachineExtensionsStatusType,
   MachineExtensionsType,
+  MachineStatusType,
 } from '@/api/resources'
 import type { WatchOptions } from '@/api/watch'
 import Watch from '@/api/watch'
@@ -37,6 +39,7 @@ import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import TInput from '@/components/common/TInput/TInput.vue'
 import TAlert from '@/components/TAlert.vue'
 import { setupClusterPermissions } from '@/methods/auth'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const machineExtensionsStatus = ref<Resource<MachineExtensionsStatusSpec>>()
 const machineExtensionsStatusWatch = new Watch(machineExtensionsStatus)
@@ -51,6 +54,17 @@ const ready = computed(() => {
 })
 
 const { canUpdateTalos } = setupClusterPermissions(computed(() => route.params.cluster as string))
+
+const { data: machineStatus } = useResourceWatch<MachineStatusSpec>(() => ({
+  resource: {
+    id: route.params.machine as string,
+    namespace: DefaultNamespace,
+    type: MachineStatusType,
+  },
+  runtime: Runtime.Omni,
+}))
+
+const invalidSchematic = computed(() => machineStatus.value?.spec.schematic?.invalid === true)
 
 machineExtensionsStatusWatch.setup(
   computed((): WatchOptions | undefined => {
@@ -224,7 +238,11 @@ const openExtensionsUpdate = () => {
           <TSpinner class="h-6 w-6" />
         </div>
         <div v-else class="flex-1">
-          <TAlert title="No Extensions Found" type="info" />
+          <TAlert v-if="invalidSchematic" title="Non-factory Machine" type="warn">
+            This machine was not provisioned using an image factory image. Extensions cannot be
+            managed by Omni for this machine.
+          </TAlert>
+          <TAlert v-else title="No Extensions Found" type="info" />
         </div>
       </div>
     </PageContainer>
@@ -232,7 +250,11 @@ const openExtensionsUpdate = () => {
     <div
       class="flex h-16 shrink-0 items-center justify-end border-t border-naturals-n5 bg-naturals-n1 px-12"
     >
-      <TButton variant="highlighted" :disabled="!canUpdateTalos" @click="openExtensionsUpdate">
+      <TButton
+        variant="highlighted"
+        :disabled="!canUpdateTalos || invalidSchematic"
+        @click="openExtensionsUpdate"
+      >
         Update Extensions
       </TButton>
     </div>

--- a/internal/backend/runtime/omni/controllers/omni/kernelargs/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kernelargs/status.go
@@ -46,6 +46,13 @@ func NewStatusController() *StatusController {
 					status.TypedSpec().Value.CurrentArgs = kernelargs.FilterExtras(ms.TypedSpec().Value.Schematic.KernelArgs)
 				}
 
+				if ms.TypedSpec().Value.Schematic.GetInvalid() {
+					status.TypedSpec().Value.UnmetConditions = append(status.TypedSpec().Value.UnmetConditions,
+						"Machine was not provisioned using an image factory image, kernel args cannot be managed")
+
+					return nil
+				}
+
 				if omni.GetMachineStatusSystemDisk(ms) == "" {
 					status.TypedSpec().Value.UnmetConditions = append(status.TypedSpec().Value.UnmetConditions, "Talos is not installed, kernel args cannot be updated yet")
 				}

--- a/internal/backend/runtime/omni/controllers/omni/kernelargs/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/kernelargs/status_test.go
@@ -124,5 +124,19 @@ func TestReconcile(t *testing.T) {
 			assertion.Equal(initialKernelArgs, res.TypedSpec().Value.CurrentArgs)
 			assertion.Equal([]string{"updated-arg-1", "updated-arg-2"}, res.TypedSpec().Value.Args)
 		})
+
+		// Mark the machine as having an invalid schematic — kernel args should no longer be manageable.
+		_, err = safe.StateUpdateWithConflicts(ctx, testContext.State, ms.Metadata(), func(res *omni.MachineStatus) error {
+			res.TypedSpec().Value.Schematic.Invalid = true
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.KernelArgsStatus, assertion *assert.Assertions) {
+			assertion.Equal([]string{
+				"Machine was not provisioned using an image factory image, kernel args cannot be managed",
+			}, res.TypedSpec().Value.UnmetConditions)
+		})
 	})
 }


### PR DESCRIPTION
Machines not provisioned via image factory cannot have their extensions or kernel args managed by Omni. Add an unmet condition in KernelArgsStatusController when the schematic is invalid, which prevents kernel args management. On the frontend, show a warning on the node extensions page and disable the Update Extensions button for these machines.

---
<img width="1509" height="711" alt="extensions" src="https://github.com/user-attachments/assets/e274c0e1-f747-43b2-ad58-6480ce03499b" />

---

<img width="1151" height="356" alt="kernel-args" src="https://github.com/user-attachments/assets/e729c99e-f415-454c-a22e-61bd6e51cef1" />
