### PR TITLE
fix: use dynamic SQLite pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/cosi-project/runtime v1.14.0
 	github.com/cosi-project/state-etcd v0.5.3
-	github.com/cosi-project/state-sqlite v0.3.0
+	github.com/cosi-project/state-sqlite v0.4.0
 	github.com/crewjam/saml v0.5.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/emicklei/dot v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/cosi-project/runtime v1.14.0 h1:puGI7sssk1h2KScC4ETjC+M7nyN+0ur44bAuS
 github.com/cosi-project/runtime v1.14.0/go.mod h1:sd2+E6DjC/QjrnlEEglINDZ4FUW7cVDMB5aG98Dl3LA=
 github.com/cosi-project/state-etcd v0.5.3 h1:jkXX1zFDMH6qsRjt4Ku9EqDtluhI3ghx1GuQpIwg88Q=
 github.com/cosi-project/state-etcd v0.5.3/go.mod h1:htNLQUC/dIx0twbudZ/wIr7aKLV0El7xHoGKvnuKzfk=
-github.com/cosi-project/state-sqlite v0.3.0 h1:6Qa66WaNOgRKwL/fSyn13krMGb1rXr1MGmhkFPkibt4=
-github.com/cosi-project/state-sqlite v0.3.0/go.mod h1:V20oy2Sfxla0zZ+SJSgjV20feg2xGARlvVPL4Z4KfRo=
+github.com/cosi-project/state-sqlite v0.4.0 h1:SwL5/LlAwnMomRjMM72igPA1F6W/88zbae4cFxqz5vw=
+github.com/cosi-project/state-sqlite v0.4.0/go.mod h1:V20oy2Sfxla0zZ+SJSgjV20feg2xGARlvVPL4Z4KfRo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/backend/discovery/sqlitestore.go
+++ b/internal/backend/discovery/sqlitestore.go
@@ -28,7 +28,7 @@ const (
 )
 
 type SQLiteStore struct {
-	db      *sqlitex.Pool
+	db      *sqlitexx.Pool
 	timeout time.Duration
 }
 
@@ -48,7 +48,7 @@ func (s *SQLiteStore) Writer(ctx context.Context) (io.WriteCloser, error) {
 	}, nil
 }
 
-func NewSQLiteStore(ctx context.Context, db *sqlitex.Pool, timeout time.Duration) (*SQLiteStore, error) {
+func NewSQLiteStore(ctx context.Context, db *sqlitexx.Pool, timeout time.Duration) (*SQLiteStore, error) {
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
@@ -76,7 +76,7 @@ func NewSQLiteStore(ctx context.Context, db *sqlitex.Pool, timeout time.Duration
 }
 
 type writer struct {
-	db *sqlitex.Pool
+	db *sqlitexx.Pool
 
 	ctx context.Context //nolint:containedctx
 
@@ -130,7 +130,7 @@ func (w *writer) Close() error {
 }
 
 type reader struct {
-	db  *sqlitex.Pool
+	db  *sqlitexx.Pool
 	ctx context.Context //nolint:containedctx
 
 	reader *bytes.Reader

--- a/internal/backend/discovery/sqlitestore_test.go
+++ b/internal/backend/discovery/sqlitestore_test.go
@@ -230,7 +230,7 @@ func TestWriteAfterClose(t *testing.T) {
 	assert.Error(t, err, "writing to a closed writer should error")
 }
 
-func setupStore(ctx context.Context, t *testing.T) (*discovery.SQLiteStore, *sqlitex.Pool) {
+func setupStore(ctx context.Context, t *testing.T) (*discovery.SQLiteStore, *sqlitexx.Pool) {
 	t.Helper()
 
 	conf := config.Default()

--- a/internal/backend/discovery/store.go
+++ b/internal/backend/discovery/store.go
@@ -9,14 +9,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/siderolabs/discovery-service/pkg/storage"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // InitSQLiteSnapshotStore initializes a SQLite snapshot store if enabled in the config.
-func InitSQLiteSnapshotStore(ctx context.Context, config config.EmbeddedDiscoveryService, db *sqlitex.Pool) (storage.SnapshotStore, error) {
+func InitSQLiteSnapshotStore(ctx context.Context, config config.EmbeddedDiscoveryService, db *sqlitexx.Pool) (storage.SnapshotStore, error) {
 	store, err := NewSQLiteStore(ctx, db, config.GetSqliteTimeout())
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize sqlite snapshot store: %w", err)

--- a/internal/backend/runtime/omni/audit/audit.go
+++ b/internal/backend/runtime/omni/audit/audit.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"go.uber.org/zap"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 	"github.com/siderolabs/omni/internal/pkg/config"
@@ -48,7 +48,7 @@ func WithCleanupCallback(cb func(int)) LogOption {
 }
 
 // NewLog creates a new audit logger.
-func NewLog(ctx context.Context, config config.LogsAudit, db *sqlitex.Pool, logger *zap.Logger, opts ...LogOption) (*Log, error) {
+func NewLog(ctx context.Context, config config.LogsAudit, db *sqlitexx.Pool, logger *zap.Logger, opts ...LogOption) (*Log, error) {
 	var cfg logConfig
 	for _, opt := range opts {
 		opt(&cfg)

--- a/internal/backend/runtime/omni/audit/audit_test.go
+++ b/internal/backend/runtime/omni/audit/audit_test.go
@@ -16,13 +16,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/siderolabs/gen/xtesting/must"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
@@ -168,7 +168,7 @@ func loadEvents(t *testing.T, events string) []any {
 	return result
 }
 
-func testDB(t *testing.T) *sqlitex.Pool {
+func testDB(t *testing.T) *sqlitexx.Pool {
 	t.Helper()
 
 	conf := config.Default().Storage.Sqlite

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
@@ -88,7 +88,7 @@ func WithCleanupCallback(cb func(int)) Option {
 
 // Store is the SQLite-backed audit log store.
 type Store struct {
-	db                 *sqlitex.Pool
+	db                 *sqlitexx.Pool
 	logger             *zap.Logger
 	onCleanup          func(int)
 	timeout            time.Duration
@@ -97,7 +97,7 @@ type Store struct {
 }
 
 // NewStore creates a new audit log SQLite store.
-func NewStore(ctx context.Context, db *sqlitex.Pool, timeout time.Duration, maxSize uint64, cleanupProbability float64, logger *zap.Logger, opts ...Option) (*Store, error) {
+func NewStore(ctx context.Context, db *sqlitexx.Pool, timeout time.Duration, maxSize uint64, cleanupProbability float64, logger *zap.Logger, opts ...Option) (*Store, error) {
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
@@ -407,7 +407,7 @@ func (s *Store) HasData(ctx context.Context) (bool, error) {
 
 type logReader struct {
 	conn *zombiesqlite.Conn
-	db   *sqlitex.Pool
+	db   *sqlitexx.Pool
 	next func() (*zombiesqlite.Stmt, error, bool)
 	stop func()
 }

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
@@ -534,11 +534,11 @@ func TestExtractedColumns(t *testing.T) {
 	}
 }
 
-func setupStore(ctx context.Context, t *testing.T, logger *zap.Logger) (*auditlogsqlite.Store, *sqlitex.Pool) {
+func setupStore(ctx context.Context, t *testing.T, logger *zap.Logger) (*auditlogsqlite.Store, *sqlitexx.Pool) {
 	return setupStoreWithOpts(ctx, t, logger, 0, 0)
 }
 
-func setupStoreWithOpts(ctx context.Context, t *testing.T, logger *zap.Logger, maxSize uint64, cleanupProbability float64) (*auditlogsqlite.Store, *sqlitex.Pool) {
+func setupStoreWithOpts(ctx context.Context, t *testing.T, logger *zap.Logger, maxSize uint64, cleanupProbability float64) (*auditlogsqlite.Store, *sqlitexx.Pool) {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "test.db")

--- a/internal/backend/runtime/omni/audit/hooks/hooks_test.go
+++ b/internal/backend/runtime/omni/audit/hooks/hooks_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/common"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit"
@@ -47,7 +47,7 @@ func TestUserManagedResourceTypes(t *testing.T) {
 	assert.Subset(t, destroyHooksResourceTypes, userManagedResourceTypes, "all user managed resource types should have destroy hooks")
 }
 
-func testDB(t *testing.T) *sqlitex.Pool {
+func testDB(t *testing.T) *sqlitexx.Pool {
 	t.Helper()
 
 	conf := config.Default().Storage.Sqlite

--- a/internal/backend/runtime/omni/audit/logger.go
+++ b/internal/backend/runtime/omni/audit/logger.go
@@ -10,15 +10,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"go.uber.org/zap"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite"
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
-func initLogger(ctx context.Context, config config.LogsAudit, db *sqlitex.Pool, logger *zap.Logger, onCleanup func(int)) (Logger, error) {
+func initLogger(ctx context.Context, config config.LogsAudit, db *sqlitexx.Pool, logger *zap.Logger, onCleanup func(int)) (Logger, error) {
 	if !config.GetEnabled() {
 		logger.Info("audit logging is disabled")
 

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -334,6 +334,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		"qcontroller_reconcile_busy": prometheus.NewDesc("omni_runtime_qcontroller_reconcile_busy_seconds", "Number of seconds queue controller reconcile is busy by controller name.", []string{"controller"}, nil),
 		"cached_resources":           prometheus.NewDesc("omni_runtime_cached_resources", "Number of cached resources by resource type.", []string{"resource_type"}, nil),
 		"memory.allocator":           prometheus.NewDesc("omni_sqlite_memory_allocator_stats", "SQLite memory allocator statistics.", []string{"kind"}, nil),
+		"sqlitexx_pool_connections":  prometheus.NewDesc("omni_sqlite_pool_connections", "Number of connections in the sqlite pool.", nil, nil),
 	})
 
 	metricsRegistry.MustRegister(expvarCollector)

--- a/internal/backend/runtime/omni/sqlite/metrics.go
+++ b/internal/backend/runtime/omni/sqlite/metrics.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	zombiesqlite "zombiezen.com/go/sqlite"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/backend/discovery"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite"
@@ -56,7 +55,7 @@ type Metrics struct {
 	dbSizeDesc               *prometheus.Desc
 	subsystemSizeDesc        *prometheus.Desc
 	cleanupRowsDeleted       *prometheus.CounterVec
-	db                       *sqlitex.Pool
+	db                       *sqlitexx.Pool
 	logger                   *zap.Logger
 	cachedSubsystemSizes     map[string]float64
 	cachedSubsystemRowCounts map[string]float64
@@ -79,7 +78,7 @@ func WithRefreshInterval(d time.Duration) MetricsOption {
 
 // NewMetrics creates a *Metrics that exposes SQLite database metrics.
 // If cosiState implements sqlState, the state subsystem size is reported via its DBSize method.
-func NewMetrics(db *sqlitex.Pool, cosiState state.CoreState, logger *zap.Logger, opts ...MetricsOption) *Metrics {
+func NewMetrics(db *sqlitexx.Pool, cosiState state.CoreState, logger *zap.Logger, opts ...MetricsOption) *Metrics {
 	dbSizer, ok := cosiState.(sqlState)
 	if !ok {
 		logger.Warn("COSI state does not implement sqlState, state subsystem size will not be reported")

--- a/internal/backend/runtime/omni/sqlite/metrics_test.go
+++ b/internal/backend/runtime/omni/sqlite/metrics_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
-func execSQL(t *testing.T, db *sqlitex.Pool, sql string) {
+func execSQL(t *testing.T, db *sqlitexx.Pool, sql string) {
 	t.Helper()
 
 	conn, err := db.Take(t.Context())
@@ -45,7 +46,7 @@ func (f *fakeSQLState) DBSize(context.Context) (int64, error) {
 	return f.size, nil
 }
 
-func setupMetrics(t *testing.T, db *sqlitex.Pool, cosiState state.CoreState, opts ...sqlite.MetricsOption) *prometheus.Registry {
+func setupMetrics(t *testing.T, db *sqlitexx.Pool, cosiState state.CoreState, opts ...sqlite.MetricsOption) *prometheus.Registry {
 	t.Helper()
 
 	logger := zaptest.NewLogger(t)
@@ -243,7 +244,7 @@ func TestCleanupCallback(t *testing.T) {
 }
 
 // setupTestDB helper handles the standard SQLite test setup.
-func setupTestDB(t *testing.T) (*sqlitex.Pool, state.State) {
+func setupTestDB(t *testing.T) (*sqlitexx.Pool, state.State) {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "test.db")

--- a/internal/backend/runtime/omni/sqlite/sqlite.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite.go
@@ -12,15 +12,15 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/siderolabs/gen/panicsafe"
 	zombiesqlite "zombiezen.com/go/sqlite"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // OpenDB opens a SQLite database with the given configuration.
-func OpenDB(config config.SQLite) (*sqlitex.Pool, error) {
+func OpenDB(config config.SQLite) (*sqlitexx.Pool, error) {
 	configPath := config.GetPath()
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create directory for sqlite database %q: %w", configPath, err)
@@ -38,10 +38,11 @@ func OpenDB(config config.SQLite) (*sqlitex.Pool, error) {
 		dsn += "?" + allParams
 	}
 
-	db, err := sqlitex.NewPool(dsn,
-		sqlitex.PoolOptions{
-			Flags:    zombiesqlite.OpenReadWrite | zombiesqlite.OpenCreate | zombiesqlite.OpenWAL | zombiesqlite.OpenURI,
-			PoolSize: config.GetPoolSize(),
+	db, err := sqlitexx.NewPool(dsn,
+		sqlitexx.PoolOptions{
+			Flags:         zombiesqlite.OpenReadWrite | zombiesqlite.OpenCreate | zombiesqlite.OpenWAL | zombiesqlite.OpenURI,
+			LowWatermark:  config.GetCachedPoolSize(),
+			HighWatermark: config.GetPoolSize(),
 		},
 	)
 	if err != nil {
@@ -55,7 +56,7 @@ func OpenDB(config config.SQLite) (*sqlitex.Pool, error) {
 //
 // The upstream Close function might block until all connections are returned to the pool.
 // Provide a timeout to avoid blocking indefinitely.
-func CloseDB(db *sqlitex.Pool, timeout time.Duration) error {
+func CloseDB(db *sqlitexx.Pool, timeout time.Duration) error {
 	errCh := make(chan error)
 
 	go func() {

--- a/internal/backend/runtime/omni/state.go
+++ b/internal/backend/runtime/omni/state.go
@@ -19,9 +19,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/cosi-project/runtime/pkg/state/registry"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	resourceregistry "github.com/siderolabs/omni/client/pkg/omni/resources/registry"
@@ -59,7 +59,7 @@ type State struct {
 
 	defaultPersistentState   *PersistentState
 	secondaryPersistentState *PersistentState
-	secondaryStorageDB       *sqlitex.Pool
+	secondaryStorageDB       *sqlitexx.Pool
 }
 
 // Default returns the default state.
@@ -68,7 +68,7 @@ func (s *State) Default() state.State {
 }
 
 // SecondaryStorageDB returns the secondary storage database.
-func (s *State) SecondaryStorageDB() *sqlitex.Pool {
+func (s *State) SecondaryStorageDB() *sqlitexx.Pool {
 	return s.secondaryStorageDB
 }
 
@@ -315,7 +315,7 @@ func stateWithMetrics(namespacedState *namespaced.State, metricsRegistry prometh
 }
 
 // NewAuditWrap creates a new audit wrap.
-func NewAuditWrap(ctx context.Context, resState state.State, params *config.Params, auditLogDB *sqlitex.Pool, logger *zap.Logger, onCleanup func(int)) (*AuditWrap, error) {
+func NewAuditWrap(ctx context.Context, resState state.State, params *config.Params, auditLogDB *sqlitexx.Pool, logger *zap.Logger, onCleanup func(int)) (*AuditWrap, error) {
 	if !params.Logs.Audit.GetEnabled() {
 		logger.Info("audit log disabled")
 

--- a/internal/backend/runtime/omni/state_sqlite.go
+++ b/internal/backend/runtime/omni/state_sqlite.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/state/impl/store"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/cosi-project/state-sqlite/pkg/state/impl/sqlite"
 	"go.uber.org/zap"
-	"zombiezen.com/go/sqlite/sqlitex"
 )
 
-func newSQLitePersistentState(ctx context.Context, db *sqlitex.Pool, logger *zap.Logger) (*PersistentState, error) {
+func newSQLitePersistentState(ctx context.Context, db *sqlitexx.Pool, logger *zap.Logger) (*PersistentState, error) {
 	st, err := sqlite.NewState(ctx, db, store.ProtobufMarshaler{},
 		sqlite.WithLogger(logger),
 		sqlite.WithTablePrefix("metrics_"),

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	protobufserver "github.com/cosi-project/runtime/pkg/state/protobuf/server"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/crewjam/saml/samlsp"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -55,7 +56,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	resapi "github.com/siderolabs/omni/client/api/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/access"
@@ -1185,7 +1185,7 @@ func (s *Server) createInitialServiceAccount(ctx context.Context) error {
 }
 
 // runEmbeddedDiscoveryService runs an embedded discovery service over Siderolink.
-func runEmbeddedDiscoveryService(ctx context.Context, secondaryStorageDB *sqlitex.Pool, logger *zap.Logger, discoveryCfg config.EmbeddedDiscoveryService) error {
+func runEmbeddedDiscoveryService(ctx context.Context, secondaryStorageDB *sqlitexx.Pool, logger *zap.Logger, discoveryCfg config.EmbeddedDiscoveryService) error {
 	logLevel, err := zapcore.ParseLevel(discoveryCfg.GetLogLevel())
 	if err != nil {
 		logLevel = zapcore.WarnLevel

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -1062,6 +1062,17 @@ func (s *SAML) SetUrl(v string) {
 	s.Url = &v
 }
 
+func (s *SQLite) GetCachedPoolSize() int {
+	if s == nil || s.CachedPoolSize == nil {
+		return *new(int)
+	}
+	return *s.CachedPoolSize
+}
+
+func (s *SQLite) SetCachedPoolSize(v int) {
+	s.CachedPoolSize = &v
+}
+
 func (s *SQLite) GetExperimentalBaseParams() string {
 	if s == nil || s.ExperimentalBaseParams == nil {
 		return *new(string)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -153,6 +153,7 @@ func Default() *Params {
 	p.Logs.Machine.Storage.SetCleanupProbability(0.01)
 
 	p.Storage.Sqlite.SetExperimentalBaseParams("_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)")
+	p.Storage.Sqlite.SetCachedPoolSize(4)
 	p.Storage.Sqlite.SetPoolSize(64)
 
 	p.Storage.Default.SetKind(StorageDefaultKindEtcd)

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -1092,6 +1092,11 @@
           "type": "string",
           "pattern": "^(?:$|[^&].*)"
         },
+        "cachedPoolSize" : {
+          "description": "CachedPoolSize controls the number of cached connections in the SQLite connection pool. The overall number of connections is limited by poolSize. CachedPoolSize should be less or equal to poolSize.",
+          "type": "integer",
+          "minimum": 1
+        },
         "poolSize" : {
           "description": "PoolSize controls the maximum number of connections in the SQLite connection pool. Raising this value may improve performance under high load, at the cost of increased resource usage.",
           "type": "integer",

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -537,6 +537,11 @@ type SAMLAttributeRules map[string]string
 type SAMLLabelRules map[string]string
 
 type SQLite struct {
+	// CachedPoolSize controls the number of cached connections in the SQLite
+	// connection pool. The overall number of connections is limited by poolSize.
+	// CachedPoolSize should be less or equal to poolSize.
+	CachedPoolSize *int `json:"cachedPoolSize,omitempty" yaml:"cachedPoolSize,omitempty"`
+
 	// ExperimentalBaseParams contains the base parameters to be used when opening the
 	// SQLite database connection. This can cause data corruption if set incorrectly,
 	// modify at your own risk. This flag is experimental and may be removed in future

--- a/internal/pkg/siderolink/loghandler.go
+++ b/internal/pkg/siderolink/loghandler.go
@@ -11,9 +11,9 @@ import (
 	"net/netip"
 
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/siderolabs/gen/optional"
 	"go.uber.org/zap"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/panichandler"
@@ -43,7 +43,7 @@ func WithLogHandlerCleanupCallback(cb func(int)) LogHandlerOption {
 }
 
 // NewLogHandler returns a new LogHandler.
-func NewLogHandler(secondaryStorageDB *sqlitex.Pool, machineMap *MachineMap, omniState state.State, storageConfig *config.LogsMachine, logger *zap.Logger,
+func NewLogHandler(secondaryStorageDB *sqlitexx.Pool, machineMap *MachineMap, omniState state.State, storageConfig *config.LogsMachine, logger *zap.Logger,
 	opts ...LogHandlerOption,
 ) (*LogHandler, error) {
 	var options logHandlerOptions

--- a/internal/pkg/siderolink/loghandler_test.go
+++ b/internal/pkg/siderolink/loghandler_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/siderolabs/gen/optional"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
 	"github.com/siderolabs/omni/internal/pkg/config"
@@ -115,7 +115,7 @@ func TestLogHandler_HandleMessage(t *testing.T) {
 	})
 }
 
-func testDB(t *testing.T) *sqlitex.Pool {
+func testDB(t *testing.T) *sqlitexx.Pool {
 	t.Helper()
 
 	conf := config.Default().Storage.Sqlite

--- a/internal/pkg/siderolink/logstore/sqlitelog/manager.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/manager.go
@@ -50,7 +50,7 @@ func WithCleanupCallback(cb func(int)) StoreManagerOption {
 // StoreManager manages log stores for machines.
 type StoreManager struct {
 	state     state.State
-	db        *sqlitex.Pool
+	db        *sqlitexx.Pool
 	logger    *zap.Logger
 	onCleanup func(int)
 	config    config.LogsMachineStorage
@@ -440,7 +440,7 @@ type schemaParams struct {
 }
 
 // NewStoreManager creates a new StoreManager.
-func NewStoreManager(ctx context.Context, db *sqlitex.Pool, config config.LogsMachineStorage, omniState state.State, logger *zap.Logger, opts ...StoreManagerOption) (*StoreManager, error) {
+func NewStoreManager(ctx context.Context, db *sqlitexx.Pool, config config.LogsMachineStorage, omniState state.State, logger *zap.Logger, opts ...StoreManagerOption) (*StoreManager, error) {
 	templateParams := schemaParams{
 		TableName:       TableName,
 		IDColumn:        idColumn,

--- a/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"go.uber.org/zap"
 	zombiesqlite "zombiezen.com/go/sqlite"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/client/pkg/panichandler"
 	"github.com/siderolabs/omni/internal/pkg/config"
@@ -53,7 +52,7 @@ func WithStoreCleanupCallback(cb func(int)) StoreOption {
 }
 
 // NewStore creates a new Store.
-func NewStore(config config.LogsMachineStorage, db *sqlitex.Pool, id string, logger *zap.Logger, opts ...StoreOption) (*Store, error) {
+func NewStore(config config.LogsMachineStorage, db *sqlitexx.Pool, id string, logger *zap.Logger, opts ...StoreOption) (*Store, error) {
 	sqliteTimeout := config.GetSqliteTimeout()
 	if sqliteTimeout <= 0 {
 		sqliteTimeout = 30 * time.Second
@@ -77,7 +76,7 @@ func NewStore(config config.LogsMachineStorage, db *sqlitex.Pool, id string, log
 // Store implements the logstore.LogStore interface using SQLite as the backend.
 type Store struct {
 	config        config.LogsMachineStorage
-	db            *sqlitex.Pool
+	db            *sqlitexx.Pool
 	logger        *zap.Logger
 	onCleanup     func(int)
 	id            string

--- a/internal/pkg/siderolink/machines.go
+++ b/internal/pkg/siderolink/machines.go
@@ -14,10 +14,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/gen/containers"
 	"go.uber.org/zap"
-	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
@@ -46,14 +46,14 @@ type MachineCache struct {
 	logger                 *zap.Logger
 	onCleanup              func(int)
 	logsConfig             *config.LogsMachine
-	secondaryStorageDB     *sqlitex.Pool
+	secondaryStorageDB     *sqlitexx.Pool
 	state                  state.State
 	mx                     sync.Mutex
 	inited                 bool
 }
 
 // NewMachineCache returns a new MachineCache.
-func NewMachineCache(secondaryStorageDB *sqlitex.Pool, logStorageConfig *config.LogsMachine, omniState state.State, logger *zap.Logger, opts ...MachineCacheOption) (*MachineCache, error) {
+func NewMachineCache(secondaryStorageDB *sqlitexx.Pool, logStorageConfig *config.LogsMachine, omniState state.State, logger *zap.Logger, opts ...MachineCacheOption) (*MachineCache, error) {
 	cache := &MachineCache{
 		logsConfig:         logStorageConfig,
 		secondaryStorageDB: secondaryStorageDB,


### PR DESCRIPTION
Configure by default number of connections: 4 cached and 64 max.

This uses https://github.com/cosi-project/state-sqlite/pull/10

The goal is to lower overall memory usage by SQLite.

New metric:

```
 # HELP omni_sqlite_pool_connections Number of connections in the sqlite pool.
 # TYPE omni_sqlite_pool_connections untyped
 omni_sqlite_pool_connections 3
```