### PR TITLE
fix: disable client IP reporting in embedded discovery service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/siderolabs/crypto v0.6.4
 	github.com/siderolabs/discovery-api v0.1.8
 	github.com/siderolabs/discovery-client v0.1.15
-	github.com/siderolabs/discovery-service v1.0.15
+	github.com/siderolabs/discovery-service v1.0.16
 	github.com/siderolabs/gen v0.8.6
 	github.com/siderolabs/go-api-signature v0.3.12
 	github.com/siderolabs/go-debug v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/siderolabs/discovery-api v0.1.8 h1:Hq/Si0fFQICvdT+P/I81fRf9t5I+J6vaJN
 github.com/siderolabs/discovery-api v0.1.8/go.mod h1:JN8aBpnsArIeLNLbqt3HIYHyFR14Qfwr4etAB2ZfygA=
 github.com/siderolabs/discovery-client v0.1.15 h1:XN2nm2U/RUtevZtKZnwYAOE+Z68VpW32Me1K19zXtHU=
 github.com/siderolabs/discovery-client v0.1.15/go.mod h1:iUpFYp40CNTnqshG7d2r9zjMruLEaT0sb49rZzVSXVA=
-github.com/siderolabs/discovery-service v1.0.15 h1:byKnJma1jiL06ntVsLvP9YdZNC1b5BKxyCWaTCiuad4=
-github.com/siderolabs/discovery-service v1.0.15/go.mod h1:iMDklAW8DwnKBsHjD0pR0YeAK3GNiuVIAs8zD9jt4kg=
+github.com/siderolabs/discovery-service v1.0.16 h1:JlNRavWxiEvxOLNWXeiX3vzH8cvnPnGl80tjR7eO2X8=
+github.com/siderolabs/discovery-service v1.0.16/go.mod h1:iMDklAW8DwnKBsHjD0pR0YeAK3GNiuVIAs8zD9jt4kg=
 github.com/siderolabs/gen v0.8.6 h1:pE6shuqov3L+5rEcAUJ/kY6iJofimljQw5G95P8a5c4=
 github.com/siderolabs/gen v0.8.6/go.mod h1:J9IbusbES2W6QWjtSHpDV9iPGZHc978h1+KJ4oQRspQ=
 github.com/siderolabs/go-api-signature v0.3.12 h1:i1X+kPh9fzo+lEjtEplZSbtq1p21vKv4FCWJcB/ozvk=

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1213,6 +1213,9 @@ func runEmbeddedDiscoveryService(ctx context.Context, secondaryStorageDB *sqlite
 			SnapshotsEnabled: snapshotsEnabled,
 			SnapshotInterval: discoveryCfg.GetSnapshotsInterval(),
 			SnapshotStore:    snapshotStore,
+			// Nodes connect over SideroLink, so the peer IP is a tunnel address, not a real public IP.
+			// Reporting it back would cause Talos to add it as a broken KubeSpan endpoint candidate.
+			DisableClientIPReporting: true,
 		}, logger.WithOptions(zap.IncreaseLevel(logLevel)).With(logging.Component("discovery_service")))
 
 		if errors.Is(err, syscall.EADDRNOTAVAIL) {


### PR DESCRIPTION
When using Omni's embedded discovery service, nodes connect over SideroLink, so the discovery service sees the SideroLink tunnel address as the peer IP. It then reports this back to Talos as the node's "public IP", which Talos adds as a KubeSpan endpoint candidate. This causes KubeSpan to try connecting to peers via SideroLink addresses, which breaks connectivity.

Disable client IP reporting in the embedded discovery service so that SideroLink addresses are never reported back as public IPs.

Also fix the embedded discovery service checkbox on the cluster create page not properly binding to the cluster state.

Fixes: siderolabs/omni#2457