### PR TITLE
fix: allow Talos API read and copy methods

### DIFF
--- a/internal/backend/grpc/router/talos_backend.go
+++ b/internal/backend/grpc/router/talos_backend.go
@@ -56,6 +56,13 @@ var adminMethodSet = xslices.ToSet([]string{
 	machine.MachineService_MetaDelete_FullMethodName,
 })
 
+// adminMethodSet1_12 is the set of methods that are allowed to be called by the minimum role of os:admin for Talos versions >= 1.12.0.
+var adminMethodSet1_12 = xslices.ToSet([]string{
+	// read/copy APIs were not considered safe for older Talos versions, as the STATE partition has always been mounted
+	machine.MachineService_Copy_FullMethodName,
+	machine.MachineService_Read_FullMethodName,
+})
+
 // TalosBackend implements a backend (proxying directly to a single Talos node over SideroLink).
 type TalosBackend struct {
 	nodeResolver NodeResolver
@@ -185,6 +192,15 @@ func (backend *TalosBackend) setRoleHeaders(ctx context.Context, md metadata.MD,
 		setHeaderData(ctx, md, constants.APIAuthzRoleMetadataKey, talosrole.MakeSet(talosrole.Admin).Strings()...)
 
 		return
+	}
+
+	// methods that should have admin access for Talos >= 1.12.0
+	if _, ok := adminMethodSet1_12[fullMethodName]; ok {
+		if minTalosVersion != nil && minTalosVersion.GTE(semver.MustParse("1.12.0")) {
+			setHeaderData(ctx, md, constants.APIAuthzRoleMetadataKey, talosrole.MakeSet(talosrole.Admin).Strings()...)
+
+			return
+		}
 	}
 
 	// min Talos version is >= 1.4.0, we can use Operator role


### PR DESCRIPTION
These methods are not allowed by default, but as Talos no longer mounts `STATE` all the time, these APIs don't bring as much "easy" risk as it was before.

Many users tried to use it, and it's a helpful debugging tool.

This makes `talosctl cgroups` work via Omni.

Fixes #2325