### PR TITLE
feat: make config validation errors human-readable

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +25,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/config"
-	"github.com/siderolabs/omni/internal/pkg/jsonschema"
 	"github.com/siderolabs/omni/internal/version"
 )
 
@@ -146,315 +144,225 @@ func buildRootCommand() (*cobra.Command, error) {
 		},
 	}
 
-	rootCmdFlagBinder = NewFlagBinder(rootCmd)
+	rootCmdFlagBinder = NewFlagBinder(rootCmd, configSchema)
 
 	rootCmd.Flags().StringArrayVar(&configPaths, "config-path", nil, "config file(s) to load, can be specified multiple times, merged in order (flags have highest priority)")
 	rootCmd.Flags().BoolVar(&debug, "debug", constants.IsDebugBuild, "enable debug logs.")
 
-	rootCmdFlagBinder.StringVar("account-id", flagDescription("account.id", configSchema), &flagConfig.Account.Id)
-	rootCmdFlagBinder.StringVar("name", flagDescription("account.name", configSchema), &flagConfig.Account.Name)
-	rootCmdFlagBinder.StringVar("user-pilot-app-token", flagDescription("account.userPilot.appToken", configSchema), &flagConfig.Account.UserPilot.AppToken)
-	rootCmdFlagBinder.Uint32Var("account-max-registered-machines", flagDescription("account.maxRegisteredMachines", configSchema), &flagConfig.Account.MaxRegisteredMachines)
+	rootCmdFlagBinder.StringVar("account.id", &flagConfig.Account.Id)
+	rootCmdFlagBinder.StringVar("account.name", &flagConfig.Account.Name)
+	rootCmdFlagBinder.StringVar("account.userPilot.appToken", &flagConfig.Account.UserPilot.AppToken)
+	rootCmdFlagBinder.Uint32Var("account.maxRegisteredMachines", &flagConfig.Account.MaxRegisteredMachines)
 
-	if err := defineServiceFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema); err != nil {
-		return nil, fmt.Errorf("failed to define service flags: %w", err)
-	}
+	defineServiceFlags(rootCmdFlagBinder, flagConfig)
+	defineAuthFlags(rootCmd, rootCmdFlagBinder, flagConfig)
 
-	defineAuthFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema)
-
-	if err := defineLogsFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema); err != nil {
+	if err := defineLogsFlags(rootCmd, rootCmdFlagBinder, flagConfig); err != nil {
 		return nil, fmt.Errorf("failed to define logs flags: %w", err)
 	}
 
-	defineStorageFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema)
-	defineRegistriesFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema)
-	defineFeatureFlags(rootCmdFlagBinder, flagConfig, configSchema)
-	defineDebugFlags(rootCmdFlagBinder, flagConfig, configSchema)
-	defineEtcdBackupsFlags(rootCmd, rootCmdFlagBinder, flagConfig, configSchema)
+	defineStorageFlags(rootCmd, rootCmdFlagBinder, flagConfig)
+	defineRegistriesFlags(rootCmdFlagBinder, flagConfig)
+	defineFeatureFlags(rootCmdFlagBinder, flagConfig)
+	defineDebugFlags(rootCmdFlagBinder, flagConfig)
+	defineEtcdBackupsFlags(rootCmd, rootCmdFlagBinder, flagConfig)
 
 	return rootCmd, nil
 }
 
-func defineServiceFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) error {
+func defineServiceFlags(b *FlagBinder, flagConfig *config.Params) {
 	// API
-	rootCmdFlagBinder.StringVar("bind-addr", flagDescription("services.api.endpoint", schema), &flagConfig.Services.Api.Endpoint)
-	rootCmdFlagBinder.StringVar("advertised-api-url", flagDescription("services.api.advertisedURL", schema), &flagConfig.Services.Api.AdvertisedURL)
-	rootCmdFlagBinder.StringVar("key", flagDescription("services.api.keyFile", schema), &flagConfig.Services.Api.KeyFile)
-	rootCmdFlagBinder.StringVar("cert", flagDescription("services.api.certFile", schema), &flagConfig.Services.Api.CertFile)
+	b.StringVar("services.api.endpoint", &flagConfig.Services.Api.Endpoint)
+	b.StringVar("services.api.advertisedURL", &flagConfig.Services.Api.AdvertisedURL)
+	b.StringVar("services.api.keyFile", &flagConfig.Services.Api.KeyFile)
+	b.StringVar("services.api.certFile", &flagConfig.Services.Api.CertFile)
 
 	// Metrics
-	rootCmdFlagBinder.StringVar("metrics-bind-addr", flagDescription("services.metrics.endpoint", schema), &flagConfig.Services.Metrics.Endpoint)
+	b.StringVar("services.metrics.endpoint", &flagConfig.Services.Metrics.Endpoint)
 
 	// KubernetesProxy
-	rootCmdFlagBinder.StringVar("k8s-proxy-bind-addr", flagDescription("services.kubernetesProxy.endpoint", schema), &flagConfig.Services.KubernetesProxy.Endpoint)
-
-	rootCmdFlagBinder.StringVar("advertised-kubernetes-proxy-url", flagDescription("services.kubernetesProxy.advertisedURL", schema), &flagConfig.Services.KubernetesProxy.AdvertisedURL)
-
-	rootCmdFlagBinder.StringVar("kubeconfig-oidc-cache-base-dir",
-		flagDescription("services.kubernetesProxy.oidcCacheBaseDir", schema), &flagConfig.Services.KubernetesProxy.OidcCacheBaseDir)
-	rootCmdFlagBinder.BoolVar("kubeconfig-oidc-cache-isolation",
-		flagDescription("services.kubernetesProxy.oidcCacheIsolation", schema), &flagConfig.Services.KubernetesProxy.OidcCacheIsolation)
+	b.StringVar("services.kubernetesProxy.endpoint", &flagConfig.Services.KubernetesProxy.Endpoint)
+	b.StringVar("services.kubernetesProxy.advertisedURL", &flagConfig.Services.KubernetesProxy.AdvertisedURL)
+	b.StringVar("services.kubernetesProxy.oidcCacheBaseDir", &flagConfig.Services.KubernetesProxy.OidcCacheBaseDir)
+	b.BoolVar("services.kubernetesProxy.oidcCacheIsolation", &flagConfig.Services.KubernetesProxy.OidcCacheIsolation)
 
 	// Siderolink
-	rootCmdFlagBinder.StringVar("siderolink-wireguard-bind-addr", flagDescription("services.siderolink.wireGuard.endpoint", schema), &flagConfig.Services.Siderolink.WireGuard.Endpoint)
-	rootCmdFlagBinder.StringVar("siderolink-wireguard-advertised-addr",
-		flagDescription("services.siderolink.wireGuard.advertisedEndpoint", schema), &flagConfig.Services.Siderolink.WireGuard.AdvertisedEndpoint)
-	rootCmdFlagBinder.BoolVar("siderolink-disable-last-endpoint",
-		flagDescription("services.siderolink.disableLastEndpoint", schema), &flagConfig.Services.Siderolink.DisableLastEndpoint)
-	rootCmdFlagBinder.BoolVar("siderolink-use-grpc-tunnel",
-		flagDescription("services.siderolink.useGRPCTunnel", schema),
-		&flagConfig.Services.Siderolink.UseGRPCTunnel,
-	)
-	rootCmdFlagBinder.IntVar("event-sink-port", flagDescription("services.siderolink.eventSinkPort", schema), &flagConfig.Services.Siderolink.EventSinkPort)
-	rootCmdFlagBinder.IntVar("log-server-port", flagDescription("services.siderolink.logServerPort", schema), &flagConfig.Services.Siderolink.LogServerPort)
-	EnumVar(rootCmdFlagBinder, "join-tokens-mode", flagDescription("services.siderolink.joinTokensMode", schema), &flagConfig.Services.Siderolink.JoinTokensMode)
-	rootCmdFlagBinder.Uint64Var("siderolink-bandwidth-limit-mbps",
-		flagDescription("services.siderolink.bandwidthLimitMbps", schema),
-		&flagConfig.Services.Siderolink.BandwidthLimitMbps)
-	rootCmdFlagBinder.Uint64Var("siderolink-bandwidth-limit-burst-bytes",
-		flagDescription("services.siderolink.bandwidthLimitBurstBytes", schema),
-		&flagConfig.Services.Siderolink.BandwidthLimitBurstBytes)
+	b.StringVar("services.siderolink.wireGuard.endpoint", &flagConfig.Services.Siderolink.WireGuard.Endpoint)
+	b.StringVar("services.siderolink.wireGuard.advertisedEndpoint", &flagConfig.Services.Siderolink.WireGuard.AdvertisedEndpoint)
+	b.BoolVar("services.siderolink.disableLastEndpoint", &flagConfig.Services.Siderolink.DisableLastEndpoint)
+	b.BoolVar("services.siderolink.useGRPCTunnel", &flagConfig.Services.Siderolink.UseGRPCTunnel)
+	b.IntVar("services.siderolink.eventSinkPort", &flagConfig.Services.Siderolink.EventSinkPort)
+	b.IntVar("services.siderolink.logServerPort", &flagConfig.Services.Siderolink.LogServerPort)
+	EnumVar(b, "services.siderolink.joinTokensMode", &flagConfig.Services.Siderolink.JoinTokensMode)
+	b.Uint64Var("services.siderolink.bandwidthLimitMbps", &flagConfig.Services.Siderolink.BandwidthLimitMbps)
+	b.Uint64Var("services.siderolink.bandwidthLimitBurstBytes", &flagConfig.Services.Siderolink.BandwidthLimitBurstBytes)
 
-	// MachineAPI
-	for _, prefix := range []string{"siderolink", "machine"} {
-		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-bind-addr", prefix), flagDescription("services.machineAPI.endpoint", schema), &flagConfig.Services.MachineAPI.Endpoint)
-		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-cert", prefix), flagDescription("services.machineAPI.certFile", schema), &flagConfig.Services.MachineAPI.CertFile)
-		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-key", prefix), flagDescription("services.machineAPI.keyFile", schema), &flagConfig.Services.MachineAPI.KeyFile)
-		rootCmdFlagBinder.StringVar(fmt.Sprintf("%s-api-advertised-url", prefix), flagDescription("services.machineAPI.advertisedURL", schema), &flagConfig.Services.MachineAPI.AdvertisedURL)
-	}
+	// MachineAPI — deprecated aliases registered first so canonical flags take precedence in BindAll()
+	b.deprecatedStringAlias("siderolink-api-bind-addr", "use --machine-api-bind-addr", &flagConfig.Services.MachineAPI.Endpoint)
+	b.deprecatedStringAlias("siderolink-api-cert", "use --machine-api-cert", &flagConfig.Services.MachineAPI.CertFile)
+	b.deprecatedStringAlias("siderolink-api-key", "use --machine-api-key", &flagConfig.Services.MachineAPI.KeyFile)
+	b.deprecatedStringAlias("siderolink-api-advertised-url", "use --machine-api-advertised-url", &flagConfig.Services.MachineAPI.AdvertisedURL)
 
-	if err := rootCmd.Flags().MarkDeprecated("siderolink-api-bind-addr", "--deprecated, use --machine-api-bind-addr"); err != nil {
-		return err
-	}
-
-	if err := rootCmd.Flags().MarkDeprecated("siderolink-api-cert", "deprecated, use --machine-api-cert"); err != nil {
-		return err
-	}
-
-	if err := rootCmd.Flags().MarkDeprecated("siderolink-api-key", "deprecated, use --machine-api-key"); err != nil {
-		return err
-	}
+	b.StringVar("services.machineAPI.endpoint", &flagConfig.Services.MachineAPI.Endpoint)
+	b.StringVar("services.machineAPI.certFile", &flagConfig.Services.MachineAPI.CertFile)
+	b.StringVar("services.machineAPI.keyFile", &flagConfig.Services.MachineAPI.KeyFile)
+	b.StringVar("services.machineAPI.advertisedURL", &flagConfig.Services.MachineAPI.AdvertisedURL)
 
 	// LoadBalancer
-	rootCmdFlagBinder.IntVar("lb-min-port", flagDescription("services.loadBalancer.minPort", schema), &flagConfig.Services.LoadBalancer.MinPort)
-	rootCmdFlagBinder.IntVar("lb-max-port", flagDescription("services.loadBalancer.maxPort", schema), &flagConfig.Services.LoadBalancer.MaxPort)
+	b.IntVar("services.loadBalancer.minPort", &flagConfig.Services.LoadBalancer.MinPort)
+	b.IntVar("services.loadBalancer.maxPort", &flagConfig.Services.LoadBalancer.MaxPort)
 
-	rootCmdFlagBinder.IntVar("local-resource-server-port", flagDescription("services.localResourceService.port", schema), &flagConfig.Services.LocalResourceService.Port)
-
-	rootCmdFlagBinder.BoolVar("local-resource-server-enabled", flagDescription("services.localResourceService.enabled", schema), &flagConfig.Services.LocalResourceService.Enabled)
+	// LocalResourceService
+	b.IntVar("services.localResourceService.port", &flagConfig.Services.LocalResourceService.Port)
+	b.BoolVar("services.localResourceService.enabled", &flagConfig.Services.LocalResourceService.Enabled)
 
 	// Embedded discovery service
-	rootCmdFlagBinder.BoolVar("embedded-discovery-service-enabled",
-		flagDescription("services.embeddedDiscoveryService.enabled", schema), &flagConfig.Services.EmbeddedDiscoveryService.Enabled)
-
-	rootCmdFlagBinder.IntVar("embedded-discovery-service-endpoint", flagDescription("services.embeddedDiscoveryService.port", schema), &flagConfig.Services.EmbeddedDiscoveryService.Port)
-
-	if err := rootCmd.Flags().MarkDeprecated("embedded-discovery-service-endpoint", "use --embedded-discovery-service-port"); err != nil {
-		return err
-	}
-
-	rootCmdFlagBinder.IntVar("embedded-discovery-service-port", flagDescription("services.embeddedDiscoveryService.port", schema), &flagConfig.Services.EmbeddedDiscoveryService.Port)
-
-	rootCmdFlagBinder.BoolVar("embedded-discovery-service-snapshots-enabled",
-		flagDescription("services.embeddedDiscoveryService.snapshotsEnabled", schema), &flagConfig.Services.EmbeddedDiscoveryService.SnapshotsEnabled)
-
-	rootCmdFlagBinder.DurationVar("embedded-discovery-service-snapshot-interval",
-		flagDescription("services.embeddedDiscoveryService.snapshotsInterval", schema), &flagConfig.Services.EmbeddedDiscoveryService.SnapshotsInterval)
-	rootCmdFlagBinder.StringVar("embedded-discovery-service-log-level",
-		flagDescription("services.embeddedDiscoveryService.logLevel", schema), &flagConfig.Services.EmbeddedDiscoveryService.LogLevel)
-	rootCmdFlagBinder.DurationVar("embedded-discovery-service-sqlite-timeout",
-		flagDescription("services.embeddedDiscoveryService.sqliteTimeout", schema), &flagConfig.Services.EmbeddedDiscoveryService.SqliteTimeout)
+	b.BoolVar("services.embeddedDiscoveryService.enabled", &flagConfig.Services.EmbeddedDiscoveryService.Enabled)
+	b.deprecatedIntAlias("embedded-discovery-service-endpoint", "use --embedded-discovery-service-port", &flagConfig.Services.EmbeddedDiscoveryService.Port)
+	b.IntVar("services.embeddedDiscoveryService.port", &flagConfig.Services.EmbeddedDiscoveryService.Port)
+	b.BoolVar("services.embeddedDiscoveryService.snapshotsEnabled", &flagConfig.Services.EmbeddedDiscoveryService.SnapshotsEnabled)
+	b.DurationVar("services.embeddedDiscoveryService.snapshotsInterval", &flagConfig.Services.EmbeddedDiscoveryService.SnapshotsInterval)
+	b.StringVar("services.embeddedDiscoveryService.logLevel", &flagConfig.Services.EmbeddedDiscoveryService.LogLevel)
+	b.DurationVar("services.embeddedDiscoveryService.sqliteTimeout", &flagConfig.Services.EmbeddedDiscoveryService.SqliteTimeout)
 
 	// DevServerProxy
-	rootCmdFlagBinder.StringVar("frontend-dst", flagDescription("services.devServerProxy.proxyTo", schema), &flagConfig.Services.DevServerProxy.ProxyTo)
-	rootCmdFlagBinder.StringVar("frontend-bind", flagDescription("services.devServerProxy.endpoint", schema), &flagConfig.Services.DevServerProxy.Endpoint)
-
-	return nil
+	b.StringVar("services.devServerProxy.proxyTo", &flagConfig.Services.DevServerProxy.ProxyTo)
+	b.StringVar("services.devServerProxy.endpoint", &flagConfig.Services.DevServerProxy.Endpoint)
 }
 
-func defineAuthFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
+func defineAuthFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *config.Params) {
 	// Auth0
-	rootCmdFlagBinder.BoolVar("auth-auth0-enabled",
-		flagDescription("auth.auth0.enabled", schema), &flagConfig.Auth.Auth0.Enabled)
-	rootCmdFlagBinder.StringVar("auth-auth0-client-id", flagDescription("auth.auth0.clientID", schema), &flagConfig.Auth.Auth0.ClientID)
-	rootCmdFlagBinder.StringVar("auth-auth0-domain", flagDescription("auth.auth0.domain", schema), &flagConfig.Auth.Auth0.Domain)
-	rootCmdFlagBinder.BoolVar("auth-auth0-use-form-data",
-		flagDescription("auth.auth0.useFormData", schema), &flagConfig.Auth.Auth0.UseFormData)
+	b.BoolVar("auth.auth0.enabled", &flagConfig.Auth.Auth0.Enabled)
+	b.StringVar("auth.auth0.clientID", &flagConfig.Auth.Auth0.ClientID)
+	b.StringVar("auth.auth0.domain", &flagConfig.Auth.Auth0.Domain)
+	b.BoolVar("auth.auth0.useFormData", &flagConfig.Auth.Auth0.UseFormData)
 
 	// Webauthn
-	rootCmdFlagBinder.BoolVar("auth-webauthn-enabled",
-		flagDescription("auth.webauthn.enabled", schema), &flagConfig.Auth.Webauthn.Enabled)
-	rootCmdFlagBinder.BoolVar("auth-webauthn-required",
-		flagDescription("auth.webauthn.required", schema), &flagConfig.Auth.Webauthn.Required)
+	b.BoolVar("auth.webauthn.enabled", &flagConfig.Auth.Webauthn.Enabled)
+	b.BoolVar("auth.webauthn.required", &flagConfig.Auth.Webauthn.Required)
 
-	rootCmdFlagBinder.BoolVar("auth-saml-enabled",
-		flagDescription("auth.saml.enabled", schema), &flagConfig.Auth.Saml.Enabled,
-	)
-	rootCmdFlagBinder.StringVar("auth-saml-url", flagDescription("auth.saml.url", schema), &flagConfig.Auth.Saml.Url)
-	rootCmdFlagBinder.StringVar("auth-saml-metadata", flagDescription("auth.saml.metadata", schema), &flagConfig.Auth.Saml.Metadata)
-	rootCmd.Flags().Var(&flagConfig.Auth.Saml.LabelRules, "auth-saml-label-rules", flagDescription("auth.saml.labelRules", schema))
-	rootCmd.Flags().Var(&flagConfig.Auth.Saml.AttributeRules, "auth-saml-attribute-rules", flagDescription("auth.saml.attributeRules", schema))
-	rootCmdFlagBinder.StringVar("auth-saml-name-id-format", flagDescription("auth.saml.nameIDFormat", schema), &flagConfig.Auth.Saml.NameIDFormat)
-	rootCmd.Flags().StringSliceVar(&flagConfig.Auth.InitialUsers, "initial-users", flagConfig.Auth.InitialUsers, flagDescription("auth.initialUsers", schema))
-	rootCmdFlagBinder.DurationVar("public-key-pruning-interval", flagDescription("auth.keyPruner.interval", schema), &flagConfig.Auth.KeyPruner.Interval)
-	rootCmdFlagBinder.BoolVar("suspended", flagDescription("auth.suspended", schema), &flagConfig.Auth.Suspended)
+	// SAML
+	b.BoolVar("auth.saml.enabled", &flagConfig.Auth.Saml.Enabled)
+	b.StringVar("auth.saml.url", &flagConfig.Auth.Saml.Url)
+	b.StringVar("auth.saml.metadata", &flagConfig.Auth.Saml.Metadata)
+	b.ValueVar("auth.saml.labelRules", &flagConfig.Auth.Saml.LabelRules)
+	b.ValueVar("auth.saml.attributeRules", &flagConfig.Auth.Saml.AttributeRules)
+	b.StringVar("auth.saml.nameIDFormat", &flagConfig.Auth.Saml.NameIDFormat)
 
-	rootCmdFlagBinder.BoolVar("create-initial-service-account",
-		flagDescription("auth.initialServiceAccount.enabled", schema), &flagConfig.Auth.InitialServiceAccount.Enabled)
+	b.StringSliceVar("auth.initialUsers", &flagConfig.Auth.InitialUsers, flagConfig.Auth.InitialUsers)
 
-	rootCmdFlagBinder.StringVar("initial-service-account-key-path", flagDescription("auth.initialServiceAccount.keyPath", schema), &flagConfig.Auth.InitialServiceAccount.KeyPath)
+	b.DurationVar("auth.keyPruner.interval", &flagConfig.Auth.KeyPruner.Interval)
+	b.BoolVar("auth.suspended", &flagConfig.Auth.Suspended)
 
-	rootCmdFlagBinder.StringVar("initial-service-account-role", flagDescription("auth.initialServiceAccount.role", schema), &flagConfig.Auth.InitialServiceAccount.Role)
+	// Initial service account
+	b.BoolVar("auth.initialServiceAccount.enabled", &flagConfig.Auth.InitialServiceAccount.Enabled)
+	b.StringVar("auth.initialServiceAccount.keyPath", &flagConfig.Auth.InitialServiceAccount.KeyPath)
+	b.StringVar("auth.initialServiceAccount.role", &flagConfig.Auth.InitialServiceAccount.Role)
+	b.DurationVar("auth.initialServiceAccount.lifetime", &flagConfig.Auth.InitialServiceAccount.Lifetime)
 
-	rootCmdFlagBinder.DurationVar("initial-service-account-lifetime",
-		flagDescription("auth.initialServiceAccount.lifetime", schema), &flagConfig.Auth.InitialServiceAccount.Lifetime)
-
-	rootCmd.MarkFlagsMutuallyExclusive("auth-saml-url", "auth-saml-metadata")
+	rootCmd.MarkFlagsMutuallyExclusive(b.mustFlagName("auth.saml.url"), b.mustFlagName("auth.saml.metadata"))
 
 	// Limits
-	rootCmdFlagBinder.Uint32Var("auth-max-users",
-		flagDescription("auth.limits.maxUsers", schema), &flagConfig.Auth.Limits.MaxUsers)
-	rootCmdFlagBinder.Uint32Var("auth-max-service-accounts",
-		flagDescription("auth.limits.maxServiceAccounts", schema), &flagConfig.Auth.Limits.MaxServiceAccounts)
+	b.Uint32Var("auth.limits.maxUsers", &flagConfig.Auth.Limits.MaxUsers)
+	b.Uint32Var("auth.limits.maxServiceAccounts", &flagConfig.Auth.Limits.MaxServiceAccounts)
 
 	// OIDC
-	rootCmdFlagBinder.BoolVar("auth-oidc-enabled", flagDescription("auth.oidc.enabled", schema), &flagConfig.Auth.Oidc.Enabled)
-	rootCmdFlagBinder.StringVar("auth-oidc-provider-url", flagDescription("auth.oidc.providerURL", schema), &flagConfig.Auth.Oidc.ProviderURL)
-	rootCmdFlagBinder.StringVar("auth-oidc-client-id", flagDescription("auth.oidc.clientID", schema), &flagConfig.Auth.Oidc.ClientID)
-	rootCmdFlagBinder.StringVar("auth-oidc-client-secret", flagDescription("auth.oidc.clientSecret", schema), &flagConfig.Auth.Oidc.ClientSecret)
-	rootCmd.Flags().StringSliceVar(&flagConfig.Auth.Oidc.Scopes, "auth-oidc-scopes", flagConfig.Auth.Oidc.Scopes, flagDescription("auth.oidc.scopes", schema))
-	rootCmdFlagBinder.StringVar("auth-oidc-logout-url", flagDescription("auth.oidc.logoutURL", schema), &flagConfig.Auth.Oidc.LogoutURL)
-	rootCmdFlagBinder.BoolVar("auth-oidc-allow-unverified-email", flagDescription("auth.oidc.allowUnverifiedEmail", schema), &flagConfig.Auth.Oidc.AllowUnverifiedEmail)
+	b.BoolVar("auth.oidc.enabled", &flagConfig.Auth.Oidc.Enabled)
+	b.StringVar("auth.oidc.providerURL", &flagConfig.Auth.Oidc.ProviderURL)
+	b.StringVar("auth.oidc.clientID", &flagConfig.Auth.Oidc.ClientID)
+	b.StringVar("auth.oidc.clientSecret", &flagConfig.Auth.Oidc.ClientSecret)
+	b.StringSliceVar("auth.oidc.scopes", &flagConfig.Auth.Oidc.Scopes, flagConfig.Auth.Oidc.Scopes)
+	b.StringVar("auth.oidc.logoutURL", &flagConfig.Auth.Oidc.LogoutURL)
+	b.BoolVar("auth.oidc.allowUnverifiedEmail", &flagConfig.Auth.Oidc.AllowUnverifiedEmail)
 }
 
-func defineLogsFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) error {
-	rootCmdFlagBinder.DurationVar("machine-log-sqlite-timeout", flagDescription("logs.machine.storage.sqliteTimeout", schema), &flagConfig.Logs.Machine.Storage.SqliteTimeout)
-	rootCmdFlagBinder.DurationVar("machine-log-cleanup-interval", flagDescription("logs.machine.storage.cleanupInterval", schema), &flagConfig.Logs.Machine.Storage.CleanupInterval)
-	rootCmdFlagBinder.DurationVar("machine-log-cleanup-older-than", flagDescription("logs.machine.storage.cleanupOlderThan", schema), &flagConfig.Logs.Machine.Storage.CleanupOlderThan)
-	rootCmdFlagBinder.IntVar("machine-log-max-lines-per-machine", flagDescription("logs.machine.storage.maxLinesPerMachine", schema), &flagConfig.Logs.Machine.Storage.MaxLinesPerMachine)
-	rootCmdFlagBinder.Uint64Var("machine-log-max-size", flagDescription("logs.machine.storage.maxSize", schema), &flagConfig.Logs.Machine.Storage.MaxSize)
-	rootCmdFlagBinder.Float64Var("machine-log-cleanup-probability",
-		flagDescription("logs.machine.storage.cleanupProbability", schema), &flagConfig.Logs.Machine.Storage.CleanupProbability)
+func defineLogsFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *config.Params) error {
+	b.DurationVar("logs.machine.storage.sqliteTimeout", &flagConfig.Logs.Machine.Storage.SqliteTimeout)
+	b.DurationVar("logs.machine.storage.cleanupInterval", &flagConfig.Logs.Machine.Storage.CleanupInterval)
+	b.DurationVar("logs.machine.storage.cleanupOlderThan", &flagConfig.Logs.Machine.Storage.CleanupOlderThan)
+	b.IntVar("logs.machine.storage.maxLinesPerMachine", &flagConfig.Logs.Machine.Storage.MaxLinesPerMachine)
+	b.Uint64Var("logs.machine.storage.maxSize", &flagConfig.Logs.Machine.Storage.MaxSize)
+	b.Float64Var("logs.machine.storage.cleanupProbability", &flagConfig.Logs.Machine.Storage.CleanupProbability)
 
-	if err := rootCmd.Flags().MarkHidden("machine-log-cleanup-probability"); err != nil {
+	if err := rootCmd.Flags().MarkHidden(b.mustFlagName("logs.machine.storage.cleanupProbability")); err != nil {
 		return err
 	}
 
-	rootCmd.Flags().StringSliceVar(&flagConfig.Logs.ResourceLogger.Types, "log-resource-updates-types",
-		flagConfig.Logs.ResourceLogger.Types, flagDescription("logs.resourceLogger.types", schema))
-	rootCmdFlagBinder.StringVar("log-resource-updates-log-level", flagDescription("logs.resourceLogger.logLevel", schema), &flagConfig.Logs.ResourceLogger.LogLevel)
-	rootCmdFlagBinder.BoolVar("audit-log-enabled", flagDescription("logs.audit.enabled", schema), &flagConfig.Logs.Audit.Enabled)
-	rootCmdFlagBinder.DurationVar("audit-log-sqlite-timeout", flagDescription("logs.audit.sqliteTimeout", schema), &flagConfig.Logs.Audit.SqliteTimeout)
-	rootCmdFlagBinder.DurationVar("audit-log-retention-period", flagDescription("logs.audit.retentionPeriod", schema), &flagConfig.Logs.Audit.RetentionPeriod)
-	rootCmdFlagBinder.Uint64Var("audit-log-max-size", flagDescription("logs.audit.maxSize", schema), &flagConfig.Logs.Audit.MaxSize)
-	rootCmdFlagBinder.Float64Var("audit-log-cleanup-probability", flagDescription("logs.audit.cleanupProbability", schema), &flagConfig.Logs.Audit.CleanupProbability)
-	rootCmdFlagBinder.BoolVar("enable-stripe-reporting", flagDescription("logs.stripe.enabled", schema), &flagConfig.Logs.Stripe.Enabled)
-	rootCmdFlagBinder.Uint32Var("stripe-minimum-commit", flagDescription("logs.stripe.minCommit", schema), &flagConfig.Logs.Stripe.MinCommit)
+	b.StringSliceVar("logs.resourceLogger.types", &flagConfig.Logs.ResourceLogger.Types, flagConfig.Logs.ResourceLogger.Types)
+	b.StringVar("logs.resourceLogger.logLevel", &flagConfig.Logs.ResourceLogger.LogLevel)
+	b.BoolVar("logs.audit.enabled", &flagConfig.Logs.Audit.Enabled)
+	b.DurationVar("logs.audit.sqliteTimeout", &flagConfig.Logs.Audit.SqliteTimeout)
+	b.DurationVar("logs.audit.retentionPeriod", &flagConfig.Logs.Audit.RetentionPeriod)
+	b.Uint64Var("logs.audit.maxSize", &flagConfig.Logs.Audit.MaxSize)
+	b.Float64Var("logs.audit.cleanupProbability", &flagConfig.Logs.Audit.CleanupProbability)
+	b.BoolVar("logs.stripe.enabled", &flagConfig.Logs.Stripe.Enabled)
+	b.Uint32Var("logs.stripe.minCommit", &flagConfig.Logs.Stripe.MinCommit)
 
-	if err := rootCmd.Flags().MarkHidden("audit-log-cleanup-probability"); err != nil {
+	if err := rootCmd.Flags().MarkHidden(b.mustFlagName("logs.audit.cleanupProbability")); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func defineStorageFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
-	EnumVar(rootCmdFlagBinder, "storage-kind", flagDescription("storage.default.kind", schema), &flagConfig.Storage.Default.Kind)
-	rootCmdFlagBinder.BoolVar("etcd-embedded", flagDescription("storage.default.etcd.embedded", schema), &flagConfig.Storage.Default.Etcd.Embedded)
-	rootCmdFlagBinder.BoolVar("etcd-embedded-unsafe-fsync", flagDescription("storage.default.etcd.embeddedUnsafeFsync", schema), &flagConfig.Storage.Default.Etcd.EmbeddedUnsafeFsync)
-	rootCmdFlagBinder.StringVar("etcd-embedded-db-path", flagDescription("storage.default.etcd.embeddedDBPath", schema), &flagConfig.Storage.Default.Etcd.EmbeddedDBPath)
+func defineStorageFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *config.Params) {
+	EnumVar(b, "storage.default.kind", &flagConfig.Storage.Default.Kind)
+	b.BoolVar("storage.default.etcd.embedded", &flagConfig.Storage.Default.Etcd.Embedded)
+	b.BoolVar("storage.default.etcd.embeddedUnsafeFsync", &flagConfig.Storage.Default.Etcd.EmbeddedUnsafeFsync)
+	b.StringVar("storage.default.etcd.embeddedDBPath", &flagConfig.Storage.Default.Etcd.EmbeddedDBPath)
 
-	ensure.NoError(rootCmd.Flags().MarkHidden("etcd-embedded-unsafe-fsync"))
+	ensure.NoError(rootCmd.Flags().MarkHidden(b.mustFlagName("storage.default.etcd.embeddedUnsafeFsync")))
 
-	rootCmd.Flags().StringSliceVar(&flagConfig.Storage.Default.Etcd.Endpoints, "etcd-endpoints", flagConfig.Storage.Default.Etcd.Endpoints, flagDescription("storage.default.etcd.endpoints", schema))
-	rootCmdFlagBinder.DurationVar("etcd-dial-keepalive-time", flagDescription("storage.default.etcd.dialKeepAliveTime", schema), &flagConfig.Storage.Default.Etcd.DialKeepAliveTime)
-	rootCmdFlagBinder.DurationVar("etcd-dial-keepalive-timeout", flagDescription("storage.default.etcd.dialKeepAliveTimeout", schema), &flagConfig.Storage.Default.Etcd.DialKeepAliveTimeout)
-	rootCmdFlagBinder.StringVar("etcd-ca-path", flagDescription("storage.default.etcd.caFile", schema), &flagConfig.Storage.Default.Etcd.CaFile)
-	rootCmdFlagBinder.StringVar("etcd-client-cert-path", flagDescription("storage.default.etcd.certFile", schema), &flagConfig.Storage.Default.Etcd.CertFile)
-	rootCmdFlagBinder.StringVar("etcd-client-key-path", flagDescription("storage.default.etcd.keyFile", schema), &flagConfig.Storage.Default.Etcd.KeyFile)
-	rootCmdFlagBinder.StringVar("private-key-source", flagDescription("storage.default.etcd.privateKeySource", schema), &flagConfig.Storage.Default.Etcd.PrivateKeySource)
+	b.StringSliceVar("storage.default.etcd.endpoints", &flagConfig.Storage.Default.Etcd.Endpoints, flagConfig.Storage.Default.Etcd.Endpoints)
+	b.DurationVar("storage.default.etcd.dialKeepAliveTime", &flagConfig.Storage.Default.Etcd.DialKeepAliveTime)
+	b.DurationVar("storage.default.etcd.dialKeepAliveTimeout", &flagConfig.Storage.Default.Etcd.DialKeepAliveTimeout)
+	b.StringVar("storage.default.etcd.caFile", &flagConfig.Storage.Default.Etcd.CaFile)
+	b.StringVar("storage.default.etcd.certFile", &flagConfig.Storage.Default.Etcd.CertFile)
+	b.StringVar("storage.default.etcd.keyFile", &flagConfig.Storage.Default.Etcd.KeyFile)
+	b.StringVar("storage.default.etcd.privateKeySource", &flagConfig.Storage.Default.Etcd.PrivateKeySource)
 
-	rootCmd.Flags().StringSliceVar(&flagConfig.Storage.Default.Etcd.PublicKeyFiles, "public-key-files", flagConfig.Storage.Default.Etcd.PublicKeyFiles,
-		flagDescription("storage.default.etcd.publicKeyFiles", schema))
-	rootCmdFlagBinder.StringVar(config.SQLiteStoragePathFlag,
-		flagDescription("storage.sqlite.path", schema), &flagConfig.Storage.Sqlite.Path)
-
-	rootCmdFlagBinder.StringVar("sqlite-storage-experimental-base-params",
-		flagDescription("storage.sqlite.experimentalBaseParams", schema), &flagConfig.Storage.Sqlite.ExperimentalBaseParams)
-
-	rootCmdFlagBinder.StringVar("sqlite-storage-extra-params",
-		flagDescription("storage.sqlite.extraParams", schema),
-		&flagConfig.Storage.Sqlite.ExtraParams)
-
-	rootCmdFlagBinder.StringVar("vault-k8s-auth-mount-path",
-		flagDescription("storage.vault.k8sAuthMountPath", schema), &flagConfig.Storage.Vault.K8SAuthMountPath)
+	b.StringSliceVar("storage.default.etcd.publicKeyFiles", &flagConfig.Storage.Default.Etcd.PublicKeyFiles, flagConfig.Storage.Default.Etcd.PublicKeyFiles)
+	b.StringVar("storage.sqlite.path", &flagConfig.Storage.Sqlite.Path)
+	b.StringVar("storage.sqlite.experimentalBaseParams", &flagConfig.Storage.Sqlite.ExperimentalBaseParams)
+	b.StringVar("storage.sqlite.extraParams", &flagConfig.Storage.Sqlite.ExtraParams)
+	b.StringVar("storage.vault.k8sAuthMountPath", &flagConfig.Storage.Vault.K8SAuthMountPath)
 }
 
-func defineRegistriesFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
-	rootCmdFlagBinder.StringVar("talos-installer-registry", flagDescription("registries.talos", schema), &flagConfig.Registries.Talos)
-	rootCmdFlagBinder.StringVar("kubernetes-registry", flagDescription("registries.kubernetes", schema), &flagConfig.Registries.Kubernetes)
-	rootCmdFlagBinder.StringVar("image-factory-address", flagDescription("registries.imageFactoryBaseURL", schema), &flagConfig.Registries.ImageFactoryBaseURL)
-	rootCmdFlagBinder.StringVar("image-factory-pxe-address", flagDescription("registries.imageFactoryPXEBaseURL", schema), &flagConfig.Registries.ImageFactoryPXEBaseURL)
+func defineRegistriesFlags(b *FlagBinder, flagConfig *config.Params) {
+	b.StringVar("registries.talos", &flagConfig.Registries.Talos)
+	b.StringVar("registries.kubernetes", &flagConfig.Registries.Kubernetes)
+	b.StringVar("registries.imageFactoryBaseURL", &flagConfig.Registries.ImageFactoryBaseURL)
+	b.StringVar("registries.imageFactoryPXEBaseURL", &flagConfig.Registries.ImageFactoryPXEBaseURL)
 
-	rootCmd.Flags().StringSliceVar(&flagConfig.Registries.Mirrors, "registry-mirror", flagConfig.Registries.Mirrors,
-		flagDescription("registries.mirrors", schema))
+	b.StringSliceVar("registries.mirrors", &flagConfig.Registries.Mirrors, flagConfig.Registries.Mirrors)
 }
 
-func defineFeatureFlags(rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
-	rootCmdFlagBinder.BoolVar("enable-talos-pre-release-versions",
-		flagDescription("features.enableTalosPreReleaseVersions", schema), &flagConfig.Features.EnableTalosPreReleaseVersions)
-
-	rootCmdFlagBinder.BoolVar("config-data-compression-enabled", flagDescription("features.enableConfigDataCompression", schema), &flagConfig.Features.EnableConfigDataCompression)
-
-	rootCmdFlagBinder.BoolVar("workload-proxying-enabled", flagDescription("services.workloadProxy.enabled", schema), &flagConfig.Services.WorkloadProxy.Enabled)
-
-	rootCmdFlagBinder.StringVar("workload-proxying-subdomain", flagDescription("services.workloadProxy.subdomain", schema), &flagConfig.Services.WorkloadProxy.Subdomain)
-
-	rootCmdFlagBinder.BoolVar("workload-proxying-use-omni-subdomain",
-		flagDescription("services.workloadProxy.useOmniSubdomain", schema), &flagConfig.Services.WorkloadProxy.UseOmniSubdomain)
-
-	rootCmdFlagBinder.DurationVar("workload-proxying-stop-lbs-after",
-		flagDescription("services.workloadProxy.stopLBsAfter", schema), &flagConfig.Services.WorkloadProxy.StopLBsAfter)
-
-	rootCmdFlagBinder.BoolVar("enable-break-glass-configs", flagDescription("features.enableBreakGlassConfigs", schema), &flagConfig.Features.EnableBreakGlassConfigs)
-
-	rootCmdFlagBinder.BoolVar("disable-controller-runtime-cache",
-		flagDescription("features.disableControllerRuntimeCache", schema), &flagConfig.Features.DisableControllerRuntimeCache)
-
-	rootCmdFlagBinder.BoolVar("enable-cluster-import", flagDescription("features.enableClusterImport", schema), &flagConfig.Features.EnableClusterImport)
+func defineFeatureFlags(b *FlagBinder, flagConfig *config.Params) {
+	b.BoolVar("features.enableTalosPreReleaseVersions", &flagConfig.Features.EnableTalosPreReleaseVersions)
+	b.BoolVar("features.enableConfigDataCompression", &flagConfig.Features.EnableConfigDataCompression)
+	b.BoolVar("services.workloadProxy.enabled", &flagConfig.Services.WorkloadProxy.Enabled)
+	b.StringVar("services.workloadProxy.subdomain", &flagConfig.Services.WorkloadProxy.Subdomain)
+	b.BoolVar("services.workloadProxy.useOmniSubdomain", &flagConfig.Services.WorkloadProxy.UseOmniSubdomain)
+	b.DurationVar("services.workloadProxy.stopLBsAfter", &flagConfig.Services.WorkloadProxy.StopLBsAfter)
+	b.BoolVar("features.enableBreakGlassConfigs", &flagConfig.Features.EnableBreakGlassConfigs)
+	b.BoolVar("features.disableControllerRuntimeCache", &flagConfig.Features.DisableControllerRuntimeCache)
+	b.BoolVar("features.enableClusterImport", &flagConfig.Features.EnableClusterImport)
 }
 
-func defineDebugFlags(rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
-	rootCmdFlagBinder.StringVar("pprof-bind-addr", flagDescription("debug.pprof.endpoint", schema), &flagConfig.Debug.Pprof.Endpoint)
-	rootCmdFlagBinder.StringVar("debug-server-endpoint", flagDescription("debug.server.endpoint", schema), &flagConfig.Debug.Server.Endpoint)
+func defineDebugFlags(b *FlagBinder, flagConfig *config.Params) {
+	b.StringVar("debug.pprof.endpoint", &flagConfig.Debug.Pprof.Endpoint)
+	b.StringVar("debug.server.endpoint", &flagConfig.Debug.Server.Endpoint)
 }
 
-func defineEtcdBackupsFlags(rootCmd *cobra.Command, rootCmdFlagBinder *FlagBinder, flagConfig *config.Params, schema *jsonschema.Schema) {
-	rootCmdFlagBinder.BoolVar("etcd-backup-s3", flagDescription("etcdBackup.s3Enabled", schema), &flagConfig.EtcdBackup.S3Enabled)
-	rootCmdFlagBinder.StringVar("etcd-backup-local-path", flagDescription("etcdBackup.localPath", schema), &flagConfig.EtcdBackup.LocalPath)
-	rootCmdFlagBinder.DurationVar("etcd-backup-tick-interval",
-		flagDescription("etcdBackup.tickInterval", schema), &flagConfig.EtcdBackup.TickInterval)
-	rootCmdFlagBinder.DurationVar("etcd-backup-jitter",
-		flagDescription("etcdBackup.jitter", schema), &flagConfig.EtcdBackup.Jitter)
-	rootCmdFlagBinder.DurationVar("etcd-backup-min-interval", flagDescription("etcdBackup.minInterval", schema), &flagConfig.EtcdBackup.MinInterval)
-	rootCmdFlagBinder.DurationVar("etcd-backup-max-interval", flagDescription("etcdBackup.maxInterval", schema), &flagConfig.EtcdBackup.MaxInterval)
-	rootCmdFlagBinder.Uint64Var("etcd-backup-upload-limit-mbps", flagDescription("etcdBackup.uploadLimitMbps", schema), &flagConfig.EtcdBackup.UploadLimitMbps)
-	rootCmdFlagBinder.Uint64Var("etcd-backup-download-limit-mbps", flagDescription("etcdBackup.downloadLimitMbps", schema), &flagConfig.EtcdBackup.DownloadLimitMbps)
+func defineEtcdBackupsFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *config.Params) {
+	b.BoolVar("etcdBackup.s3Enabled", &flagConfig.EtcdBackup.S3Enabled)
+	b.StringVar("etcdBackup.localPath", &flagConfig.EtcdBackup.LocalPath)
+	b.DurationVar("etcdBackup.tickInterval", &flagConfig.EtcdBackup.TickInterval)
+	b.DurationVar("etcdBackup.jitter", &flagConfig.EtcdBackup.Jitter)
+	b.DurationVar("etcdBackup.minInterval", &flagConfig.EtcdBackup.MinInterval)
+	b.DurationVar("etcdBackup.maxInterval", &flagConfig.EtcdBackup.MaxInterval)
+	b.Uint64Var("etcdBackup.uploadLimitMbps", &flagConfig.EtcdBackup.UploadLimitMbps)
+	b.Uint64Var("etcdBackup.downloadLimitMbps", &flagConfig.EtcdBackup.DownloadLimitMbps)
 
-	rootCmd.MarkFlagsMutuallyExclusive("etcd-backup-s3", "etcd-backup-local-path")
-}
-
-func flagDescription(fieldPath string, schema *jsonschema.Schema) string {
-	description := schema.Description(fieldPath)
-	if description == "" {
-		panic("no description for " + fieldPath)
-	}
-
-	// remove the first two words like "XYZ is" from the description
-	parts := strings.SplitN(description, " ", 3)
-	if len(parts) < 3 {
-		return description
-	}
-
-	return strings.TrimSpace(parts[2])
+	rootCmd.MarkFlagsMutuallyExclusive(b.mustFlagName("etcdBackup.s3Enabled"), b.mustFlagName("etcdBackup.localPath"))
 }

--- a/cmd/omni/cmd/flag.go
+++ b/cmd/omni/cmd/flag.go
@@ -7,76 +7,103 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/siderolabs/omni/internal/pkg/jsonschema"
 )
 
 // FlagBinder handles the deferred binding of Cobra flags to nil-able pointers.
+// Flag names and descriptions are derived from the JSON schema field path.
 type FlagBinder struct {
 	cmd       *cobra.Command
+	schema    *jsonschema.Schema
 	callbacks []func() error
 }
 
 // NewFlagBinder creates a new binder for the given command.
-func NewFlagBinder(cmd *cobra.Command) *FlagBinder {
-	return &FlagBinder{cmd: cmd}
+func NewFlagBinder(cmd *cobra.Command, schema *jsonschema.Schema) *FlagBinder {
+	return &FlagBinder{cmd: cmd, schema: schema}
 }
 
-func (f *FlagBinder) StringVar(name string, usage string, target **string) {
+// StringVar binds a string flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) StringVar(fieldPath string, target **string) {
+	name, usage := f.mustFlagInfo(fieldPath)
+
 	var val string
+
 	f.cmd.Flags().StringVar(&val, name, "", usage)
 	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, target, &val))
 }
 
-func (f *FlagBinder) IntVar(name string, usage string, target **int) {
+// BoolVar binds a bool flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) BoolVar(fieldPath string, ptr **bool) {
+	name, usage := f.mustFlagInfo(fieldPath)
+
+	var val bool
+
+	f.cmd.Flags().BoolVar(&val, name, false, usage)
+	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, ptr, &val))
+}
+
+// IntVar binds an int flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) IntVar(fieldPath string, target **int) {
+	name, usage := f.mustFlagInfo(fieldPath)
+
 	var val int
+
 	f.cmd.Flags().IntVar(&val, name, 0, usage)
 	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, target, &val))
 }
 
-func (f *FlagBinder) BoolVar(name string, usage string, ptr **bool) {
-	var val bool
+// DurationVar binds a duration flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) DurationVar(fieldPath string, ptr **time.Duration) {
+	name, usage := f.mustFlagInfo(fieldPath)
 
-	f.cmd.Flags().BoolVar(&val, name, false, usage)
-
-	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, ptr, &val))
-}
-
-func (f *FlagBinder) DurationVar(name string, usage string, ptr **time.Duration) {
 	var val time.Duration
 
 	f.cmd.Flags().DurationVar(&val, name, 0, usage)
-
 	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, ptr, &val))
 }
 
-func (f *FlagBinder) Uint64Var(name string, usage string, ptr **uint64) {
-	var val uint64
+// Uint32Var binds a uint32 flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) Uint32Var(fieldPath string, ptr **uint32) {
+	name, usage := f.mustFlagInfo(fieldPath)
 
-	f.cmd.Flags().Uint64Var(&val, name, 0, usage)
-
-	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, ptr, &val))
-}
-
-func (f *FlagBinder) Uint32Var(name string, usage string, ptr **uint32) {
 	var val uint32
 
 	f.cmd.Flags().Uint32Var(&val, name, 0, usage)
-
 	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, ptr, &val))
 }
 
-func (f *FlagBinder) Float64Var(name string, usage string, ptr **float64) {
+// Uint64Var binds a uint64 flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) Uint64Var(fieldPath string, ptr **uint64) {
+	name, usage := f.mustFlagInfo(fieldPath)
+
+	var val uint64
+
+	f.cmd.Flags().Uint64Var(&val, name, 0, usage)
+	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, ptr, &val))
+}
+
+// Float64Var binds a float64 flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) Float64Var(fieldPath string, ptr **float64) {
+	name, usage := f.mustFlagInfo(fieldPath)
+
 	var val float64
 
 	f.cmd.Flags().Float64Var(&val, name, 0, usage)
-
 	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, ptr, &val))
 }
 
-// EnumVar binds a string flag restricted to specific allowed values.
-func EnumVar[T ~string](binder *FlagBinder, name string, usage string, target **T) {
+// EnumVar binds a string flag for an enum field, derived from the schema field path.
+// Enum constraints are enforced later by JSON schema validation, not at flag parse time.
+func EnumVar[T ~string](binder *FlagBinder, fieldPath string, target **T) {
+	name, usage := binder.mustFlagInfo(fieldPath)
+
 	var val string
 
 	binder.cmd.Flags().StringVar(&val, name, "", usage)
@@ -96,6 +123,42 @@ func EnumVar[T ~string](binder *FlagBinder, name string, usage string, target **
 	})
 }
 
+// StringSliceVar binds a string slice flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) StringSliceVar(fieldPath string, target *[]string, defaultVal []string) {
+	name, usage := f.mustFlagInfo(fieldPath)
+	f.cmd.Flags().StringSliceVar(target, name, defaultVal, usage)
+}
+
+// ValueVar binds a custom pflag.Value flag whose name and description are derived from the schema field path.
+func (f *FlagBinder) ValueVar(fieldPath string, value pflag.Value) {
+	name, usage := f.mustFlagInfo(fieldPath)
+	f.cmd.Flags().Var(value, name, usage)
+}
+
+// deprecatedStringAlias registers a deprecated string flag alias that points to the same target.
+func (f *FlagBinder) deprecatedStringAlias(name, deprecationMsg string, target **string) {
+	var val string
+
+	f.cmd.Flags().StringVar(&val, name, "", "")
+
+	//nolint:errcheck
+	f.cmd.Flags().MarkDeprecated(name, deprecationMsg)
+
+	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, target, &val))
+}
+
+// deprecatedIntAlias registers a deprecated int flag alias that points to the same target.
+func (f *FlagBinder) deprecatedIntAlias(name, deprecationMsg string, target **int) {
+	var val int
+
+	f.cmd.Flags().IntVar(&val, name, 0, "")
+
+	//nolint:errcheck
+	f.cmd.Flags().MarkDeprecated(name, deprecationMsg)
+
+	f.callbacks = append(f.callbacks, makeApplier(f.cmd, name, target, &val))
+}
+
 func (f *FlagBinder) BindAll() error {
 	for _, cb := range f.callbacks {
 		if err := cb(); err != nil {
@@ -104,6 +167,34 @@ func (f *FlagBinder) BindAll() error {
 	}
 
 	return nil
+}
+
+func (f *FlagBinder) mustFlagInfo(fieldPath string) (name, usage string) {
+	return f.mustFlagName(fieldPath), f.mustFlagDescription(fieldPath)
+}
+
+func (f *FlagBinder) mustFlagName(fieldPath string) string {
+	name := f.schema.FlagName("/" + strings.ReplaceAll(fieldPath, ".", "/"))
+	if name == "" {
+		panic("no x-cli-flag in schema for " + fieldPath)
+	}
+
+	return name
+}
+
+func (f *FlagBinder) mustFlagDescription(fieldPath string) string {
+	description := f.schema.Description(fieldPath)
+	if description == "" {
+		panic("no description in schema for " + fieldPath)
+	}
+
+	// remove the first two words like "XYZ is" from the description
+	parts := strings.SplitN(description, " ", 3)
+	if len(parts) < 3 {
+		return description
+	}
+
+	return strings.TrimSpace(parts[2])
 }
 
 // makeApplier creates the closure that assigns the temp flag value to the target pointer.

--- a/cmd/omni/cmd/flag_test.go
+++ b/cmd/omni/cmd/flag_test.go
@@ -14,27 +14,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/omni/cmd/omni/cmd"
-)
-
-type TestEnum string
-
-var (
-	EnumValueA TestEnum = "valueA"
-	EnumValueB TestEnum = "valueB"
+	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 func TestFlagBinder(t *testing.T) {
+	configSchema, err := config.ParseSchema()
+	require.NoError(t, err)
+
 	var (
 		strFlag      *string
-		intFlag      *int
 		boolFlag     *bool
 		durationFlag *time.Duration
+		intFlag      *int
 		uint64Flag   *uint64
 		uint32Flag   *uint32
 		floatFlag    *float64
-		enumFlag     *TestEnum
 		unsetFlag    *string
 	)
+
+	type testEnum string
+
+	var enumFlag *testEnum
 
 	var flagBinder *cmd.FlagBinder
 
@@ -42,9 +42,9 @@ func TestFlagBinder(t *testing.T) {
 		Use: "test",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assert.Nil(t, strFlag, "flags should be nil before binding")
-			assert.Nil(t, intFlag, "flags should be nil before binding")
 			assert.Nil(t, boolFlag, "flags should be nil before binding")
 			assert.Nil(t, durationFlag, "flags should be nil before binding")
+			assert.Nil(t, intFlag, "flags should be nil before binding")
 			assert.Nil(t, uint64Flag, "flags should be nil before binding")
 			assert.Nil(t, uint32Flag, "flags should be nil before binding")
 			assert.Nil(t, floatFlag, "flags should be nil before binding")
@@ -54,40 +54,41 @@ func TestFlagBinder(t *testing.T) {
 			require.NoError(t, flagBinder.BindAll())
 
 			assert.Equal(t, "hello", *strFlag)
-			assert.Equal(t, 42, *intFlag)
 			assert.Equal(t, true, *boolFlag)
 			assert.Equal(t, 90*time.Minute, *durationFlag)
+			assert.Equal(t, 42, *intFlag)
 			assert.Equal(t, uint64(123456789), *uint64Flag)
 			assert.Equal(t, uint32(987654321), *uint32Flag)
 			assert.InEpsilon(t, 3.14159, *floatFlag, 0.01)
-			assert.Equal(t, EnumValueB, *enumFlag)
+			assert.Equal(t, testEnum("legacyAllowed"), *enumFlag)
 			assert.Nil(t, unsetFlag, "unset flag should remain nil")
 
 			return nil
 		},
 	}
 
-	flagBinder = cmd.NewFlagBinder(command)
+	flagBinder = cmd.NewFlagBinder(command, configSchema)
 
-	flagBinder.StringVar("str-flag", "A string flag", &strFlag)
-	flagBinder.IntVar("int-flag", "An int flag", &intFlag)
-	flagBinder.BoolVar("bool-flag", "A bool flag", &boolFlag)
-	flagBinder.DurationVar("duration-flag", "A duration flag", &durationFlag)
-	flagBinder.Uint64Var("uint64-flag", "A uint64 flag", &uint64Flag)
-	flagBinder.Uint32Var("uint32-flag", "A uint32 flag", &uint32Flag)
-	flagBinder.Float64Var("float-flag", "A float64 flag", &floatFlag)
-	cmd.EnumVar(flagBinder, "enum-flag", "An enum flag", &enumFlag)
-	flagBinder.StringVar("unset-flag", "An unset flag", &unsetFlag)
+	// Use real schema field paths to test that names and descriptions are derived correctly
+	flagBinder.StringVar("account.id", &strFlag)
+	flagBinder.BoolVar("auth.auth0.enabled", &boolFlag)
+	flagBinder.DurationVar("auth.keyPruner.interval", &durationFlag)
+	flagBinder.IntVar("services.siderolink.eventSinkPort", &intFlag)
+	flagBinder.Uint64Var("etcdBackup.uploadLimitMbps", &uint64Flag)
+	flagBinder.Uint32Var("auth.limits.maxUsers", &uint32Flag)
+	flagBinder.Float64Var("logs.audit.cleanupProbability", &floatFlag)
+	cmd.EnumVar(flagBinder, "services.siderolink.joinTokensMode", &enumFlag)
+	flagBinder.StringVar("account.name", &unsetFlag)
 
 	command.SetArgs([]string{
-		"--str-flag=hello",
-		"--int-flag=42",
-		"--bool-flag",
-		"--duration-flag=1h30m",
-		"--uint64-flag=123456789",
-		"--uint32-flag=987654321",
-		"--float-flag=3.14159",
-		"--enum-flag=valueB",
+		"--account-id=hello",
+		"--auth-auth0-enabled",
+		"--public-key-pruning-interval=1h30m",
+		"--event-sink-port=42",
+		"--etcd-backup-upload-limit-mbps=123456789",
+		"--auth-max-users=987654321",
+		"--audit-log-cleanup-probability=3.14159",
+		"--join-tokens-mode=legacyAllowed",
 	})
 
 	require.NoError(t, command.Execute())

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/siderolabs/talos/pkg/machinery v1.13.0-alpha.2.0.20260226180725-cc636f1dd1f1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v76 v76.25.0
 	github.com/zitadel/logging v0.7.0
@@ -257,7 +258,6 @@ require (
 	github.com/siderolabs/tcpproxy v0.1.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/sosodev/duration v1.4.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -34,10 +34,7 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/jsonschema"
 )
 
-const (
-	wireguardDefaultPort  = "50180"
-	SQLiteStoragePathFlag = "sqlite-storage-path"
-)
+const wireguardDefaultPort = "50180"
 
 //go:embed schema.json
 var schemaData string

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -111,50 +111,11 @@ func TestValidateConfig(t *testing.T) {
 		loadErr          string
 		config           []byte
 	}{
-		{
-			name:        "empty",
-			config:      []byte("{}"),
-			validateErr: "got null, want string",
-		},
+		// --- Valid configs ---
+
 		{
 			name:   "full",
 			config: configFull,
-		},
-		{
-			name:   "kubernetes proxy insecure advertised url",
-			config: configFull,
-			configModifyFunc: func(cfg *config.Params) {
-				cfg.Services.KubernetesProxy.SetAdvertisedURL("http://1.1.1.1:1111")
-			},
-			validateErr: `- at '/services/kubernetesProxy/advertisedURL': 'http://1.1.1.1:1111' does not match pattern '^https://'`,
-		},
-		{
-			name:   "prevent enabling unsupported webauthn",
-			config: configFull,
-			configModifyFunc: func(cfg *config.Params) {
-				cfg.Auth.Webauthn.SetEnabled(true)
-			},
-			validateErr: "- at '/auth/webauthn/enabled': value must be false",
-		},
-		{
-			name:        "invalid join tokens mode",
-			config:      configInvalidJoinTokenMode,
-			validateErr: "at '/services/siderolink/joinTokensMode': value must be one of 'strict', 'legacyAllowed', 'legacy'",
-		},
-		{
-			name:        "conflicting auth",
-			config:      conflictingAuth,
-			validateErr: "at '/auth/saml/enabled': 'not' failed",
-		},
-		{
-			name:        "conflicting backups",
-			config:      backups,
-			validateErr: "at '/etcdBackup': 'not' failed",
-		},
-		{
-			name:    "unknown keys",
-			config:  unknownKeys,
-			loadErr: "unknown keys found",
 		},
 		{
 			// Having no TLS cert/key neither for the API nor for Kubernetes Proxy Server is NOT an error,
@@ -166,18 +127,153 @@ func TestValidateConfig(t *testing.T) {
 			name:   "SAML with initial users",
 			config: enableSAML,
 		},
+
+		// --- Load errors ---
+
 		{
-			name: "missing sqlite path",
-			config: []byte(`storage:
-  sqlite: {}`),
-			validateErr: "at '/storage/sqlite/path': got null, want string",
+			name:    "unknown keys",
+			config:  unknownKeys,
+			loadErr: "unknown keys found",
+		},
+
+		// --- type: got null, want string (required field not set) ---
+
+		{
+			name:        "type null: empty config",
+			config:      []byte("{}"),
+			validateErr: `or flag "--sqlite-storage-path": is required but was not set`,
 		},
 		{
-			name: "empty sqlite path",
+			name: "type null: missing sqlite path",
+			config: []byte(`storage:
+  sqlite: {}`),
+			validateErr: `config value ".storage.sqlite.path" or flag "--sqlite-storage-path": is required but was not set`,
+		},
+
+		// --- minLength ---
+
+		{
+			name: "minLength: empty sqlite path",
 			config: []byte(`storage:
   sqlite:
     path: ""`),
-			validateErr: "at '/storage/sqlite/path': minLength: got 0, want 1",
+			validateErr: `config value ".storage.sqlite.path" or flag "--sqlite-storage-path": must not be empty`,
+		},
+		{
+			name: "minLength: empty account id",
+			config: []byte(`account:
+  id: ""`),
+			validateErr: `config value ".account.id" or flag "--account-id": must not be empty`,
+		},
+		{
+			name: "minLength: empty account name",
+			config: []byte(`account:
+  name: ""`),
+			validateErr: `config value ".account.name" or flag "--name": must not be empty`,
+		},
+		{
+			name: "minLength: empty etcd private key source",
+			config: []byte(`storage:
+  default:
+    etcd:
+      privateKeySource: ""`),
+			validateErr: `config value ".storage.default.etcd.privateKeySource" or flag "--private-key-source": must not be empty`,
+		},
+
+		// --- minimum ---
+
+		{
+			name: "minimum: sqlite cached pool size below 1",
+			config: []byte(`storage:
+  sqlite:
+    cachedPoolSize: 0`),
+			validateErr: `config value ".storage.sqlite.cachedPoolSize": must be at least 1`,
+		},
+		{
+			name: "minimum: sqlite pool size below 1",
+			config: []byte(`storage:
+  sqlite:
+    poolSize: 0`),
+			validateErr: `config value ".storage.sqlite.poolSize": must be at least 1`,
+		},
+
+		// --- enum ---
+
+		{
+			name:        "enum: invalid join tokens mode",
+			config:      configInvalidJoinTokenMode,
+			validateErr: `config value ".services.siderolink.joinTokensMode" or flag "--join-tokens-mode": must be one of 'strict', 'legacyAllowed', 'legacy'`,
+		},
+		{
+			name: "enum: invalid storage kind",
+			config: []byte(`storage:
+  default:
+    kind: invalid`),
+			validateErr: `config value ".storage.default.kind" or flag "--storage-kind": must be one of 'etcd', 'boltdb'`,
+		},
+
+		// --- const ---
+
+		{
+			name:   "const: webauthn enabled must be false",
+			config: configFull,
+			configModifyFunc: func(cfg *config.Params) {
+				cfg.Auth.Webauthn.SetEnabled(true)
+			},
+			validateErr: `config value ".auth.webauthn.enabled" or flag "--auth-webauthn-enabled": must be false`,
+		},
+		{
+			name:   "const: webauthn required must be false",
+			config: configFull,
+			configModifyFunc: func(cfg *config.Params) {
+				cfg.Auth.Webauthn.SetRequired(true)
+			},
+			validateErr: `config value ".auth.webauthn.required" or flag "--auth-webauthn-required": must be false`,
+		},
+
+		// --- pattern ---
+
+		{
+			name:   "pattern: kubernetes proxy advertised URL must be https",
+			config: configFull,
+			configModifyFunc: func(cfg *config.Params) {
+				cfg.Services.KubernetesProxy.SetAdvertisedURL("http://1.1.1.1:1111")
+			},
+			validateErr: `config value ".services.kubernetesProxy.advertisedURL" or flag "--advertised-kubernetes-proxy-url": must start with 'https://'`,
+		},
+		{
+			name: "pattern: workload proxy subdomain invalid",
+			config: []byte(`services:
+  workloadProxy:
+    subdomain: "INVALID!!"`),
+			validateErr: `config value ".services.workloadProxy.subdomain" or flag "--workload-proxying-subdomain": must be a valid DNS subdomain (lowercase alphanumeric, dots, hyphens)`,
+		},
+		{
+			name: "pattern: sqlite experimental base params starts with ?",
+			config: []byte(`storage:
+  sqlite:
+    experimentalBaseParams: "?bad"`),
+			validateErr: `config value ".storage.sqlite.experimentalBaseParams" or flag "--sqlite-storage-experimental-base-params": must not start with '?'`,
+		},
+		{
+			name: "pattern: sqlite extra params starts with &",
+			config: []byte(`storage:
+  sqlite:
+    extraParams: "&bad"`),
+			validateErr: `config value ".storage.sqlite.extraParams" or flag "--sqlite-storage-extra-params": must not start with '&'`,
+		},
+
+		// --- if/then/else + not (kept as-is for now, TODO: move to Go validation) ---
+
+		{
+			name:        "if/then: conflicting auth providers",
+			config:      conflictingAuth,
+			validateErr: "'not' failed",
+		},
+		{
+			name:        "if/then: conflicting backup storage",
+			config:      backups,
+			validateErr: "'not' failed",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -70,6 +70,7 @@
           "type": "string",
           "minLength": 1,
           "description": "Id is the unique UUID identifier of the account. It is used to uniquely identify the account in etcd, therefore it should never be changed after initial setup.",
+          "x-cli-flag": "account-id",
           "goJSONSchema": {
             "type": "*string"
           }
@@ -78,6 +79,7 @@
           "type": "string",
           "minLength": 1,
           "description": "Name is the human-readable name of the account.",
+          "x-cli-flag": "name",
           "goJSONSchema": {
             "type": "*string"
           }
@@ -90,6 +92,7 @@
           "description": "MaxRegisteredMachines is the maximum number of registered machines allowed. 0 means unlimited.",
           "type": "integer",
           "minimum": 0,
+          "x-cli-flag": "account-max-registered-machines",
           "goJSONSchema": {
             "type": "uint32"
           }
@@ -101,6 +104,7 @@
       "properties": {
         "appToken": {
           "description": "AppToken is the UserPilot application token.",
+          "x-cli-flag": "user-pilot-app-token",
           "type": "string"
         }
       }
@@ -116,6 +120,7 @@
         "talos": {
           "type": "string",
           "description": "Talos is the Talos installer registry configuration.",
+          "x-cli-flag": "talos-installer-registry",
           "minLength": 1,
           "goJSONSchema": {
             "type": "*string"
@@ -124,6 +129,7 @@
         "kubernetes": {
           "type": "string",
           "description": "Kubernetes is the Kubernetes container registry configuration.",
+          "x-cli-flag": "kubernetes-registry",
           "minLength": 1,
           "goJSONSchema": {
             "type": "*string"
@@ -132,6 +138,7 @@
         "imageFactoryBaseURL": {
           "type": "string",
           "description": "ImageFactoryBaseURL is the base URL of the Image Factory service used to build custom machine images.",
+          "x-cli-flag": "image-factory-address",
           "minLength": 1,
           "goJSONSchema": {
             "type": "*string"
@@ -139,10 +146,12 @@
         },
         "imageFactoryPXEBaseURL": {
           "description": "ImageFactoryPXEBaseURL is the base URL of the Image Factory PXE endpoint used to build custom PXE boot images.",
+          "x-cli-flag": "image-factory-pxe-address",
           "type": "string"
         },
         "mirrors": {
           "description": "Mirrors is the list of container image registry mirrors. Used mainly for the development purposes. It must be in the format: <registry host>=<mirror URL>",
+          "x-cli-flag": "registry-mirror",
           "type": "array",
           "goJSONSchema": {
             "extraTags": {
@@ -172,7 +181,13 @@
       "properties": {
         "api": {
           "description": "Api contains API/UI service configuration.",
-          "$ref": "#/definitions/Service"
+          "$ref": "#/definitions/Service",
+          "properties": {
+            "endpoint": { "x-cli-flag": "bind-addr" },
+            "advertisedURL": { "x-cli-flag": "advertised-api-url" },
+            "certFile": { "x-cli-flag": "cert" },
+            "keyFile": { "x-cli-flag": "key" }
+          }
         },
         "devServerProxy": {
           "description": "DevServerProxy is the node dev server proxy service configuration. It exists for the development purposes only.",
@@ -180,7 +195,10 @@
         },
         "metrics": {
           "description": "Metrics contains metrics service configuration.",
-          "$ref": "#/definitions/Service"
+          "$ref": "#/definitions/Service",
+          "properties": {
+            "endpoint": { "x-cli-flag": "metrics-bind-addr" }
+          }
         },
         "kubernetesProxy": {
           "description": "KubernetesProxy contains Kubernetes proxy service configuration. It is the service responsible for proxying Kubernetes API requests to the clusters.",
@@ -192,7 +210,13 @@
         },
         "machineAPI": {
           "description": "MachineAPI contains SideroLink API service configuration. It is responsible for provisioning SideroLink connections by validating node join requests and issuing machine join tokens.",
-          "$ref": "#/definitions/Service"
+          "$ref": "#/definitions/Service",
+          "properties": {
+            "endpoint": { "x-cli-flag": "machine-api-bind-addr" },
+            "advertisedURL": { "x-cli-flag": "machine-api-advertised-url" },
+            "certFile": { "x-cli-flag": "machine-api-cert" },
+            "keyFile": { "x-cli-flag": "machine-api-key" }
+          }
         },
         "localResourceService": {
           "description": "LocalResourceService contains local resource service configuration. Omni runs a local service to allow access to its resources without authorization checks. It is primarily used by infra providers (e.g., sidecars).",
@@ -239,6 +263,7 @@
       "properties": {
         "endpoint": {
           "description": "Endpoint is the network endpoint the dev server proxy service listens on. It is in the form \"host:port\".",
+          "x-cli-flag": "frontend-bind",
           "type": "string"
         },
         "advertisedURL": {
@@ -255,6 +280,7 @@
         },
         "proxyTo": {
           "description": "ProxyTo is the address to which the dev server proxy service forwards incoming requests. It is in the form \"http(s)://host:port\".",
+          "x-cli-flag": "frontend-dst",
           "type": "string"
         }
       }
@@ -264,12 +290,15 @@
       "properties": {
         "endpoint": {
           "description": "Endpoint is the network endpoint the Kubernetes proxy service listens on. It is in the form \"host:port\".",
+          "x-cli-flag": "k8s-proxy-bind-addr",
           "type": "string"
         },
         "advertisedURL": {
           "description": "AdvertisedURL is the URL that the Kubernetes proxy service advertises to clients. It is in the form \"https://host:port\". When not set, it is generated by the system based on the endpoint and TLS cert/key configuration.",
+          "x-cli-flag": "advertised-kubernetes-proxy-url",
           "type": "string",
-          "pattern": "^https://"
+          "pattern": "^https://",
+          "x-pattern-message": "must start with 'https://'"
         },
         "certFile": {
           "description": "CertFile is the path to the TLS certificate file for the Kubernetes proxy service.",
@@ -281,10 +310,12 @@
         },
         "oidcCacheBaseDir": {
           "description": "OidcCacheBaseDir overrides the base cache directory for kubelogin in generated kubeconfigs. When empty, kubelogin uses its default (~/.kube/cache/oidc-login).",
+          "x-cli-flag": "kubeconfig-oidc-cache-base-dir",
           "type": "string"
         },
         "oidcCacheIsolation": {
           "description": "OidcCacheIsolation isolates OIDC token caches across clusters by appending a per-context subdirectory to the cache directory in generated kubeconfigs.",
+          "x-cli-flag": "kubeconfig-oidc-cache-isolation",
           "type": "boolean"
         }
       }
@@ -301,6 +332,7 @@
         },
         "joinTokensMode": {
           "description": "JoinTokensMode configures how machine join tokens are generated and used. Set to strict to use the secure join tokens mode.",
+          "x-cli-flag": "join-tokens-mode",
           "type": "string",
           "enum": [
             "strict",
@@ -310,28 +342,34 @@
         },
         "disableLastEndpoint": {
           "description": "DisableLastEndpoint controls whether the SideroLink service should stop using the last known endpoint of a node when it becomes unreachable via WireGuard.",
+          "x-cli-flag": "siderolink-disable-last-endpoint",
           "type": "boolean"
         },
         "useGRPCTunnel": {
           "description": "UseGRPCTunnel controls whether the SideroLink service should tunnel WireGuard traffic over gRPC, in setups where direct Wireguard connectivity is not possible (e.g., due to firewall restrictions). When enabled, the SideroLink connections from Talos machines will be configured to use the tunnel mode, regardless of their individual configuration.",
+          "x-cli-flag": "siderolink-use-grpc-tunnel",
           "type": "boolean"
         },
         "eventSinkPort": {
           "description": "EventSinkPort is the port to be used by the nodes to publish their events over SideroLink to Omni.",
+          "x-cli-flag": "event-sink-port",
           "type": "integer"
         },
         "logServerPort": {
           "description": "LogServerPort is the port to be used by the nodes to send their logs over SideroLink to Omni.",
+          "x-cli-flag": "log-server-port",
           "type": "integer"
         },
         "bandwidthLimitMbps": {
           "description": "BandwidthLimitMbps is the maximum total bandwidth in megabits per second through the SideroLink tunnel. Uses a token bucket algorithm: the rate controls sustained throughput while burst allows temporary spikes. Zero means unlimited.",
+          "x-cli-flag": "siderolink-bandwidth-limit-mbps",
           "type": "integer",
           "goJSONSchema": { "type": "uint64" },
           "minimum": 0
         },
         "bandwidthLimitBurstBytes": {
           "description": "BandwidthLimitBurstBytes is the maximum number of bytes that can pass through the SideroLink tunnel in a single burst (token bucket capacity). The bucket refills continuously at the rate set by bandwidthLimitMbps. When zero and bandwidthLimitMbps is set, defaults to one second worth of the rate. For example, with bandwidthLimitMbps=10 (1.25 MB/s) and burstBytes=5000000 (5 MB), up to 5 MB can transfer instantly, then throughput settles to 1.25 MB/s.",
+          "x-cli-flag": "siderolink-bandwidth-limit-burst-bytes",
           "type": "integer",
           "goJSONSchema": { "type": "uint64" },
           "minimum": 0
@@ -343,10 +381,12 @@
       "properties": {
         "endpoint": {
           "description": "Endpoint is the network endpoint the WireGuard interface listens on. It is in the form \"ip:port\" (IP address is required, not hostname).",
+          "x-cli-flag": "siderolink-wireguard-bind-addr",
           "type": "string"
         },
         "advertisedEndpoint": {
           "description": "AdvertisedEndpoint is the endpoint that the SideroLink service advertises to nodes for WireGuard connectivity. It is in the form \"ip:port\" (IP address is required, not hostname). When not set, it is generated by the system based on the WireGuard endpoint.",
+          "x-cli-flag": "siderolink-wireguard-advertised-addr",
           "type": "string"
         }
       }
@@ -356,10 +396,12 @@
       "properties": {
         "enabled": {
           "description": "Enabled controls whether the local resource service is enabled.",
+          "x-cli-flag": "local-resource-server-enabled",
           "type": "boolean"
         },
         "port": {
           "description": "Port is the network port the local resource service listens on.",
+          "x-cli-flag": "local-resource-server-port",
           "type": "integer"
         }
       }
@@ -369,32 +411,40 @@
       "properties": {
         "enabled": {
           "description": "Enabled controls whether the embedded discovery service is enabled. It binds only to the SideroLink WireGuard address.",
+          "x-cli-flag": "embedded-discovery-service-enabled",
           "type": "boolean"
         },
         "port": {
           "description": "Port is the network port the embedded discovery service listens on.",
+          "x-cli-flag": "embedded-discovery-service-port",
           "type": "integer"
         },
         "snapshotsEnabled": {
           "description": "SnapshotsEnabled controls whether the embedded discovery service periodically persists snapshots of its state to disk.",
+          "x-cli-flag": "embedded-discovery-service-snapshots-enabled",
           "type": "boolean"
         },
         "snapshotsInterval": {
           "description": "SnapshotsInterval is the interval at which the embedded discovery service persists snapshots of its state.",
+          "x-cli-flag": "embedded-discovery-service-snapshot-interval",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "logLevel": {
           "description": "LogLevel is the logging level used by the embedded discovery service.",
+          "x-cli-flag": "embedded-discovery-service-log-level",
           "type": "string"
         },
         "sqliteTimeout": {
           "description": "SqliteTimeout is the timeout for SQLite operations used by the embedded discovery service.",
+          "x-cli-flag": "embedded-discovery-service-sqlite-timeout",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
@@ -406,16 +456,19 @@
       "properties": {
         "minPort": {
           "description": "MinPort is the minimum port number that can be picked by the load balancer service when allocating a new LB port to a cluster.",
+          "x-cli-flag": "lb-min-port",
           "type": "integer"
         },
         "maxPort": {
           "description": "MaxPort is the maximum port number that can be picked by the load balancer service when allocating a new LB port to a cluster.",
+          "x-cli-flag": "lb-max-port",
           "type": "integer"
         },
         "dialTimeout": {
           "description": "DialTimeout is the timeout used by the load balancer service when dialing backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
@@ -424,6 +477,7 @@
           "description": "KeepAlivePeriod is the period used by the load balancer service for keep-alive pings to backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
@@ -432,6 +486,7 @@
           "description": "TCPUserTimeout is the TCP user timeout value set on connections between the load balancer and backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
@@ -440,6 +495,7 @@
           "description": "HealthCheckInterval is the interval between health checks performed by the load balancer service on backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
@@ -448,6 +504,7 @@
           "description": "HealthCheckTimeout is the timeout for health checks performed by the load balancer service on backend control plane nodes.",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
@@ -459,23 +516,29 @@
       "properties": {
         "subdomain": {
           "description": "Subdomain is the subdomain used by the workload proxy service to expose workloads. By default, it lives at the same level as Omni (e.g., \"omni-apps.example.com\" for Omni at \"omni.example.com\"). When useOmniSubdomain is true, it is placed under Omni's domain instead (e.g., \"proxy.omni.example.com\"). When useOmniSubdomain is true and subdomain is empty, services are exposed directly as subdomains of Omni (e.g., \"grafana.omni.example.com\").",
+          "x-cli-flag": "workload-proxying-subdomain",
           "type": "string",
-          "pattern": "^([a-z0-9]([a-z0-9.-]*[a-z0-9])?)?$"
+          "pattern": "^([a-z0-9]([a-z0-9.-]*[a-z0-9])?)?$",
+          "x-pattern-message": "must be a valid DNS subdomain (lowercase alphanumeric, dots, hyphens)"
         },
         "enabled": {
           "description": "Enabled controls whether the workload proxy service is enabled.",
+          "x-cli-flag": "workload-proxying-enabled",
           "type": "boolean"
         },
         "stopLBsAfter": {
           "description": "StopLBsAfter is the duration after which the workload proxy service stops load balancers for workloads that have not received any traffic.",
+          "x-cli-flag": "workload-proxying-stop-lbs-after",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "useOmniSubdomain": {
           "description": "UseOmniSubdomain controls whether the workload proxy subdomain is placed under Omni's own domain (as a subdomain) rather than as a sibling. When true, the proxy domain becomes '<subdomain>.<omni-domain>' instead of '<subdomain>.<parent-of-omni-domain>'. This also simplifies exposed service URLs to '<alias>.<proxy-domain>' (without the instance name) and allows dashes in service aliases. When true and subdomain is empty, services are exposed directly as subdomains of Omni (e.g., '<alias>.<omni-domain>').",
+          "x-cli-flag": "workload-proxying-use-omni-subdomain",
           "type": "boolean"
         }
       }
@@ -625,6 +688,7 @@
         },
         "initialUsers": {
           "description": "InitialUsers is a list of emails which should be created as admins when Omni is run for the first time.",
+          "x-cli-flag": "initial-users",
           "type": "array",
           "items": {
             "type": "string"
@@ -636,6 +700,7 @@
         },
         "suspended": {
           "description": "Suspended is whether the Omni account is suspended. If true, Omni will run on read-only mode with a warning banner displayed in the UI.",
+          "x-cli-flag": "suspended",
           "type": "boolean"
         },
         "initialServiceAccount": {
@@ -653,6 +718,7 @@
       "properties": {
         "maxUsers": {
           "description": "MaxUsers is the maximum number of users allowed. 0 means unlimited.",
+          "x-cli-flag": "auth-max-users",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -661,6 +727,7 @@
         },
         "maxServiceAccounts": {
           "description": "MaxServiceAccounts is the maximum number of service accounts allowed. 0 means unlimited.",
+          "x-cli-flag": "auth-max-service-accounts",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -682,18 +749,22 @@
         },
         "domain": {
           "description": "Domain is the Auth0 domain.",
+          "x-cli-flag": "auth-auth0-domain",
           "type": "string"
         },
         "clientID": {
           "description": "ClientID is the Auth0 client ID.",
+          "x-cli-flag": "auth-auth0-client-id",
           "type": "string"
         },
         "useFormData": {
           "description": "UseFormData controls whether the Auth0 provider should use form data for authentication requests. When true, data to the token endpoint is transmitted as x-www-form-urlencoded data instead of JSON.",
+          "x-cli-flag": "auth-auth0-use-form-data",
           "type": "boolean"
         },
         "enabled": {
           "description": "Enabled controls whether the Auth0 authentication provider is enabled. Once set to true, it cannot be set back to false.",
+          "x-cli-flag": "auth-auth0-enabled",
           "type": "boolean"
         }
       }
@@ -703,11 +774,13 @@
       "properties": {
         "enabled": {
           "description": "Enabled controls whether WebAuthn authentication is enabled. It is NOT SUPPORTED as it is currently unimplemented.",
+          "x-cli-flag": "auth-webauthn-enabled",
           "type": "boolean",
           "const": false
         },
         "required": {
           "description": "Required controls whether WebAuthn authentication is required. It is NOT SUPPORTED as it is currently unimplemented.",
+          "x-cli-flag": "auth-webauthn-required",
           "type": "boolean",
           "const": false
         }
@@ -718,22 +791,27 @@
       "properties": {
         "providerURL": {
           "description": "ProviderURL is the OIDC provider URL.",
+          "x-cli-flag": "auth-oidc-provider-url",
           "type": "string"
         },
         "clientID": {
           "description": "ClientID is the OIDC client ID.",
+          "x-cli-flag": "auth-oidc-client-id",
           "type": "string"
         },
         "clientSecret": {
           "description": "ClientSecret is the OIDC client secret.",
+          "x-cli-flag": "auth-oidc-client-secret",
           "type": "string"
         },
         "logoutURL": {
           "description": "LogoutURL is the OIDC logout URL.",
+          "x-cli-flag": "auth-oidc-logout-url",
           "type": "string"
         },
         "scopes": {
           "description": "Scopes is the list of OIDC scopes to request during authentication.",
+          "x-cli-flag": "auth-oidc-scopes",
           "type": "array",
           "items": {
             "type": "string"
@@ -741,10 +819,12 @@
         },
         "enabled": {
           "description": "Enabled controls whether the OIDC authentication provider is enabled.",
+          "x-cli-flag": "auth-oidc-enabled",
           "type": "boolean"
         },
         "allowUnverifiedEmail": {
           "description": "AllowUnverifiedEmail controls whether users with unverified emails (without email_verified claim) are allowed to authenticate.",
+          "x-cli-flag": "auth-oidc-allow-unverified-email",
           "type": "boolean"
         }
       }
@@ -764,6 +844,7 @@
       "properties": {
         "labelRules": {
           "description": "LabelRules defines mapping of SAML assertion attributes into Omni identity labels.",
+          "x-cli-flag": "auth-saml-label-rules",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -771,6 +852,7 @@
         },
         "attributeRules": {
           "description": "AttributeRules defines additional identity, fullname, firstname and lastname mappings.",
+          "x-cli-flag": "auth-saml-attribute-rules",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -778,18 +860,22 @@
         },
         "url": {
           "description": "URL is the SAML provider URL. Mutually exclusive with metadata URL (.metadata).",
+          "x-cli-flag": "auth-saml-url",
           "type": "string"
         },
         "metadata": {
           "description": "Metadata is the SAML provider metadata URL. Mutually exclusive with URL (.url).",
+          "x-cli-flag": "auth-saml-metadata",
           "type": "string"
         },
         "nameIDFormat": {
           "description": "NameIDFormat is the SAML NameID format to be used.",
+          "x-cli-flag": "auth-saml-name-id-format",
           "type": "string"
         },
         "enabled": {
           "description": "Enabled controls whether the SAML authentication provider is enabled.",
+          "x-cli-flag": "auth-saml-enabled",
           "type": "boolean"
         }
       }
@@ -799,8 +885,10 @@
       "properties": {
         "interval": {
           "description": "Interval is the interval at which the key pruner runs.",
+          "x-cli-flag": "public-key-pruning-interval",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
@@ -812,10 +900,12 @@
       "properties": {
         "role": {
           "description": "Role is the role assigned to the initial service account.",
+          "x-cli-flag": "initial-service-account-role",
           "type": "string"
         },
         "keyPath": {
           "description": "KeyPath is the path where the initial service account key is stored.",
+          "x-cli-flag": "initial-service-account-key-path",
           "type": "string"
         },
         "name": {
@@ -824,14 +914,17 @@
         },
         "lifetime": {
           "description": "Lifetime is the lifetime of the initial service account key.",
+          "x-cli-flag": "initial-service-account-lifetime",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "enabled": {
           "description": "Enabled controls whether the initial service account is created. This happens only on the first start of Omni.",
+          "x-cli-flag": "create-initial-service-account",
           "type": "boolean"
         }
       }
@@ -880,34 +973,42 @@
       "properties": {
         "sqliteTimeout": {
           "description": "SqliteTimeout is the timeout for SQLite operations used for machine logs storage.",
+          "x-cli-flag": "machine-log-sqlite-timeout",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "cleanupInterval": {
           "description": "CleanupInterval is the interval at which old machine logs are cleaned up.",
+          "x-cli-flag": "machine-log-cleanup-interval",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "cleanupOlderThan": {
           "description": "CleanupOlderThan is the duration after which machine logs are considered old and eligible for cleanup.",
+          "x-cli-flag": "machine-log-cleanup-older-than",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "maxLinesPerMachine": {
           "description": "MaxLinesPerMachine is the maximum number of log lines to keep per machine.",
+          "x-cli-flag": "machine-log-max-lines-per-machine",
           "type": "integer"
         },
         "maxSize": {
           "description": "MaxSize is the maximum allowed size (in bytes) of the machine logs table. When exceeded, the oldest entries are removed globally across all machines. 0 means unlimited.",
+          "x-cli-flag": "machine-log-max-size",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -916,6 +1017,7 @@
         },
         "cleanupProbability": {
           "description": "CleanupProbability is the probability of triggering the cleanup on each log write for that machine.",
+          "x-cli-flag": "machine-log-cleanup-probability",
           "type": "number"
         }
       }
@@ -925,26 +1027,32 @@
       "properties": {
         "enabled": {
           "description": "Enabled controls whether audit logging is enabled.",
+          "x-cli-flag": "audit-log-enabled",
           "type": "boolean"
         },
         "sqliteTimeout": {
           "description": "SqliteTimeout is the timeout for SQLite operations used for audit logs storage.",
+          "x-cli-flag": "audit-log-sqlite-timeout",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "retentionPeriod": {
           "description": "RetentionPeriod is the duration after which audit logs are considered old and eligible for cleanup.",
+          "x-cli-flag": "audit-log-retention-period",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "maxSize": {
           "description": "MaxSize is the maximum allowed size (in bytes) of the audit logs. When exceeded, the oldest entries are removed. 0 means unlimited.",
+          "x-cli-flag": "audit-log-max-size",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -953,6 +1061,7 @@
         },
         "cleanupProbability": {
           "description": "CleanupProbability is the probability of triggering size-based cleanup on each audit log write. When triggered, a best-effort cleanup removes a bounded batch of the oldest rows to reduce the table size toward maxSize; multiple cleanups may be required for the table to fall below maxSize. 0 disables size-based cleanup.",
+          "x-cli-flag": "audit-log-cleanup-probability",
           "type": "number"
         }
       }
@@ -962,10 +1071,12 @@
       "properties": {
         "logLevel": {
           "description": "LogLevel is the logging level used by the resource logger.",
+          "x-cli-flag": "log-resource-updates-log-level",
           "type": "string"
         },
         "types": {
           "description": "Types is the list of resource types to be logged by the resource logger.",
+          "x-cli-flag": "log-resource-updates-types",
           "type": "array",
           "goJSONSchema": {
             "extraTags": {
@@ -983,10 +1094,12 @@
       "properties": {
         "enabled": {
           "description": "Enabled controls whether Stripe logging is enabled.",
+          "x-cli-flag": "enable-stripe-reporting",
           "type": "boolean"
         },
         "minCommit": {
           "description": "MinCommit is the minimum number of machines committed for billing purposes, reported to Stripe for the given account.",
+          "x-cli-flag": "stripe-minimum-commit",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -1030,6 +1143,7 @@
         },
         "k8sAuthMountPath": {
           "description": "K8sAuthMountPath is the mount path of the Kubernetes auth method in Vault. When not set, it defaults to \"kubernetes\". This is useful when Vault is running on a different cluster and has multiple Kubernetes auth mounts.",
+          "x-cli-flag": "vault-k8s-auth-mount-path",
           "type": "string"
         }
       }
@@ -1043,6 +1157,7 @@
       "properties": {
         "kind": {
           "description": "Kind is the kind of the default storage backend.",
+          "x-cli-flag": "storage-kind",
           "type": "string",
           "enum": [
             "etcd",
@@ -1078,19 +1193,24 @@
           "description": "Path is the path where the SQLite database file is stored.",
           "type": "string",
           "minLength": 1,
+          "x-cli-flag": "sqlite-storage-path",
           "goJSONSchema": {
             "type": "*string"
           }
         },
         "experimentalBaseParams": {
           "description": "ExperimentalBaseParams contains the base parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. This flag is experimental and may be removed in future versions. It must not start with a question mark (?).",
+          "x-cli-flag": "sqlite-storage-experimental-base-params",
           "type": "string",
-          "pattern": "^(?:$|[^?].*)"
+          "pattern": "^(?:$|[^?].*)",
+          "x-pattern-message": "must not start with '?'"
         },
         "extraParams": {
           "description": "ExtraParams contains the extra parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. It must not start with an ampersand (&).",
+          "x-cli-flag": "sqlite-storage-extra-params",
           "type": "string",
-          "pattern": "^(?:$|[^&].*)"
+          "pattern": "^(?:$|[^&].*)",
+          "x-pattern-message": "must not start with '&'"
         },
         "cachedPoolSize" : {
           "description": "CachedPoolSize controls the number of cached connections in the SQLite connection pool. The overall number of connections is limited by poolSize. CachedPoolSize should be less or equal to poolSize.",
@@ -1112,6 +1232,7 @@
       "properties": {
         "endpoints": {
           "description": "Endpoints is the list of etcd endpoints. Only used when external etcd is used (i.e., embedded is false).",
+          "x-cli-flag": "etcd-endpoints",
           "type": "array",
           "goJSONSchema": {
             "extraTags": {
@@ -1124,42 +1245,52 @@
         },
         "dialKeepAliveTime": {
           "description": "DialKeepAliveTime is the keep-alive time for etcd client connections.",
+          "x-cli-flag": "etcd-dial-keepalive-time",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "dialKeepAliveTimeout": {
           "description": "DialKeepAliveTimeout is the keep-alive timeout for etcd client connections.",
+          "x-cli-flag": "etcd-dial-keepalive-timeout",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "caFile": {
           "description": "CaFile is the path to the CA certificate file for etcd client connections.",
+          "x-cli-flag": "etcd-ca-path",
           "type": "string"
         },
         "certFile": {
           "description": "CertFile is the path to the TLS certificate file for etcd client connections.",
+          "x-cli-flag": "etcd-client-cert-path",
           "type": "string"
         },
         "keyFile": {
           "description": "KeyFile is the path to the TLS key file for etcd client connections.",
+          "x-cli-flag": "etcd-client-key-path",
           "type": "string"
         },
         "embedded": {
           "description": "Embedded controls whether to use embedded etcd server as the storage backend.",
+          "x-cli-flag": "etcd-embedded",
           "type": "boolean"
         },
         "embeddedDBPath": {
           "description": "EmbeddedDBPath is the path where the embedded etcd database files are stored.",
+          "x-cli-flag": "etcd-embedded-db-path",
           "type": "string"
         },
         "embeddedUnsafeFsync": {
           "description": "EmbeddedUnsafeFsync controls whether the embedded etcd server should skip fsync calls for improved performance at the cost of durability.",
+          "x-cli-flag": "etcd-embedded-unsafe-fsync",
           "type": "boolean"
         },
         "runElections": {
@@ -1168,6 +1299,7 @@
         },
         "privateKeySource": {
           "description": "PrivateKeySource is the source of the private key for the embedded etcd server. It is used for decrypting master key slot.",
+          "x-cli-flag": "private-key-source",
           "type": "string",
           "minLength": 1,
           "goJSONSchema": {
@@ -1176,6 +1308,7 @@
         },
         "publicKeyFiles": {
           "description": "PublicKeyFiles is the list of public key files for the embedded etcd server. They are used for encrypting keys slots.",
+          "x-cli-flag": "public-key-files",
           "type": "array",
           "goJSONSchema": {
             "extraTags": {
@@ -1210,38 +1343,47 @@
       "properties": {
         "localPath": {
           "description": "LocalPath is the local path where etcd backups are stored before being uploaded to remote storage. Mutually exclusive with s3Enabled (.s3Enabled).",
+          "x-cli-flag": "etcd-backup-local-path",
           "type": "string"
         },
         "s3Enabled": {
           "description": "S3Enabled controls whether an S3-compatible storage is used for etcd backups. Mutually exclusive with localPath (.localPath).",
+          "x-cli-flag": "etcd-backup-s3",
           "type": "boolean"
         },
         "tickInterval": {
           "description": "TickInterval is the interval between etcd backups ticks (controller events to check if any cluster needs to be backed up)",
+          "x-cli-flag": "etcd-backup-tick-interval",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "minInterval": {
           "description": "MinInterval is the minimum interval between two etcd backups for a cluster.",
+          "x-cli-flag": "etcd-backup-min-interval",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "maxInterval": {
           "description": "MaxInterval is the maximum interval between two etcd backups for a cluster.",
+          "x-cli-flag": "etcd-backup-max-interval",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
         },
         "uploadLimitMbps": {
           "description": "UploadLimitMbps is the optional upload bandwidth limit for etcd backups to remote storage in megabits per second. If not specified or is set to 0, it is unlimited.",
+          "x-cli-flag": "etcd-backup-upload-limit-mbps",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -1250,6 +1392,7 @@
         },
         "downloadLimitMbps": {
           "description": "DownloadLimitMbps is the optional download bandwidth limit for etcd backups from remote storage in megabits per second. If not specified or is set to 0, it is unlimited.",
+          "x-cli-flag": "etcd-backup-download-limit-mbps",
           "type": "integer",
           "minimum": 0,
           "goJSONSchema": {
@@ -1258,8 +1401,10 @@
         },
         "jitter": {
           "description": "Jitter is the jitter for etcd backups, randomly added/subtracted from the interval between automatic etcd backups.",
+          "x-cli-flag": "etcd-backup-jitter",
           "type": "string",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
           "goJSONSchema": {
             "type": "time.Duration"
           }
@@ -1288,6 +1433,7 @@
       "properties": {
         "endpoint": {
           "description": "Endpoint is the network endpoint the debug server listens on. It is in the form \"[host]:port\".",
+          "x-cli-flag": "debug-server-endpoint",
           "type": "string"
         }
       }
@@ -1297,6 +1443,7 @@
       "properties": {
         "endpoint": {
           "description": "Endpoint is the network endpoint the pprof server listens on. It is in the form \"[host]:port\".",
+          "x-cli-flag": "pprof-bind-addr",
           "type": "string"
         }
       }
@@ -1306,22 +1453,27 @@
       "properties": {
         "enableTalosPreReleaseVersions": {
           "description": "EnableTalosPreReleaseVersions controls whether pre-release Talos versions (e.g., release candidates, betas) are available for selection when creating/upgrading clusters.",
+          "x-cli-flag": "enable-talos-pre-release-versions",
           "type": "boolean"
         },
         "enableBreakGlassConfigs": {
           "description": "EnableBreakGlassConfigs controls whether break-glass machine configurations are enabled. Break-glass configs allow direct access to the machines without going through Omni. Recommended to be disabled.",
+          "x-cli-flag": "enable-break-glass-configs",
           "type": "boolean"
         },
         "enableConfigDataCompression": {
           "description": "EnableConfigDataCompression controls whether machine configuration data stored in etcd is compressed to save space.",
+          "x-cli-flag": "config-data-compression-enabled",
           "type": "boolean"
         },
         "enableClusterImport": {
           "description": "EnableClusterImport controls whether the cluster import feature is enabled. When enabled, users can import existing Talos clusters into Omni.",
+          "x-cli-flag": "enable-cluster-import",
           "type": "boolean"
         },
         "disableControllerRuntimeCache": {
           "description": "DisableControllerRuntimeCache controls whether the controller-runtime cache is disabled. When disabled, etcd is accessed for all reads. Recommended to be enabled, unless debugging specific issues.",
+          "x-cli-flag": "disable-controller-runtime-cache",
           "type": "boolean"
         }
       }

--- a/internal/pkg/jsonschema/jsonschema.go
+++ b/internal/pkg/jsonschema/jsonschema.go
@@ -7,17 +7,53 @@
 package jsonschema
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
 	"go.yaml.in/yaml/v4"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
+var defaultPrinter = message.NewPrinter(language.English)
+
+// Schema wraps a compiled JSON schema with additional metadata for human-friendly error reporting.
 type Schema struct {
-	Schema    *jsonschema.Schema
-	nanRegexp *regexp.Regexp
+	Schema        *jsonschema.Schema
+	nanRegexp     *regexp.Regexp
+	flagMap       map[string]string // maps slash-delimited instance paths to CLI flag names
+	patternMsgMap map[string]string // maps slash-delimited instance paths to custom pattern error messages
+}
+
+// ConfigValidationError is a human-friendly validation error wrapping the original jsonschema.ValidationError.
+type ConfigValidationError struct {
+	Original *jsonschema.ValidationError
+	Messages []string
+}
+
+func (e *ConfigValidationError) Error() string {
+	var sb strings.Builder
+
+	for i, msg := range e.Messages {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+
+		sb.WriteString("- ")
+		sb.WriteString(msg)
+	}
+
+	return sb.String()
+}
+
+func (e *ConfigValidationError) Unwrap() error {
+	return e.Original
 }
 
 // Parse parses and compiles the JSON schema file.
@@ -39,12 +75,20 @@ func Parse(name string, data string) (*Schema, error) {
 		return nil, err
 	}
 
+	flagMap, patternMsgMap, err := buildExtensionMaps(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build extension maps from schema: %w", err)
+	}
+
 	return &Schema{
-		Schema:    sch,
-		nanRegexp: regexp.MustCompile(`(?i)\.nan`),
+		Schema:        sch,
+		nanRegexp:     regexp.MustCompile(`(?i)\.nan`),
+		flagMap:       flagMap,
+		patternMsgMap: patternMsgMap,
 	}, nil
 }
 
+// Validate validates the given YAML data against the schema, returning human-friendly errors.
 func (schema *Schema) Validate(data string) error {
 	// NaN type causes jsonschema validator to crash with nil reference error
 	data = schema.nanRegexp.ReplaceAllString(data, "null")
@@ -58,9 +102,20 @@ func (schema *Schema) Validate(data string) error {
 		v = map[string]any{}
 	}
 
-	return schema.Schema.Validate(v)
+	err := schema.Schema.Validate(v)
+	if err == nil {
+		return nil
+	}
+
+	var validationErr *jsonschema.ValidationError
+	if !errors.As(err, &validationErr) {
+		return err
+	}
+
+	return schema.humanizeError(validationErr)
 }
 
+// Description returns the description of a field in the schema by its dot-delimited path.
 func (schema *Schema) Description(fieldPath string) string {
 	fields := strings.Split(fieldPath, ".")
 
@@ -79,4 +134,261 @@ func (schema *Schema) Description(fieldPath string) string {
 	}
 
 	return s.Description
+}
+
+// FlagName returns the CLI flag name for the given slash-delimited instance path,
+// or empty string if no flag is defined.
+func (schema *Schema) FlagName(instancePath string) string {
+	return schema.flagMap[instancePath]
+}
+
+// PatternMessage returns the custom pattern error message for the given slash-delimited instance path,
+// or empty string if no custom message is defined.
+func (schema *Schema) PatternMessage(instancePath string) string {
+	return schema.patternMsgMap[instancePath]
+}
+
+func (schema *Schema) humanizeError(verr *jsonschema.ValidationError) *ConfigValidationError {
+	leaves := collectLeafErrors(verr)
+
+	messages := make([]string, 0, len(leaves))
+
+	for _, leaf := range leaves {
+		messages = append(messages, schema.formatLeafError(leaf))
+	}
+
+	return &ConfigValidationError{
+		Messages: messages,
+		Original: verr,
+	}
+}
+
+// collectLeafErrors walks the validation error tree and collects leaf errors
+// (those with concrete validation kinds, not wrapper/grouping kinds).
+func collectLeafErrors(validationErr *jsonschema.ValidationError) []*jsonschema.ValidationError {
+	switch validationErr.ErrorKind.(type) {
+	case *kind.Schema, *kind.Reference, *kind.Group, *kind.AllOf, *kind.AnyOf, *kind.OneOf:
+		leaves := make([]*jsonschema.ValidationError, 0, len(validationErr.Causes))
+
+		for _, cause := range validationErr.Causes {
+			leaves = append(leaves, collectLeafErrors(cause)...)
+		}
+
+		return leaves
+	default:
+		return []*jsonschema.ValidationError{validationErr}
+	}
+}
+
+func (schema *Schema) formatLeafError(leaf *jsonschema.ValidationError) string { //nolint:cyclop
+	switch ek := leaf.ErrorKind.(type) {
+	case *kind.Required:
+		return schema.formatRequiredError(leaf, ek)
+	case *kind.Type:
+		return schema.formatFieldError(leaf.InstanceLocation, formatTypeMessage(ek))
+	case *kind.MinLength:
+		return schema.formatFieldError(leaf.InstanceLocation, formatMinLengthMessage(ek))
+	case *kind.MaxLength:
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("must have at most %d characters", ek.Want))
+	case *kind.Minimum:
+		return schema.formatFieldError(leaf.InstanceLocation, formatMinimumMessage(ek))
+	case *kind.Maximum:
+		want, _ := ek.Want.Float64()
+
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("must be at most %v", want))
+	case *kind.ExclusiveMinimum:
+		want, _ := ek.Want.Float64()
+
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("must be greater than %v", want))
+	case *kind.ExclusiveMaximum:
+		want, _ := ek.Want.Float64()
+
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("must be less than %v", want))
+	case *kind.MultipleOf:
+		want, _ := ek.Want.Float64()
+
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("must be a multiple of %v", want))
+	case *kind.Pattern:
+		return schema.formatFieldError(leaf.InstanceLocation, schema.formatPatternMessage(leaf.InstanceLocation, ek))
+	case *kind.Format:
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("must be a valid %s", ek.Want))
+	case *kind.Enum:
+		return schema.formatFieldError(leaf.InstanceLocation, formatEnumMessage(ek))
+	case *kind.Const:
+		return schema.formatFieldError(leaf.InstanceLocation, formatConstMessage(ek))
+	case *kind.AdditionalProperties:
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("has unknown properties: %s", strings.Join(ek.Properties, ", ")))
+	case *kind.MinItems:
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("must have at least %d items", ek.Want))
+	case *kind.MaxItems:
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("must have at most %d items", ek.Want))
+	case *kind.UniqueItems:
+		return schema.formatFieldError(leaf.InstanceLocation, fmt.Sprintf("items at index %d and %d must be unique", ek.Duplicates[0], ek.Duplicates[1]))
+	default:
+		return formatOriginal(leaf)
+	}
+}
+
+func (schema *Schema) formatRequiredError(leaf *jsonschema.ValidationError, ek *kind.Required) string {
+	messages := make([]string, 0, len(ek.Missing))
+
+	for _, missing := range ek.Missing {
+		childLocation := append(slices.Clone(leaf.InstanceLocation), missing)
+		messages = append(messages, schema.formatFieldError(childLocation, "is required"))
+	}
+
+	return strings.Join(messages, "; ")
+}
+
+func (schema *Schema) formatFieldError(instanceLocation []string, message string) string {
+	dottedPath := "." + strings.Join(instanceLocation, ".")
+	slashPath := "/" + strings.Join(instanceLocation, "/")
+	flagName := schema.FlagName(slashPath)
+
+	if flagName != "" {
+		return fmt.Sprintf("config value %q or flag \"--%s\": %s", dottedPath, flagName, message)
+	}
+
+	return fmt.Sprintf("config value %q: %s", dottedPath, message)
+}
+
+func formatTypeMessage(ek *kind.Type) string {
+	if ek.Got == "null" {
+		return "is required but was not set"
+	}
+
+	return fmt.Sprintf("must be of type %s, but got %s", strings.Join(ek.Want, " or "), ek.Got)
+}
+
+func formatMinLengthMessage(ek *kind.MinLength) string {
+	if ek.Want == 1 {
+		return "must not be empty"
+	}
+
+	return fmt.Sprintf("must have at least %d characters", ek.Want)
+}
+
+func formatMinimumMessage(ek *kind.Minimum) string {
+	want, _ := ek.Want.Float64()
+
+	return fmt.Sprintf("must be at least %v", want)
+}
+
+func (schema *Schema) formatPatternMessage(instanceLocation []string, ek *kind.Pattern) string {
+	slashPath := "/" + strings.Join(instanceLocation, "/")
+
+	if msg := schema.PatternMessage(slashPath); msg != "" {
+		return msg
+	}
+
+	return fmt.Sprintf("does not match the expected pattern '%s'", ek.Want)
+}
+
+func formatEnumMessage(ek *kind.Enum) string {
+	values := make([]string, 0, len(ek.Want))
+	for _, v := range ek.Want {
+		values = append(values, fmt.Sprintf("'%v'", v))
+	}
+
+	return fmt.Sprintf("must be one of %s", strings.Join(values, ", "))
+}
+
+func formatConstMessage(ek *kind.Const) string {
+	return fmt.Sprintf("must be %v", ek.Want)
+}
+
+func formatOriginal(leaf *jsonschema.ValidationError) string {
+	path := "/" + strings.Join(leaf.InstanceLocation, "/")
+	msg := leaf.ErrorKind.LocalizedString(defaultPrinter)
+
+	return fmt.Sprintf("at '%s': %s", path, msg)
+}
+
+// buildExtensionMaps parses the raw JSON schema and collects x-cli-flag and x-pattern-message
+// annotations into maps from slash-delimited paths to their values.
+func buildExtensionMaps(data string) (flagMap, patternMsgMap map[string]string, err error) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(data), &raw); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal schema JSON: %w", err)
+	}
+
+	definitions, ok := raw["definitions"].(map[string]any)
+	if !ok {
+		definitions = map[string]any{}
+	}
+
+	flagMap = map[string]string{}
+	patternMsgMap = map[string]string{}
+
+	if props, ok := raw["properties"].(map[string]any); ok {
+		walkProperties(props, definitions, "", flagMap, patternMsgMap)
+	}
+
+	return flagMap, patternMsgMap, nil
+}
+
+func walkProperties(props, definitions map[string]any, pathPrefix string, flagMap, patternMsgMap map[string]string) {
+	for name, propRaw := range props {
+		propObj, ok := propRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		currentPath := pathPrefix + "/" + name
+
+		// Check extensions on the local property (takes precedence over resolved $ref)
+		collectExtensions(propObj, currentPath, flagMap, patternMsgMap)
+
+		resolved := resolveRef(propObj, definitions)
+
+		// Check extensions on the resolved definition (only if not already set locally)
+		collectExtensions(resolved, currentPath, flagMap, patternMsgMap)
+
+		// Walk sub-properties from the resolved definition
+		if subProps, ok := resolved["properties"].(map[string]any); ok {
+			walkProperties(subProps, definitions, currentPath, flagMap, patternMsgMap)
+		}
+
+		// Walk local property overrides (e.g., x-cli-flag on $ref sites), local takes precedence
+		if localProps, ok := propObj["properties"].(map[string]any); ok {
+			walkProperties(localProps, definitions, currentPath, flagMap, patternMsgMap)
+		}
+	}
+}
+
+func collectExtensions(obj map[string]any, path string, flagMap, patternMsgMap map[string]string) {
+	if flag, ok := obj["x-cli-flag"].(string); ok {
+		if _, exists := flagMap[path]; !exists {
+			flagMap[path] = flag
+		}
+	}
+
+	if msg, ok := obj["x-pattern-message"].(string); ok {
+		if _, exists := patternMsgMap[path]; !exists {
+			patternMsgMap[path] = msg
+		}
+	}
+}
+
+func resolveRef(obj, definitions map[string]any) map[string]any {
+	ref, ok := obj["$ref"].(string)
+	if !ok {
+		return obj
+	}
+
+	// Parse "#/definitions/X"
+	const prefix = "#/definitions/"
+	if !strings.HasPrefix(ref, prefix) {
+		return obj
+	}
+
+	defName := ref[len(prefix):]
+
+	def, ok := definitions[defName].(map[string]any)
+	if !ok {
+		return obj
+	}
+
+	// Recurse in case the definition itself has a $ref
+	return resolveRef(def, definitions)
 }


### PR DESCRIPTION
Replace cryptic JSON schema validation errors with clear messages that show the config path and CLI flag name. For example, instead of "at '/storage/sqlite/path': got null, want string", users now see: config value ".storage.sqlite.path" or flag "--sqlite-storage-path": is required but was not set.

Flag names and custom pattern messages (e.g., "must be a valid Go duration") live as extension properties in schema.json, making it the single source of truth for config field metadata. FlagBinder derives all flag names and descriptions from the schema directly.

Closes: siderolabs/omni#2450
Closes: siderolabs/omni#2449

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>