### PR TITLE
fix(frontend): cater for cmd/ctrl click on cluster/machine links

### DIFF
--- a/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
+++ b/frontend/src/views/cluster/ClusterMachines/ClusterMachine.vue
@@ -98,6 +98,7 @@ const updateLock = async () => {
           params: { cluster: clusterName, machine: machine.metadata.id },
         }"
         class="list-item-link truncate"
+        @click.stop
       >
         {{ nodeName }}
       </RouterLink>

--- a/frontend/src/views/omni/Clusters/ClusterItem.vue
+++ b/frontend/src/views/omni/Clusters/ClusterItem.vue
@@ -83,6 +83,7 @@ const clusterDestroyDialogOpen = ref(false)
           :id="labelId"
           :to="{ name: 'ClusterOverview', params: { cluster: item.metadata.id } }"
           class="list-item-link truncate"
+          @click.stop
         >
           <WordHighlighter
             :query="searchQuery"


### PR DESCRIPTION
When clicking on a cluster name or machine ID in the clusters list, we need to @click.stop so that we prevent other click handlers from triggering. This prevents collapsing the cluster when we only want to navigate, and allows CMD/CTRL clicking to open in a new tab, whilst keeping the current tab on the same page.