### PR TITLE
chore: export the SQLite memory allocator stats

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -867,3 +867,9 @@ spec:
     - e2e-upgrades
     - e2e-backups
     - e2e-forced-removal
+---
+kind: golang.Toolchain
+spec:
+  defaultBuildTags:
+    - memory.counters # enable memory counters in modernc.org/memory
+    - libc.memexpvar # enable memexpvar in modernc.org/libc to export the counters

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-03-17T09:12:54Z by kres 7bfd168.
+# Generated on 2026-03-17T18:02:11Z by kres 7c15198-dirty.
 
 # common variables
 
@@ -32,7 +32,7 @@ GOLANGCILINT_VERSION ?= v2.11.3
 GOFUMPT_VERSION ?= v0.9.2
 GO_VERSION ?= 1.26.1
 GO_BUILDFLAGS ?=
-GO_BUILDTAGS ?= ,
+GO_BUILDTAGS ?= memory.counters,libc.memexpvar,
 GO_LDFLAGS ?=
 CGO_ENABLED ?= 0
 GOTOOLCHAIN ?= local
@@ -492,4 +492,3 @@ release-notes: $(ARTIFACTS)
 conformance:
 	@docker pull $(CONFORMANCE_IMAGE)
 	@docker run --rm -it -v $(PWD):/src -w /src $(CONFORMANCE_IMAGE) enforce
-

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -332,6 +332,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		"qcontroller_map_busy":       prometheus.NewDesc("omni_runtime_qcontroller_map_busy_seconds", "Number of seconds queue controller is busy by controller name.", []string{"controller"}, nil),
 		"qcontroller_reconcile_busy": prometheus.NewDesc("omni_runtime_qcontroller_reconcile_busy_seconds", "Number of seconds queue controller reconcile is busy by controller name.", []string{"controller"}, nil),
 		"cached_resources":           prometheus.NewDesc("omni_runtime_cached_resources", "Number of cached resources by resource type.", []string{"resource_type"}, nil),
+		"memory.allocator":           prometheus.NewDesc("omni_sqlite_memory_allocator_stats", "SQLite memory allocator statistics.", []string{"kind"}, nil),
 	})
 
 	metricsRegistry.MustRegister(expvarCollector)


### PR DESCRIPTION
Example metrics:

```
-# HELP omni_sqlite_memory_allocator_stats SQLite memory allocator statistics.
-# TYPE omni_sqlite_memory_allocator_stats untyped
omni_sqlite_memory_allocator_stats{kind="Allocs"} 3041
omni_sqlite_memory_allocator_stats{kind="Bytes"} 1.4852096e+07
omni_sqlite_memory_allocator_stats{kind="Mmaps"} 242
```