### PR TITLE
fix: correct SQLite size metrics to include indexes and freelist

### DIFF
--- a/hack/compose/grafana/dashboards/omni-details.json
+++ b/hack/compose/grafana/dashboards/omni-details.json
@@ -1723,6 +1723,17 @@
           "legendFormat": "Total DB size",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_sqlite_db_freelist_size_bytes",
+          "legendFormat": "Freelist size",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Database Size",
@@ -2014,6 +2025,190 @@
         }
       ],
       "title": "Cleanup Rows Deleted (rate/min)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 87
+      },
+      "id": 215,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_sqlite_memory_allocator_stats",
+          "legendFormat": "{{kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Allocator",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 87
+      },
+      "id": 216,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_sqlite_pool_connections",
+          "legendFormat": "Pool connections",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pool Connections",
       "type": "timeseries"
     }
   ],

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
@@ -256,7 +256,7 @@ func (s *Store) Remove(ctx context.Context, start, end time.Time) error {
 }
 
 func (s *Store) removeBySize(conn *zombiesqlite.Conn) error {
-	sizeQuery := fmt.Sprintf(`SELECT SUM(pgsize) FROM dbstat WHERE name = '%s'`, TableName)
+	sizeQuery := fmt.Sprintf(`SELECT COALESCE(SUM(d.pgsize), 0) FROM dbstat d JOIN sqlite_master m ON d.name = m.name WHERE m.tbl_name = '%s'`, TableName)
 
 	q, err := sqlitexx.NewQuery(conn, sizeQuery)
 	if err != nil {

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
@@ -223,7 +223,7 @@ func TestRemoveByMaxSize(t *testing.T) {
 
 	var tableSize int64
 
-	err = sqlitex.ExecuteTransient(conn, "SELECT SUM(pgsize) FROM dbstat WHERE name = 'audit_logs'", &sqlitex.ExecOptions{
+	err = sqlitex.ExecuteTransient(conn, "SELECT COALESCE(SUM(d.pgsize), 0) FROM dbstat d JOIN sqlite_master m ON d.name = m.name WHERE m.tbl_name = 'audit_logs'", &sqlitex.ExecOptions{
 		ResultFunc: func(stmt *zombiesqlite.Stmt) error {
 			tableSize = stmt.ColumnInt64(0)
 

--- a/internal/backend/runtime/omni/sqlite/metrics.go
+++ b/internal/backend/runtime/omni/sqlite/metrics.go
@@ -53,6 +53,7 @@ type Metrics struct {
 	sqlState                 sqlState
 	subsystemRowCountDesc    *prometheus.Desc
 	dbSizeDesc               *prometheus.Desc
+	dbFreelistSizeDesc       *prometheus.Desc
 	subsystemSizeDesc        *prometheus.Desc
 	cleanupRowsDeleted       *prometheus.CounterVec
 	db                       *sqlitexx.Pool
@@ -61,6 +62,7 @@ type Metrics struct {
 	cachedSubsystemRowCounts map[string]float64
 	refreshInterval          time.Duration
 	cachedDBSize             float64
+	cachedFreelistSize       float64
 	mu                       sync.Mutex
 }
 
@@ -93,6 +95,11 @@ func NewMetrics(db *sqlitexx.Pool, cosiState state.CoreState, logger *zap.Logger
 		dbSizeDesc: prometheus.NewDesc(
 			"omni_sqlite_db_size_bytes",
 			"Total size of the SQLite database in bytes.",
+			nil, nil,
+		),
+		dbFreelistSizeDesc: prometheus.NewDesc(
+			"omni_sqlite_db_freelist_size_bytes",
+			"Size of free pages in the SQLite database in bytes.",
 			nil, nil,
 		),
 		subsystemSizeDesc: prometheus.NewDesc(
@@ -143,6 +150,8 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- prometheus.MustNewConstMetric(m.dbSizeDesc, prometheus.GaugeValue, m.cachedDBSize)
 
+	ch <- prometheus.MustNewConstMetric(m.dbFreelistSizeDesc, prometheus.GaugeValue, m.cachedFreelistSize)
+
 	for subsystem, size := range m.cachedSubsystemSizes {
 		ch <- prometheus.MustNewConstMetric(m.subsystemSizeDesc, prometheus.GaugeValue, size, subsystem)
 	}
@@ -182,6 +191,13 @@ func (m *Metrics) refresh() {
 	dbSize, err := m.queryDBSize(conn)
 	if err != nil {
 		m.logger.Warn("failed to query db size for metrics", zap.Error(err))
+
+		return
+	}
+
+	freelistSize, err := m.queryFreelistSize(conn)
+	if err != nil {
+		m.logger.Warn("failed to query freelist pages for metrics", zap.Error(err))
 
 		return
 	}
@@ -229,6 +245,7 @@ func (m *Metrics) refresh() {
 	}
 
 	m.cachedDBSize = dbSize
+	m.cachedFreelistSize = freelistSize
 	m.cachedSubsystemSizes = subsystemSizes
 	m.cachedSubsystemRowCounts = subsystemRowCounts
 }
@@ -253,7 +270,7 @@ func (m *Metrics) discoverTables(conn *zombiesqlite.Conn) (map[string]struct{}, 
 }
 
 func (m *Metrics) queryDBSize(conn *zombiesqlite.Conn) (float64, error) {
-	q, err := sqlitexx.NewQuery(conn, `SELECT COALESCE(SUM(pgsize), 0) FROM dbstat`)
+	q, err := sqlitexx.NewQuery(conn, `SELECT page_count * page_size FROM pragma_page_count, pragma_page_size`)
 	if err != nil {
 		return 0, fmt.Errorf("failed to prepare db size query: %w", err)
 	}
@@ -271,8 +288,27 @@ func (m *Metrics) queryDBSize(conn *zombiesqlite.Conn) (float64, error) {
 	return size, nil
 }
 
+func (m *Metrics) queryFreelistSize(conn *zombiesqlite.Conn) (float64, error) {
+	q, err := sqlitexx.NewQuery(conn, `SELECT freelist_count * page_size FROM pragma_freelist_count, pragma_page_size`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare freelist query: %w", err)
+	}
+
+	var sizeBytes float64
+
+	if err = q.QueryRow(func(stmt *zombiesqlite.Stmt) error {
+		sizeBytes = stmt.ColumnFloat(0)
+
+		return nil
+	}); err != nil {
+		return 0, fmt.Errorf("failed to query freelist size: %w", err)
+	}
+
+	return sizeBytes, nil
+}
+
 func (m *Metrics) queryTableSizes(conn *zombiesqlite.Conn) (map[string]float64, error) {
-	q, err := sqlitexx.NewQuery(conn, `SELECT name, SUM(pgsize) FROM dbstat GROUP BY name`)
+	q, err := sqlitexx.NewQuery(conn, `SELECT m.tbl_name, SUM(d.pgsize) FROM dbstat d JOIN sqlite_master m ON d.name = m.name GROUP BY m.tbl_name`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare table sizes query: %w", err)
 	}

--- a/internal/backend/runtime/omni/sqlite/metrics_test.go
+++ b/internal/backend/runtime/omni/sqlite/metrics_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
+const (
+	metricSubsystemSizeBytes = "omni_sqlite_subsystem_size_bytes"
+	labelSubsystem           = "subsystem"
+)
+
 func execSQL(t *testing.T, db *sqlitexx.Pool, sql string) {
 	t.Helper()
 
@@ -92,12 +97,12 @@ func TestMetricsCollect(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, f := range families {
-		if f.GetName() == "omni_sqlite_subsystem_size_bytes" {
+		if f.GetName() == metricSubsystemSizeBytes {
 			assert.Len(t, f.GetMetric(), 4)
 
 			for _, m := range f.GetMetric() {
 				for _, lp := range m.GetLabel() {
-					if lp.GetName() == "subsystem" && lp.GetValue() == "state" {
+					if lp.GetName() == labelSubsystem && lp.GetValue() == "state" {
 						assert.Equal(t, float64(8192), m.GetGauge().GetValue())
 					}
 				}
@@ -167,7 +172,7 @@ func TestMetricsStateSubsystemUsesDBSizer(t *testing.T) {
 		omni_sqlite_subsystem_size_bytes{subsystem="machine_logs"} 0
 		omni_sqlite_subsystem_size_bytes{subsystem="state"} 42000
 	`
-	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), "omni_sqlite_subsystem_size_bytes"))
+	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), metricSubsystemSizeBytes))
 }
 
 func TestMetricsEmptyDB(t *testing.T) {
@@ -241,6 +246,67 @@ func TestCleanupCallback(t *testing.T) {
 		omni_sqlite_cleanup_rows_deleted_total{subsystem="machine_logs"} 10
 	`
 	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected2), "omni_sqlite_cleanup_rows_deleted_total"))
+}
+
+func TestMetricsSubsystemSizeIncludesIndexes(t *testing.T) {
+	t.Parallel()
+
+	db, st := setupTestDB(t)
+
+	// Create the machine_logs table without an index and measure its size.
+	execSQL(t, db, `
+		CREATE TABLE machine_logs (id INTEGER PRIMARY KEY, machine_id TEXT, message TEXT);
+		INSERT INTO machine_logs (machine_id, message) VALUES ('m1', 'log1');
+	`)
+
+	registry := setupMetrics(t, db, &fakeSQLState{CoreState: st}, sqlite.WithRefreshInterval(0))
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	var sizeWithoutIndex float64
+
+	for _, f := range families {
+		if f.GetName() != metricSubsystemSizeBytes {
+			continue
+		}
+
+		for _, m := range f.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == labelSubsystem && lp.GetValue() == sqlite.SubsystemMachineLogs {
+					sizeWithoutIndex = m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+
+	require.Greater(t, sizeWithoutIndex, float64(0), "table size should be > 0")
+
+	// Add an index — the subsystem size should grow.
+	execSQL(t, db, `CREATE INDEX idx_machine_logs_machine_id ON machine_logs (machine_id)`)
+
+	registry2 := setupMetrics(t, db, &fakeSQLState{CoreState: st}, sqlite.WithRefreshInterval(0))
+
+	families, err = registry2.Gather()
+	require.NoError(t, err)
+
+	var sizeWithIndex float64
+
+	for _, f := range families {
+		if f.GetName() != metricSubsystemSizeBytes {
+			continue
+		}
+
+		for _, m := range f.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == labelSubsystem && lp.GetValue() == sqlite.SubsystemMachineLogs {
+					sizeWithIndex = m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+
+	assert.Greater(t, sizeWithIndex, sizeWithoutIndex, "subsystem size should include index size")
 }
 
 // setupTestDB helper handles the standard SQLite test setup.

--- a/internal/pkg/siderolink/logstore/sqlitelog/manager.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/manager.go
@@ -265,7 +265,7 @@ func (m *StoreManager) removeBySize(ctx context.Context) (int, error) {
 // computeSizeExcess estimates how many rows need to be deleted based on the table size and average row size.
 // Returns 0 when the table is within limits or empty.
 func (m *StoreManager) computeSizeExcess(conn *sqlite.Conn) (int64, error) {
-	sizeQuery := fmt.Sprintf(`SELECT COALESCE(SUM(pgsize), 0) FROM dbstat WHERE name = '%s'`, TableName)
+	sizeQuery := fmt.Sprintf(`SELECT COALESCE(SUM(d.pgsize), 0) FROM dbstat d JOIN sqlite_master m ON d.name = m.name WHERE m.tbl_name = '%s'`, TableName)
 
 	q, err := sqlitexx.NewQuery(conn, sizeQuery)
 	if err != nil {


### PR DESCRIPTION
Table size queries (`omni_sqlite_subsystem_size_bytes`) filtered by dbstat name, missing index sizes. Join with sqlite_master to attribute index pages to their parent table.

DB size (`omni_sqlite_db_size_bytes`) used dbstat sum which excludes freelist pages. Use page_count * page_size to match actual file size.

Add `omni_sqlite_db_freelist_size_bytes` metric to track wasted space.
