### PR TITLE
feat: add deprecation notification for non-ImageFactory machines

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -6522,18 +6522,19 @@ func (x *MachineExtensionsStatusSpec) GetTalosVersion() string {
 
 // MachineStatusMetricsSpec provides aggregated state of the number of registered and connected machines for the Omni instance.
 type MachineStatusMetricsSpec struct {
-	state                    protoimpl.MessageState `protogen:"open.v1"`
-	RegisteredMachinesCount  uint32                 `protobuf:"varint,1,opt,name=registered_machines_count,json=registeredMachinesCount,proto3" json:"registered_machines_count,omitempty"`
-	ConnectedMachinesCount   uint32                 `protobuf:"varint,2,opt,name=connected_machines_count,json=connectedMachinesCount,proto3" json:"connected_machines_count,omitempty"`
-	AllocatedMachinesCount   uint32                 `protobuf:"varint,3,opt,name=allocated_machines_count,json=allocatedMachinesCount,proto3" json:"allocated_machines_count,omitempty"`
-	PendingMachinesCount     uint32                 `protobuf:"varint,4,opt,name=pending_machines_count,json=pendingMachinesCount,proto3" json:"pending_machines_count,omitempty"`
-	Platforms                map[string]uint32      `protobuf:"bytes,6,rep,name=platforms,proto3" json:"platforms,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
-	SecureBootStatus         map[string]uint32      `protobuf:"bytes,7,rep,name=secure_boot_status,json=secureBootStatus,proto3" json:"secure_boot_status,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
-	UkiStatus                map[string]uint32      `protobuf:"bytes,8,rep,name=uki_status,json=ukiStatus,proto3" json:"uki_status,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
-	RegisteredMachinesLimit  uint32                 `protobuf:"varint,9,opt,name=registered_machines_limit,json=registeredMachinesLimit,proto3" json:"registered_machines_limit,omitempty"`
-	RegistrationLimitReached bool                   `protobuf:"varint,10,opt,name=registration_limit_reached,json=registrationLimitReached,proto3" json:"registration_limit_reached,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	state                         protoimpl.MessageState `protogen:"open.v1"`
+	RegisteredMachinesCount       uint32                 `protobuf:"varint,1,opt,name=registered_machines_count,json=registeredMachinesCount,proto3" json:"registered_machines_count,omitempty"`
+	ConnectedMachinesCount        uint32                 `protobuf:"varint,2,opt,name=connected_machines_count,json=connectedMachinesCount,proto3" json:"connected_machines_count,omitempty"`
+	AllocatedMachinesCount        uint32                 `protobuf:"varint,3,opt,name=allocated_machines_count,json=allocatedMachinesCount,proto3" json:"allocated_machines_count,omitempty"`
+	PendingMachinesCount          uint32                 `protobuf:"varint,4,opt,name=pending_machines_count,json=pendingMachinesCount,proto3" json:"pending_machines_count,omitempty"`
+	Platforms                     map[string]uint32      `protobuf:"bytes,6,rep,name=platforms,proto3" json:"platforms,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	SecureBootStatus              map[string]uint32      `protobuf:"bytes,7,rep,name=secure_boot_status,json=secureBootStatus,proto3" json:"secure_boot_status,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	UkiStatus                     map[string]uint32      `protobuf:"bytes,8,rep,name=uki_status,json=ukiStatus,proto3" json:"uki_status,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	RegisteredMachinesLimit       uint32                 `protobuf:"varint,9,opt,name=registered_machines_limit,json=registeredMachinesLimit,proto3" json:"registered_machines_limit,omitempty"`
+	RegistrationLimitReached      bool                   `protobuf:"varint,10,opt,name=registration_limit_reached,json=registrationLimitReached,proto3" json:"registration_limit_reached,omitempty"`
+	InvalidSchematicMachinesCount uint32                 `protobuf:"varint,11,opt,name=invalid_schematic_machines_count,json=invalidSchematicMachinesCount,proto3" json:"invalid_schematic_machines_count,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *MachineStatusMetricsSpec) Reset() {
@@ -6627,6 +6628,13 @@ func (x *MachineStatusMetricsSpec) GetRegistrationLimitReached() bool {
 		return x.RegistrationLimitReached
 	}
 	return false
+}
+
+func (x *MachineStatusMetricsSpec) GetInvalidSchematicMachinesCount() uint32 {
+	if x != nil {
+		return x.InvalidSchematicMachinesCount
+	}
+	return 0
 }
 
 // ClusterMetricsSpec contains metrics about the clusters in the Omni instance.
@@ -11234,7 +11242,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\tInstalled\x10\x00\x12\x0e\n" +
 	"\n" +
 	"Installing\x10\x01\x12\f\n" +
-	"\bRemoving\x10\x02\"\xc3\x06\n" +
+	"\bRemoving\x10\x02\"\x8c\a\n" +
 	"\x18MachineStatusMetricsSpec\x12:\n" +
 	"\x19registered_machines_count\x18\x01 \x01(\rR\x17registeredMachinesCount\x128\n" +
 	"\x18connected_machines_count\x18\x02 \x01(\rR\x16connectedMachinesCount\x128\n" +
@@ -11246,7 +11254,8 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"uki_status\x18\b \x03(\v2..specs.MachineStatusMetricsSpec.UkiStatusEntryR\tukiStatus\x12:\n" +
 	"\x19registered_machines_limit\x18\t \x01(\rR\x17registeredMachinesLimit\x12<\n" +
 	"\x1aregistration_limit_reached\x18\n" +
-	" \x01(\bR\x18registrationLimitReached\x1a<\n" +
+	" \x01(\bR\x18registrationLimitReached\x12G\n" +
+	" invalid_schematic_machines_count\x18\v \x01(\rR\x1dinvalidSchematicMachinesCount\x1a<\n" +
 	"\x0ePlatformsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\rR\x05value:\x028\x01\x1aC\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1355,6 +1355,7 @@ message MachineStatusMetricsSpec {
   map<string, uint32> uki_status = 8;
   uint32 registered_machines_limit = 9;
   bool registration_limit_reached = 10;
+  uint32 invalid_schematic_machines_count = 11;
 }
 
 // ClusterMetricsSpec contains metrics about the clusters in the Omni instance.

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -2449,6 +2449,7 @@ func (m *MachineStatusMetricsSpec) CloneVT() *MachineStatusMetricsSpec {
 	r.PendingMachinesCount = m.PendingMachinesCount
 	r.RegisteredMachinesLimit = m.RegisteredMachinesLimit
 	r.RegistrationLimitReached = m.RegistrationLimitReached
+	r.InvalidSchematicMachinesCount = m.InvalidSchematicMachinesCount
 	if rhs := m.Platforms; rhs != nil {
 		tmpContainer := make(map[string]uint32, len(rhs))
 		for k, v := range rhs {
@@ -6525,6 +6526,9 @@ func (this *MachineStatusMetricsSpec) EqualVT(that *MachineStatusMetricsSpec) bo
 		return false
 	}
 	if this.RegistrationLimitReached != that.RegistrationLimitReached {
+		return false
+	}
+	if this.InvalidSchematicMachinesCount != that.InvalidSchematicMachinesCount {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -14038,6 +14042,11 @@ func (m *MachineStatusMetricsSpec) MarshalToSizedBufferVT(dAtA []byte) (int, err
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.InvalidSchematicMachinesCount != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.InvalidSchematicMachinesCount))
+		i--
+		dAtA[i] = 0x58
+	}
 	if m.RegistrationLimitReached {
 		i--
 		if m.RegistrationLimitReached {
@@ -18433,6 +18442,9 @@ func (m *MachineStatusMetricsSpec) SizeVT() (n int) {
 	}
 	if m.RegistrationLimitReached {
 		n += 2
+	}
+	if m.InvalidSchematicMachinesCount != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.InvalidSchematicMachinesCount))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -36120,6 +36132,25 @@ func (m *MachineStatusMetricsSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.RegistrationLimitReached = bool(v != 0)
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InvalidSchematicMachinesCount", wireType)
+			}
+			m.InvalidSchematicMachinesCount = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.InvalidSchematicMachinesCount |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/omni/resources/omni/notification.go
+++ b/client/pkg/omni/resources/omni/notification.go
@@ -30,6 +30,10 @@ const (
 	// NotificationMachineRegistrationLimitID is the ID for the machine registration limit notification.
 	// tsgen:NotificationMachineRegistrationLimitID
 	NotificationMachineRegistrationLimitID = "machine-registration-limit"
+
+	// NotificationNonImageFactoryMachinesID is the ID for the non-ImageFactory machines deprecation notification.
+	// tsgen:NotificationNonImageFactoryMachinesID
+	NotificationNonImageFactoryMachinesID = "non-image-factory-machines"
 )
 
 // Notification describes a generic notification emitted by a controller.

--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -164,6 +164,7 @@ func buildRootCommand() (*cobra.Command, error) {
 	defineStorageFlags(rootCmd, rootCmdFlagBinder, flagConfig)
 	defineRegistriesFlags(rootCmdFlagBinder, flagConfig)
 	defineFeatureFlags(rootCmdFlagBinder, flagConfig)
+	defineNotificationFlags(rootCmdFlagBinder, flagConfig)
 	defineDebugFlags(rootCmdFlagBinder, flagConfig)
 	defineEtcdBackupsFlags(rootCmd, rootCmdFlagBinder, flagConfig)
 
@@ -347,6 +348,12 @@ func defineFeatureFlags(b *FlagBinder, flagConfig *config.Params) {
 	b.BoolVar("features.enableBreakGlassConfigs", &flagConfig.Features.EnableBreakGlassConfigs)
 	b.BoolVar("features.disableControllerRuntimeCache", &flagConfig.Features.DisableControllerRuntimeCache)
 	b.BoolVar("features.enableClusterImport", &flagConfig.Features.EnableClusterImport)
+}
+
+func defineNotificationFlags(b *FlagBinder, flagConfig *config.Params) {
+	b.BoolVar("notifications.nonImageFactoryDeprecation.enabled", &flagConfig.Notifications.NonImageFactoryDeprecation.Enabled)
+	b.StringVar("notifications.nonImageFactoryDeprecation.title", &flagConfig.Notifications.NonImageFactoryDeprecation.Title)
+	b.StringVar("notifications.nonImageFactoryDeprecation.body", &flagConfig.Notifications.NonImageFactoryDeprecation.Body)
 }
 
 func defineDebugFlags(b *FlagBinder, flagConfig *config.Params) {

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -906,6 +906,7 @@ export type MachineStatusMetricsSpec = {
   uki_status?: {[key: string]: number}
   registered_machines_limit?: number
   registration_limit_reached?: boolean
+  invalid_schematic_machines_count?: number
 }
 
 export type ClusterMetricsSpec = {

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -209,6 +209,7 @@ export const MaintenanceConfigStatusType = "MaintenanceConfigStatuses.omni.sider
 export const NodeForceDestroyRequestType = "NodeForceDestroyRequests.omni.sidero.dev";
 export const NotificationType = "Notifications.omni.sidero.dev";
 export const NotificationMachineRegistrationLimitID = "machine-registration-limit";
+export const NotificationNonImageFactoryMachinesID = "non-image-factory-machines";
 export const OngoingTaskType = "OngoingTasks.omni.sidero.dev";
 export const RedactedClusterMachineConfigType = "RedactedClusterMachineConfigs.omni.sidero.dev";
 export const RotateKubernetesCAType = "RotateKubernetesCAs.omni.sidero.dev";

--- a/hack/compose/grafana/dashboards/omni-details.json
+++ b/hack/compose/grafana/dashboards/omni-details.json
@@ -2210,6 +2210,415 @@
       ],
       "title": "Pool Connections",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 95
+      },
+      "id": 220,
+      "panels": [],
+      "title": "Machine Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 96
+      },
+      "id": 221,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_machines",
+          "legendFormat": "Registered",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_connected_machines",
+          "legendFormat": "Connected",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_machines_invalid_schematic",
+          "legendFormat": "Invalid Schematic",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Machine Counts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 96
+      },
+      "id": 222,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_machine_platforms",
+          "legendFormat": "{{platform}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Machines by Platform",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 104
+      },
+      "id": 223,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_machine_secure_boot_status",
+          "legendFormat": "Secure Boot: {{enabled}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Secure Boot Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 104
+      },
+      "id": 224,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "omni_machine_uki_status",
+          "legendFormat": "UKI: {{booted_with_uki}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "UKI Status",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_metrics.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_metrics.go
@@ -34,10 +34,18 @@ type nodeInfo struct {
 	connected    bool
 }
 
+// NonImageFactoryDeprecationConfig contains configuration for the non-ImageFactory deprecation notification.
+type NonImageFactoryDeprecationConfig struct {
+	Title   string
+	Body    string
+	Enabled bool
+}
+
 // NewMachineStatusMetricsController creates a new MachineStatusMetricsController.
-func NewMachineStatusMetricsController(maxRegisteredMachines uint32) *MachineStatusMetricsController {
+func NewMachineStatusMetricsController(maxRegisteredMachines uint32, nonImageFactoryDeprecation NonImageFactoryDeprecationConfig) *MachineStatusMetricsController {
 	return &MachineStatusMetricsController{
-		maxRegisteredMachines: maxRegisteredMachines,
+		maxRegisteredMachines:      maxRegisteredMachines,
+		nonImageFactoryDeprecation: nonImageFactoryDeprecation,
 	}
 }
 
@@ -50,16 +58,19 @@ type MachineStatusMetricsController struct {
 
 	metricsOnce sync.Once
 
+	nonImageFactoryDeprecation NonImageFactoryDeprecationConfig
+
 	maxRegisteredMachines uint32
 
 	platformNames []string
 
-	metricNumMachines             prometheus.Gauge
-	metricNumConnectedMachines    prometheus.Gauge
-	metricNumMachinesPerVersion   *prometheus.Desc
-	metricMachinePlatforms        *prometheus.GaugeVec
-	metricMachineSecureBootStatus *prometheus.GaugeVec
-	metricMachineUKIStatus        *prometheus.GaugeVec
+	metricNumMachines                 prometheus.Gauge
+	metricNumConnectedMachines        prometheus.Gauge
+	metricNumInvalidSchematicMachines prometheus.Gauge
+	metricNumMachinesPerVersion       *prometheus.Desc
+	metricMachinePlatforms            *prometheus.GaugeVec
+	metricMachineSecureBootStatus     *prometheus.GaugeVec
+	metricMachineUKIStatus            *prometheus.GaugeVec
 }
 
 // Name implements controller.Controller interface.
@@ -107,6 +118,11 @@ func (ctrl *MachineStatusMetricsController) initMetrics() {
 		ctrl.metricNumConnectedMachines = prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "omni_connected_machines",
 			Help: "Number of machines in the instance that are connected.",
+		})
+
+		ctrl.metricNumInvalidSchematicMachines = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "omni_machines_invalid_schematic",
+			Help: "Number of machines in the instance that were provisioned without using ImageFactory.",
 		})
 
 		ctrl.metricNumMachinesPerVersion = prometheus.NewDesc(
@@ -182,6 +198,12 @@ func (ctrl *MachineStatusMetricsController) Run(ctx context.Context, r controlle
 			}
 		}
 
+		if ctrl.nonImageFactoryDeprecation.Enabled {
+			if err = ctrl.reconcileNonImageFactoryDeprecationNotification(ctx, r, metricsSpec); err != nil {
+				return err
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			return nil
@@ -210,6 +232,25 @@ func (ctrl *MachineStatusMetricsController) reconcileRegistrationLimitNotificati
 	return err
 }
 
+func (ctrl *MachineStatusMetricsController) reconcileNonImageFactoryDeprecationNotification(ctx context.Context, r controller.Runtime, metricsSpec *specs.MachineStatusMetricsSpec) error {
+	invalidSchematicCount := int(metricsSpec.InvalidSchematicMachinesCount)
+	if invalidSchematicCount > 0 {
+		return safe.WriterModify(ctx, r, omni.NewNotification(omni.NotificationNonImageFactoryMachinesID),
+			func(res *omni.Notification) error {
+				res.TypedSpec().Value.Title = ctrl.nonImageFactoryDeprecation.Title
+				res.TypedSpec().Value.Body = fmt.Sprintf(ctrl.nonImageFactoryDeprecation.Body, invalidSchematicCount)
+				res.TypedSpec().Value.Type = specs.NotificationSpec_WARNING
+
+				return nil
+			},
+		)
+	}
+
+	_, err := helpers.TeardownAndDestroy(ctx, r, omni.NewNotification(omni.NotificationNonImageFactoryMachinesID).Metadata())
+
+	return err
+}
+
 func (ctrl *MachineStatusMetricsController) gatherMetrics(statuses iter.Seq[*omni.MachineStatus], numPendingMachines int) *specs.MachineStatusMetricsSpec {
 	platformMetrics := make(map[string]uint32, len(ctrl.platformNames))
 	for _, p := range ctrl.platformNames {
@@ -229,7 +270,7 @@ func (ctrl *MachineStatusMetricsController) gatherMetrics(statuses iter.Seq[*omn
 		"false":       0,
 	}
 
-	var machines, connectedMachines, allocatedMachines int
+	var machines, connectedMachines, allocatedMachines, invalidSchematicMachines int
 
 	ctrl.versionsMu.Lock()
 	ctrl.versionsMap = map[nodeInfo]int32{}
@@ -253,6 +294,10 @@ func (ctrl *MachineStatusMetricsController) gatherMetrics(statuses iter.Seq[*omn
 			allocatedMachines++
 		}
 
+		if ms.TypedSpec().Value.SchematicReady() && ms.TypedSpec().Value.GetSchematic().GetInvalid() {
+			invalidSchematicMachines++
+		}
+
 		platform := ms.TypedSpec().Value.PlatformMetadata.GetPlatform()
 		if platform != "" {
 			platformMetrics[platform]++
@@ -272,6 +317,7 @@ func (ctrl *MachineStatusMetricsController) gatherMetrics(statuses iter.Seq[*omn
 
 	ctrl.metricNumMachines.Set(float64(machines))
 	ctrl.metricNumConnectedMachines.Set(float64(connectedMachines))
+	ctrl.metricNumInvalidSchematicMachines.Set(float64(invalidSchematicMachines))
 
 	for key, num := range platformMetrics {
 		ctrl.metricMachinePlatforms.WithLabelValues(key).Set(float64(num))
@@ -286,15 +332,16 @@ func (ctrl *MachineStatusMetricsController) gatherMetrics(statuses iter.Seq[*omn
 	}
 
 	return &specs.MachineStatusMetricsSpec{
-		ConnectedMachinesCount:   uint32(connectedMachines),
-		RegisteredMachinesCount:  uint32(machines),
-		AllocatedMachinesCount:   uint32(allocatedMachines),
-		PendingMachinesCount:     uint32(numPendingMachines),
-		Platforms:                platformMetrics,
-		SecureBootStatus:         secureBootStatusMetrics,
-		UkiStatus:                ukiMetrics,
-		RegisteredMachinesLimit:  ctrl.maxRegisteredMachines,
-		RegistrationLimitReached: ctrl.maxRegisteredMachines > 0 && uint32(machines) >= ctrl.maxRegisteredMachines,
+		ConnectedMachinesCount:        uint32(connectedMachines),
+		RegisteredMachinesCount:       uint32(machines),
+		AllocatedMachinesCount:        uint32(allocatedMachines),
+		PendingMachinesCount:          uint32(numPendingMachines),
+		Platforms:                     platformMetrics,
+		SecureBootStatus:              secureBootStatusMetrics,
+		UkiStatus:                     ukiMetrics,
+		RegisteredMachinesLimit:       ctrl.maxRegisteredMachines,
+		RegistrationLimitReached:      ctrl.maxRegisteredMachines > 0 && uint32(machines) >= ctrl.maxRegisteredMachines,
+		InvalidSchematicMachinesCount: uint32(invalidSchematicMachines),
 	}
 }
 
@@ -317,6 +364,7 @@ func (ctrl *MachineStatusMetricsController) Collect(ch chan<- prometheus.Metric)
 
 	ctrl.metricNumMachines.Collect(ch)
 	ctrl.metricNumConnectedMachines.Collect(ch)
+	ctrl.metricNumInvalidSchematicMachines.Collect(ch)
 	ctrl.metricMachinePlatforms.Collect(ch)
 	ctrl.metricMachineSecureBootStatus.Collect(ch)
 	ctrl.metricMachineUKIStatus.Collect(ch)

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_metrics_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_metrics_test.go
@@ -7,10 +7,12 @@ package omni_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -19,6 +21,14 @@ import (
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
 )
+
+func newNonImageFactoryDeprecationConfig(enabled bool) omnictrl.NonImageFactoryDeprecationConfig {
+	return omnictrl.NonImageFactoryDeprecationConfig{
+		Enabled: enabled,
+		Title:   "Non-ImageFactory Machines Detected",
+		Body:    "%d machine(s) were provisioned without ImageFactory.",
+	}
+}
 
 func TestMachineStatusMetricsController_RegistrationLimit(t *testing.T) {
 	t.Parallel()
@@ -72,7 +82,7 @@ func TestMachineStatusMetricsController_RegistrationLimit(t *testing.T) {
 
 			testutils.WithRuntime(ctx, t, testutils.TestOptions{},
 				func(_ context.Context, tc testutils.TestContext) {
-					require.NoError(t, tc.Runtime.RegisterController(omnictrl.NewMachineStatusMetricsController(tt.maxRegistered)))
+					require.NoError(t, tc.Runtime.RegisterController(omnictrl.NewMachineStatusMetricsController(tt.maxRegistered, omnictrl.NonImageFactoryDeprecationConfig{})))
 				},
 				func(ctx context.Context, tc testutils.TestContext) {
 					for _, id := range tt.machineIDs {
@@ -101,4 +111,133 @@ func TestMachineStatusMetricsController_RegistrationLimit(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestMachineStatusMetricsController_NonImageFactoryDeprecation(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name                string
+		invalidSchematicIDs []string
+		validSchematicIDs   []string
+		enabled             bool
+		expectNotification  bool
+		expectCount         int
+	}{
+		{
+			name:                "disabled, invalid machines present",
+			invalidSchematicIDs: []string{"m1"},
+			enabled:             false,
+			expectNotification:  false,
+		},
+		{
+			name:               "enabled, no invalid machines",
+			validSchematicIDs:  []string{"m1", "m2"},
+			enabled:            true,
+			expectNotification: false,
+		},
+		{
+			name:                "enabled, some invalid machines",
+			invalidSchematicIDs: []string{"m1", "m2"},
+			validSchematicIDs:   []string{"m3"},
+			enabled:             true,
+			expectNotification:  true,
+			expectCount:         2,
+		},
+		{
+			name:                "enabled, all invalid machines",
+			invalidSchematicIDs: []string{"m1", "m2", "m3"},
+			enabled:             true,
+			expectNotification:  true,
+			expectCount:         3,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			testutils.WithRuntime(ctx, t, testutils.TestOptions{},
+				func(_ context.Context, tc testutils.TestContext) {
+					require.NoError(t, tc.Runtime.RegisterController(
+						omnictrl.NewMachineStatusMetricsController(0, newNonImageFactoryDeprecationConfig(tt.enabled)),
+					))
+				},
+				func(ctx context.Context, tc testutils.TestContext) {
+					for _, id := range tt.invalidSchematicIDs {
+						ms := omni.NewMachineStatus(id)
+						ms.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+							Invalid: true,
+						}
+
+						require.NoError(t, tc.State.Create(ctx, ms))
+					}
+
+					for _, id := range tt.validSchematicIDs {
+						ms := omni.NewMachineStatus(id)
+						ms.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+							Id:     "valid-id",
+							FullId: "valid-full-id",
+						}
+
+						require.NoError(t, tc.State.Create(ctx, ms))
+					}
+
+					if tt.expectNotification {
+						rtestutils.AssertResource(ctx, t, tc.State, omni.NotificationNonImageFactoryMachinesID, func(res *omni.Notification, a *assert.Assertions) {
+							a.Equal("Non-ImageFactory Machines Detected", res.TypedSpec().Value.Title)
+							a.Contains(res.TypedSpec().Value.Body, fmt.Sprintf("%d machine(s)", tt.expectCount))
+							a.Equal(specs.NotificationSpec_WARNING, res.TypedSpec().Value.Type)
+						})
+					} else {
+						// Notification should not exist. Sleep briefly since there is no state change to poll on.
+						time.Sleep(500 * time.Millisecond)
+						rtestutils.AssertNoResource[*omni.Notification](ctx, t, tc.State, omni.NotificationNonImageFactoryMachinesID)
+					}
+				},
+			)
+		})
+	}
+}
+
+func TestMachineStatusMetricsController_NonImageFactoryDeprecationTeardown(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterController(
+				omnictrl.NewMachineStatusMetricsController(0, newNonImageFactoryDeprecationConfig(true)),
+			))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			// Create a machine with invalid schematic.
+			ms := omni.NewMachineStatus("m1")
+			ms.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{Invalid: true}
+
+			require.NoError(t, tc.State.Create(ctx, ms))
+
+			// Wait for the notification to appear.
+			rtestutils.AssertResource(ctx, t, tc.State, omni.NotificationNonImageFactoryMachinesID, func(res *omni.Notification, a *assert.Assertions) {
+				a.Equal(specs.NotificationSpec_WARNING, res.TypedSpec().Value.Type)
+			})
+
+			// Fix the machine schematic (no longer invalid).
+			_, err := safe.StateUpdateWithConflicts(ctx, tc.State, ms.Metadata(), func(res *omni.MachineStatus) error {
+				res.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+					Id:     "valid-id",
+					FullId: "valid-full-id",
+				}
+
+				return nil
+			})
+			require.NoError(t, err)
+
+			// Notification should be torn down.
+			rtestutils.AssertNoResource[*omni.Notification](ctx, t, tc.State, omni.NotificationNonImageFactoryMachinesID)
+		},
+	)
 }

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -165,7 +165,11 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 			LBConfig: cfg.Services.LoadBalancer,
 		},
 		omnictrl.NewMachineCleanupController(),
-		omnictrl.NewMachineStatusMetricsController(cfg.Account.GetMaxRegisteredMachines()),
+		omnictrl.NewMachineStatusMetricsController(cfg.Account.GetMaxRegisteredMachines(), omnictrl.NonImageFactoryDeprecationConfig{
+			Enabled: cfg.Notifications.NonImageFactoryDeprecation.GetEnabled(),
+			Title:   cfg.Notifications.NonImageFactoryDeprecation.GetTitle(),
+			Body:    cfg.Notifications.NonImageFactoryDeprecation.GetBody(),
+		}),
 		omnictrl.NewVersionsController(cfg.Registries.GetImageFactoryBaseURL(), cfg.Features.GetEnableTalosPreReleaseVersions(), cfg.Registries.GetKubernetes()),
 		omnictrl.NewClusterLoadBalancerController(
 			cfg.Services.LoadBalancer.GetMinPort(),

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -897,6 +897,39 @@ func (s *LogsStripe) SetMinCommit(v uint32) {
 	s.MinCommit = &v
 }
 
+func (s *NonImageFactoryDeprecation) GetBody() string {
+	if s == nil || s.Body == nil {
+		return *new(string)
+	}
+	return *s.Body
+}
+
+func (s *NonImageFactoryDeprecation) SetBody(v string) {
+	s.Body = &v
+}
+
+func (s *NonImageFactoryDeprecation) GetEnabled() bool {
+	if s == nil || s.Enabled == nil {
+		return *new(bool)
+	}
+	return *s.Enabled
+}
+
+func (s *NonImageFactoryDeprecation) SetEnabled(v bool) {
+	s.Enabled = &v
+}
+
+func (s *NonImageFactoryDeprecation) GetTitle() string {
+	if s == nil || s.Title == nil {
+		return *new(string)
+	}
+	return *s.Title
+}
+
+func (s *NonImageFactoryDeprecation) SetTitle(v string) {
+	s.Title = &v
+}
+
 func (s *OIDC) GetAllowUnverifiedEmail() bool {
 	if s == nil || s.AllowUnverifiedEmail == nil {
 		return *new(bool)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -168,6 +168,11 @@ func Default() *Params {
 	p.Features.SetEnableConfigDataCompression(true)
 	p.Features.SetEnableClusterImport(true)
 
+	p.Notifications.NonImageFactoryDeprecation.SetEnabled(false)
+	p.Notifications.NonImageFactoryDeprecation.SetTitle("Non-ImageFactory Machines Detected")
+	p.Notifications.NonImageFactoryDeprecation.SetBody("%d machine(s) were provisioned without ImageFactory. Support for these machines will end after a future release. Please re-provision them " +
+		"using ImageFactory.")
+
 	p.EtcdBackup.SetTickInterval(time.Minute)
 	p.EtcdBackup.SetMinInterval(time.Hour)
 	p.EtcdBackup.SetMaxInterval(24 * time.Hour)

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -12,7 +12,8 @@
     "etcdBackup",
     "registries",
     "debug",
-    "features"
+    "features",
+    "notifications"
   ],
   "goJSONSchema": {
     "imports": [
@@ -55,6 +56,10 @@
     "features": {
       "description": "Features contains feature flags to enable/disable various Omni features.",
       "$ref": "#/definitions/Features"
+    },
+    "notifications": {
+      "description": "Notifications contains configuration for system notifications emitted by controllers.",
+      "$ref": "#/definitions/Notifications"
     }
   },
   "definitions": {
@@ -1475,6 +1480,38 @@
           "description": "DisableControllerRuntimeCache controls whether the controller-runtime cache is disabled. When disabled, etcd is accessed for all reads. Recommended to be enabled, unless debugging specific issues.",
           "x-cli-flag": "disable-controller-runtime-cache",
           "type": "boolean"
+        }
+      }
+    },
+    "Notifications": {
+      "type": "object",
+      "required": [
+        "nonImageFactoryDeprecation"
+      ],
+      "properties": {
+        "nonImageFactoryDeprecation": {
+          "description": "NonImageFactoryDeprecation contains configuration for the notification shown when machines are provisioned without using ImageFactory.",
+          "$ref": "#/definitions/NonImageFactoryDeprecation"
+        }
+      }
+    },
+    "NonImageFactoryDeprecation": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enabled controls whether the non-ImageFactory deprecation notification is shown when machines with invalid schematics are detected.",
+          "x-cli-flag": "non-image-factory-deprecation-enabled",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "Title is the title of the non-ImageFactory deprecation notification.",
+          "x-cli-flag": "non-image-factory-deprecation-title",
+          "type": "string"
+        },
+        "body": {
+          "description": "Body is the body of the non-ImageFactory deprecation notification. Use %d as a placeholder for the number of affected machines.",
+          "x-cli-flag": "non-image-factory-deprecation-body",
+          "type": "string"
         }
       }
     }

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -424,6 +424,25 @@ type LogsStripe struct {
 	MinCommit *uint32 `json:"minCommit,omitempty" yaml:"minCommit,omitempty"`
 }
 
+type NonImageFactoryDeprecation struct {
+	// Body is the body of the non-ImageFactory deprecation notification. Use %d as a
+	// placeholder for the number of affected machines.
+	Body *string `json:"body,omitempty" yaml:"body,omitempty"`
+
+	// Enabled controls whether the non-ImageFactory deprecation notification is shown
+	// when machines with invalid schematics are detected.
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+
+	// Title is the title of the non-ImageFactory deprecation notification.
+	Title *string `json:"title,omitempty" yaml:"title,omitempty"`
+}
+
+type Notifications struct {
+	// NonImageFactoryDeprecation contains configuration for the notification shown
+	// when machines are provisioned without using ImageFactory.
+	NonImageFactoryDeprecation NonImageFactoryDeprecation `json:"nonImageFactoryDeprecation" yaml:"nonImageFactoryDeprecation"`
+}
+
 type OIDC struct {
 	// AllowUnverifiedEmail controls whether users with unverified emails (without
 	// email_verified claim) are allowed to authenticate.
@@ -467,6 +486,10 @@ type Params struct {
 
 	// Logs contains logging-related configuration.
 	Logs Logs `json:"logs" yaml:"logs"`
+
+	// Notifications contains configuration for system notifications emitted by
+	// controllers.
+	Notifications Notifications `json:"notifications" yaml:"notifications"`
 
 	// Registries contains container image registries configuration.
 	Registries Registries `json:"registries" yaml:"registries"`


### PR DESCRIPTION
Warn users when machines are provisioned without ImageFactory by creating a notification resource when invalid schematics are detected. The notification is gated behind a configurable flag under notifications.nonImageFactoryDeprecation with customizable title/body.

Also adds omni_machines_invalid_schematic Prometheus metric, exposes the count in MachineStatusMetricsSpec, and adds a Machine Status section to the Grafana dashboard.

Resolves: #2363
