### PR TITLE
fix(frontend): respect embedded discovery checkbox in cluster create

### DIFF
--- a/frontend/src/methods/cluster.ts
+++ b/frontend/src/methods/cluster.ts
@@ -3,7 +3,6 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 import isEqual from 'lodash/isEqual'
-import * as semver from 'semver'
 import type { Ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -41,7 +40,6 @@ import {
   TalosUpgradeStatusType,
 } from '@/api/resources'
 import type { Metadata } from '@/api/v1alpha1/resource.pb'
-import { embeddedDiscoveryServiceFeatureAvailable } from '@/methods/features'
 import { parseLabels } from '@/methods/labels'
 import { controlPlaneMachineSetId } from '@/methods/machineset'
 
@@ -559,25 +557,6 @@ export const setClusterWorkloadProxy = async (clusterID: string, enabled: boolea
   await ResourceService.Update(resource, resource.metadata.version, withRuntime(Runtime.Omni))
 }
 
-export const setUseEmbeddedDiscoveryService = async (clusterID: string, enabled: boolean) => {
-  const resource: Resource<ClusterSpec> = await ResourceService.Get(
-    {
-      type: ClusterType,
-      namespace: DefaultNamespace,
-      id: clusterID,
-    },
-    withRuntime(Runtime.Omni),
-  )
-
-  if (!resource.spec.features) {
-    resource.spec.features = {}
-  }
-
-  resource.spec.features.use_embedded_discovery_service = enabled
-
-  await ResourceService.Update(resource, resource.metadata.version, withRuntime(Runtime.Omni))
-}
-
 export const setClusterEtcdBackupsConfig = async (clusterID: string, spec: ClusterSpec) => {
   const resource: Resource<ClusterSpec> = await ResourceService.Get(
     {
@@ -629,20 +608,6 @@ export const triggerEtcdBackup = async (clusterID: string) => {
   }
 
   return await ResourceService.Update(manualBackup, undefined, withRuntime(Runtime.Omni))
-}
-
-export const embeddedDiscoveryServiceAvailable = async (
-  talosVersion?: string,
-): Promise<boolean> => {
-  if (!talosVersion) {
-    return false
-  }
-
-  if (semver.compare(talosVersion, 'v1.5.0') < 0) {
-    return false
-  }
-
-  return await embeddedDiscoveryServiceFeatureAvailable()
 }
 
 export const updateClusterLock = async (id: string, locked: boolean) => {

--- a/frontend/src/methods/features.ts
+++ b/frontend/src/methods/features.ts
@@ -4,38 +4,17 @@
 // included in the LICENSE file.
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
-import { ResourceService } from '@/api/grpc'
 import type { FeaturesConfigSpec } from '@/api/omni/specs/omni.pb'
-import { withRuntime } from '@/api/options'
 import { DefaultNamespace, FeaturesConfigID, FeaturesConfigType } from '@/api/resources'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
-const resource = {
-  type: FeaturesConfigType,
-  namespace: DefaultNamespace,
-  id: FeaturesConfigID,
-}
-
 export function useFeatures() {
   return useResourceWatch<FeaturesConfigSpec>({
-    resource,
+    resource: {
+      type: FeaturesConfigType,
+      namespace: DefaultNamespace,
+      id: FeaturesConfigID,
+    },
     runtime: Runtime.Omni,
   })
-}
-
-let cachedFeaturesConfig: Resource<FeaturesConfigSpec> | undefined
-
-export const embeddedDiscoveryServiceFeatureAvailable = async (): Promise<boolean> => {
-  const featuresConfig = await getFeaturesConfig()
-
-  return featuresConfig.spec?.embedded_discovery_service ?? false
-}
-
-const getFeaturesConfig = async (): Promise<Resource<FeaturesConfigSpec>> => {
-  if (!cachedFeaturesConfig) {
-    cachedFeaturesConfig = await ResourceService.Get(resource, withRuntime(Runtime.Omni))
-  }
-
-  return cachedFeaturesConfig
 }

--- a/frontend/src/pages/(authenticated)/clusters/create.vue
+++ b/frontend/src/pages/(authenticated)/clusters/create.vue
@@ -8,7 +8,7 @@ included in the LICENSE file.
 import { dump } from 'js-yaml'
 import * as semver from 'semver'
 import type { Ref } from 'vue'
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, ref, useTemplateRef, watch, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -41,12 +41,8 @@ import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 import TAlert from '@/components/TAlert.vue'
 import { setupBackupStatus } from '@/methods'
 import { usePermissions } from '@/methods/auth'
-import {
-  ClusterCommandError,
-  clusterSync,
-  embeddedDiscoveryServiceAvailable,
-  nextAvailableClusterName,
-} from '@/methods/cluster'
+import { ClusterCommandError, clusterSync, nextAvailableClusterName } from '@/methods/cluster'
+import { useFeatures } from '@/methods/features'
 import { showModal } from '@/modal'
 import { showError, showSuccess } from '@/notification'
 import { initState, PatchID } from '@/states/cluster-management'
@@ -143,39 +139,21 @@ talosVersionsWatch.setup({
   },
 })
 
-const isEmbeddedDiscoveryServiceAvailable = ref(false)
+const { data: features } = useFeatures()
 
-watch(state.value.cluster, async (cluster) => {
-  isEmbeddedDiscoveryServiceAvailable.value = await embeddedDiscoveryServiceAvailable(
-    cluster?.talosVersion,
-  )
+const isEmbeddedDiscoveryServiceAvailable = computed(
+  () => features.value?.spec.embedded_discovery_service ?? false,
+)
 
+watchEffect(() => {
   if (!isEmbeddedDiscoveryServiceAvailable.value) {
     state.value.cluster.features.useEmbeddedDiscoveryService = false
   }
 })
 
-const toggleUseEmbeddedDiscoveryService = async () => {
-  isEmbeddedDiscoveryServiceAvailable.value = await embeddedDiscoveryServiceAvailable(
-    state.value.cluster?.talosVersion,
-  )
-
-  if (!isEmbeddedDiscoveryServiceAvailable.value) {
-    state.value.cluster.features.useEmbeddedDiscoveryService = false
-
-    return
-  }
-
-  state.value.cluster.features.useEmbeddedDiscoveryService =
-    !state.value.cluster.features.useEmbeddedDiscoveryService
-}
-
 onMounted(async () => {
   state.value.cluster.name = await nextAvailableClusterName(
     state.value.cluster.name ?? 'talos-default',
-  )
-  isEmbeddedDiscoveryServiceAvailable.value = await embeddedDiscoveryServiceAvailable(
-    state.value.cluster?.talosVersion,
   )
 })
 
@@ -382,10 +360,8 @@ const list = useTemplateRef('list')
         </Tooltip>
         <ClusterWorkloadProxyingCheckbox v-model="state.cluster.features.enableWorkloadProxy" />
         <EmbeddedDiscoveryServiceCheckbox
-          :checked="state.cluster.features.useEmbeddedDiscoveryService"
+          v-model="state.cluster.features.useEmbeddedDiscoveryService"
           :disabled="!isEmbeddedDiscoveryServiceAvailable"
-          :talos-version="state.cluster.talosVersion"
-          @click="toggleUseEmbeddedDiscoveryService"
         />
         <ClusterEtcdBackupCheckbox
           :backup-status="backupStatus"

--- a/frontend/src/views/cluster/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/cluster/Overview/components/OverviewContent.vue
@@ -5,10 +5,11 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, onMounted, ref, watchEffect } from 'vue'
+import { gte } from 'semver'
+import { computed, ref, watchEffect } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
+import { type Resource, ResourceService } from '@/api/grpc'
 import {
   type ClusterSecretsRotationStatusSpec,
   type ClusterSpec,
@@ -20,10 +21,12 @@ import {
   type TalosUpgradeStatusSpec,
   TalosUpgradeStatusSpecPhase,
 } from '@/api/omni/specs/omni.pb'
+import { withRuntime } from '@/api/options'
 import {
   ClusterLocked,
   ClusterSecretsRotationStatusType,
   ClusterStatusType,
+  ClusterType,
   DefaultNamespace,
   KubernetesUpgradeStatusType,
   KubernetesUsageType,
@@ -43,9 +46,8 @@ import {
   revertTalosUpgrade,
   setClusterEtcdBackupsConfig,
   setClusterWorkloadProxy,
-  setUseEmbeddedDiscoveryService,
 } from '@/methods/cluster'
-import { embeddedDiscoveryServiceFeatureAvailable, useFeatures } from '@/methods/features'
+import { useFeatures } from '@/methods/features'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import ClusterMachines from '@/views/cluster/ClusterMachines/ClusterMachines.vue'
 import OverviewRightPanel from '@/views/cluster/Overview/components/OverviewRightPanel/OverviewRightPanel.vue'
@@ -122,10 +124,26 @@ const { canManageClusterFeatures } = useClusterPermissions(clusterId)
 
 const { data: features } = useFeatures()
 
-const isEmbeddedDiscoveryServiceAvailable = ref(false)
+const isEmbeddedDiscoveryServiceAvailable = computed(
+  () =>
+    gte(currentCluster.spec.talos_version!, 'v1.5.0') &&
+    (features.value?.spec.embedded_discovery_service ?? false),
+)
 
 const toggleUseEmbeddedDiscoveryService = async (value: boolean) => {
-  await setUseEmbeddedDiscoveryService(clusterId.value, value)
+  const resource = await ResourceService.Get<Resource<ClusterSpec>>(
+    {
+      namespace: DefaultNamespace,
+      type: ClusterType,
+      id: clusterId.value,
+    },
+    withRuntime(Runtime.Omni),
+  )
+
+  resource.spec.features ||= {}
+  resource.spec.features.use_embedded_discovery_service = value
+
+  await ResourceService.Update(resource, resource.metadata.version, withRuntime(Runtime.Omni))
 }
 
 const { data: secretRotationStatus } = useResourceWatch<ClusterSecretsRotationStatusSpec>(() => ({
@@ -160,10 +178,6 @@ const machineLockedForKubernetesUpgrade = computed(() => {
 
 const machineLockedForSecretRotation = computed(() => {
   return secretRotationStatus.value?.spec.status === 'rotation paused'
-})
-
-onMounted(async () => {
-  isEmbeddedDiscoveryServiceAvailable.value = await embeddedDiscoveryServiceFeatureAvailable()
 })
 </script>
 

--- a/frontend/src/views/omni/Clusters/EmbeddedDiscoveryServiceCheckbox.vue
+++ b/frontend/src/views/omni/Clusters/EmbeddedDiscoveryServiceCheckbox.vue
@@ -9,7 +9,6 @@ import TCheckbox from '@/components/common/Checkbox/TCheckbox.vue'
 import Tooltip from '@/components/common/Tooltip/Tooltip.vue'
 
 type Props = {
-  talosVersion?: string
   disabled?: boolean
 }
 


### PR DESCRIPTION
During cluster creation the embedded discovery checkbox was not being respected. This fixes it to correctly use v-model, and simplfies the code a bit by reactively computing enabled/disabled staff off of useFeatures.