### PR TITLE
feat: allow empty subdomain for workload proxy

### DIFF
--- a/deploy/helm/omni/README.md
+++ b/deploy/helm/omni/README.md
@@ -145,19 +145,22 @@ For details on exposing services, see [Expose an HTTP Service from a Cluster](ht
 The workload proxy domain is a **subdomain of Omni**. For example:
 
 - Omni: `omni.example.com`
-- Workload Proxy: `*.proxy.omni.example.com`
+- Workload Proxy (with subdomain `proxy`): `*.proxy.omni.example.com`
+- Workload Proxy (with empty subdomain): `*.omni.example.com`
 
 Exposed services have URLs in the format:
 
 ```
-https://<prefix>.<subdomain>.<omni-domain>/
+https://<prefix>.[<subdomain>.]<omni-domain>/
 ```
 
-For example: `https://grafana.proxy.omni.example.com/`
+For example:
+- With `subdomain: proxy`: `https://grafana.proxy.omni.example.com/`
+- With empty subdomain: `https://grafana.omni.example.com/`
 
 Where:
 - `<prefix>` is randomly generated, or user-specified via a Service annotation (dashes are allowed, e.g., `my-grafana`)
-- `<subdomain>` is the value of `config.services.workloadProxy.subdomain`
+- `<subdomain>` is the value of `config.services.workloadProxy.subdomain` (can be empty for the simplest setup)
 - `<omni-domain>` is the full domain of your Omni installation
 
 > [!NOTE]

--- a/deploy/helm/omni/README.md.gotmpl
+++ b/deploy/helm/omni/README.md.gotmpl
@@ -141,19 +141,22 @@ For details on exposing services, see [Expose an HTTP Service from a Cluster](ht
 The workload proxy domain is a **subdomain of Omni**. For example:
 
 - Omni: `omni.example.com`
-- Workload Proxy: `*.proxy.omni.example.com`
+- Workload Proxy (with subdomain `proxy`): `*.proxy.omni.example.com`
+- Workload Proxy (with empty subdomain): `*.omni.example.com`
 
 Exposed services have URLs in the format:
 
 ```
-https://<prefix>.<subdomain>.<omni-domain>/
+https://<prefix>.[<subdomain>.]<omni-domain>/
 ```
 
-For example: `https://grafana.proxy.omni.example.com/`
+For example:
+- With `subdomain: proxy`: `https://grafana.proxy.omni.example.com/`
+- With empty subdomain: `https://grafana.omni.example.com/`
 
 Where:
 - `<prefix>` is randomly generated, or user-specified via a Service annotation (dashes are allowed, e.g., `my-grafana`)
-- `<subdomain>` is the value of `config.services.workloadProxy.subdomain`
+- `<subdomain>` is the value of `config.services.workloadProxy.subdomain` (can be empty for the simplest setup)
 - `<omni-domain>` is the full domain of your Omni installation
 
 > [!NOTE]

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -396,6 +396,7 @@ config:
       # When true, the proxy domain becomes '<subdomain>.<omni-domain>' instead of
       # '<subdomain>.<parent-of-omni-domain>'. Service URLs become '<alias>.<proxy-domain>'
       # without the instance name suffix, and dashes are allowed in service aliases.
+      # When true and subdomain is empty, services are exposed directly as subdomains of Omni.
       # useOmniSubdomain: false
       # StopLBsAfter is the duration after which load balancers are stopped for idle workloads.
       #stopLBsAfter: 5m

--- a/hack/test/helm/templates/omni-values.yaml
+++ b/hack/test/helm/templates/omni-values.yaml
@@ -52,6 +52,8 @@ config:
       advertisedURL: grpc://${NODE_IP}:30090
     workloadProxy:
       enabled: true
+      subdomain: ""
+      useOmniSubdomain: true
     siderolink:
       wireGuard:
         advertisedEndpoint: ${NODE_IP}:30180
@@ -87,7 +89,8 @@ ingress:
     enabled: false
 
 # Traefik IngressRoute for workload proxy wildcard domain.
-# Uses the default TLS store (which has the wildcard cert covering *.omni-workload.example.org).
+# With useOmniSubdomain: true and empty subdomain, services are direct subdomains of Omni (*.omni.example.org).
+# Uses the default TLS store (which has the wildcard cert covering *.omni.example.org).
 extraObjects:
   - apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
@@ -98,7 +101,7 @@ extraObjects:
         - websecure
       routes:
         - kind: Rule
-          match: "HostRegexp(`.+\\.omni-workload\\.example\\.org`)"
+          match: "HostRegexp(`.+\\.omni\\.example\\.org`)"
           services:
             - kind: Service
               name: omni

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler.go
@@ -225,10 +225,15 @@ func (reconciler *Reconciler) buildExposedServiceURL(alias string) (string, erro
 			return "", fmt.Errorf("invalid advertised API URL: %w", err)
 		}
 
-		// Build: <scheme>://<alias>.<subdomain>.<omni-host>
+		// Build: <scheme>://<alias>.[<subdomain>.]<omni-host>
+		host := apiURL.Host
+		if reconciler.workloadProxySubdomain != "" {
+			host = reconciler.workloadProxySubdomain + "." + host
+		}
+
 		serviceURL := &url.URL{
 			Scheme: apiURL.Scheme,
-			Host:   alias + "." + reconciler.workloadProxySubdomain + "." + apiURL.Host,
+			Host:   alias + "." + host,
 		}
 
 		return serviceURL.String(), nil

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
@@ -168,6 +168,50 @@ func TestReconcilerUseOmniSubdomainWithPort(t *testing.T) {
 	assert.Equal(t, "https://grafana."+testProxySubdomain+".omni.example.com:8099", exposedServices[0].TypedSpec().Value.Url)
 }
 
+func TestReconcilerUseOmniSubdomainEmptySubdomain(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	var exposedServices []*omni.ExposedService
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{"default", "test-service-1", "11111", "grafana", "Grafana"},
+		kubernetesService{"default", "test-service-2", "22222", "my-dashboard", "Dashboard"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2)
+	assert.Empty(t, exposedServices[0].TypedSpec().Value.Error)
+	assert.Equal(t, "https://grafana.omni.example.com", exposedServices[0].TypedSpec().Value.Url)
+
+	assert.Empty(t, exposedServices[1].TypedSpec().Value.Error)
+	assert.Equal(t, "https://my-dashboard.omni.example.com", exposedServices[1].TypedSpec().Value.Url)
+}
+
+func TestReconcilerUseOmniSubdomainEmptySubdomainWithPort(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	var exposedServices []*omni.ExposedService
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{"default", "test-service-1", "11111", "grafana", "Grafana"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com:8099", true, exposedServices, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err = reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 1)
+	assert.Empty(t, exposedServices[0].TypedSpec().Value.Error)
+	assert.Equal(t, "https://grafana.omni.example.com:8099", exposedServices[0].TypedSpec().Value.Url)
+}
+
 func TestReconcilerInvalidAliases(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/services/workloadproxy/handler.go
+++ b/internal/backend/services/workloadproxy/handler.go
@@ -74,9 +74,18 @@ func NewHTTPHandler(
 
 	mainDomain := getMainDomain(mainURL)
 
+	if !useOmniSubdomain && workloadProxySubdomain == "" {
+		return nil, errors.New("workload proxy subdomain must not be empty when useOmniSubdomain is false")
+	}
+
 	var workloadProxyDomain string
+
 	if useOmniSubdomain {
-		workloadProxyDomain = workloadProxySubdomain + "." + mainDomain
+		if workloadProxySubdomain == "" {
+			workloadProxyDomain = mainDomain
+		} else {
+			workloadProxyDomain = workloadProxySubdomain + "." + mainDomain
+		}
 	} else {
 		workloadProxyDomain = getWorkloadProxyDomain(workloadProxySubdomain, mainDomain)
 	}

--- a/internal/backend/services/workloadproxy/handler_test.go
+++ b/internal/backend/services/workloadproxy/handler_test.go
@@ -219,56 +219,13 @@ func TestHandlerUseOmniSubdomain(t *testing.T) {
 	t.Run("proxy request with cookies", func(t *testing.T) {
 		t.Parallel()
 
-		next := &mockHandler{}
-		proxyProvider := &mockProxyProvider{}
-		accessValidator := &mockAccessValidator{}
-		logger := zaptest.NewLogger(t)
-
-		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy", true, logger, redirectSignature)
-		require.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://my-service.proxy.omni.example.com/example", nil)
-		require.NoError(t, err)
-
-		testPublicKeyIDSignatureBase64 := base64.StdEncoding.EncodeToString([]byte("test-signed-public-key-id"))
-
-		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDCookie, Value: testPublicKeyID})
-		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDSignatureBase64Cookie, Value: testPublicKeyIDSignatureBase64})
-
-		handler.ServeHTTP(rr, req)
-
-		require.Equal(t, []string{"my-service"}, proxyProvider.aliases)
-		require.Equal(t, http.StatusOK, rr.Code)
-		require.Equal(t, []string{testPublicKeyID}, accessValidator.publicKeyIDs)
+		testUseOmniSubdomainWithCookies(ctx, t, mainURL, "proxy", "https://my-service.proxy.omni.example.com/example", "my-service")
 	})
 
 	t.Run("proxy request with dashes in alias", func(t *testing.T) {
 		t.Parallel()
 
-		next := &mockHandler{}
-		proxyProvider := &mockProxyProvider{}
-		accessValidator := &mockAccessValidator{}
-		logger := zaptest.NewLogger(t)
-
-		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy", true, logger, redirectSignature)
-		require.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://my-cool-service.proxy.omni.example.com/path", nil)
-		require.NoError(t, err)
-
-		testPublicKeyIDSignatureBase64 := base64.StdEncoding.EncodeToString([]byte("test-signed-public-key-id"))
-
-		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDCookie, Value: testPublicKeyID})
-		req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDSignatureBase64Cookie, Value: testPublicKeyIDSignatureBase64})
-
-		handler.ServeHTTP(rr, req)
-
-		require.Equal(t, []string{"my-cool-service"}, proxyProvider.aliases)
-		require.Equal(t, http.StatusOK, rr.Code)
+		testUseOmniSubdomainWithCookies(ctx, t, mainURL, "proxy", "https://my-cool-service.proxy.omni.example.com/path", "my-cool-service")
 	})
 
 	t.Run("proxy request without cookies redirects to login", func(t *testing.T) {
@@ -298,6 +255,72 @@ func TestHandlerUseOmniSubdomain(t *testing.T) {
 		require.Equal(t, "omni.example.com", redirectedURL.Host)
 		require.Equal(t, "/authenticate", redirectedURL.Path)
 	})
+}
+
+func TestHandlerUseOmniSubdomainEmptySubdomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	mainURL, err := url.Parse("https://omni.example.com")
+	require.NoError(t, err)
+
+	t.Run("proxy request with cookies", func(t *testing.T) {
+		t.Parallel()
+
+		testUseOmniSubdomainWithCookies(ctx, t, mainURL, "", "https://grafana.omni.example.com/dashboard", "grafana")
+	})
+
+	t.Run("omni itself is not a proxy request", func(t *testing.T) {
+		t.Parallel()
+
+		next := &mockHandler{}
+		proxyProvider := &mockProxyProvider{}
+		accessValidator := &mockAccessValidator{}
+		logger := zaptest.NewLogger(t)
+
+		handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "", true, logger, redirectSignature)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://omni.example.com/", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Len(t, next.requests, 1)
+		require.Empty(t, proxyProvider.aliases)
+	})
+}
+
+func testUseOmniSubdomainWithCookies(ctx context.Context, t *testing.T, mainURL *url.URL, subdomain, requestURL, expectedAlias string) {
+	t.Helper()
+
+	next := &mockHandler{}
+	proxyProvider := &mockProxyProvider{}
+	accessValidator := &mockAccessValidator{}
+	logger := zaptest.NewLogger(t)
+
+	handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, subdomain, true, logger, redirectSignature)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	require.NoError(t, err)
+
+	testPublicKeyIDSignatureBase64 := base64.StdEncoding.EncodeToString([]byte("test-signed-public-key-id"))
+
+	req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDCookie, Value: testPublicKeyID})
+	req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDSignatureBase64Cookie, Value: testPublicKeyIDSignatureBase64})
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, []string{expectedAlias}, proxyProvider.aliases)
+	require.Equal(t, http.StatusOK, rr.Code)
 }
 
 func testSubdomainRequestWithCookies(ctx context.Context, t *testing.T, mainURL *url.URL, instanceID string) {

--- a/internal/integration/workloadproxy/workloadproxy.go
+++ b/internal/integration/workloadproxy/workloadproxy.go
@@ -290,7 +290,7 @@ func prepareServices(ctx context.Context, t *testing.T, logger *zap.Logger, omni
 				assertion.Equal(hasExplicitAlias, r.TypedSpec().Value.HasExplicitAlias)
 
 				if hasExplicitAlias {
-					assertion.Contains(r.TypedSpec().Value.Url, explicitAlias+"-")
+					assertion.Contains(r.TypedSpec().Value.Url, explicitAlias)
 				}
 
 				res = r
@@ -480,7 +480,7 @@ func testAccessSingle(ctx context.Context, httpClient *http.Client, svcURL strin
 // prepareRequest prepares a request to the workload proxy.
 // It uses the Omni base URL to access Omni with proper name resolution, but set the Host header to the original URL to test the workload proxy logic
 //
-// sample svcURL: https://j2s7hf-local.proxy-us.localhost:8099/
+// sample svcURL: https://j2s7hf-local.proxy-us.localhost:8099/ or https://grafana.omni.example.org/
 func prepareRequest(ctx context.Context, svcURL string) (*http.Request, error) {
 	parsedURL, err := url.Parse(svcURL)
 	if err != nil {

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -458,9 +458,9 @@
       "type": "object",
       "properties": {
         "subdomain": {
-          "description": "Subdomain is the subdomain used by the workload proxy service to expose workloads. By default, it lives at the same level as Omni (e.g., \"omni-apps.example.com\" for Omni at \"omni.example.com\"). When useOmniSubdomain is true, it is placed under Omni's domain instead (e.g., \"proxy.omni.example.com\").",
+          "description": "Subdomain is the subdomain used by the workload proxy service to expose workloads. By default, it lives at the same level as Omni (e.g., \"omni-apps.example.com\" for Omni at \"omni.example.com\"). When useOmniSubdomain is true, it is placed under Omni's domain instead (e.g., \"proxy.omni.example.com\"). When useOmniSubdomain is true and subdomain is empty, services are exposed directly as subdomains of Omni (e.g., \"grafana.omni.example.com\").",
           "type": "string",
-          "pattern": "^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$"
+          "pattern": "^([a-z0-9]([a-z0-9.-]*[a-z0-9])?)?$"
         },
         "enabled": {
           "description": "Enabled controls whether the workload proxy service is enabled.",
@@ -475,7 +475,7 @@
           }
         },
         "useOmniSubdomain": {
-          "description": "UseOmniSubdomain controls whether the workload proxy subdomain is placed under Omni's own domain (as a subdomain) rather than as a sibling. When true, the proxy domain becomes '<subdomain>.<omni-domain>' instead of '<subdomain>.<parent-of-omni-domain>'. This also simplifies exposed service URLs to '<alias>.<proxy-domain>' (without the instance name) and allows dashes in service aliases.",
+          "description": "UseOmniSubdomain controls whether the workload proxy subdomain is placed under Omni's own domain (as a subdomain) rather than as a sibling. When true, the proxy domain becomes '<subdomain>.<omni-domain>' instead of '<subdomain>.<parent-of-omni-domain>'. This also simplifies exposed service URLs to '<alias>.<proxy-domain>' (without the instance name) and allows dashes in service aliases. When true and subdomain is empty, services are exposed directly as subdomains of Omni (e.g., '<alias>.<omni-domain>').",
           "type": "boolean"
         }
       }

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -754,7 +754,9 @@ type WorkloadProxy struct {
 	// workloads. By default, it lives at the same level as Omni (e.g.,
 	// "omni-apps.example.com" for Omni at "omni.example.com"). When useOmniSubdomain
 	// is true, it is placed under Omni's domain instead (e.g.,
-	// "proxy.omni.example.com").
+	// "proxy.omni.example.com"). When useOmniSubdomain is true and subdomain is
+	// empty, services are exposed directly as subdomains of Omni (e.g.,
+	// "grafana.omni.example.com").
 	Subdomain *string `json:"subdomain,omitempty" yaml:"subdomain,omitempty"`
 
 	// UseOmniSubdomain controls whether the workload proxy subdomain is placed under
@@ -762,6 +764,7 @@ type WorkloadProxy struct {
 	// proxy domain becomes '<subdomain>.<omni-domain>' instead of
 	// '<subdomain>.<parent-of-omni-domain>'. This also simplifies exposed service
 	// URLs to '<alias>.<proxy-domain>' (without the instance name) and allows dashes
-	// in service aliases.
+	// in service aliases. When true and subdomain is empty, services are exposed
+	// directly as subdomains of Omni (e.g., '<alias>.<omni-domain>').
 	UseOmniSubdomain *bool `json:"useOmniSubdomain,omitempty" yaml:"useOmniSubdomain,omitempty"`
 }


### PR DESCRIPTION
Allow setting the workload proxy subdomain to an empty string when useOmniSubdomain is true. This exposes services directly as subdomains of Omni (e.g., grafana.omni.example.com), which is the simplest possible setup for on-prem deployments needing only a wildcard DNS and cert on the Omni domain.

Continuation of https://github.com/siderolabs/omni/pull/2538.