### PR TITLE
feat: update github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: 🐞 Bug
 description: File a bug/issue
-title: "[bug] <title>"
-labels: [bug, needs triage]
+type: Bug
+labels: [needs triage]
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,7 +1,7 @@
 name: 🔧 Feature request
 description: Suggest an idea for this project
-title: "[feature] <title>"
-labels: [feature]
+type: Feature
+labels: [needs triage]
 body:
 - type: textarea
   attributes:


### PR DESCRIPTION
Update Github issue templates to use issue types, and remove unneeded labels.