### PR TITLE
test: lock prepared for Omni upgrade cluster, then check pending changes

### DIFF
--- a/internal/integration/omni_upgrade_test.go
+++ b/internal/integration/omni_upgrade_test.go
@@ -105,6 +105,31 @@ func SaveClusterSnapshot(testCtx context.Context, options *TestOptions, clusterN
 	}
 }
 
+// AssertNoPendingMachineUpdates asserts that there are no pending machine updates for the cluster.
+func AssertNoPendingMachineUpdates(testCtx context.Context, options *TestOptions, clusterName string) TestFunc {
+	return func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(testCtx, time.Minute)
+		defer cancel()
+
+		omniClient := options.omniClient
+		st := omniClient.Omni().State()
+
+		machinePendingUpdates := rtestutils.ResourceIDs[*omni.MachinePendingUpdates](ctx, t, st,
+			state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, clusterName)),
+		)
+
+		assert.Empty(t, machinePendingUpdates)
+
+		for _, id := range machinePendingUpdates {
+			res, err := safe.ReaderGetByID[*omni.MachinePendingUpdates](ctx, st, id)
+			require.NoError(t, err)
+
+			assert.Empty(t, res.TypedSpec().Value.Upgrade)
+			assert.Empty(t, res.TypedSpec().Value.ConfigDiff)
+		}
+	}
+}
+
 // AssertClusterSnapshot reads the snapshot from the cluster resource and asserts that versions did not change
 // and the last events still can be found in the node events.
 func AssertClusterSnapshot(testCtx context.Context, options *TestOptions, clusterName string) TestFunc {

--- a/internal/integration/suites_test.go
+++ b/internal/integration/suites_test.go
@@ -13,10 +13,12 @@ import (
 
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/extensions"
 	"github.com/siderolabs/omni/internal/integration/workloadproxy"
+	"github.com/stretchr/testify/require"
 )
 
 type assertClusterReadyOptions struct {
@@ -1545,6 +1547,17 @@ Test Omni upgrades, the first half that runs on the previous Omni version
 		})
 
 		t.Run("SaveClusterSnapshot", SaveClusterSnapshot(t.Context(), options, clusterName))
+
+		// lock the cluster
+		t.Run("LockCluster", func(t *testing.T) {
+			_, err := safe.StateUpdateWithConflicts(parentCtx, omniClient.Omni().State(), omni.NewCluster(clusterName).Metadata(), func(res *omni.Cluster) error {
+				res.Metadata().Annotations().Set(omni.ClusterLocked, "")
+
+				return nil
+			})
+
+			require.NoError(t, err)
+		})
 	}
 }
 
@@ -1574,6 +1587,19 @@ Test Omni upgrades, the second half that runs on the current Omni version
 			machineOptions.KubernetesVersion))
 
 		parentCtx := t.Context()
+
+		t.Run("AssertNoPendingMachineUpdates", AssertNoPendingMachineUpdates(t.Context(), options, clusterName))
+
+		// unlock the cluster
+		t.Run("UnlockCluster", func(t *testing.T) {
+			_, err := safe.StateUpdateWithConflicts(parentCtx, omniClient.Omni().State(), omni.NewCluster(clusterName).Metadata(), func(res *omni.Cluster) error {
+				res.Metadata().Annotations().Delete(omni.ClusterLocked)
+
+				return nil
+			})
+
+			require.NoError(t, err)
+		})
 
 		t.Run("AssertMachinesNotRebootedConfigUnchanged", AssertClusterSnapshot(t.Context(), options, clusterName))
 


### PR DESCRIPTION
This check will show actual unexpected introduced diffs.