### PR TITLE
fix: add missing timeout to the backup download calls in secrets ctrl

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/secrets/secrets.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/secrets.go
@@ -193,6 +193,7 @@ func NewSecretsController(etcdBackupStoreFactory store.Factory) *Controller {
 		qtransform.WithExtraMappedInput[*omni.SecretRotation](
 			qtransform.MapperSameID[*omni.Cluster](),
 		),
+		qtransform.WithConcurrency(8),
 	)
 
 	return ctrl
@@ -204,6 +205,9 @@ func (s *Controller) getBackupDataFromBootstrapSpec(
 	etcdBackupStoreFactory store.Factory,
 	spec *specs.MachineSetSpec_BootstrapSpec,
 ) (etcdbackup.BackupData, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+
 	backupStore, err := etcdBackupStoreFactory.GetStore()
 	if err != nil {
 		return etcdbackup.BackupData{}, fmt.Errorf("failed to get backup store: %w", err)


### PR DESCRIPTION
Without the timeout the controller might hang indefinitely. With parallelism 1 it's easy to get `SecretsController` hanging.