### PR TITLE
feat(frontend): display appropriate message for talos apis when booting

### DIFF
--- a/frontend/src/api/watch.ts
+++ b/frontend/src/api/watch.ts
@@ -25,7 +25,7 @@ export type WatchEventSpec = {
   old?: Resource
 }
 
-export class WatchFunc {
+class WatchFunc {
   protected runtime: Runtime = Runtime.Kubernetes
   protected callback: (resp: WatchResponse) => void
   protected stream?: Stream<WatchRequest, WatchResponse>

--- a/frontend/src/views/cluster/Nodes/NodeDetails.vue
+++ b/frontend/src/views/cluster/Nodes/NodeDetails.vue
@@ -8,9 +8,13 @@ included in the LICENSE file.
 import { computed } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 
+import { Runtime } from '@/api/common/omni.pb'
+import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
+import { DefaultNamespace, MachineStatusType } from '@/api/resources'
 import TabButton from '@/components/common/Tabs/TabButton.vue'
 import TabContent from '@/components/common/Tabs/TabContent.vue'
 import Tabs from '@/components/common/Tabs/Tabs.vue'
+import { useResourceGet } from '@/methods/useResourceGet'
 import NodesHeader from '@/views/cluster/Nodes/NodesHeader.vue'
 
 const route = useRoute()
@@ -60,11 +64,24 @@ const routes = computed(() => {
     },
   ]
 })
+
+const { data } = useResourceGet<MachineStatusSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: MachineStatusType,
+    id: machine.value,
+  },
+}))
+
+const nodeName = computed(
+  () => data.value?.spec.network?.hostname || data.value?.metadata.id || machine.value,
+)
 </script>
 
 <template>
   <div class="flex h-full flex-col pt-6">
-    <NodesHeader class="px-4 md:px-6" />
+    <NodesHeader class="px-4 md:px-6" :node-name />
 
     <Tabs
       :model-value="$route.name?.toString()"

--- a/frontend/src/views/cluster/Nodes/NodeDevices.vue
+++ b/frontend/src/views/cluster/Nodes/NodeDevices.vue
@@ -71,6 +71,7 @@ import { TreeItem, TreeRoot, TreeVirtualizer } from 'reka-ui'
 import { computed } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
+import { Code } from '@/api/google/rpc/code.pb'
 import type { Resource } from '@/api/grpc'
 import { TalosHardwareNamespace, TalosPCIDeviceType } from '@/api/resources'
 import TIcon, { type IconType } from '@/components/common/Icon/TIcon.vue'
@@ -84,6 +85,7 @@ const {
   data: devices,
   loading,
   err,
+  errCode,
 } = useResourceWatch<TalosPCIDeviceSpec>({
   resource: {
     namespace: TalosHardwareNamespace,
@@ -140,11 +142,12 @@ function isLastChild(item?: DeviceTreeItem) {
 
 <template>
   <PageContainer class="h-full">
-    <TSpinner v-if="loading" class="size-4" />
-    <TAlert v-else-if="err" type="error" title="Error">{{ err }}</TAlert>
-    <TAlert v-else-if="!devices.length" type="info" title="No Records">
-      No entries of the requested resource type are found on the server.
+    <TAlert v-if="errCode === Code.UNAVAILABLE" type="warn" title="Machine not ready">
+      Talos API is not ready yet
     </TAlert>
+    <TSpinner v-else-if="loading" class="mx-auto size-6" />
+    <TAlert v-else-if="err" type="error" title="Error">{{ err }}</TAlert>
+    <TAlert v-else-if="!devices.length" type="info" title="No Records">No devices found.</TAlert>
 
     <TreeRoot
       v-else

--- a/frontend/src/views/cluster/Nodes/NodeDisks.vue
+++ b/frontend/src/views/cluster/Nodes/NodeDisks.vue
@@ -83,6 +83,7 @@ export interface TalosVolumeStatusSpec {
 import { computed } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
+import { Code } from '@/api/google/rpc/code.pb'
 import {
   TalosDiscoveredVolumeType,
   TalosDiskType,
@@ -101,7 +102,12 @@ import DiskUsageBar from '@/views/cluster/Nodes/components/DiskUsageBar.vue'
 
 const context = getContext()
 
-const { data: disks, loading: disksLoading } = useResourceWatch<TalosDiskSpec>(() => ({
+const {
+  data: disks,
+  loading: disksLoading,
+  err: disksErr,
+  errCode: disksErrCode,
+} = useResourceWatch<TalosDiskSpec>(() => ({
   resource: {
     namespace: TalosRuntimeNamespace,
     type: TalosDiskType,
@@ -110,29 +116,41 @@ const { data: disks, loading: disksLoading } = useResourceWatch<TalosDiskSpec>((
   context,
 }))
 
-const { data: volumes, loading: volumesLoading } = useResourceWatch<TalosDiscoveredVolumeSpec>(
-  () => ({
-    resource: {
-      namespace: TalosRuntimeNamespace,
-      type: TalosDiscoveredVolumeType,
-    },
-    runtime: Runtime.Talos,
-    context,
-  }),
-)
+const {
+  data: volumes,
+  loading: volumesLoading,
+  err: volumesErr,
+  errCode: volumesErrCode,
+} = useResourceWatch<TalosDiscoveredVolumeSpec>(() => ({
+  resource: {
+    namespace: TalosRuntimeNamespace,
+    type: TalosDiscoveredVolumeType,
+  },
+  runtime: Runtime.Talos,
+  context,
+}))
 
-const { data: volumeStatuses, loading: volumeStatusesLoading } =
-  useResourceWatch<TalosVolumeStatusSpec>(() => ({
-    resource: {
-      namespace: TalosRuntimeNamespace,
-      type: TalosVolumeStatusType,
-    },
-    runtime: Runtime.Talos,
-    context,
-  }))
+const {
+  data: volumeStatuses,
+  loading: volumeStatusesLoading,
+  err: volumeStatusesErr,
+  errCode: volumeStatusesErrCode,
+} = useResourceWatch<TalosVolumeStatusSpec>(() => ({
+  resource: {
+    namespace: TalosRuntimeNamespace,
+    type: TalosVolumeStatusType,
+  },
+  runtime: Runtime.Talos,
+  context,
+}))
 
 const loading = computed(
   () => disksLoading.value || volumesLoading.value || volumeStatusesLoading.value,
+)
+
+const err = computed(() => disksErr.value || volumesErr.value || volumeStatusesErr.value)
+const errCode = computed(
+  () => disksErrCode.value || volumesErrCode.value || volumeStatusesErrCode.value,
 )
 
 const organizedDisks = computed(() =>
@@ -155,8 +173,11 @@ const organizedDisks = computed(() =>
 
 <template>
   <PageContainer class="space-y-4">
-    <TSpinner v-if="loading" class="mx-auto size-6" />
-
+    <TAlert v-if="errCode === Code.UNAVAILABLE" type="warn" title="Machine not ready">
+      Talos API is not ready yet
+    </TAlert>
+    <TSpinner v-else-if="loading" class="mx-auto size-6" />
+    <TAlert v-else-if="err" type="error" title="Error">{{ err }}</TAlert>
     <TAlert v-else-if="!organizedDisks.length" type="info" title="No Records">
       No disks found.
     </TAlert>

--- a/frontend/src/views/cluster/Nodes/NodeMonitor.vue
+++ b/frontend/src/views/cluster/Nodes/NodeMonitor.vue
@@ -240,13 +240,15 @@ const sortBy = (id: keyof Proc) => {
             class="h-full"
             name="cpu"
             title="CPU usage"
-            :runtime="Runtime.Talos"
-            :resource="{
-              type: TalosCPUType,
-              namespace: TalosPerfNamespace,
-              id: TalosCPUID,
+            :watch-opts="{
+              runtime: Runtime.Talos,
+              resource: {
+                type: TalosCPUType,
+                namespace: TalosPerfNamespace,
+                id: TalosCPUID,
+              },
+              context,
             }"
-            :context="context"
             :point-fn="handleCPU"
             :total-fn="handleTotalCPU"
             :min-fn="() => 0"
@@ -264,14 +266,16 @@ const sortBy = (id: keyof Proc) => {
               'var(--color-naturals-n11)',
               'var(--color-naturals-n11)',
             ]"
-            :runtime="Runtime.Talos"
-            :resource="{
-              type: TalosMemoryType,
-              namespace: TalosPerfNamespace,
-              id: TalosMemoryID,
+            :watch-opts="{
+              runtime: Runtime.Talos,
+              resource: {
+                type: TalosMemoryType,
+                namespace: TalosPerfNamespace,
+                id: TalosMemoryID,
+              },
+              context,
             }"
             stacked
-            :context="context"
             :point-fn="handleMem"
             :total-fn="handleTotalMem"
             :min-fn="() => 0"
@@ -292,13 +296,15 @@ const sortBy = (id: keyof Proc) => {
             name="procs"
             title="Processes"
             :colors="['var(--color-blue-b1)', 'var(--color-green-g1)', 'var(--color-yellow-y1)']"
-            :runtime="Runtime.Talos"
-            :resource="{
-              type: TalosCPUType,
-              namespace: TalosPerfNamespace,
-              id: TalosCPUID,
+            :watch-opts="{
+              runtime: Runtime.Talos,
+              resource: {
+                type: TalosCPUType,
+                namespace: TalosPerfNamespace,
+                id: TalosCPUID,
+              },
+              context,
             }"
-            :context="context"
             :point-fn="handleProcs"
           />
         </div>

--- a/frontend/src/views/cluster/Nodes/NodesHeader.vue
+++ b/frontend/src/views/cluster/Nodes/NodesHeader.vue
@@ -5,37 +5,23 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
-import { ResourceService } from '@/api/grpc'
-import type { MachineSetNodeSpec, MachineStatusSpec } from '@/api/omni/specs/omni.pb'
-import { withRuntime } from '@/api/options'
-import { DefaultNamespace, MachineSetNodeType, MachineStatusType } from '@/api/resources'
+import type { MachineSetNodeSpec } from '@/api/omni/specs/omni.pb'
+import { DefaultNamespace, MachineSetNodeType } from '@/api/resources'
 import TButton from '@/components/common/Button/TButton.vue'
 import TBreadcrumbs from '@/components/TBreadcrumbs.vue'
 import { setupClusterPermissions } from '@/methods/auth'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
+const { nodeName } = defineProps<{
+  nodeName: string
+}>()
+
 const route = useRoute()
 const router = useRouter()
-
-const nodeName = ref(route.params.machine as string)
-
-onMounted(async () => {
-  const res: Resource<MachineStatusSpec> = await ResourceService.Get(
-    {
-      namespace: DefaultNamespace,
-      type: MachineStatusType,
-      id: route.params.machine! as string,
-    },
-    withRuntime(Runtime.Omni),
-  )
-
-  nodeName.value = res.spec.network?.hostname || res.metadata.id!
-})
 
 const shutdownNode = () => {
   router.push({

--- a/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/cluster/Nodes/components/NodesMonitorChart.vue
@@ -11,23 +11,21 @@ import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
 import type { ApexOptions } from 'apexcharts'
 import { DateTime } from 'luxon'
 import type { Ref } from 'vue'
-import { computed, ref, toRefs } from 'vue'
+import { computed, ref } from 'vue'
 import VueApexCharts from 'vue3-apexcharts/core'
 
-import { Runtime } from '@/api/common/omni.pb'
+import { Code } from '@/api/google/rpc/code.pb'
 import type { WatchResponse } from '@/api/omni/resources/resources.pb'
 import { EventType } from '@/api/omni/resources/resources.pb'
-import type { Metadata } from '@/api/v1alpha1/resource.pb'
-import type { WatchContext, WatchEventSpec } from '@/api/watch'
-import { WatchFunc } from '@/api/watch'
+import type { WatchEventSpec, WatchOptions } from '@/api/watch'
 import TSpinner from '@/components/common/Spinner/TSpinner.vue'
 import { getNonce } from '@/methods'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 type Props<T> = {
+  watchOpts: WatchOptions
   name: string
   title: string
-  resource: Metadata
-  runtime: Runtime
   pointFn: (spec: T, old: T) => Record<string, number>
   animations?: boolean
   legend?: boolean
@@ -35,40 +33,27 @@ type Props<T> = {
   stacked?: boolean
   stroke?: ApexOptions['stroke']
   colors?: string[]
-  tailEvents?: number
-  context?: WatchContext
   totalFn?: (spec: T, old: T) => string
   minFn?: (spec: T, old: T) => number
   maxFn?: (spec: T, old: T) => number
   formatter?: (value: string | number) => string
 }
 
-const props = withDefaults(defineProps<Props<T>>(), {
-  stroke: () => {
-    return { curve: 'smooth', width: 2, dashArray: 0 }
-  },
-  colors: () => ['var(--color-yellow-y1)', 'var(--color-primary-p3)'],
-  tailEvents: () => 25,
-})
-
 const {
+  watchOpts,
   name,
-  resource,
-  runtime,
-  context,
   animations,
   legend,
   dataLabels,
-  stroke,
+  stroke = { curve: 'smooth', width: 2, dashArray: 0 },
   pointFn,
-  colors,
+  colors = ['var(--color-yellow-y1)', 'var(--color-primary-p3)'],
   totalFn,
-  tailEvents,
   minFn,
   maxFn,
   stacked,
   formatter,
-} = toRefs(props)
+} = defineProps<Props<T>>()
 
 type Point = number | number[]
 const series = ref<{ name: string; data: Point[] }[]>([])
@@ -80,6 +65,8 @@ const total = ref<string>()
 const min: Ref<number | undefined> = ref(undefined)
 const max: Ref<number | undefined> = ref(undefined)
 
+const tailEvents = computed(() => watchOpts.tailEvents ?? 25)
+
 const handlePoint = (message: WatchResponse, spec: WatchEventSpec) => {
   if (message.event?.event_type !== EventType.UPDATED) {
     return
@@ -88,18 +75,18 @@ const handlePoint = (message: WatchResponse, spec: WatchEventSpec) => {
   const resource = spec.res
   const old = spec.old
 
-  const data = pointFn.value(resource?.spec, old?.spec)
+  const data = pointFn(resource?.spec, old?.spec)
 
-  if (totalFn?.value) {
-    total.value = totalFn.value(resource?.spec, old?.spec)
+  if (totalFn) {
+    total.value = totalFn(resource?.spec, old?.spec)
   }
 
-  if (minFn?.value) {
-    min.value = minFn.value(resource?.spec, old?.spec)
+  if (minFn) {
+    min.value = minFn(resource?.spec, old?.spec)
   }
 
-  if (maxFn?.value) {
-    max.value = maxFn.value(resource?.spec, old?.spec)
+  if (maxFn) {
+    max.value = maxFn(resource?.spec, old?.spec)
   }
 
   for (const key in data) {
@@ -149,23 +136,12 @@ const handlePoint = (message: WatchResponse, spec: WatchEventSpec) => {
   }
 }
 
-const w = new WatchFunc(handlePoint)
-
-w.setup(
-  runtime.value === Runtime.Omni
-    ? {
-        resource: resource.value,
-        runtime: runtime.value,
-        tailEvents: tailEvents.value,
-      }
-    : context.value
-      ? {
-          resource: resource.value,
-          runtime: runtime.value,
-          tailEvents: tailEvents.value,
-          context: context.value,
-        }
-      : undefined,
+const { err, errCode, loading } = useResourceWatch(
+  () => ({
+    ...watchOpts,
+    tailEvents: tailEvents.value,
+  }),
+  handlePoint,
 )
 
 const options = computed(() => {
@@ -173,26 +149,26 @@ const options = computed(() => {
     chart: {
       nonce: getNonce(),
       background: 'transparent',
-      id: name.value,
+      id: name,
       zoom: {
         enabled: false,
       },
       animations: {
-        enabled: animations.value,
+        enabled: animations,
       },
       toolbar: {
         show: false,
       },
-      stacked: stacked.value,
+      stacked: stacked,
     },
     legend: {
-      show: legend.value,
-      formatter: formatter.value,
+      show: legend,
+      formatter: formatter,
     },
     dataLabels: {
-      enabled: dataLabels.value,
+      enabled: dataLabels,
     },
-    stroke: stroke.value,
+    stroke: stroke,
     tooltip: {
       theme: 'dark',
       x: {
@@ -203,7 +179,7 @@ const options = computed(() => {
         fontFamily: 'var(--font-sans)',
       },
     },
-    colors: colors.value,
+    colors: colors,
     fill: {
       type: 'gradient',
       gradient: {
@@ -257,7 +233,7 @@ const options = computed(() => {
       min: min.value,
       max: max.value,
       labels: {
-        formatter: formatter?.value,
+        formatter: formatter,
         style: {
           colors: 'var(--color-naturals-n8)',
           fontSize: '0.625rem',
@@ -268,9 +244,6 @@ const options = computed(() => {
     },
   } satisfies ApexOptions
 })
-
-const err = w.err
-const loading = w.loading
 </script>
 
 <template>
@@ -292,7 +265,8 @@ const loading = w.loading
           <div class="flex-0">
             <ExclamationCircleIcon class="h-6 w-6" />
           </div>
-          <div>{{ err }}</div>
+          <div v-if="errCode === Code.UNAVAILABLE">Talos API is not ready yet</div>
+          <div v-else>{{ err }}</div>
         </div>
         <TSpinner v-else class="h-5 w-5" />
       </div>


### PR DESCRIPTION
When Talos machines are still booting and not reporting talos events, show an appropriate message in the UI rather than a gRPC error or not found. Also does some `watch` refactoring in `NodesMonitorChart`

Related #1471 

<img width="1241" height="870" alt="Screenshot 2026-03-11 at 16 43 18" src="https://github.com/user-attachments/assets/affc7f28-56e5-414c-b5fc-34fe1ca00139" />

<img width="1236" height="875" alt="Screenshot 2026-03-11 at 16 43 12" src="https://github.com/user-attachments/assets/53cbad47-911b-4b56-a0ba-32fb25d9bf57" />
