### PR TITLE
fix: clean up stale identity last active resources on identity removal

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/auth/identity_cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/auth/identity_cleanup.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package auth
+
+import (
+	"github.com/cosi-project/runtime/pkg/controller/generic/cleanup"
+
+	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
+	customcleanup "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/cleanup"
+)
+
+// IdentityCleanupController cleans up IdentityLastActive resources when the corresponding Identity is removed.
+type IdentityCleanupController = cleanup.Controller[*authres.Identity]
+
+// NewIdentityCleanupController returns a new IdentityCleanup controller.
+func NewIdentityCleanupController() *IdentityCleanupController {
+	return cleanup.NewController(
+		cleanup.Settings[*authres.Identity]{
+			Name:    "IdentityCleanupController",
+			Handler: &customcleanup.SameIDHandler[*authres.Identity, *authres.IdentityLastActive]{},
+		},
+	)
+}

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -293,6 +293,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: dropWorkloadProxyConfigPatches,
 				name:     "dropWorkloadProxyConfigPatches",
 			},
+			{
+				callback: removeStaleIdentityLastActiveResources,
+				name:     "removeStaleIdentityLastActiveResources",
+			},
 		},
 	}
 }

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -442,6 +442,53 @@ func (suite *MigrationSuite) TestDropRedactedMachineConfigFinalizersFromClusterM
 	suite.True(cm3VersionBefore.Equal(cm3Migrated.Metadata().Version()), "expected cm3 to be left untouched")
 }
 
+func (suite *MigrationSuite) TestRemoveStaleIdentityLastActiveResources() {
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Second)
+	defer cancel()
+
+	// Identity with a matching IdentityLastActive — should be kept.
+	identity1 := authres.NewIdentity("user@example.com")
+	identity1.TypedSpec().Value.UserId = "user-1"
+	identity1.Metadata().Labels().Set(authres.LabelIdentityUserID, "user-1")
+	suite.Require().NoError(suite.state.Create(ctx, identity1))
+
+	ila1 := authres.NewIdentityLastActive("user@example.com")
+	suite.Require().NoError(suite.state.Create(ctx, ila1))
+
+	// Stale IdentityLastActive — no matching Identity.
+	ila2 := authres.NewIdentityLastActive("deleted-infra-provider@serviceaccount.omni.sidero.dev")
+	suite.Require().NoError(suite.state.Create(ctx, ila2))
+
+	// Stale IdentityLastActive in TearingDown phase.
+	ila3 := authres.NewIdentityLastActive("tearing-down@serviceaccount.omni.sidero.dev")
+	ila3.Metadata().SetPhase(resource.PhaseTearingDown)
+	suite.Require().NoError(suite.state.Create(ctx, ila3))
+
+	// Stale IdentityLastActive with a finalizer.
+	ila4 := authres.NewIdentityLastActive("with-finalizer@serviceaccount.omni.sidero.dev")
+	ila4.Metadata().Finalizers().Add("SomeFinalizer")
+	suite.Require().NoError(suite.state.Create(ctx, ila4))
+
+	_, err := suite.manager.Run(ctx, migration.WithFilter(filterWith("removeStaleIdentityLastActiveResources")))
+	suite.Require().NoError(err)
+
+	// The one with a matching Identity should still exist.
+	kept, err := safe.ReaderGetByID[*authres.IdentityLastActive](ctx, suite.state, "user@example.com")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(kept)
+
+	// All stale ones should be gone.
+	for _, id := range []string{
+		"deleted-infra-provider@serviceaccount.omni.sidero.dev",
+		"tearing-down@serviceaccount.omni.sidero.dev",
+		"with-finalizer@serviceaccount.omni.sidero.dev",
+	} {
+		_, err = safe.ReaderGetByID[*authres.IdentityLastActive](ctx, suite.state, id)
+		suite.Require().Error(err, "IdentityLastActive %q should have been removed", id)
+		suite.Require().True(state.IsNotFoundError(err), "IdentityLastActive %q should have been removed", id)
+	}
+}
+
 func TestMigrationSuite(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -298,6 +298,59 @@ func dropRedactedClusterMachineConfigFinalizers(ctx context.Context, st state.St
 	return dropFinalizers[*omni.ClusterMachineConfig](ctx, st, "RedactedClusterMachineConfigController")
 }
 
+func removeStaleIdentityLastActiveResources(ctx context.Context, st state.State, logger *zap.Logger, _ migrationContext) error {
+	identityLastActives, err := safe.ReaderListAll[*authres.IdentityLastActive](ctx, st)
+	if err != nil {
+		return err
+	}
+
+	identities, err := safe.ReaderListAll[*authres.Identity](ctx, st)
+	if err != nil {
+		return err
+	}
+
+	identitySet := make(map[resource.ID]struct{}, identities.Len())
+
+	for identity := range identities.All() {
+		identitySet[identity.Metadata().ID()] = struct{}{}
+	}
+
+	var removed int
+
+	for ila := range identityLastActives.All() {
+		if _, identityOk := identitySet[ila.Metadata().ID()]; identityOk { // exists, continue
+			continue
+		}
+
+		// Strip any finalizers defensively before destroying.
+		if !ila.Metadata().Finalizers().Empty() {
+			if _, err = safe.StateUpdateWithConflicts(ctx, st, ila.Metadata(), func(res *authres.IdentityLastActive) error {
+				for _, f := range *res.Metadata().Finalizers() {
+					res.Metadata().Finalizers().Remove(f)
+				}
+
+				return nil
+			}, state.WithUpdateOwner(ila.Metadata().Owner()), state.WithExpectedPhaseAny()); err != nil {
+				return fmt.Errorf("failed to strip finalizers from IdentityLastActive %q: %w", ila.Metadata().ID(), err)
+			}
+		}
+
+		if err = st.TeardownAndDestroy(ctx, ila.Metadata(), state.WithTeardownAndDestroyOwner(ila.Metadata().Owner())); err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
+			return fmt.Errorf("failed to destroy IdentityLastActive %q: %w", ila.Metadata().ID(), err)
+		}
+
+		removed++
+	}
+
+	logger.Info("removed stale IdentityLastActive resources", zap.Int("removed", removed))
+
+	return nil
+}
+
 func dropWorkloadProxyConfigPatches(ctx context.Context, st state.State, _ *zap.Logger, _ migrationContext) error {
 	configPatches, err := safe.ReaderListAll[*omni.ConfigPatch](ctx, st)
 	if err != nil {

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -189,6 +189,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		omnictrl.NewMachineRequestStatusCleanupController(),
 		omnictrl.NewInfraProviderCleanupController(),
 		omnictrl.NewLinkCleanupController(),
+		authctrl.NewIdentityCleanupController(),
 	}
 
 	imageFactoryHost := imageFactoryClient.Host()

--- a/internal/pkg/auth/serviceaccount/serviceaccount.go
+++ b/internal/pkg/auth/serviceaccount/serviceaccount.go
@@ -181,10 +181,5 @@ func Destroy(ctx context.Context, st state.State, name string) error {
 		destroyErr = multierror.Append(destroyErr, err)
 	}
 
-	err = st.TeardownAndDestroy(ctx, authres.NewIdentityLastActive(id).Metadata())
-	if err != nil && !state.IsNotFoundError(err) {
-		destroyErr = multierror.Append(destroyErr, err)
-	}
-
 	return destroyErr
 }

--- a/internal/pkg/auth/user/user.go
+++ b/internal/pkg/auth/user/user.go
@@ -146,10 +146,6 @@ func Destroy(ctx context.Context, st state.State, email string) error {
 		destroyErr = multierror.Append(destroyErr, err)
 	}
 
-	if err = st.TeardownAndDestroy(ctx, auth.NewIdentityLastActive(email).Metadata()); err != nil && !state.IsNotFoundError(err) {
-		destroyErr = multierror.Append(destroyErr, err)
-	}
-
 	return destroyErr
 }
 


### PR DESCRIPTION
Add a cleanup controller that removes the identity last active resource when its corresponding identity is destroyed. This covers all identity types uniformly: users, service accounts, and infra providers.

Previously, users and service accounts had manual cleanup in their destroy paths, but infra providers did not, leaving orphaned resources. Remove the manual cleanup from user and service account destruction, as the controller now handles it.

Add a migration to remove any already-orphaned identity last active resources that have no matching identity.