### PR TITLE
chore(frontend): bump monaco-editor to 0.55.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.23",
         "luxon": "^3.7.2",
-        "monaco-editor": "~0.54.0",
+        "monaco-editor": "^0.55.1",
         "monaco-yaml": "^5.4.1",
         "pluralize": "^8.0.0",
         "reka-ui": "^2.9.2",
@@ -3083,6 +3083,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
@@ -5174,10 +5181,13 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -7600,12 +7610,12 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
-      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.1.7",
+        "dompurify": "3.2.7",
         "marked": "14.0.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.23",
     "luxon": "^3.7.2",
-    "monaco-editor": "~0.54.0",
+    "monaco-editor": "^0.55.1",
     "monaco-yaml": "^5.4.1",
     "pluralize": "^8.0.0",
     "reka-ui": "^2.9.2",

--- a/frontend/src/components/common/CodeEditor/CodeEditor.vue
+++ b/frontend/src/components/common/CodeEditor/CodeEditor.vue
@@ -22,6 +22,18 @@ window.MonacoEnvironment = {
   },
 }
 
+// Work around https://github.com/remcohaszing/monaco-yaml/issues/272.
+const { createWebWorker: oldCreateWebWorker } = monaco.editor
+monaco.editor.createWebWorker = (
+  opts: monaco.IWebWorkerOptions | monaco.editor.IInternalWebWorkerOptions,
+) => {
+  if ('worker' in opts) {
+    return oldCreateWebWorker(opts)
+  }
+
+  return monaco.createWebWorker(opts)
+}
+
 const configSchemaMap = Object.entries(configSchemas).map(
   ([path, schema]) =>
     [path.replace(/\.\/config_(.*)\.schema\.json/, '$1').replace('_', '.'), schema] as const,


### PR DESCRIPTION
Bump monaco-editor to 0.55.1. Includes a workaround for https://github.com/remcohaszing/monaco-yaml/issues/272 which is needed until [monaco-editor 0.56.0](https://github.com/microsoft/vscode/issues/280534) which should address this issue.