### PR TITLE
git fix: properly update infra provider connection status

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/infraprovider/combined_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/infraprovider/combined_status.go
@@ -3,7 +3,7 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 
-package omni
+package infraprovider
 
 import (
 	"context"
@@ -16,16 +16,15 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
-// InfraProviderCombinedStatusController merges infra.Provider and infra.ProviderHealthStatus into a single status resource.
-type InfraProviderCombinedStatusController = qtransform.QController[*infra.Provider, *omni.InfraProviderCombinedStatus]
+// CombinedStatusController merges infra.Provider and infra.ProviderHealthStatus into a single status resource.
+type CombinedStatusController = qtransform.QController[*infra.Provider, *omni.InfraProviderCombinedStatus]
 
-// NewInfraProviderCombinedStatusController initializes InfraProviderCombinedStatusController.
-func NewInfraProviderCombinedStatusController() *InfraProviderCombinedStatusController {
+// NewCombinedStatusController initializes InfraProviderCombinedStatusController.
+func NewCombinedStatusController(healthCheckInterval time.Duration) *CombinedStatusController {
 	return qtransform.NewQController(
 		qtransform.Settings[*infra.Provider, *omni.InfraProviderCombinedStatus]{
 			Name: "InfraProviderStatusController",
@@ -48,10 +47,16 @@ func NewInfraProviderCombinedStatusController() *InfraProviderCombinedStatusCont
 
 				infraProviderStatus.TypedSpec().Value.Health = &specs.InfraProviderCombinedStatusSpec_Health{}
 
+				var requeueInterval time.Duration
+
 				if providerHealthStatus != nil {
 					lastHeartbeatTime := providerHealthStatus.TypedSpec().Value.LastHeartbeatTimestamp.AsTime()
 
-					infraProviderStatus.TypedSpec().Value.Health.Connected = time.Since(lastHeartbeatTime) < constants.InfraProviderHealthCheckInterval+time.Second
+					infraProviderStatus.TypedSpec().Value.Health.Connected = time.Since(lastHeartbeatTime) < healthCheckInterval+time.Second
+
+					if infraProviderStatus.TypedSpec().Value.Health.Connected {
+						requeueInterval = healthCheckInterval - time.Since(lastHeartbeatTime) + time.Second*2
+					}
 
 					infraProviderStatus.TypedSpec().Value.Health.Error = providerHealthStatus.TypedSpec().Value.Error
 				}
@@ -62,6 +67,10 @@ func NewInfraProviderCombinedStatusController() *InfraProviderCombinedStatusCont
 					infraProviderStatus.TypedSpec().Value.Name = providerStatus.TypedSpec().Value.Name
 
 					infraProviderStatus.TypedSpec().Value.Health.Initialized = true
+				}
+
+				if requeueInterval > 0 {
+					return controller.NewRequeueInterval(requeueInterval)
 				}
 
 				return nil

--- a/internal/backend/runtime/omni/controllers/omni/infraprovider/combined_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infraprovider/combined_status_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package infraprovider_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/infraprovider"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock/options"
+)
+
+func TestCombinedStatusController(t *testing.T) {
+	t.Parallel()
+
+	const healthCheckInterval = time.Second
+
+	addControllers := func(_ context.Context, testContext testutils.TestContext) {
+		require.NoError(t, testContext.Runtime.RegisterQController(infraprovider.NewCombinedStatusController(healthCheckInterval)))
+	}
+
+	t.Run("disconnectedAfterHealthCheckInterval", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*10)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(ctx, t, testutils.TestOptions{}, addControllers,
+			func(ctx context.Context, testContext testutils.TestContext) {
+				providerID := "test-provider"
+
+				rmock.Mock[*infra.Provider](ctx, t, testContext.State,
+					options.WithID(providerID),
+				)
+
+				// Create a health status with a recent heartbeat - should be connected.
+				rmock.Mock[*infra.ProviderHealthStatus](ctx, t, testContext.State,
+					options.WithID(providerID),
+					options.Modify(func(res *infra.ProviderHealthStatus) error {
+						res.TypedSpec().Value.LastHeartbeatTimestamp = timestamppb.Now()
+
+						return nil
+					}),
+				)
+
+				rtestutils.AssertResources(ctx, t, testContext.State, []string{providerID},
+					func(res *omni.InfraProviderCombinedStatus, assertions *assert.Assertions) {
+						assertions.True(res.TypedSpec().Value.Health.Connected, "provider should be connected with a recent heartbeat")
+					},
+				)
+
+				// Wait for the heartbeat to expire, then poke the provider health status to trigger reconciliation.
+				time.Sleep(healthCheckInterval + time.Second)
+
+				rmock.Mock[*infra.ProviderHealthStatus](ctx, t, testContext.State,
+					options.WithID(providerID),
+				)
+
+				rtestutils.AssertResources(ctx, t, testContext.State, []string{providerID},
+					func(res *omni.InfraProviderCombinedStatus, assertions *assert.Assertions) {
+						assertions.False(res.TypedSpec().Value.Health.Connected, "provider should be disconnected after health check interval")
+					},
+				)
+			},
+		)
+	})
+}

--- a/internal/backend/runtime/omni/controllers/omni/infraprovider/infraprovider.go
+++ b/internal/backend/runtime/omni/controllers/omni/infraprovider/infraprovider.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package infraprovider contains the infra provider related controllers.
+package infraprovider

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -52,6 +52,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/clustermachine"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/etcdbackup/store"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/image"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/infraprovider"
 	kernelargsctrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/kernelargs"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/machineconfig"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/machineupgrade"
@@ -248,7 +249,6 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 			cfg.Services.Siderolink.GetEventSinkPort(),
 			cfg.Services.Siderolink.GetLogServerPort()),
 		omnictrl.NewDiscoveryAffiliateDeleteTaskController(clockwork.NewRealClock(), discoveryClientCache),
-		omnictrl.NewInfraProviderCombinedStatusController(),
 		omnictrl.NewServiceAccountStatusController(),
 		authctrl.NewIdentityStatusController(),
 		omnictrl.NewInfraMachineRegistrationController(),
@@ -263,6 +263,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		machineupgrade.NewStatusController(imageFactoryHost, cfg.Registries.GetTalos(), nil),
 		kernelargsctrl.NewStatusController(),
 		talosupgrade.NewStatusController(),
+		infraprovider.NewCombinedStatusController(constants.InfraProviderHealthCheckInterval),
 	}
 
 	if cfg.Auth.Saml.GetEnabled() {


### PR DESCRIPTION
The controller was missing requeue interval. Without it nothing will poke it co trigger reconciliation when the provider is gone.

Fixes: https://github.com/siderolabs/omni/issues/2464