### PR TITLE
feat: update omnictl version warning text

### DIFF
--- a/client/pkg/omnictl/internal/access/client.go
+++ b/client/pkg/omnictl/internal/access/client.go
@@ -252,7 +252,7 @@ func checkVersionWarning(sysVersion *system.SysVersion) {
 	}
 
 	if clientVersion.Major != backendVersion.Major || clientVersion.Minor != backendVersion.Minor {
-		fmt.Fprintf(os.Stderr, "[WARN] omnictl version differs from the backend version: %q vs %q.\n", clientVersion.String(), backendVersion.String())
+		fmt.Fprintf(os.Stderr, "[WARN] omnictl version %q differs from the backend version %q.\n", clientVersion.String(), backendVersion.String())
 	}
 }
 


### PR DESCRIPTION
Update the omnictl version warning text to more clearly show which is the CLI version and which is the backend version.