### PR TITLE
fix(frontend): fix cluster details layout for ultrawide and mobile

### DIFF
--- a/frontend/src/views/cluster/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewContent.vue
@@ -168,249 +168,248 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div>
-    <div class="flex w-full items-start justify-start">
-      <div class="mr-6 w-full max-w-[80%] max-lg:mr-2 max-lg:w-full">
-        <TAlert v-if="clusterLocked" title="Cluster is Locked" type="warn" class="mb-4">
-          All operations on this cluster are currently disabled. Config patches can be created,
-          updated or deleted but these changes will not be applied while the cluster is locked.
-        </TAlert>
-        <div class="relative mb-6 min-h-25 bg-naturals-n2 p-5">
-          <div
-            class="flex w-full flex-wrap gap-2 transition-opacity duration-500 *:flex-1"
-            :class="{ 'opacity-25': !showStats }"
-          >
-            <RadialBar
-              title="CPU"
-              vertical
-              :total="usage?.spec?.cpu?.capacity ?? 0"
-              :items="[
-                { label: 'Requests', value: usage?.spec?.cpu?.requests ?? 0 },
-                { label: 'Limits', value: usage?.spec?.cpu?.limits ?? 0 },
-              ]"
-              :legend-formatter="(input) => input.toFixed(2)"
-            />
-            <RadialBar
-              title="Pods"
-              vertical
-              :total="usage?.spec?.pods?.capacity ?? 0"
-              :items="[{ label: 'Requests', value: usage?.spec?.pods?.count ?? 0 }]"
-            />
-            <RadialBar
-              title="Memory"
-              vertical
-              :total="usage?.spec?.mem?.capacity ?? 0"
-              :items="[
-                { label: 'Requests', value: usage?.spec?.mem?.requests ?? 0 },
-                { label: 'Limits', value: usage?.spec?.mem?.limits ?? 0 },
-              ]"
-              :legend-formatter="formatBytes"
-            />
-            <RadialBar
-              title="Ephemeral Storage"
-              vertical
-              :total="usage?.spec?.storage?.capacity ?? 0"
-              :items="[
-                { label: 'Requests', value: usage?.spec?.storage?.requests ?? 0 },
-                { label: 'Limits', value: usage?.spec?.storage?.limits ?? 0 },
-              ]"
-              :legend-formatter="formatBytes"
-            />
-          </div>
-          <div
-            v-if="!showStats"
-            class="absolute top-0 right-0 bottom-0 left-0 flex items-center justify-center text-sm"
-          >
-            <div class="flex flex-col gap-2">
-              <div class="text-naturals-n13">
-                Kubernetes stats are disabled due to the size of the cluster
-              </div>
-            </div>
-          </div>
+  <div class="flex flex-col justify-start gap-6 max-lg:gap-4 lg:flex-row lg:items-start">
+    <div class="grow">
+      <TAlert v-if="clusterLocked" title="Cluster is Locked" type="warn" class="mb-4">
+        All operations on this cluster are currently disabled. Config patches can be created,
+        updated or deleted but these changes will not be applied while the cluster is locked.
+      </TAlert>
+      <div class="relative mb-6 min-h-25 bg-naturals-n2 p-5">
+        <div
+          class="flex w-full flex-wrap gap-2 transition-opacity duration-500 *:flex-1"
+          :class="{ 'opacity-25': !showStats }"
+        >
+          <RadialBar
+            title="CPU"
+            vertical
+            :total="usage?.spec?.cpu?.capacity ?? 0"
+            :items="[
+              { label: 'Requests', value: usage?.spec?.cpu?.requests ?? 0 },
+              { label: 'Limits', value: usage?.spec?.cpu?.limits ?? 0 },
+            ]"
+            :legend-formatter="(input) => input.toFixed(2)"
+          />
+          <RadialBar
+            title="Pods"
+            vertical
+            :total="usage?.spec?.pods?.capacity ?? 0"
+            :items="[{ label: 'Requests', value: usage?.spec?.pods?.count ?? 0 }]"
+          />
+          <RadialBar
+            title="Memory"
+            vertical
+            :total="usage?.spec?.mem?.capacity ?? 0"
+            :items="[
+              { label: 'Requests', value: usage?.spec?.mem?.requests ?? 0 },
+              { label: 'Limits', value: usage?.spec?.mem?.limits ?? 0 },
+            ]"
+            :legend-formatter="formatBytes"
+          />
+          <RadialBar
+            title="Ephemeral Storage"
+            vertical
+            :total="usage?.spec?.storage?.capacity ?? 0"
+            :items="[
+              { label: 'Requests', value: usage?.spec?.storage?.requests ?? 0 },
+              { label: 'Limits', value: usage?.spec?.storage?.limits ?? 0 },
+            ]"
+            :legend-formatter="formatBytes"
+          />
         </div>
         <div
-          v-if="kubernetesUpgradeStatus && kubernetesUpgradeStatus.spec.step"
-          class="mb-5 rounded bg-naturals-n2 pt-5"
+          v-if="!showStats"
+          class="absolute top-0 right-0 bottom-0 left-0 flex items-center justify-center text-sm"
         >
-          <div class="flex items-center gap-1 px-6 pb-4">
-            <span class="flex-1 text-sm text-naturals-n13">Kubernetes Update</span>
-            <template v-if="kubernetesUpgradeStatus.spec.current_upgrade_version">
-              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
-                {{ kubernetesUpgradeStatus.spec.last_upgrade_version }}
-              </span>
-              <span>⇾</span>
-              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
-                {{ kubernetesUpgradeStatus.spec.current_upgrade_version }}
-              </span>
-            </template>
-            <template v-else>
-              <span class="text-sm text-naturals-n13">Reverting back to</span>
-              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
-                {{ kubernetesUpgradeStatus.spec.last_upgrade_version }}
-              </span>
-            </template>
-          </div>
-          <div class="flex min-h-20 items-center gap-2 border-t-8 border-naturals-n4 p-4 text-xs">
-            <TIcon
-              v-if="clusterLocked || machineLockedForKubernetesUpgrade"
-              icon="pause-circle"
-              class="h-6 w-6"
-            />
-            <TIcon v-else icon="loading" class="h-6 w-6 animate-spin text-yellow-y1" />
-            <div class="flex-1">
-              {{ kubernetesUpgradeStatus.spec.step }}
-              <template v-if="kubernetesUpgradeStatus.spec.status && !clusterLocked">
-                - {{ kubernetesUpgradeStatus.spec.status }}
-              </template>
-              <template v-if="clusterLocked">- waiting for cluster to be unlocked</template>
+          <div class="flex flex-col gap-2">
+            <div class="text-naturals-n13">
+              Kubernetes stats are disabled due to the size of the cluster
             </div>
-            <TButton
-              v-if="
-                kubernetesUpgradeStatus.spec.phase === KubernetesUpgradeStatusSpecPhase.Upgrading &&
-                !clusterLocked
-              "
-              variant="secondary"
-              class="place-self-end"
-              icon="close"
-              @click="revertKubernetesUpgrade(clusterId)"
-            >
-              Cancel
-            </TButton>
-          </div>
-        </div>
-        <div
-          v-if="talosUpgradeStatus && talosUpgradeStatus.spec.status"
-          class="mb-5 rounded bg-naturals-n2 pt-5"
-        >
-          <div class="flex items-center gap-1 px-6 pb-4">
-            <span class="flex-1 text-sm text-naturals-n13">Talos Update</span>
-            <template v-if="talosUpgradeStatus.spec.current_upgrade_version">
-              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
-                {{ talosUpgradeStatus.spec.last_upgrade_version }}
-              </span>
-              <span>⇾</span>
-              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
-                {{ talosUpgradeStatus.spec.current_upgrade_version }}
-              </span>
-            </template>
-            <template
-              v-else-if="talosUpgradeStatus.spec.phase === TalosUpgradeStatusSpecPhase.Reverting"
-            >
-              <span class="text-sm text-naturals-n13">Reverting back to</span>
-              <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
-                {{ talosUpgradeStatus.spec.last_upgrade_version }}
-              </span>
-            </template>
-            <template
-              v-else-if="
-                talosUpgradeStatus.spec.phase ===
-                TalosUpgradeStatusSpecPhase.UpdatingMachineSchematics
-              "
-            >
-              <span class="text-sm text-naturals-n13">Updating Machine Schematics</span>
-            </template>
-          </div>
-          <div class="flex min-h-20 items-center gap-2 border-t-8 border-naturals-n4 p-4 text-xs">
-            <TIcon
-              v-if="clusterLocked || machineLockedForTalosUpgrade"
-              icon="pause-circle"
-              class="h-6 w-6"
-            />
-            <TIcon v-else icon="loading" class="h-6 w-6 animate-spin text-yellow-y1" />
-            <div class="flex-1">
-              {{ talosUpgradeStatus.spec.status }}
-              <template v-if="talosUpgradeStatus.spec.status && !clusterLocked">
-                - {{ talosUpgradeStatus.spec.step }}
-              </template>
-              <template v-if="clusterLocked">- waiting for cluster to be unlocked</template>
-            </div>
-            <TButton
-              v-if="
-                talosUpgradeStatus.spec.phase === TalosUpgradeStatusSpecPhase.Upgrading &&
-                talosUpgradeStatus.spec.current_upgrade_version &&
-                !clusterLocked
-              "
-              variant="secondary"
-              class="place-self-end"
-              icon="close"
-              @click="revertTalosUpgrade(clusterId)"
-            >
-              Cancel
-            </TButton>
-          </div>
-        </div>
-        <div
-          v-if="secretRotationStatus && secretRotationStatus.spec.status"
-          class="mb-5 rounded bg-naturals-n2 pt-5"
-        >
-          <div class="flex items-center gap-1 px-6 pb-4">
-            <span class="flex-1 text-sm text-naturals-n13">Secret Rotation</span>
-            <span class="text-sm text-naturals-n13">{{ getComponentInRotation }}</span>
-          </div>
-          <div class="flex min-h-20 items-center gap-2 border-t-8 border-naturals-n4 p-4 text-xs">
-            <TIcon
-              v-if="clusterLocked || machineLockedForSecretRotation"
-              icon="pause-circle"
-              class="h-6 w-6"
-            />
-            <TIcon v-else icon="loading" class="h-6 w-6 animate-spin text-yellow-y1" />
-            <div class="flex-1">
-              {{ secretRotationStatus.spec.status }}
-              <template v-if="clusterLocked">- waiting for cluster to be unlocked</template>
-              <template v-else-if="secretRotationStatus.spec.status">
-                - {{ secretRotationStatus.spec.step }}
-              </template>
-            </div>
-          </div>
-        </div>
-        <div class="flex gap-5">
-          <div class="mb-5 flex-1 rounded bg-naturals-n2 px-6 py-5">
-            <div class="mb-3">
-              <span class="text-sm text-naturals-n13">Features</span>
-            </div>
-            <div class="flex flex-col gap-2">
-              <ClusterWorkloadProxyingCheckbox
-                :model-value="enableWorkloadProxy"
-                :disabled="!canManageClusterFeatures || !features?.spec.enable_workload_proxying"
-                @update:model-value="(value) => setClusterWorkloadProxy(clusterId, value)"
-              />
-              <EmbeddedDiscoveryServiceCheckbox
-                :model-value="useEmbeddedDiscoveryService"
-                :disabled="!canManageClusterFeatures || !isEmbeddedDiscoveryServiceAvailable"
-                @update:model-value="(value) => toggleUseEmbeddedDiscoveryService(value)"
-              />
-              <ClusterEtcdBackupCheckbox
-                :backup-status="backupStatus"
-                :cluster="currentCluster.spec"
-                @update:cluster="(spec) => setClusterEtcdBackupsConfig(clusterId, spec)"
-              />
-            </div>
-          </div>
-          <div class="mb-5 flex-1 rounded bg-naturals-n2 px-6 py-5">
-            <div class="mb-3">
-              <span class="text-sm text-naturals-n13">Labels</span>
-            </div>
-            <ItemLabels
-              :resource="currentCluster"
-              :add-label-func="addClusterLabels"
-              :remove-label-func="removeClusterLabels"
-            />
-          </div>
-        </div>
-        <div class="flex-col rounded bg-naturals-n2 pt-5">
-          <div class="flex px-6 pb-4">
-            <span class="text-sm text-naturals-n13">Machines</span>
-          </div>
-          <div class="grid grid-cols-[repeat(4,1fr)_--spacing(18)]">
-            <ClusterMachines is-subgrid :cluster-i-d="clusterId" />
           </div>
         </div>
       </div>
-      <OverviewRightPanel
-        :kubernetes-upgrade-status="kubernetesUpgradeStatus"
-        :talos-upgrade-status="talosUpgradeStatus"
-        :etcd-backups="backupStatus"
-      />
+      <div
+        v-if="kubernetesUpgradeStatus && kubernetesUpgradeStatus.spec.step"
+        class="mb-5 rounded bg-naturals-n2 pt-5"
+      >
+        <div class="flex items-center gap-1 px-6 pb-4">
+          <span class="flex-1 text-sm text-naturals-n13">Kubernetes Update</span>
+          <template v-if="kubernetesUpgradeStatus.spec.current_upgrade_version">
+            <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
+              {{ kubernetesUpgradeStatus.spec.last_upgrade_version }}
+            </span>
+            <span>⇾</span>
+            <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
+              {{ kubernetesUpgradeStatus.spec.current_upgrade_version }}
+            </span>
+          </template>
+          <template v-else>
+            <span class="text-sm text-naturals-n13">Reverting back to</span>
+            <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
+              {{ kubernetesUpgradeStatus.spec.last_upgrade_version }}
+            </span>
+          </template>
+        </div>
+        <div class="flex min-h-20 items-center gap-2 border-t-8 border-naturals-n4 p-4 text-xs">
+          <TIcon
+            v-if="clusterLocked || machineLockedForKubernetesUpgrade"
+            icon="pause-circle"
+            class="h-6 w-6"
+          />
+          <TIcon v-else icon="loading" class="h-6 w-6 animate-spin text-yellow-y1" />
+          <div class="flex-1">
+            {{ kubernetesUpgradeStatus.spec.step }}
+            <template v-if="kubernetesUpgradeStatus.spec.status && !clusterLocked">
+              - {{ kubernetesUpgradeStatus.spec.status }}
+            </template>
+            <template v-if="clusterLocked">- waiting for cluster to be unlocked</template>
+          </div>
+          <TButton
+            v-if="
+              kubernetesUpgradeStatus.spec.phase === KubernetesUpgradeStatusSpecPhase.Upgrading &&
+              !clusterLocked
+            "
+            variant="secondary"
+            class="place-self-end"
+            icon="close"
+            @click="revertKubernetesUpgrade(clusterId)"
+          >
+            Cancel
+          </TButton>
+        </div>
+      </div>
+      <div
+        v-if="talosUpgradeStatus && talosUpgradeStatus.spec.status"
+        class="mb-5 rounded bg-naturals-n2 pt-5"
+      >
+        <div class="flex items-center gap-1 px-6 pb-4">
+          <span class="flex-1 text-sm text-naturals-n13">Talos Update</span>
+          <template v-if="talosUpgradeStatus.spec.current_upgrade_version">
+            <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
+              {{ talosUpgradeStatus.spec.last_upgrade_version }}
+            </span>
+            <span>⇾</span>
+            <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
+              {{ talosUpgradeStatus.spec.current_upgrade_version }}
+            </span>
+          </template>
+          <template
+            v-else-if="talosUpgradeStatus.spec.phase === TalosUpgradeStatusSpecPhase.Reverting"
+          >
+            <span class="text-sm text-naturals-n13">Reverting back to</span>
+            <span class="rounded bg-naturals-n4 px-2 text-sm font-bold text-naturals-n13">
+              {{ talosUpgradeStatus.spec.last_upgrade_version }}
+            </span>
+          </template>
+          <template
+            v-else-if="
+              talosUpgradeStatus.spec.phase ===
+              TalosUpgradeStatusSpecPhase.UpdatingMachineSchematics
+            "
+          >
+            <span class="text-sm text-naturals-n13">Updating Machine Schematics</span>
+          </template>
+        </div>
+        <div class="flex min-h-20 items-center gap-2 border-t-8 border-naturals-n4 p-4 text-xs">
+          <TIcon
+            v-if="clusterLocked || machineLockedForTalosUpgrade"
+            icon="pause-circle"
+            class="h-6 w-6"
+          />
+          <TIcon v-else icon="loading" class="h-6 w-6 animate-spin text-yellow-y1" />
+          <div class="flex-1">
+            {{ talosUpgradeStatus.spec.status }}
+            <template v-if="talosUpgradeStatus.spec.status && !clusterLocked">
+              - {{ talosUpgradeStatus.spec.step }}
+            </template>
+            <template v-if="clusterLocked">- waiting for cluster to be unlocked</template>
+          </div>
+          <TButton
+            v-if="
+              talosUpgradeStatus.spec.phase === TalosUpgradeStatusSpecPhase.Upgrading &&
+              talosUpgradeStatus.spec.current_upgrade_version &&
+              !clusterLocked
+            "
+            variant="secondary"
+            class="place-self-end"
+            icon="close"
+            @click="revertTalosUpgrade(clusterId)"
+          >
+            Cancel
+          </TButton>
+        </div>
+      </div>
+      <div
+        v-if="secretRotationStatus && secretRotationStatus.spec.status"
+        class="mb-5 rounded bg-naturals-n2 pt-5"
+      >
+        <div class="flex items-center gap-1 px-6 pb-4">
+          <span class="flex-1 text-sm text-naturals-n13">Secret Rotation</span>
+          <span class="text-sm text-naturals-n13">{{ getComponentInRotation }}</span>
+        </div>
+        <div class="flex min-h-20 items-center gap-2 border-t-8 border-naturals-n4 p-4 text-xs">
+          <TIcon
+            v-if="clusterLocked || machineLockedForSecretRotation"
+            icon="pause-circle"
+            class="h-6 w-6"
+          />
+          <TIcon v-else icon="loading" class="h-6 w-6 animate-spin text-yellow-y1" />
+          <div class="flex-1">
+            {{ secretRotationStatus.spec.status }}
+            <template v-if="clusterLocked">- waiting for cluster to be unlocked</template>
+            <template v-else-if="secretRotationStatus.spec.status">
+              - {{ secretRotationStatus.spec.step }}
+            </template>
+          </div>
+        </div>
+      </div>
+      <div class="flex gap-5">
+        <div class="mb-5 flex-1 rounded bg-naturals-n2 px-6 py-5">
+          <div class="mb-3">
+            <span class="text-sm text-naturals-n13">Features</span>
+          </div>
+          <div class="flex flex-col gap-2">
+            <ClusterWorkloadProxyingCheckbox
+              :model-value="enableWorkloadProxy"
+              :disabled="!canManageClusterFeatures || !features?.spec.enable_workload_proxying"
+              @update:model-value="(value) => setClusterWorkloadProxy(clusterId, value)"
+            />
+            <EmbeddedDiscoveryServiceCheckbox
+              :model-value="useEmbeddedDiscoveryService"
+              :disabled="!canManageClusterFeatures || !isEmbeddedDiscoveryServiceAvailable"
+              @update:model-value="(value) => toggleUseEmbeddedDiscoveryService(value)"
+            />
+            <ClusterEtcdBackupCheckbox
+              :backup-status="backupStatus"
+              :cluster="currentCluster.spec"
+              @update:cluster="(spec) => setClusterEtcdBackupsConfig(clusterId, spec)"
+            />
+          </div>
+        </div>
+        <div class="mb-5 flex-1 rounded bg-naturals-n2 px-6 py-5">
+          <div class="mb-3">
+            <span class="text-sm text-naturals-n13">Labels</span>
+          </div>
+          <ItemLabels
+            :resource="currentCluster"
+            :add-label-func="addClusterLabels"
+            :remove-label-func="removeClusterLabels"
+          />
+        </div>
+      </div>
+      <div class="flex-col rounded bg-naturals-n2 pt-5">
+        <div class="flex px-6 pb-4">
+          <span class="text-sm text-naturals-n13">Machines</span>
+        </div>
+        <div class="grid grid-cols-[repeat(4,1fr)_--spacing(18)]">
+          <ClusterMachines is-subgrid :cluster-i-d="clusterId" />
+        </div>
+      </div>
     </div>
+
+    <OverviewRightPanel
+      :kubernetes-upgrade-status="kubernetesUpgradeStatus"
+      :talos-upgrade-status="talosUpgradeStatus"
+      :etcd-backups="backupStatus"
+    />
   </div>
 </template>

--- a/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue
@@ -242,8 +242,8 @@ const downloadSupportBundleModalOpen = ref(false)
 </script>
 
 <template>
-  <div class="mb-4 h-auto max-w-[20%] min-w-67 rounded bg-naturals-n2 py-5">
-    <div class="flex flex-col gap-4 px-2 lg:px-6">
+  <div class="min-w-67 rounded bg-naturals-n2 py-5">
+    <div class="flex flex-col gap-4 px-4 lg:px-6">
       <h3 class="text-sm text-naturals-n13">Cluster Details</h3>
       <ManagedByTemplatesWarning warning-style="short" />
       <OverviewRightPanelItem
@@ -307,7 +307,7 @@ const downloadSupportBundleModalOpen = ref(false)
     </div>
     <template v-if="clusterStatus?.spec">
       <div class="my-3 h-px bg-naturals-n4" />
-      <div class="flex flex-col gap-4 px-2 lg:px-6">
+      <div class="flex flex-col gap-4 px-4 lg:px-6">
         <h3 class="text-sm text-naturals-n13">Control Plane</h3>
         <OverviewRightPanelItem name="Ready">
           <span :class="clusterStatus.spec.controlplaneReady ? '' : 'text-red-r1'">
@@ -343,7 +343,7 @@ const downloadSupportBundleModalOpen = ref(false)
         />
       </div>
       <div class="my-3 h-px bg-naturals-n4" />
-      <div class="flex flex-col gap-4 px-2 lg:px-6">
+      <div class="flex flex-col gap-4 px-4 lg:px-6">
         <h3 class="text-sm text-naturals-n13">Kubernetes</h3>
         <OverviewRightPanelItem
           name="API Available"
@@ -356,7 +356,7 @@ const downloadSupportBundleModalOpen = ref(false)
         />
       </div>
       <div class="my-3 h-px bg-naturals-n4" />
-      <div class="flex flex-col gap-4 px-2 lg:px-6">
+      <div class="flex flex-col gap-4 px-4 lg:px-6">
         <TButton
           :disabled="!canDownloadKubeconfig"
           variant="primary"
@@ -408,7 +408,7 @@ const downloadSupportBundleModalOpen = ref(false)
         </TButton>
       </div>
       <div class="my-3 h-px bg-naturals-n4" />
-      <div class="flex flex-col gap-4 px-2 lg:px-6">
+      <div class="flex flex-col gap-4 px-4 lg:px-6">
         <Tooltip
           class="grow"
           :disabled="!locked"


### PR DESCRIPTION
On ultrawide screens there was unnecessary padding appearing at the end which has been removed, and for mobile we now switch to column layout when screen shrinks.