### PR TITLE
fix(frontend): prevent flashing no access during login

### DIFF
--- a/frontend/src/pages/(authenticated).vue
+++ b/frontend/src/pages/(authenticated).vue
@@ -38,11 +38,13 @@ onBeforeMount(async () => {
 </script>
 
 <template>
-  <RouterView v-if="authorized" />
+  <template v-if="authorized">
+    <RouterView />
 
-  <UserConsent
-    v-if="trackingFeatureEnabled && trackingPending"
-    @decline="disableTracking"
-    @accept="enableTracking"
-  />
+    <UserConsent
+      v-if="trackingFeatureEnabled && trackingPending"
+      @decline="disableTracking"
+      @accept="enableTracking"
+    />
+  </template>
 </template>

--- a/frontend/src/pages/(authenticated)/index.vue
+++ b/frontend/src/pages/(authenticated)/index.vue
@@ -17,16 +17,12 @@ definePage({ name: 'Home' })
 
 const currentUser = useCurrentUser()
 
-const hasRoleNone = computed(() => {
-  const role = currentUser.value?.spec.role
-
-  return !role || role === RoleNone
-})
+const role = computed(() => currentUser.value?.spec.role ?? RoleNone)
 </script>
 
 <template>
-  <PageContainer>
-    <HomeNoAccess v-if="hasRoleNone" />
+  <PageContainer v-if="currentUser" class="h-full">
+    <HomeNoAccess v-if="role === RoleNone" />
     <HomeContent v-else />
   </PageContainer>
 </template>


### PR DESCRIPTION
When logging in, prevent the brief flash of HomeNoAccess until we resolve who the current user is. Also fix alignment there so that it is centered if it should appear.