### PR TITLE
feat: restrict directories for included files in the cluster templates

### DIFF
--- a/client/pkg/omnictl/cluster/template/delete.go
+++ b/client/pkg/omnictl/cluster/template/delete.go
@@ -39,7 +39,7 @@ func deleteImpl(ctx context.Context, client *client.Client, _ access.ServerInfo)
 
 	defer f.Close() //nolint:errcheck
 
-	return operations.DeleteTemplate(ctx, f, os.Stdout, client.Omni().State(), deleteCmdFlags.options)
+	return operations.DeleteTemplate(ctx, f, os.Stdout, client.Omni().State(), deleteCmdFlags.options, resolvedRoot)
 }
 
 func init() {

--- a/client/pkg/omnictl/cluster/template/diff.go
+++ b/client/pkg/omnictl/cluster/template/diff.go
@@ -35,7 +35,7 @@ func diff(ctx context.Context, client *client.Client, _ access.ServerInfo) error
 
 	defer f.Close() //nolint:errcheck
 
-	return operations.DiffTemplate(ctx, f, os.Stdout, client.Omni().State())
+	return operations.DiffTemplate(ctx, f, os.Stdout, client.Omni().State(), resolvedRoot)
 }
 
 func init() {

--- a/client/pkg/omnictl/cluster/template/render.go
+++ b/client/pkg/omnictl/cluster/template/render.go
@@ -32,7 +32,7 @@ func render() error {
 
 	defer f.Close() //nolint:errcheck
 
-	return operations.RenderTemplate(f, os.Stdout)
+	return operations.RenderTemplate(f, os.Stdout, resolvedRoot)
 }
 
 func init() {

--- a/client/pkg/omnictl/cluster/template/status.go
+++ b/client/pkg/omnictl/cluster/template/status.go
@@ -52,7 +52,7 @@ func status(ctx context.Context, client *client.Client, _ access.ServerInfo) err
 		statusCmdFlags.options.Wait = false
 	}
 
-	return operations.StatusTemplate(ctx, f, os.Stdout, client.Omni().State(), statusCmdFlags.options)
+	return operations.StatusTemplate(ctx, f, os.Stdout, client.Omni().State(), statusCmdFlags.options, resolvedRoot)
 }
 
 func init() {

--- a/client/pkg/omnictl/cluster/template/sync.go
+++ b/client/pkg/omnictl/cluster/template/sync.go
@@ -100,7 +100,7 @@ func syncTemplateFiles(ctx context.Context, client *client.Client, _ access.Serv
 			return fmt.Errorf("failed to open template file %q: %w", file, err)
 		}
 
-		err = operations.SyncTemplate(ctx, f, os.Stdout, client.Omni().State(), syncCmdFlags.options)
+		err = operations.SyncTemplate(ctx, f, os.Stdout, client.Omni().State(), syncCmdFlags.options, resolvedRoot)
 		f.Close() //nolint:errcheck
 
 		if err != nil {

--- a/client/pkg/omnictl/cluster/template/template.go
+++ b/client/pkg/omnictl/cluster/template/template.go
@@ -6,6 +6,9 @@
 package template
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/siderolabs/gen/ensure"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +17,13 @@ import (
 var cmdFlags struct {
 	// Path to the cluster template file.
 	TemplatePath string
+	// AllowedDir is the directory that restricts file access in the template.
+	AllowedDir string
 }
+
+// resolvedRoot is an *os.Root opened at the root dir, resolved relative to the template file's directory.
+// It is populated by PersistentPreRunE on templateCmd before any subcommand runs.
+var resolvedRoot *os.Root
 
 // templateCmd represents the template sub-command.
 var templateCmd = &cobra.Command{
@@ -23,14 +32,35 @@ var templateCmd = &cobra.Command{
 	Short:   "Cluster template management subcommands.",
 	Long:    `Commands to render, validate, manage cluster templates.`,
 	Example: "",
+	PersistentPreRunE: func(*cobra.Command, []string) error {
+		templateDir := filepath.Dir(cmdFlags.TemplatePath)
+
+		p := cmdFlags.AllowedDir
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(templateDir, p)
+		}
+
+		var err error
+
+		resolvedRoot, err = os.OpenRoot(p)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
 }
 
 // RootCmd exports templateCmd.
 func RootCmd() *cobra.Command {
+	templateCmd.PersistentFlags().StringVar(&cmdFlags.AllowedDir, "allowed-dir", "./", "allowed directory for file access in the template;"+
+		" relative paths are resolved against the template file's directory.")
+
 	return templateCmd
 }
 
 func addRequiredFileFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&cmdFlags.TemplatePath, "file", "f", "", "path to the cluster template file or directory.")
+
 	ensure.NoError(cmd.MarkPersistentFlagRequired("file"))
 }

--- a/client/pkg/omnictl/cluster/template/validate.go
+++ b/client/pkg/omnictl/cluster/template/validate.go
@@ -32,7 +32,7 @@ func validate() error {
 
 	defer f.Close() //nolint:errcheck
 
-	return operations.ValidateTemplate(f)
+	return operations.ValidateTemplate(f, resolvedRoot)
 }
 
 func init() {

--- a/client/pkg/template/internal/models/cluster.go
+++ b/client/pkg/template/internal/models/cluster.go
@@ -82,7 +82,7 @@ type TalosCluster struct {
 }
 
 // Validate the model.
-func (cluster *Cluster) Validate() error {
+func (cluster *Cluster) Validate(opts ValidateOptions) error {
 	var multiErr error
 
 	validator := omni.ClusterValidator{
@@ -101,11 +101,11 @@ func (cluster *Cluster) Validate() error {
 		multiErr = multierror.Append(multiErr, err)
 	}
 
-	if err := cluster.Patches.Validate(); err != nil {
+	if err := cluster.Patches.Validate(opts); err != nil {
 		multiErr = multierror.Append(multiErr, err)
 	}
 
-	if err := cluster.Kubernetes.Manifests.Validate(); err != nil {
+	if err := cluster.Kubernetes.Manifests.Validate(opts); err != nil {
 		multiErr = multierror.Append(multiErr, err)
 	}
 
@@ -132,12 +132,12 @@ func (cluster *Cluster) Translate(ctx TranslateContext) ([]resource.Resource, er
 	clusterResource.TypedSpec().Value.KubernetesVersion = strings.TrimLeft(cluster.Kubernetes.Version, "v")
 	clusterResource.TypedSpec().Value.TalosVersion = strings.TrimLeft(cluster.Talos.Version, "v")
 
-	patches, err := cluster.Patches.Translate(fmt.Sprintf("cluster-%s", cluster.Name), constants.PatchBaseWeightCluster, pair.MakePair(omni.LabelCluster, cluster.Name))
+	patches, err := cluster.Patches.Translate(ctx, fmt.Sprintf("cluster-%s", cluster.Name), constants.PatchBaseWeightCluster, pair.MakePair(omni.LabelCluster, cluster.Name))
 	if err != nil {
 		return nil, err
 	}
 
-	manifests, err := cluster.Kubernetes.Manifests.Translate(fmt.Sprintf("cluster-%s", cluster.Name), constants.PatchBaseWeightCluster,
+	manifests, err := cluster.Kubernetes.Manifests.Translate(ctx, fmt.Sprintf("cluster-%s", cluster.Name), constants.PatchBaseWeightCluster,
 		pair.MakePair(omni.LabelCluster, cluster.Name),
 	)
 	if err != nil {

--- a/client/pkg/template/internal/models/controlplane.go
+++ b/client/pkg/template/internal/models/controlplane.go
@@ -22,7 +22,7 @@ type ControlPlane struct {
 }
 
 // Validate the model.
-func (controlplane *ControlPlane) Validate() error {
+func (controlplane *ControlPlane) Validate(opts ValidateOptions) error {
 	var multiErr error
 
 	if controlplane.Name != "" {
@@ -47,7 +47,7 @@ func (controlplane *ControlPlane) Validate() error {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("deleteStrategy is not allowed in the controlplane"))
 	}
 
-	multiErr = joinErrors(multiErr, controlplane.MachineSet.Validate(), controlplane.Machines.Validate(), controlplane.Patches.Validate())
+	multiErr = joinErrors(multiErr, controlplane.MachineSet.Validate(), controlplane.Machines.Validate(), controlplane.Patches.Validate(opts))
 	if multiErr != nil {
 		return fmt.Errorf("controlplane is invalid: %w", multiErr)
 	}

--- a/client/pkg/template/internal/models/kubernetes_manifest.go
+++ b/client/pkg/template/internal/models/kubernetes_manifest.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/kvutils"
@@ -65,7 +64,7 @@ type KubernetesManifest struct {
 }
 
 // Validate a kubernetes manifest.
-func (km *KubernetesManifest) Validate() error {
+func (km *KubernetesManifest) Validate(opts ValidateOptions) error {
 	var errs error
 
 	name := km.Name
@@ -95,7 +94,7 @@ func (km *KubernetesManifest) Validate() error {
 
 	switch {
 	case km.File != "":
-		_, err := os.Stat(km.File)
+		_, err := StatFile(opts.Root, km.File)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("failed to access %q: %w", km.File, err))
 		}
@@ -110,7 +109,7 @@ func (km *KubernetesManifest) Validate() error {
 }
 
 // Translate the model into a resource.
-func (km *KubernetesManifest) Translate(prefix string, weight int, labels ...pair.Pair[string, string]) (*omni.KubernetesManifestGroup, error) {
+func (km *KubernetesManifest) Translate(ctx TranslateContext, prefix string, weight int, labels ...pair.Pair[string, string]) (*omni.KubernetesManifestGroup, error) {
 	name := km.Name
 	if name == "" {
 		name = km.File
@@ -125,7 +124,7 @@ func (km *KubernetesManifest) Translate(prefix string, weight int, labels ...pai
 
 	switch {
 	case km.File != "":
-		raw, err = os.ReadFile(km.File)
+		raw, err = ReadFile(ctx.Root, km.File)
 	case km.Inline != nil:
 		var buf bytes.Buffer
 
@@ -172,11 +171,11 @@ func (km *KubernetesManifest) Translate(prefix string, weight int, labels ...pai
 type KubernetesManifestsList []KubernetesManifest
 
 // Validate the manifests in the list.
-func (k KubernetesManifestsList) Validate() error {
+func (k KubernetesManifestsList) Validate(opts ValidateOptions) error {
 	names := make(map[string]struct{}, len(k))
 
 	return errors.Join(xslices.Map(k, func(m KubernetesManifest) error {
-		if err := m.Validate(); err != nil {
+		if err := m.Validate(opts); err != nil {
 			return err
 		}
 
@@ -196,11 +195,11 @@ func (k KubernetesManifestsList) Validate() error {
 }
 
 // Translate the list of KubernetesManifests into a list of resources.
-func (l KubernetesManifestsList) Translate(prefix string, baseWeight int, labels ...pair.Pair[string, string]) ([]resource.Resource, error) {
+func (l KubernetesManifestsList) Translate(ctx TranslateContext, prefix string, baseWeight int, labels ...pair.Pair[string, string]) ([]resource.Resource, error) {
 	resources := make([]resource.Resource, 0, len(l))
 
 	for i, manifest := range l {
-		r, err := manifest.Translate(prefix, baseWeight+i, labels...)
+		r, err := manifest.Translate(ctx, prefix, baseWeight+i, labels...)
 		if err != nil {
 			return nil, err
 		}

--- a/client/pkg/template/internal/models/list.go
+++ b/client/pkg/template/internal/models/list.go
@@ -6,6 +6,7 @@ package models
 
 import (
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -24,11 +25,11 @@ type List []Model
 // Each model should be valid, but also the set of models should be complete.
 //
 //nolint:gocyclo,cyclop
-func (l List) Validate() error {
+func (l List) Validate(opts ValidateOptions) error {
 	var multiErr error
 
 	for _, model := range l {
-		multiErr = joinErrors(multiErr, model.Validate())
+		multiErr = joinErrors(multiErr, model.Validate(opts))
 	}
 
 	// complete template should contain 1 cluster, 1 controlplane, 0-N workers
@@ -121,11 +122,12 @@ func (l List) Validate() error {
 // Translate a set of models (template) to a set of Omni resources.
 //
 // Translate assumes that the template is valid.
-func (l List) Translate() ([]resource.Resource, error) {
+func (l List) Translate(root *os.Root) ([]resource.Resource, error) {
 	context := TranslateContext{
 		LockedMachines:            map[MachineID]struct{}{},
 		MachineDescriptors:        map[MachineID]Descriptors{},
 		MachineSetLevelKernelArgs: map[MachineID]KernelArgs{},
+		Root:                      root,
 	}
 
 	for _, model := range l {

--- a/client/pkg/template/internal/models/machine.go
+++ b/client/pkg/template/internal/models/machine.go
@@ -81,7 +81,7 @@ func (install *MachineInstall) Validate() error {
 }
 
 // Validate the model.
-func (machine *Machine) Validate() error {
+func (machine *Machine) Validate(opts ValidateOptions) error {
 	var multiErr error
 
 	if machine.Name == "" {
@@ -92,7 +92,7 @@ func (machine *Machine) Validate() error {
 		multiErr = multierror.Append(multiErr, err)
 	}
 
-	multiErr = joinErrors(multiErr, machine.Name.Validate(), machine.Install.Validate(), machine.Patches.Validate())
+	multiErr = joinErrors(multiErr, machine.Name.Validate(), machine.Install.Validate(), machine.Patches.Validate(opts))
 	if multiErr != nil {
 		return fmt.Errorf("machine %q is invalid: %w", machine.Name, multiErr)
 	}
@@ -117,6 +117,7 @@ func (machine *Machine) Translate(ctx TranslateContext) ([]resource.Resource, er
 		}
 
 		patchResource, err := patch.Translate(
+			ctx,
 			fmt.Sprintf("cm-%s", machine.Name),
 			constants.PatchWeightInstallDisk,
 			pair.MakePair(omni.LabelCluster, ctx.ClusterName),
@@ -131,6 +132,7 @@ func (machine *Machine) Translate(ctx TranslateContext) ([]resource.Resource, er
 	}
 
 	patches, err := machine.Patches.Translate(
+		ctx,
 		fmt.Sprintf("cm-%s", machine.Name),
 		constants.PatchBaseWeightClusterMachine,
 		pair.MakePair(omni.LabelCluster, ctx.ClusterName),

--- a/client/pkg/template/internal/models/machineset.go
+++ b/client/pkg/template/internal/models/machineset.go
@@ -273,6 +273,7 @@ func (machineset *MachineSet) translate(ctx TranslateContext, nameSuffix, roleLa
 	}
 
 	patches, err := machineset.Patches.Translate(
+		ctx,
 		id,
 		constants.PatchBaseWeightMachineSet,
 		pair.MakePair(omni.LabelCluster, ctx.ClusterName),

--- a/client/pkg/template/internal/models/models.go
+++ b/client/pkg/template/internal/models/models.go
@@ -7,6 +7,8 @@ package models
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -24,6 +26,8 @@ type Meta struct {
 
 // TranslateContext is a context for translation.
 type TranslateContext struct {
+	// Root restricts file access to a single directory tree. When nil, no restriction is applied.
+	Root                      *os.Root
 	LockedMachines            map[MachineID]struct{}
 	MachineDescriptors        map[MachineID]Descriptors
 	MachineSetLevelKernelArgs map[MachineID]KernelArgs
@@ -97,9 +101,58 @@ func (d *Descriptors) Apply(res resource.Resource) {
 	}
 }
 
+// ValidateOptions contains options for model validation.
+type ValidateOptions struct {
+	// Root restricts file access to a single directory tree. When nil, no restriction is applied.
+	Root *os.Root
+}
+
+// resolveForRoot translates a CWD-relative path into a path relative to the root directory.
+func resolveForRoot(root *os.Root, path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	rootAbs, err := filepath.Abs(root.Name())
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Rel(rootAbs, absPath)
+}
+
+// ReadFile reads a file, using root to restrict access when non-nil.
+func ReadFile(root *os.Root, path string) ([]byte, error) {
+	if root == nil {
+		return os.ReadFile(path)
+	}
+
+	rel, err := resolveForRoot(root, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return root.ReadFile(rel)
+}
+
+// StatFile stats a file, using root to restrict access when non-nil.
+func StatFile(root *os.Root, path string) (os.FileInfo, error) {
+	if root == nil {
+		return os.Stat(path)
+	}
+
+	rel, err := resolveForRoot(root, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return root.Stat(rel)
+}
+
 // Model is a base interface for cluster templates.
 type Model interface {
-	Validate() error
+	Validate(ValidateOptions) error
 	Translate(TranslateContext) ([]resource.Resource, error)
 }
 

--- a/client/pkg/template/internal/models/patch.go
+++ b/client/pkg/template/internal/models/patch.go
@@ -6,7 +6,6 @@ package models
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/hashicorp/go-multierror"
@@ -42,22 +41,22 @@ type Patch struct { //nolint:govet
 }
 
 // Validate the model.
-func (l PatchList) Validate() error {
+func (l PatchList) Validate(opts ValidateOptions) error {
 	var multiErr error
 
 	for _, patch := range l {
-		multiErr = joinErrors(multiErr, patch.Validate())
+		multiErr = joinErrors(multiErr, patch.Validate(opts))
 	}
 
 	return multiErr
 }
 
 // Translate the list of patches into a list of resources.
-func (l PatchList) Translate(prefix string, baseWeight int, labels ...pair.Pair[string, string]) ([]resource.Resource, error) {
+func (l PatchList) Translate(ctx TranslateContext, prefix string, baseWeight int, labels ...pair.Pair[string, string]) ([]resource.Resource, error) {
 	resources := make([]resource.Resource, 0, len(l))
 
 	for i, patch := range l {
-		r, err := patch.Translate(prefix, baseWeight+i, labels...)
+		r, err := patch.Translate(ctx, prefix, baseWeight+i, labels...)
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +68,7 @@ func (l PatchList) Translate(prefix string, baseWeight int, labels ...pair.Pair[
 }
 
 // Validate the model.
-func (patch *Patch) Validate() error {
+func (patch *Patch) Validate(opts ValidateOptions) error {
 	var multiErr error
 
 	name := patch.Name
@@ -91,7 +90,7 @@ func (patch *Patch) Validate() error {
 
 	switch {
 	case patch.File != "":
-		raw, err := os.ReadFile(patch.File)
+		raw, err := ReadFile(opts.Root, patch.File)
 		if err != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("failed to access %q: %w", patch.File, err))
 		} else {
@@ -122,7 +121,7 @@ func (patch *Patch) Validate() error {
 }
 
 // Translate the model into a resource.
-func (patch *Patch) Translate(prefix string, weight int, labels ...pair.Pair[string, string]) (*omni.ConfigPatch, error) {
+func (patch *Patch) Translate(ctx TranslateContext, prefix string, weight int, labels ...pair.Pair[string, string]) (*omni.ConfigPatch, error) {
 	name := patch.Name
 	if name == "" {
 		name = patch.File
@@ -140,7 +139,7 @@ func (patch *Patch) Translate(prefix string, weight int, labels ...pair.Pair[str
 
 	switch {
 	case patch.File != "":
-		raw, err = os.ReadFile(patch.File)
+		raw, err = ReadFile(ctx.Root, patch.File)
 	case patch.Inline != nil:
 		raw, err = yaml.Marshal(patch.Inline)
 	default:

--- a/client/pkg/template/internal/models/workers.go
+++ b/client/pkg/template/internal/models/workers.go
@@ -22,7 +22,7 @@ type Workers struct {
 }
 
 // Validate the model.
-func (workers *Workers) Validate() error {
+func (workers *Workers) Validate(opts ValidateOptions) error {
 	var multiErr error
 
 	if workers.Name == omni.ControlPlanesIDSuffix {
@@ -33,7 +33,7 @@ func (workers *Workers) Validate() error {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("bootstrapSpec is not allowed in workers"))
 	}
 
-	multiErr = joinErrors(multiErr, workers.MachineSet.Validate(), workers.Machines.Validate(), workers.Patches.Validate())
+	multiErr = joinErrors(multiErr, workers.MachineSet.Validate(), workers.Machines.Validate(), workers.Patches.Validate(opts))
 	if multiErr != nil {
 		return fmt.Errorf("workers is invalid: %w", multiErr)
 	}

--- a/client/pkg/template/operations/delete.go
+++ b/client/pkg/template/operations/delete.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -20,8 +21,8 @@ import (
 )
 
 // DeleteTemplate removes all template resources from Omni.
-func DeleteTemplate(ctx context.Context, templateReader io.Reader, out io.Writer, st state.State, syncOptions SyncOptions) error {
-	tmpl, err := template.Load(templateReader)
+func DeleteTemplate(ctx context.Context, templateReader io.Reader, out io.Writer, st state.State, syncOptions SyncOptions, root *os.Root) error {
+	tmpl, err := template.Load(templateReader, template.WithRoot(root))
 	if err != nil {
 		return fmt.Errorf("error loading template: %w", err)
 	}

--- a/client/pkg/template/operations/diff.go
+++ b/client/pkg/template/operations/diff.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/cosi-project/runtime/pkg/state"
 
@@ -16,8 +17,8 @@ import (
 )
 
 // DiffTemplate outputs the diff between template resources and existing resources.
-func DiffTemplate(ctx context.Context, templateReader io.Reader, output io.Writer, st state.State) error {
-	tmpl, err := template.Load(templateReader)
+func DiffTemplate(ctx context.Context, templateReader io.Reader, output io.Writer, st state.State, root *os.Root) error {
+	tmpl, err := template.Load(templateReader, template.WithRoot(root))
 	if err != nil {
 		return fmt.Errorf("error loading template: %w", err)
 	}

--- a/client/pkg/template/operations/export.go
+++ b/client/pkg/template/operations/export.go
@@ -104,7 +104,7 @@ func ExportTemplate(ctx context.Context, st state.State, clusterID string, inclu
 	}
 
 	modelList := buildModelList(clusterModel, controlPlaneMachineSetModel, workerMachineSetModels, machineModels)
-	if err = modelList.Validate(); err != nil {
+	if err = modelList.Validate(models.ValidateOptions{}); err != nil {
 		return nil, fmt.Errorf("error validating models: %w", err)
 	}
 

--- a/client/pkg/template/operations/export_test.go
+++ b/client/pkg/template/operations/export_test.go
@@ -90,7 +90,7 @@ func assertSync(ctx context.Context, t *testing.T, st state.State, exportedTempl
 
 	resourcesBeforeSync := readResources(ctx, t, st)
 
-	err := operations.SyncTemplate(ctx, strings.NewReader(exportedTemplate), &sb, st, operations.SyncOptions{})
+	err := operations.SyncTemplate(ctx, strings.NewReader(exportedTemplate), &sb, st, operations.SyncOptions{}, nil)
 	require.NoError(t, err)
 
 	resourcesAfterSync := readResources(ctx, t, st)

--- a/client/pkg/template/operations/render.go
+++ b/client/pkg/template/operations/render.go
@@ -7,6 +7,7 @@ package operations
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"go.yaml.in/yaml/v4"
@@ -15,8 +16,8 @@ import (
 )
 
 // RenderTemplate outputs the rendered template to the given output.
-func RenderTemplate(templateReader io.Reader, output io.Writer) error {
-	tmpl, err := template.Load(templateReader)
+func RenderTemplate(templateReader io.Reader, output io.Writer, root *os.Root) error {
+	tmpl, err := template.Load(templateReader, template.WithRoot(root))
 	if err != nil {
 		return fmt.Errorf("error loading template: %w", err)
 	}

--- a/client/pkg/template/operations/status.go
+++ b/client/pkg/template/operations/status.go
@@ -33,8 +33,8 @@ type StatusOptions struct {
 }
 
 // StatusTemplate queries, renders and (optionally) waits for the cluster status (health).
-func StatusTemplate(ctx context.Context, templateReader io.Reader, out io.Writer, st state.State, options StatusOptions) error {
-	tmpl, err := template.Load(templateReader)
+func StatusTemplate(ctx context.Context, templateReader io.Reader, out io.Writer, st state.State, options StatusOptions, root *os.Root) error {
+	tmpl, err := template.Load(templateReader, template.WithRoot(root))
 	if err != nil {
 		return fmt.Errorf("error loading template: %w", err)
 	}

--- a/client/pkg/template/operations/sync.go
+++ b/client/pkg/template/operations/sync.go
@@ -32,8 +32,8 @@ type SyncOptions struct {
 }
 
 // SyncTemplate performs resource sync to Omni.
-func SyncTemplate(ctx context.Context, templateReader io.Reader, out io.Writer, st state.State, syncOptions SyncOptions) error {
-	tmpl, err := template.Load(templateReader)
+func SyncTemplate(ctx context.Context, templateReader io.Reader, out io.Writer, st state.State, syncOptions SyncOptions, root *os.Root) error {
+	tmpl, err := template.Load(templateReader, template.WithRoot(root))
 	if err != nil {
 		return fmt.Errorf("error loading template: %w", err)
 	}

--- a/client/pkg/template/operations/validate.go
+++ b/client/pkg/template/operations/validate.go
@@ -7,13 +7,14 @@ package operations
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/siderolabs/omni/client/pkg/template"
 )
 
 // ValidateTemplate performs template validation.
-func ValidateTemplate(templateReader io.Reader) error {
-	tmpl, err := template.Load(templateReader)
+func ValidateTemplate(templateReader io.Reader, root *os.Root) error {
+	tmpl, err := template.Load(templateReader, template.WithRoot(root))
 	if err != nil {
 		return fmt.Errorf("error loading template: %w", err)
 	}

--- a/client/pkg/template/template.go
+++ b/client/pkg/template/template.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -23,16 +24,31 @@ import (
 	"github.com/siderolabs/omni/client/pkg/template/internal/models"
 )
 
+// Option configures a Template.
+type Option func(*Template)
+
+// WithRoot sets the root directory for file access restriction.
+func WithRoot(root *os.Root) Option {
+	return func(t *Template) {
+		t.root = root
+	}
+}
+
 // Template is a cluster template.
 type Template struct {
+	root   *os.Root
 	models models.List
 }
 
 // Load the template from input.
-func Load(input io.Reader) (*Template, error) {
+func Load(input io.Reader, opts ...Option) (*Template, error) {
 	dec := yaml.NewDecoder(input)
 
 	var template Template
+
+	for _, opt := range opts {
+		opt(&template)
+	}
 
 	for {
 		var docNode yaml.Node
@@ -126,12 +142,14 @@ func WithCluster(clusterName string) *Template {
 
 // Validate the template.
 func (t *Template) Validate() error {
-	return t.models.Validate()
+	return t.models.Validate(models.ValidateOptions{
+		Root: t.root,
+	})
 }
 
 // Translate the template into resources.
 func (t *Template) Translate() ([]resource.Resource, error) {
-	return t.models.Translate()
+	return t.models.Translate(t.root)
 }
 
 // ClusterName returns the name of the cluster associated with the template.

--- a/client/pkg/template/template_test.go
+++ b/client/pkg/template/template_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -99,6 +100,26 @@ var clusterWithKernelArgsResources []byte
 //go:embed testdata/cluster-with-manifests-resources.yaml
 var clusterWithManifestsResources []byte
 
+// clusterWithParentDirPatch is a minimal template that references a patch file outside
+// the testdata directory, at client/pkg/testdata/parent-patch.yaml.
+var clusterWithParentDirPatch = []byte(`kind: Cluster
+name: parent-dir-test
+kubernetes:
+  version: v1.30.0
+talos:
+  version: v1.7.0
+patches:
+  - file: ../../testdata/parent-patch.yaml
+---
+kind: ControlPlane
+machines:
+  - aaaaaaaa-1111-2222-3333-444444444444
+---
+kind: Workers
+machines:
+  - bbbbbbbb-1111-2222-3333-444444444444
+`)
+
 func TestLoad(t *testing.T) {
 	for _, tt := range []struct { //nolint:govet
 		name          string
@@ -146,6 +167,11 @@ func TestLoad(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	t.Chdir("testdata")
+
+	root, err := os.OpenRoot(".")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { root.Close() }) //nolint:errcheck
 
 	for _, tt := range []struct { //nolint:govet
 		name          string
@@ -208,7 +234,7 @@ func TestValidate(t *testing.T) {
 
 
 	* patch "does-not-exist.yaml" is invalid: 1 error occurred:
-	* failed to access "does-not-exist.yaml": open does-not-exist.yaml: no such file or directory
+	* failed to access "does-not-exist.yaml": openat does-not-exist.yaml: no such file or directory
 
 
 	* patch "" is invalid: 1 error occurred:
@@ -313,7 +339,7 @@ machine:
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			templ, err := template.Load(bytes.NewReader(tt.data))
+			templ, err := template.Load(bytes.NewReader(tt.data), template.WithRoot(root))
 			require.NoError(t, err)
 
 			err = templ.Validate()
@@ -347,6 +373,11 @@ func TestTranslate(t *testing.T) {
 	defer specs.SetCompressionConfig(originalCompressionConfig)
 
 	t.Chdir("testdata")
+
+	root, err := os.OpenRoot(".")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { root.Close() }) //nolint:errcheck
 
 	for _, tt := range []struct {
 		name     string
@@ -385,7 +416,7 @@ func TestTranslate(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			templ, err := template.Load(bytes.NewReader(tt.template))
+			templ, err := template.Load(bytes.NewReader(tt.template), template.WithRoot(root))
 			require.NoError(t, err)
 
 			require.NoError(t, templ.Validate())
@@ -423,11 +454,13 @@ func TestTranslate(t *testing.T) {
 func TestSync(t *testing.T) {
 	t.Chdir("testdata")
 
+	root := openTestRoot(t)
+
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 
 	ctx := t.Context()
 
-	templ1, err := template.Load(bytes.NewReader(cluster1))
+	templ1, err := template.Load(bytes.NewReader(cluster1), template.WithRoot(root))
 	require.NoError(t, err)
 
 	sync1, err := templ1.Sync(ctx, st)
@@ -441,7 +474,7 @@ func TestSync(t *testing.T) {
 		require.NoError(t, st.Create(ctx, r))
 	}
 
-	templ2, err := template.Load(bytes.NewReader(cluster2))
+	templ2, err := template.Load(bytes.NewReader(cluster2), template.WithRoot(root))
 	require.NoError(t, err)
 
 	sync2, err := templ2.Sync(ctx, st)
@@ -471,10 +504,12 @@ func TestSync(t *testing.T) {
 func TestSync_KubernetesManifests(t *testing.T) {
 	t.Chdir("testdata")
 
+	root := openTestRoot(t)
+
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 	ctx := t.Context()
 
-	templ, err := template.Load(bytes.NewReader(clusterWithManifests))
+	templ, err := template.Load(bytes.NewReader(clusterWithManifests), template.WithRoot(root))
 	require.NoError(t, err)
 
 	syncRes, err := templ.Sync(ctx, st)
@@ -514,11 +549,13 @@ func TestSync_KubernetesManifests(t *testing.T) {
 func TestDelete(t *testing.T) {
 	t.Chdir("testdata")
 
+	root := openTestRoot(t)
+
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 
 	ctx := t.Context()
 
-	templ1, err := template.Load(bytes.NewReader(cluster1))
+	templ1, err := template.Load(bytes.NewReader(cluster1), template.WithRoot(root))
 	require.NoError(t, err)
 
 	sync1, err := templ1.Sync(ctx, st)
@@ -528,7 +565,7 @@ func TestDelete(t *testing.T) {
 		require.NoError(t, st.Create(ctx, r))
 	}
 
-	templ2, err := template.Load(bytes.NewReader(cluster2))
+	templ2, err := template.Load(bytes.NewReader(cluster2), template.WithRoot(root))
 	require.NoError(t, err)
 
 	syncDelete, err := templ2.Delete(ctx, st)
@@ -544,11 +581,13 @@ func TestDelete(t *testing.T) {
 func TestSync_KernelArgs_Lifecycle(t *testing.T) {
 	t.Chdir("testdata")
 
+	root := openTestRoot(t)
+
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 	ctx := t.Context()
 
 	// 1. Initial Sync: Apply the template with KernelArgs
-	templ, err := template.Load(bytes.NewReader(clusterWithKernelArgs))
+	templ, err := template.Load(bytes.NewReader(clusterWithKernelArgs), template.WithRoot(root))
 	require.NoError(t, err)
 
 	syncRes, err := templ.Sync(ctx, st)
@@ -570,7 +609,7 @@ func TestSync_KernelArgs_Lifecycle(t *testing.T) {
 
 	clusterWithKernelArgsRemoved := removeKernelArgs(t, clusterWithKernelArgs)
 
-	templRemoved, err := template.Load(bytes.NewReader(clusterWithKernelArgsRemoved))
+	templRemoved, err := template.Load(bytes.NewReader(clusterWithKernelArgsRemoved), template.WithRoot(root))
 	require.NoError(t, err)
 
 	syncResRemoved, err := templRemoved.Sync(ctx, st)
@@ -638,6 +677,94 @@ func TestSync_KernelArgs_Lifecycle(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestValidate_RootRestriction(t *testing.T) {
+	t.Chdir("testdata")
+
+	for _, tt := range []struct { //nolint:govet
+		name        string
+		data        []byte
+		rootPath    string
+		expectError bool
+	}{
+		{
+			name:     "patches allowed under current dir",
+			data:     cluster1,
+			rootPath: ".",
+		},
+		{
+			name:     "manifests file allowed",
+			data:     clusterWithManifests,
+			rootPath: ".",
+		},
+		{
+			name:     "patches allowed by specific subdirectory",
+			data:     cluster1,
+			rootPath: "patches",
+		},
+		{
+			name:        "manifests file blocked by patches-only root",
+			data:        clusterWithManifests,
+			rootPath:    "patches",
+			expectError: true,
+		},
+		{
+			name:     "manifests file allowed by specific dir",
+			data:     clusterWithManifests,
+			rootPath: "manifests",
+		},
+		{
+			name:     "nil root skips restriction",
+			data:     cluster1,
+			rootPath: "", // will pass nil root
+		},
+		{
+			name:        "parent dir patch blocked by current dir root",
+			data:        clusterWithParentDirPatch,
+			rootPath:    ".",
+			expectError: true,
+		},
+		{
+			name:     "parent dir patch allowed by widened root",
+			data:     clusterWithParentDirPatch,
+			rootPath: "../..",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []template.Option
+
+			if tt.rootPath != "" {
+				root, rootErr := os.OpenRoot(tt.rootPath)
+				require.NoError(t, rootErr)
+
+				t.Cleanup(func() { root.Close() }) //nolint:errcheck
+
+				opts = append(opts, template.WithRoot(root))
+			}
+
+			templ, err := template.Load(bytes.NewReader(tt.data), opts...)
+			require.NoError(t, err)
+
+			err = templ.Validate()
+			if !tt.expectError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func openTestRoot(t *testing.T) *os.Root {
+	t.Helper()
+
+	root, err := os.OpenRoot(".")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { root.Close() }) //nolint:errcheck
+
+	return root
 }
 
 func removeKernelArgs(t *testing.T, in []byte) []byte {

--- a/client/pkg/template/testdata/cluster-invalid4.yaml
+++ b/client/pkg/template/testdata/cluster-invalid4.yaml
@@ -8,7 +8,7 @@ features:
   diskEncryption: true
 patches:
   - file: patches/my-cluster-patch.yaml
-  - file: ../testdata/patches/my-registry-mirrors.yaml
+  - file: patches/my-registry-mirrors.yaml
 ---
 kind: ControlPlane
 machineClass:

--- a/client/pkg/template/testdata/cluster1-resources.yaml
+++ b/client/pkg/template/testdata/cluster1-resources.yaml
@@ -42,7 +42,7 @@ spec:
 metadata:
     namespace: default
     type: ConfigPatches.omni.sidero.dev
-    id: 201-cluster-my-first-cluster-../testdata/patches/my-registry-mirrors.yaml
+    id: 201-cluster-my-first-cluster-patches/my-registry-mirrors.yaml
     version: undefined
     owner:
     phase: running
@@ -51,7 +51,7 @@ metadata:
     labels:
         omni.sidero.dev/cluster: my-first-cluster
     annotations:
-        name: ../testdata/patches/my-registry-mirrors.yaml
+        name: patches/my-registry-mirrors.yaml
 spec:
     data: |
         machine:

--- a/client/pkg/template/testdata/cluster1.yaml
+++ b/client/pkg/template/testdata/cluster1.yaml
@@ -8,7 +8,7 @@ features:
   diskEncryption: true
 patches:
   - file: patches/my-cluster-patch.yaml
-  - file: ../testdata/patches/my-registry-mirrors.yaml
+  - file: patches/my-registry-mirrors.yaml
 ---
 kind: ControlPlane
 machines:

--- a/client/pkg/template/testdata/cluster2-resources.yaml
+++ b/client/pkg/template/testdata/cluster2-resources.yaml
@@ -42,7 +42,7 @@ spec:
 metadata:
     namespace: default
     type: ConfigPatches.omni.sidero.dev
-    id: 201-cluster-my-first-cluster-../testdata/patches/my-registry-mirrors.yaml
+    id: 201-cluster-my-first-cluster-patches/my-registry-mirrors.yaml
     version: undefined
     owner:
     phase: running
@@ -51,7 +51,7 @@ metadata:
     labels:
         omni.sidero.dev/cluster: my-first-cluster
     annotations:
-        name: ../testdata/patches/my-registry-mirrors.yaml
+        name: patches/my-registry-mirrors.yaml
 spec:
     data: |
         machine:

--- a/client/pkg/template/testdata/cluster2.yaml
+++ b/client/pkg/template/testdata/cluster2.yaml
@@ -9,7 +9,7 @@ features:
   useEmbeddedDiscoveryService: true
 patches:
   - file: patches/my-cluster-patch.yaml
-  - file: ../testdata/patches/my-registry-mirrors.yaml
+  - file: patches/my-registry-mirrors.yaml
 ---
 kind: ControlPlane
 machines:

--- a/client/pkg/testdata/parent-patch.yaml
+++ b/client/pkg/testdata/parent-patch.yaml
@@ -1,0 +1,4 @@
+machine:
+  network:
+    kubespan:
+      enabled: true

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -15,4 +15,7 @@ title = "Urgent Upgrade Notes **(No, really, you MUST read this before you upgra
 description = """\
 As Omni is now using `--join-tokens-mode=legacyAllowed` by default it won't start if there are any nodes running Talos below 1.6 connected to the instance.
 If you want to keep using Omni with the outdated Talos you will need to set the flag to `legacy`. But of course we strongly recommend you to update Talos ASAP.
+
+`omnictl cluster template` has breaking changes: it now restricts including files outside of the current directory.
+If using files in the parent dirs, old behavior can be enabled by using `--allowed-dir`.
 """

--- a/internal/integration/template_test.go
+++ b/internal/integration/template_test.go
@@ -130,13 +130,13 @@ func AssertClusterTemplateFlow(testCtx context.Context, st state.State, options 
 
 			tmpl1 = renderTemplate(t, cluster1Tmpl, opts)
 
-			require.NoError(operations.ValidateTemplate(bytes.NewReader(tmpl1)))
+			require.NoError(operations.ValidateTemplate(bytes.NewReader(tmpl1), nil))
 
 			t.Log("creating template cluster")
 
 			require.NoError(operations.SyncTemplate(ctx, bytes.NewReader(tmpl1), os.Stderr, st, operations.SyncOptions{
 				Verbose: true,
-			}))
+			}, nil))
 
 			// assert that machines got allocated (label available is removed)
 			rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
@@ -180,7 +180,7 @@ func AssertClusterTemplateFlow(testCtx context.Context, st state.State, options 
 		// wait using the status command
 		require.NoError(operations.StatusTemplate(ctx, bytes.NewReader(tmpl1), os.Stderr, st, operations.StatusOptions{
 			Wait: true,
-		}))
+		}, nil))
 
 		// re-check with short timeout to make sure the cluster is ready
 		checkCtx, checkCancel := context.WithTimeout(ctx, 30*time.Second)
@@ -212,7 +212,7 @@ func AssertClusterTemplateFlow(testCtx context.Context, st state.State, options 
 
 		require.NoError(operations.SyncTemplate(ctx, bytes.NewReader(tmpl2), os.Stderr, st, operations.SyncOptions{
 			Verbose: true,
-		}))
+		}, nil))
 
 		t.Log("waiting for cluster operations to apply")
 
@@ -223,7 +223,7 @@ func AssertClusterTemplateFlow(testCtx context.Context, st state.State, options 
 		// wait using the status command
 		require.NoError(operations.StatusTemplate(ctx, bytes.NewReader(tmpl2), os.Stderr, st, operations.StatusOptions{
 			Wait: true,
-		}))
+		}, nil))
 
 		newAutomaticallyALlocatedMachines := rtestutils.ResourceIDs[*omni.MachineSetNode](ctx, t, st, state.WithLabelQuery(
 			resource.LabelEqual(omni.LabelMachineSet, clusterName+"-"+machineClassBasedMachineSetName),
@@ -255,13 +255,13 @@ func AssertClusterTemplateFlow(testCtx context.Context, st state.State, options 
 			assert.EqualValues(len(opts.CP)+len(opts.W)+2, spec.GetMachines().Total, "total machines is not the same as in the machine sets: %s", resourceDetails(status))
 		})
 
-		require.NoError(operations.ValidateTemplate(bytes.NewReader(tmpl1)))
+		require.NoError(operations.ValidateTemplate(bytes.NewReader(tmpl1), nil))
 
 		t.Log("deleting template cluster")
 
 		require.NoError(operations.DeleteTemplate(ctx, bytes.NewReader(tmpl1), os.Stderr, st, operations.SyncOptions{
 			Verbose: true,
-		}))
+		}, nil))
 
 		rtestutils.AssertNoResource[*omni.Cluster](ctx, t, st, clusterName)
 


### PR DESCRIPTION
By default only allow to include files from the same directory where the template file lives.
This is to prevent malicious cluster templates that include something like `/etc/passwd`.
Fixes: https://github.com/siderolabs/omni/issues/2590