### PR TITLE
feat: add useOmniSubdomain option for workload proxy

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -410,6 +410,9 @@ func defineFeatureFlags(rootCmdFlagBinder *FlagBinder, flagConfig *config.Params
 
 	rootCmdFlagBinder.StringVar("workload-proxying-subdomain", flagDescription("services.workloadProxy.subdomain", schema), &flagConfig.Services.WorkloadProxy.Subdomain)
 
+	rootCmdFlagBinder.BoolVar("workload-proxying-use-omni-subdomain",
+		flagDescription("services.workloadProxy.useOmniSubdomain", schema), &flagConfig.Services.WorkloadProxy.UseOmniSubdomain)
+
 	rootCmdFlagBinder.DurationVar("workload-proxying-stop-lbs-after",
 		flagDescription("services.workloadProxy.stopLBsAfter", schema), &flagConfig.Services.WorkloadProxy.StopLBsAfter)
 

--- a/deploy/helm/omni/README.md
+++ b/deploy/helm/omni/README.md
@@ -142,24 +142,26 @@ For details on exposing services, see [Expose an HTTP Service from a Cluster](ht
 
 ### Domain Structure
 
-The workload proxy domain is **not** a subdomain of Omni—it exists alongside it. For example:
+The workload proxy domain is a **subdomain of Omni**. For example:
 
 - Omni: `omni.example.com`
-- Workload Proxy: `*.omni-workload.example.com`
+- Workload Proxy: `*.proxy.omni.example.com`
 
 Exposed services have URLs in the format:
 
 ```
-https://<prefix>-<account-name>.<subdomain>.<parent-domain>/
+https://<prefix>.<subdomain>.<omni-domain>/
 ```
 
-For example: `https://grafana-app.omni-workload.example.com/`
+For example: `https://grafana.proxy.omni.example.com/`
 
 Where:
-- `<prefix>` is randomly generated, or user-specified via a Service annotation
-- `<account-name>` is the value of `config.account.name`
-- `<subdomain>` is the value of `config.services.workloadProxy.subdomain` (default: `omni-workload`)
-- `<parent-domain>` is the parent domain of your Omni installation
+- `<prefix>` is randomly generated, or user-specified via a Service annotation (dashes are allowed, e.g., `my-grafana`)
+- `<subdomain>` is the value of `config.services.workloadProxy.subdomain`
+- `<omni-domain>` is the full domain of your Omni installation
+
+> [!NOTE]
+> Without `useOmniSubdomain: true`, the proxy domain is placed as a sibling of Omni (e.g., `*.omni-workload.example.com`) with a different URL format. This is not recommended for new installations.
 
 ### Requirements
 
@@ -171,14 +173,15 @@ To set up workload proxy, you need:
      services:
        workloadProxy:
          enabled: true
-         subdomain: omni-workload  # default
+         subdomain: proxy
+         useOmniSubdomain: true
    ```
 
-2. **Wildcard TLS certificate** for `*.<subdomain>.<parent-domain>` (e.g., `*.omni-workload.example.com`). You can use cert-manager to create one.
+2. **Wildcard TLS certificate** for `*.<subdomain>.<omni-domain>` (e.g., `*.proxy.omni.example.com`). You can use cert-manager to create one.
 
-3. **Wildcard DNS record** pointing `*.<subdomain>.<parent-domain>` to your ingress controller IP address.
+3. **Wildcard DNS record** pointing `*.<subdomain>.<omni-domain>` to your ingress controller IP address.
 
-4. **Ingress/routing rule** to route traffic matching `*-<account-name>.<subdomain>.<parent-domain>` to the Omni service. Standard Kubernetes Ingress does not support wildcard hostnames well, so you may need to use ingress controller-specific resources.
+4. **Ingress/routing rule** to route traffic matching `*.<subdomain>.<omni-domain>` to the Omni service. Standard Kubernetes Ingress does not support wildcard hostnames well, so you may need to use ingress controller-specific resources.
 
 ### Traefik Example
 
@@ -186,12 +189,11 @@ With Traefik, you can use an `IngressRoute` custom resource via `extraObjects`:
 
 ```yaml
 config:
-  account:
-    name: app  # This will be part of the workload proxy URL
   services:
     workloadProxy:
       enabled: true
-      subdomain: omni-workload
+      subdomain: proxy
+      useOmniSubdomain: true
 
 extraObjects:
   # Wildcard certificate for workload proxy (using cert-manager)
@@ -205,7 +207,7 @@ extraObjects:
         name: your-cluster-issuer
         kind: ClusterIssuer
       dnsNames:
-        - "*.omni-workload.example.com"
+        - "*.proxy.omni.example.com"
 
   # Traefik IngressRoute for wildcard routing
   - apiVersion: traefik.io/v1alpha1
@@ -217,8 +219,8 @@ extraObjects:
         - websecure
       routes:
         - kind: Rule
-          # Match any subdomain of omni-workload.example.com
-          match: HostRegexp(`.+\.omni-workload\.example\.com`)
+          # Match any subdomain of proxy.omni.example.com
+          match: HostRegexp(`.+\.proxy\.omni\.example\.com`)
           services:
             - kind: Service
               name: omni

--- a/deploy/helm/omni/README.md.gotmpl
+++ b/deploy/helm/omni/README.md.gotmpl
@@ -138,24 +138,26 @@ For details on exposing services, see [Expose an HTTP Service from a Cluster](ht
 
 ### Domain Structure
 
-The workload proxy domain is **not** a subdomain of Omni—it exists alongside it. For example:
+The workload proxy domain is a **subdomain of Omni**. For example:
 
 - Omni: `omni.example.com`
-- Workload Proxy: `*.omni-workload.example.com`
+- Workload Proxy: `*.proxy.omni.example.com`
 
 Exposed services have URLs in the format:
 
 ```
-https://<prefix>-<account-name>.<subdomain>.<parent-domain>/
+https://<prefix>.<subdomain>.<omni-domain>/
 ```
 
-For example: `https://grafana-app.omni-workload.example.com/`
+For example: `https://grafana.proxy.omni.example.com/`
 
 Where:
-- `<prefix>` is randomly generated, or user-specified via a Service annotation
-- `<account-name>` is the value of `config.account.name`
-- `<subdomain>` is the value of `config.services.workloadProxy.subdomain` (default: `omni-workload`)
-- `<parent-domain>` is the parent domain of your Omni installation
+- `<prefix>` is randomly generated, or user-specified via a Service annotation (dashes are allowed, e.g., `my-grafana`)
+- `<subdomain>` is the value of `config.services.workloadProxy.subdomain`
+- `<omni-domain>` is the full domain of your Omni installation
+
+> [!NOTE]
+> Without `useOmniSubdomain: true`, the proxy domain is placed as a sibling of Omni (e.g., `*.omni-workload.example.com`) with a different URL format. This is not recommended for new installations.
 
 ### Requirements
 
@@ -167,14 +169,15 @@ To set up workload proxy, you need:
      services:
        workloadProxy:
          enabled: true
-         subdomain: omni-workload  # default
+         subdomain: proxy
+         useOmniSubdomain: true
    ```
 
-2. **Wildcard TLS certificate** for `*.<subdomain>.<parent-domain>` (e.g., `*.omni-workload.example.com`). You can use cert-manager to create one.
+2. **Wildcard TLS certificate** for `*.<subdomain>.<omni-domain>` (e.g., `*.proxy.omni.example.com`). You can use cert-manager to create one.
 
-3. **Wildcard DNS record** pointing `*.<subdomain>.<parent-domain>` to your ingress controller IP address.
+3. **Wildcard DNS record** pointing `*.<subdomain>.<omni-domain>` to your ingress controller IP address.
 
-4. **Ingress/routing rule** to route traffic matching `*-<account-name>.<subdomain>.<parent-domain>` to the Omni service. Standard Kubernetes Ingress does not support wildcard hostnames well, so you may need to use ingress controller-specific resources.
+4. **Ingress/routing rule** to route traffic matching `*.<subdomain>.<omni-domain>` to the Omni service. Standard Kubernetes Ingress does not support wildcard hostnames well, so you may need to use ingress controller-specific resources.
 
 ### Traefik Example
 
@@ -182,12 +185,11 @@ With Traefik, you can use an `IngressRoute` custom resource via `extraObjects`:
 
 ```yaml
 config:
-  account:
-    name: app  # This will be part of the workload proxy URL
   services:
     workloadProxy:
       enabled: true
-      subdomain: omni-workload
+      subdomain: proxy
+      useOmniSubdomain: true
 
 extraObjects:
   # Wildcard certificate for workload proxy (using cert-manager)
@@ -201,7 +203,7 @@ extraObjects:
         name: your-cluster-issuer
         kind: ClusterIssuer
       dnsNames:
-        - "*.omni-workload.example.com"
+        - "*.proxy.omni.example.com"
 
   # Traefik IngressRoute for wildcard routing
   - apiVersion: traefik.io/v1alpha1
@@ -213,8 +215,8 @@ extraObjects:
         - websecure
       routes:
         - kind: Rule
-          # Match any subdomain of omni-workload.example.com
-          match: HostRegexp(`.+\.omni-workload\.example\.com`)
+          # Match any subdomain of proxy.omni.example.com
+          match: HostRegexp(`.+\.proxy\.omni\.example\.com`)
           services:
             - kind: Service
               name: omni

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -391,6 +391,12 @@ config:
       enabled: false
       # -- Subdomain is the subdomain used by the workload proxy service to expose workloads.
       subdomain: omni-workload
+      # -- UseOmniSubdomain controls whether the workload proxy subdomain is placed
+      # under Omni's own domain (as a subdomain) rather than as a sibling.
+      # When true, the proxy domain becomes '<subdomain>.<omni-domain>' instead of
+      # '<subdomain>.<parent-of-omni-domain>'. Service URLs become '<alias>.<proxy-domain>'
+      # without the instance name suffix, and dashes are allowed in service aliases.
+      # useOmniSubdomain: false
       # StopLBsAfter is the duration after which load balancers are stopped for idle workloads.
       #stopLBsAfter: 5m
   # Storage contains persistent storage related configuration.

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -27,24 +28,25 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
+// dnsLabelRegexp validates an RFC 1123 DNS label: lowercase alphanumeric with optional dashes, no leading/trailing dash, max 63 chars.
+var dnsLabelRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
 // Reconciler is the reconciler for ExposedService resources.
 type Reconciler struct {
-	logger *zap.Logger
-
-	exposedServices map[resource.ID]*omni.ExposedService
-	usedAliases     map[string]resource.ID
-
+	logger                 *zap.Logger
+	exposedServices        map[resource.ID]*omni.ExposedService
+	usedAliases            map[string]resource.ID
 	cluster                string
 	workloadProxySubdomain string
 	advertisedAPIURL       string
-
-	services []*corev1.Service
+	services               []*corev1.Service
+	useOmniSubdomain       bool
 }
 
 // NewReconciler creates a new ExposedService reconciler.
 //
 // The Reconciler is supposed to be used only once.
-func NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL string,
+func NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL string, useOmniSubdomain bool,
 	exposedServices []*omni.ExposedService, kubernetesServices []*corev1.Service, logger *zap.Logger,
 ) (*Reconciler, error) {
 	exposedServicesMap := make(map[resource.ID]*omni.ExposedService, len(exposedServices))
@@ -63,6 +65,7 @@ func NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL string,
 		cluster:                cluster,
 		workloadProxySubdomain: workloadProxySubdomain,
 		advertisedAPIURL:       advertisedAPIURL,
+		useOmniSubdomain:       useOmniSubdomain,
 		services:               kubernetesServices,
 	}, nil
 }
@@ -183,6 +186,7 @@ func (reconciler *Reconciler) updateExposedService(res *omni.ExposedService, exp
 	if serviceURL, err = reconciler.buildExposedServiceURL(alias); err != nil {
 		// this error might be caused by an invalid prefix set by the user: save it on the resource, do not crash the controller
 		res.TypedSpec().Value.Error = fmt.Sprintf("error building exposed service URL for alias %q: %s", alias, err)
+		res.TypedSpec().Value.Url = "" // clear the stale URL
 
 		logger.Warn(res.TypedSpec().Value.Error)
 
@@ -209,12 +213,30 @@ func (reconciler *Reconciler) buildExposedServiceURL(alias string) (string, erro
 		return "", errors.New("empty alias")
 	}
 
-	// - dot ('.') is not allowed in the alias for the URL to not be treated as subdomain
-	// - dash ('-') is not allowed, as it is used to separate the alias from the instance name
-	const notAllowedChars = ".-"
+	// Validate alias as an RFC 1123 DNS label: lowercase alphanumeric with optional dashes,
+	// no leading/trailing dash, max 63 chars.
+	if !dnsLabelRegexp.MatchString(alias) {
+		return "", fmt.Errorf("alias %q is not a valid DNS label (must be lowercase alphanumeric with optional dashes, no leading/trailing dash, max 63 chars)", alias)
+	}
 
-	if strings.ContainsAny(alias, notAllowedChars) {
-		return "", fmt.Errorf("alias contains a not allowed character - one of: %q", notAllowedChars)
+	if reconciler.useOmniSubdomain {
+		apiURL, err := url.Parse(reconciler.advertisedAPIURL)
+		if err != nil {
+			return "", fmt.Errorf("invalid advertised API URL: %w", err)
+		}
+
+		// Build: <scheme>://<alias>.<subdomain>.<omni-host>
+		serviceURL := &url.URL{
+			Scheme: apiURL.Scheme,
+			Host:   alias + "." + reconciler.workloadProxySubdomain + "." + apiURL.Host,
+		}
+
+		return serviceURL.String(), nil
+	}
+
+	// When useOmniSubdomain is false, dashes are additionally forbidden, as they are used to separate the alias from the instance name.
+	if strings.Contains(alias, "-") {
+		return "", fmt.Errorf("alias %q contains a dash, which is not allowed when useOmniSubdomain is not enabled", alias)
 	}
 
 	apiURLParts := strings.SplitN(reconciler.advertisedAPIURL, "//", 2)

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
@@ -20,9 +20,14 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/exposedservice"
 )
 
+const (
+	testProxySubdomain = "proxy"
+	testClusterName    = "test-cluster"
+)
+
 func TestReconcilerAddRemove(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cluster := "test-cluster"
+	cluster := testClusterName
 	workloadProxySubdomain := "test"
 	advertisedAPIURL := "https://api.test"
 
@@ -33,7 +38,7 @@ func TestReconcilerAddRemove(t *testing.T) {
 		kubernetesService{"default", "test-service-2", "22222", "", ""},
 	)
 
-	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, false, exposedServices, kubernetesServices, logger)
 	require.NoError(t, err)
 
 	exposedServices, err = reconciler.ReconcileServices()
@@ -46,7 +51,7 @@ func TestReconcilerAddRemove(t *testing.T) {
 	// remove one service
 	kubernetesServices = kubernetesServices[:1]
 
-	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, false, exposedServices, kubernetesServices, logger)
 	require.NoError(t, err)
 
 	exposedServices, err = reconciler.ReconcileServices()
@@ -58,7 +63,7 @@ func TestReconcilerAddRemove(t *testing.T) {
 	// add a new service
 	kubernetesServices = append(kubernetesServices, makeKubernetesServices(kubernetesService{"default", "test-service-3", "33333", "foobar", "Some Label"})...)
 
-	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, false, exposedServices, kubernetesServices, logger)
 	require.NoError(t, err)
 
 	exposedServices, err = reconciler.ReconcileServices()
@@ -72,7 +77,7 @@ func TestReconcilerAddRemove(t *testing.T) {
 
 func TestReconcilerConflictResolution(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cluster := "test-cluster"
+	cluster := testClusterName
 	workloadProxySubdomain := "test"
 	advertisedAPIURL := "https://api.test"
 
@@ -83,7 +88,7 @@ func TestReconcilerConflictResolution(t *testing.T) {
 		kubernetesService{"default", "test-service-2", "11111", "testprefix", ""},
 	)
 
-	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, false, exposedServices, kubernetesServices, logger)
 	require.NoError(t, err)
 
 	exposedServices, err = reconciler.ReconcileServices()
@@ -97,7 +102,7 @@ func TestReconcilerConflictResolution(t *testing.T) {
 	// resolve the conflict
 	kubernetesServices[0].Annotations[constants.ExposedServicePrefixAnnotationKey] = "newprefix"
 
-	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, exposedServices, kubernetesServices, logger)
+	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, false, exposedServices, kubernetesServices, logger)
 	require.NoError(t, err)
 
 	exposedServices, err = reconciler.ReconcileServices()
@@ -106,6 +111,99 @@ func TestReconcilerConflictResolution(t *testing.T) {
 	require.Len(t, exposedServices, 2, "expected two ExposedServices to be created after conflict resolution")
 	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
 	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], true)
+}
+
+func TestReconcilerUseOmniSubdomain(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	cluster := testClusterName
+	workloadProxySubdomain := testProxySubdomain
+	advertisedAPIURL := "https://omni.example.com"
+
+	var exposedServices []*omni.ExposedService
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{"default", "test-service-1", "11111", "my-grafana", "Grafana"},
+		kubernetesService{"default", "test-service-2", "22222", "", ""},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, true, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2)
+
+	// Explicit alias with dashes should work
+	assert.Empty(t, exposedServices[0].TypedSpec().Value.Error)
+	assert.Equal(t, "https://my-grafana."+testProxySubdomain+".omni.example.com", exposedServices[0].TypedSpec().Value.Url)
+	assert.True(t, exposedServices[0].TypedSpec().Value.HasExplicitAlias)
+
+	// Generated alias should also work
+	assert.Empty(t, exposedServices[1].TypedSpec().Value.Error)
+	assert.Contains(t, exposedServices[1].TypedSpec().Value.Url, "."+testProxySubdomain+".omni.example.com")
+	assert.False(t, exposedServices[1].TypedSpec().Value.HasExplicitAlias)
+}
+
+func TestReconcilerUseOmniSubdomainWithPort(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	cluster := testClusterName
+	workloadProxySubdomain := testProxySubdomain
+	advertisedAPIURL := "https://omni.example.com:8099"
+
+	var exposedServices []*omni.ExposedService
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{"default", "test-service-1", "11111", "grafana", "Grafana"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, true, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 1)
+	assert.Empty(t, exposedServices[0].TypedSpec().Value.Error)
+	assert.Equal(t, "https://grafana."+testProxySubdomain+".omni.example.com:8099", exposedServices[0].TypedSpec().Value.Url)
+}
+
+func TestReconcilerInvalidAliases(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name             string
+		prefix           string
+		expectError      string
+		useOmniSubdomain bool
+	}{
+		{name: "dot in alias - useOmniSubdomain", prefix: "my.service", useOmniSubdomain: true, expectError: "not a valid DNS label"},
+		{name: "dot in alias - default mode", prefix: "my.service", useOmniSubdomain: false, expectError: "not a valid DNS label"},
+		{name: "underscore in alias - useOmniSubdomain", prefix: "my_service", useOmniSubdomain: true, expectError: "not a valid DNS label"},
+		{name: "underscore in alias - default mode", prefix: "my_service", useOmniSubdomain: false, expectError: "not a valid DNS label"},
+		{name: "dash in alias - default mode", prefix: "my-service", useOmniSubdomain: false, expectError: "contains a dash"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := zaptest.NewLogger(t)
+
+			var exposedServices []*omni.ExposedService
+
+			kubernetesServices := makeKubernetesServices(
+				kubernetesService{"default", "test-service-1", "11111", tc.prefix, ""},
+			)
+
+			reconciler, err := exposedservice.NewReconciler(testClusterName, testProxySubdomain, "https://omni.example.com", tc.useOmniSubdomain, exposedServices, kubernetesServices, logger)
+			require.NoError(t, err)
+
+			exposedServices, err = reconciler.ReconcileServices()
+			require.NoError(t, err)
+
+			require.Len(t, exposedServices, 1)
+			assert.Contains(t, exposedServices[0].TypedSpec().Value.Error, tc.expectError)
+		})
+	}
 }
 
 //nolint:unparam

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
@@ -49,15 +49,19 @@ type KubernetesStatusController struct {
 	advertisedAPIURL       string
 	workloadProxySubdomain string
 	workloadProxyEnabled   bool
+	useOmniSubdomain       bool
 }
 
 // NewKubernetesStatusController creates a new KubernetesStatusController.
-func NewKubernetesStatusController(kubernetesRuntime KubernetesRuntime, advertisedAPIURL, workloadProxySubdomain string, workloadProxyEnabled bool) *KubernetesStatusController {
+func NewKubernetesStatusController(kubernetesRuntime KubernetesRuntime, advertisedAPIURL, workloadProxySubdomain string,
+	workloadProxyEnabled, useOmniSubdomain bool,
+) *KubernetesStatusController {
 	return &KubernetesStatusController{
 		kubernetesRuntime:      kubernetesRuntime,
 		advertisedAPIURL:       advertisedAPIURL,
 		workloadProxySubdomain: workloadProxySubdomain,
 		workloadProxyEnabled:   workloadProxyEnabled,
+		useOmniSubdomain:       useOmniSubdomain,
 	}
 }
 
@@ -185,7 +189,7 @@ func (ctrl *KubernetesStatusController) updateExposedServices(ctx context.Contex
 
 	exposedServices := slices.Collect(exposedServiceList.All())
 
-	reconciler, err := exposedservice.NewReconciler(cluster, ctrl.workloadProxySubdomain, ctrl.advertisedAPIURL, exposedServices, services, logger)
+	reconciler, err := exposedservice.NewReconciler(cluster, ctrl.workloadProxySubdomain, ctrl.advertisedAPIURL, ctrl.useOmniSubdomain, exposedServices, services, logger)
 	if err != nil {
 		return fmt.Errorf("error creating exposed service reconciler: %w", err)
 	}

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -158,7 +158,8 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 			TalosClientFactory: talosClientFactory,
 			NodeResolver:       dnsService,
 		}),
-		omnictrl.NewKubernetesStatusController(kubernetesRuntime, cfg.Services.Api.URL(), cfg.Services.WorkloadProxy.GetSubdomain(), cfg.Services.WorkloadProxy.GetEnabled()),
+		omnictrl.NewKubernetesStatusController(kubernetesRuntime, cfg.Services.Api.URL(), cfg.Services.WorkloadProxy.GetSubdomain(),
+			cfg.Services.WorkloadProxy.GetEnabled(), cfg.Services.WorkloadProxy.GetUseOmniSubdomain()),
 		&omnictrl.LoadBalancerController{
 			LBConfig: cfg.Services.LoadBalancer,
 		},

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -712,6 +712,7 @@ func (s *Server) workloadProxyHandler(next http.Handler) (http.Handler, error) {
 		pgpSignatureValidator,
 		mainURL,
 		s.cfg.Services.WorkloadProxy.GetSubdomain(),
+		s.cfg.Services.WorkloadProxy.GetUseOmniSubdomain(),
 		s.logger.With(logging.Component("workload_proxy_handler")),
 		s.workloadProxyKey,
 	)

--- a/internal/backend/services/workloadproxy/handler.go
+++ b/internal/backend/services/workloadproxy/handler.go
@@ -42,6 +42,7 @@ type HTTPHandler struct {
 	mainDomain          string
 	workloadProxyDomain string
 	redirectKey         []byte
+	useOmniSubdomain    bool
 }
 
 // NewHTTPHandler creates a new HTTP handler that will proxy requests to the workload proxy.
@@ -51,6 +52,7 @@ func NewHTTPHandler(
 	accessValidator AccessValidator,
 	mainURL *url.URL,
 	workloadProxySubdomain string,
+	useOmniSubdomain bool,
 	logger *zap.Logger,
 	redirectKey []byte,
 ) (*HTTPHandler, error) {
@@ -71,7 +73,13 @@ func NewHTTPHandler(
 	}
 
 	mainDomain := getMainDomain(mainURL)
-	workloadProxyDomain := getWorkloadProxyDomain(workloadProxySubdomain, mainDomain)
+
+	var workloadProxyDomain string
+	if useOmniSubdomain {
+		workloadProxyDomain = workloadProxySubdomain + "." + mainDomain
+	} else {
+		workloadProxyDomain = getWorkloadProxyDomain(workloadProxySubdomain, mainDomain)
+	}
 
 	return &HTTPHandler{
 		next:                next,
@@ -82,6 +90,7 @@ func NewHTTPHandler(
 		workloadProxyDomain: workloadProxyDomain,
 		logger:              logger,
 		redirectKey:         redirectKey,
+		useOmniSubdomain:    useOmniSubdomain,
 	}, nil
 }
 
@@ -171,18 +180,46 @@ func (h *HTTPHandler) checkCookies(writer http.ResponseWriter, request *http.Req
 
 // parseServiceAliasFromHost parses the service alias from the request host.
 //
-// The host will have the pattern: p-<alias>-<instance-name>.<main domain>.
+// When useOmniSubdomain is true, the alias is the entire first DNS label (e.g., "my-service" from "my-service.proxy.omni.example.com").
+// Otherwise, the host will have the pattern: <alias>-<instance-name>.<workload-proxy-domain> or legacy p-<alias>-<instance-name>.<main domain>.
 func (h *HTTPHandler) parseServiceAliasFromHost(request *http.Request) string {
-	hostParts := strings.SplitN(request.Host, ".", 2)
+	host := request.Host
+
+	// strip port if present
+	if hostOnly, _, err := net.SplitHostPort(host); err == nil {
+		host = hostOnly
+	}
+
+	if h.useOmniSubdomain {
+		// In useOmniSubdomain mode, the alias is the entire first DNS label.
+		// Host format: <alias>.<workloadProxyDomain>
+		suffix := "." + h.workloadProxyDomain
+		if !strings.HasSuffix(host, suffix) {
+			h.logger.Debug("host does not match workload proxy domain", zap.String("host", host))
+
+			return ""
+		}
+
+		alias := strings.TrimSuffix(host, suffix)
+		if alias == "" || strings.Contains(alias, ".") {
+			h.logger.Debug("invalid alias in host", zap.String("host", host), zap.String("alias", alias))
+
+			return ""
+		}
+
+		return alias
+	}
+
+	hostParts := strings.SplitN(host, ".", 2)
 	if len(hostParts) == 0 {
-		h.logger.Debug("empty proxy service host", zap.String("host", request.Host))
+		h.logger.Debug("empty proxy service host", zap.String("host", host))
 
 		return ""
 	}
 
 	proxyServiceHostPrefixParts := strings.SplitN(hostParts[0], "-", 3)
 	if len(proxyServiceHostPrefixParts) < 2 {
-		h.logger.Debug("invalid proxy service host prefix: wrong number of parts", zap.String("host", request.Host), zap.Strings("parts", proxyServiceHostPrefixParts))
+		h.logger.Debug("invalid proxy service host prefix: wrong number of parts", zap.String("host", host), zap.Strings("parts", proxyServiceHostPrefixParts))
 
 		return ""
 	}
@@ -193,7 +230,7 @@ func (h *HTTPHandler) parseServiceAliasFromHost(request *http.Request) string {
 
 	// handle legacy format
 	if proxyServiceHostPrefixParts[0] != LegacyHostPrefix {
-		h.logger.Debug("invalid proxy service host prefix: doesn't start with the prefix", zap.String("host", request.Host), zap.Strings("parts", proxyServiceHostPrefixParts))
+		h.logger.Debug("invalid proxy service host prefix: doesn't start with the prefix", zap.String("host", host), zap.Strings("parts", proxyServiceHostPrefixParts))
 
 		return ""
 	}

--- a/internal/backend/services/workloadproxy/handler_test.go
+++ b/internal/backend/services/workloadproxy/handler_test.go
@@ -24,6 +24,8 @@ import (
 
 var redirectSignature = []byte("1234")
 
+const testPublicKeyID = "test-public-key-id"
+
 type mockProxyProvider struct {
 	aliases []string
 }
@@ -78,7 +80,7 @@ func TestHandler(t *testing.T) {
 		accessValidator := &mockAccessValidator{}
 		logger := zaptest.NewLogger(t)
 
-		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy-us", logger, redirectSignature)
+		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy-us", false, logger, redirectSignature)
 		require.NoError(t, err)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://instanceid.example.com/example", nil)
@@ -100,7 +102,7 @@ func TestHandler(t *testing.T) {
 		accessValidator := &mockAccessValidator{}
 		logger := zaptest.NewLogger(t)
 
-		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy-us", logger, redirectSignature)
+		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy-us", false, logger, redirectSignature)
 		require.NoError(t, err)
 
 		rr := httptest.NewRecorder()
@@ -155,7 +157,7 @@ func TestHandler(t *testing.T) {
 		accessValidator := &mockAccessValidator{}
 		logger := zaptest.NewLogger(t)
 
-		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy-us", logger, redirectSignature)
+		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy-us", false, logger, redirectSignature)
 		require.NoError(t, err)
 
 		rr := httptest.NewRecorder()
@@ -165,7 +167,6 @@ func TestHandler(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s-%s-instanceid.example.com/example", workloadproxy.LegacyHostPrefix, testServiceAlias), nil)
 		require.NoError(t, err)
 
-		testPublicKeyID := "test-public-key-id"
 		testPublicKeyIDSignatureBase64 := base64.StdEncoding.EncodeToString([]byte("test-signed-public-key-id"))
 
 		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDCookie, Value: testPublicKeyID})
@@ -183,13 +184,129 @@ func TestHandler(t *testing.T) {
 	})
 }
 
+func TestHandlerUseOmniSubdomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	mainURL, err := url.Parse("https://omni.example.com")
+	require.NoError(t, err)
+
+	t.Run("not a proxy request", func(t *testing.T) {
+		t.Parallel()
+
+		next := &mockHandler{}
+		proxyProvider := &mockProxyProvider{}
+		accessValidator := &mockAccessValidator{}
+		logger := zaptest.NewLogger(t)
+
+		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy", true, logger, redirectSignature)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://omni.example.com/example", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Len(t, next.requests, 1)
+		require.Empty(t, proxyProvider.aliases)
+	})
+
+	t.Run("proxy request with cookies", func(t *testing.T) {
+		t.Parallel()
+
+		next := &mockHandler{}
+		proxyProvider := &mockProxyProvider{}
+		accessValidator := &mockAccessValidator{}
+		logger := zaptest.NewLogger(t)
+
+		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy", true, logger, redirectSignature)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://my-service.proxy.omni.example.com/example", nil)
+		require.NoError(t, err)
+
+		testPublicKeyIDSignatureBase64 := base64.StdEncoding.EncodeToString([]byte("test-signed-public-key-id"))
+
+		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDCookie, Value: testPublicKeyID})
+		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDSignatureBase64Cookie, Value: testPublicKeyIDSignatureBase64})
+
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, []string{"my-service"}, proxyProvider.aliases)
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(t, []string{testPublicKeyID}, accessValidator.publicKeyIDs)
+	})
+
+	t.Run("proxy request with dashes in alias", func(t *testing.T) {
+		t.Parallel()
+
+		next := &mockHandler{}
+		proxyProvider := &mockProxyProvider{}
+		accessValidator := &mockAccessValidator{}
+		logger := zaptest.NewLogger(t)
+
+		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy", true, logger, redirectSignature)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://my-cool-service.proxy.omni.example.com/path", nil)
+		require.NoError(t, err)
+
+		testPublicKeyIDSignatureBase64 := base64.StdEncoding.EncodeToString([]byte("test-signed-public-key-id"))
+
+		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDCookie, Value: testPublicKeyID})
+		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDSignatureBase64Cookie, Value: testPublicKeyIDSignatureBase64})
+
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, []string{"my-cool-service"}, proxyProvider.aliases)
+		require.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("proxy request without cookies redirects to login", func(t *testing.T) {
+		t.Parallel()
+
+		next := &mockHandler{}
+		proxyProvider := &mockProxyProvider{}
+		accessValidator := &mockAccessValidator{}
+		logger := zaptest.NewLogger(t)
+
+		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy", true, logger, redirectSignature)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://grafana.proxy.omni.example.com/dashboard", nil)
+		require.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, []string{"grafana"}, proxyProvider.aliases)
+		require.Equal(t, http.StatusSeeOther, rr.Code)
+
+		redirectedURL, err := url.Parse(rr.Header().Get("Location"))
+		require.NoError(t, err)
+
+		require.Equal(t, "omni.example.com", redirectedURL.Host)
+		require.Equal(t, "/authenticate", redirectedURL.Path)
+	})
+}
+
 func testSubdomainRequestWithCookies(ctx context.Context, t *testing.T, mainURL *url.URL, instanceID string) {
 	next := &mockHandler{}
 	proxyProvider := &mockProxyProvider{}
 	accessValidator := &mockAccessValidator{}
 	logger := zaptest.NewLogger(t)
 
-	handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy-us", logger, redirectSignature)
+	handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy-us", false, logger, redirectSignature)
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -199,7 +316,6 @@ func testSubdomainRequestWithCookies(ctx context.Context, t *testing.T, mainURL 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s-%s.proxy-us.example.com/example", testServiceAlias, instanceID), nil)
 	require.NoError(t, err)
 
-	testPublicKeyID := "test-public-key-id"
 	testPublicKeyIDSignatureBase64 := base64.StdEncoding.EncodeToString([]byte("test-signed-public-key-id"))
 
 	req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDCookie, Value: testPublicKeyID})

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -1358,3 +1358,14 @@ func (s *WorkloadProxy) GetSubdomain() string {
 func (s *WorkloadProxy) SetSubdomain(v string) {
 	s.Subdomain = &v
 }
+
+func (s *WorkloadProxy) GetUseOmniSubdomain() bool {
+	if s == nil || s.UseOmniSubdomain == nil {
+		return *new(bool)
+	}
+	return *s.UseOmniSubdomain
+}
+
+func (s *WorkloadProxy) SetUseOmniSubdomain(v bool) {
+	s.UseOmniSubdomain = &v
+}

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -458,8 +458,9 @@
       "type": "object",
       "properties": {
         "subdomain": {
-          "description": "Subdomain is the subdomain used by the workload proxy service to expose workloads. This subdomain lives at the same level as Omni, for example, if Omni is accessible at \"omni.example.com\", and the subdomain is \"omni-apps\", workloads will be exposed at \"<service-prefix>.omni-apps.example.com\".",
-          "type": "string"
+          "description": "Subdomain is the subdomain used by the workload proxy service to expose workloads. By default, it lives at the same level as Omni (e.g., \"omni-apps.example.com\" for Omni at \"omni.example.com\"). When useOmniSubdomain is true, it is placed under Omni's domain instead (e.g., \"proxy.omni.example.com\").",
+          "type": "string",
+          "pattern": "^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$"
         },
         "enabled": {
           "description": "Enabled controls whether the workload proxy service is enabled.",
@@ -472,6 +473,10 @@
           "goJSONSchema": {
             "type": "time.Duration"
           }
+        },
+        "useOmniSubdomain": {
+          "description": "UseOmniSubdomain controls whether the workload proxy subdomain is placed under Omni's own domain (as a subdomain) rather than as a sibling. When true, the proxy domain becomes '<subdomain>.<omni-domain>' instead of '<subdomain>.<parent-of-omni-domain>'. This also simplifies exposed service URLs to '<alias>.<proxy-domain>' (without the instance name) and allows dashes in service aliases.",
+          "type": "boolean"
         }
       }
     },

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -746,8 +746,17 @@ type WorkloadProxy struct {
 	StopLBsAfter *time.Duration `json:"stopLBsAfter,omitempty" yaml:"stopLBsAfter,omitempty"`
 
 	// Subdomain is the subdomain used by the workload proxy service to expose
-	// workloads. This subdomain lives at the same level as Omni, for example, if Omni
-	// is accessible at "omni.example.com", and the subdomain is "omni-apps",
-	// workloads will be exposed at "<service-prefix>.omni-apps.example.com".
+	// workloads. By default, it lives at the same level as Omni (e.g.,
+	// "omni-apps.example.com" for Omni at "omni.example.com"). When useOmniSubdomain
+	// is true, it is placed under Omni's domain instead (e.g.,
+	// "proxy.omni.example.com").
 	Subdomain *string `json:"subdomain,omitempty" yaml:"subdomain,omitempty"`
+
+	// UseOmniSubdomain controls whether the workload proxy subdomain is placed under
+	// Omni's own domain (as a subdomain) rather than as a sibling. When true, the
+	// proxy domain becomes '<subdomain>.<omni-domain>' instead of
+	// '<subdomain>.<parent-of-omni-domain>'. This also simplifies exposed service
+	// URLs to '<alias>.<proxy-domain>' (without the instance name) and allows dashes
+	// in service aliases.
+	UseOmniSubdomain *bool `json:"useOmniSubdomain,omitempty" yaml:"useOmniSubdomain,omitempty"`
 }


### PR DESCRIPTION
Add a new boolean config field `services.workloadProxy.useOmniSubdomain` that places the workload proxy subdomain under Omni's own domain rather than as a sibling. When enabled, service URLs become `<alias>.<subdomain>.<omni-domain>` without the instance name suffix, and dashes are allowed in service aliases. This is recommended for on-prem and single-instance deployments.

Also add a regex pattern validation on the `subdomain` config field, and clear the stale URL on ExposedService resources when alias validation fails.

Closes: https://github.com/siderolabs/omni/issues/2280