### PR TITLE
fix: restore resolved node address fallback

### DIFF
--- a/internal/backend/dns/export_test.go
+++ b/internal/backend/dns/export_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package dns
+
+// NewInfo creates an Info with the given fields, including the unexported address.
+func NewInfo(cluster, id, name, address string) Info {
+	return Info{
+		Cluster: cluster,
+		ID:      id,
+		Name:    name,
+		address: address,
+	}
+}

--- a/internal/backend/dns/service.go
+++ b/internal/backend/dns/service.go
@@ -35,13 +35,25 @@ type Info struct {
 	Name         string
 	TalosVersion string
 
-	// Address is the node's cluster-internal IP (from ClusterMachineIdentity.NodeIPs).
-	// Used for inter-node communication (e.g., apid One2Many fan-out).
-	Address string
+	// address is the node's cluster-internal IP (from ClusterMachineIdentity.NodeIPs).
+	address string
 
 	// ManagementEndpoint is the node's SideroLink address (from MachineStatus.ManagementAddress).
-	// Only routable from Omni, not between nodes.
+	// Only routable from Omni, not between nodes. Used as a fallback by GetAddress()
+	// when the cluster-internal IP is not yet known.
 	ManagementEndpoint string
+}
+
+// GetAddress returns the node's cluster-internal IP if known,
+// falling back to the SideroLink management address.
+// The fallback covers the race window during cluster bootstrap
+// when ClusterMachineIdentity.NodeIPs is not yet populated.
+func (i Info) GetAddress() string {
+	if i.address != "" {
+		return i.address
+	}
+
+	return i.ManagementEndpoint
 }
 
 type resolverMap map[string][]resource.ID
@@ -191,7 +203,7 @@ func (d *Service) updateEntryByIdentity(res *omni.ClusterMachineIdentity) {
 		address = nodeIPs[0]
 	}
 
-	info.Address = address
+	info.address = address
 
 	d.machineIDToInfo[id] = info
 	d.machineIDToAddress[id] = address
@@ -300,7 +312,7 @@ func (d *Service) deleteIdentityMappings(id resource.ID) {
 
 	info.Cluster = ""
 	info.Name = ""
-	info.Address = ""
+	info.address = ""
 
 	d.machineIDToInfo[id] = info
 	delete(d.machineIDToAddress, id)

--- a/internal/backend/dns/service_test.go
+++ b/internal/backend/dns/service_test.go
@@ -73,7 +73,7 @@ func (suite *ServiceSuite) TearDownTest() {
 }
 
 func (suite *ServiceSuite) TestResolve() {
-	suite.assertResolve("test-bootstrap-cluster-1", "test-bootstrap-1-node", dns.Info{Cluster: "test-bootstrap-cluster-1", ID: "test-bootstrap-1", Name: "test-bootstrap-1-node", Address: "10.0.0.84"})
+	suite.assertResolve("test-bootstrap-cluster-1", "test-bootstrap-1-node", dns.NewInfo("test-bootstrap-cluster-1", "test-bootstrap-1", "test-bootstrap-1-node", "10.0.0.84"))
 
 	identity := omni.NewClusterMachineIdentity("test-1")
 	identity.Metadata().Labels().Set(omni.LabelCluster, "test-cluster-1")
@@ -84,7 +84,7 @@ func (suite *ServiceSuite) TestResolve() {
 	// create and assert that it resolves by machine ID, address and node name
 	suite.Require().NoError(suite.state.Create(suite.ctx, identity))
 
-	expected := dns.Info{Cluster: cluster, ID: "test-1", Name: "test-1-node", Address: "10.0.0.42"}
+	expected := dns.NewInfo(cluster, "test-1", "test-1-node", "10.0.0.42")
 	suite.assertResolve(cluster, "test-1", expected)
 	suite.assertResolve(cluster, "test-1-node", expected)
 	suite.assertResolve(cluster, "10.0.0.42", expected)
@@ -94,7 +94,7 @@ func (suite *ServiceSuite) TestResolve() {
 
 	suite.Require().NoError(suite.state.Update(suite.ctx, identity))
 
-	expected = dns.Info{Cluster: cluster, ID: "test-1", Name: "test-1-node", Address: "10.0.0.43"}
+	expected = dns.NewInfo(cluster, "test-1", "test-1-node", "10.0.0.43")
 	suite.assertResolve(cluster, "test-1", expected)
 	suite.assertResolve(cluster, "test-1-node", expected)
 	suite.assertResolve(cluster, "10.0.0.43", expected)

--- a/internal/backend/grpc/router/talos_backend.go
+++ b/internal/backend/grpc/router/talos_backend.go
@@ -159,13 +159,15 @@ func (backend *TalosBackend) GetConnection(ctx context.Context, fullMethodName s
 	// Always strip the "node" header — Omni has already resolved and routed directly.
 	md.Delete(nodeHeaderKey)
 
-	// Preserve the "nodes" header (rewritten with resolved cluster-internal IPs) when
+	// Preserve the "nodes" header (rewritten with resolved node addresses) when
 	// the original request had "nodes". Talos apid uses it for One2Many fan-out (2+ nodes)
 	// or loopback (1 node pointing to self), which sets Metadata.Hostname in the response.
 	// This preserves the response shape that talosctl and other API consumers expect.
+	// GetAddress() returns the cluster-internal IP when available, falling back to the
+	// SideroLink management address during early bootstrap before NodeIPs are populated.
 	if len(md.Get(nodesHeaderKey)) > 0 {
 		addresses := xslices.Map(nodes, func(info dns.Info) string {
-			return info.Address
+			return info.GetAddress()
 		})
 
 		setHeaderData(ctx, md, nodesHeaderKey, addresses...)


### PR DESCRIPTION
Bring back the fallback from cluster-internal IP to SideroLink management address when resolving node addresses, which was removed in #2507. During cluster bootstrap, the cluster-internal IP may not be populated yet, leaving the resolved address empty. This causes the `nodes` header to be rewritten with an empty string, which makes apid fail with `invalid target ""`.