### PR TITLE
feat(frontend): place machine labels on new line for cluster scale/create

### DIFF
--- a/frontend/src/components/List/TListItem.vue
+++ b/frontend/src/components/List/TListItem.vue
@@ -15,6 +15,12 @@ const { isDefaultOpened } = defineProps<{
   disableBorderOnExpand?: boolean
 }>()
 
+defineSlots<{
+  default(): unknown
+  secondary(): unknown
+  details(): unknown
+}>()
+
 const isDropdownOpened = ref(isDefaultOpened)
 </script>
 
@@ -28,19 +34,22 @@ const isDropdownOpened = ref(isDefaultOpened)
     "
     role="row"
   >
-    <div class="flex items-center gap-1">
-      <div v-if="$slots.details" class="flex flex-col items-center gap-2">
+    <div class="flex flex-col gap-1">
+      <div class="flex items-center gap-1">
         <TIcon
+          v-if="$slots.details"
           class="size-6 cursor-pointer rounded fill-current text-naturals-n11 transition-all duration-300 hover:bg-naturals-n7"
           :class="isDropdownOpened ? 'rotate-0' : '-rotate-180'"
           icon="drop-up"
           @click="isDropdownOpened = !isDropdownOpened"
         />
+
+        <div class="min-w-0 flex-1 px-1">
+          <slot></slot>
+        </div>
       </div>
 
-      <div class="min-w-0 flex-1 px-1">
-        <slot></slot>
-      </div>
+      <slot name="secondary"></slot>
     </div>
 
     <TSlideDownWrapper :expanded="isDropdownOpened">

--- a/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
@@ -241,70 +241,71 @@ ${isTalos112 ? talos112 : preTalos112}
   <TListItem>
     <template #default>
       <div class="flex items-center text-naturals-n13">
-        <div class="flex flex-1 items-center gap-2 truncate">
-          <span class="pr-2 font-bold">
-            <WordHighlighter
-              :query="searchQuery ?? ''"
-              :text-to-highlight="item?.spec?.network?.hostname ?? item?.metadata?.id"
-              split-by-space
-              highlight-class="bg-naturals-n14"
-            />
-          </span>
-          <MachineItemLabels
-            :resource="item"
-            :add-label-func="addMachineLabels"
-            :remove-label-func="removeMachineLabels"
-            @filter-label="(label) => $emit('filterLabel', label)"
+        <span class="grow truncate pr-2 font-bold">
+          <WordHighlighter
+            :query="searchQuery ?? ''"
+            :text-to-highlight="item?.spec?.network?.hostname ?? item?.metadata?.id"
+            split-by-space
+            highlight-class="bg-naturals-n14"
           />
-        </div>
-        <div class="flex w-lg flex-initial items-center justify-end gap-4">
-          <template v-if="machineSetIndex !== undefined">
-            <div
-              v-if="systemDiskPath"
-              class="cursor-not-allowed rounded border border-naturals-n6 py-1.5 pr-8 pl-3 text-naturals-n11"
-            >
-              Install Disk: {{ systemDiskPath }}
-            </div>
-            <div v-else>
-              <TSelectList
-                class="h-7"
-                title="Install Disk"
-                :values="disks"
-                :default-value="defaultInstallDisk"
-                @checked-value="setInstallDisk"
-              />
-            </div>
-          </template>
+        </span>
 
-          <MachineSetPicker v-model="machineSetIndex" :options="options" />
-
-          <div class="flex items-center gap-1">
-            <IconButton
-              :id="
-                machineSetIndex !== undefined
-                  ? `extensions-${options?.[machineSetIndex]?.id}`
-                  : undefined
-              "
-              class="my-auto text-naturals-n14"
-              :disabled="machineSetIndex === undefined || options?.[machineSetIndex]?.disabled"
-              :icon="systemExtensions ? 'extensions-toggle' : 'extensions'"
-              @click="openExtensionConfig"
-            />
-            <IconButton
-              :id="machineSetIndex !== undefined ? options?.[machineSetIndex]?.id : undefined"
-              class="my-auto text-naturals-n14"
-              :disabled="machineSetIndex === undefined || options?.[machineSetIndex]?.disabled"
-              :icon="
-                machineSetNode.patches[machinePatchID] && machineSetIndex !== undefined
-                  ? 'settings-toggle'
-                  : 'settings'
-              "
-              @click="openPatchConfig"
+        <template v-if="machineSetIndex !== undefined">
+          <div
+            v-if="systemDiskPath"
+            class="cursor-not-allowed rounded border border-naturals-n6 py-1.5 pr-8 pl-3 text-naturals-n11"
+          >
+            Install Disk: {{ systemDiskPath }}
+          </div>
+          <div v-else>
+            <TSelectList
+              class="h-7"
+              title="Install Disk"
+              :values="disks"
+              :default-value="defaultInstallDisk"
+              @checked-value="setInstallDisk"
             />
           </div>
+        </template>
+
+        <MachineSetPicker v-model="machineSetIndex" :options="options" />
+
+        <div class="flex items-center gap-1">
+          <IconButton
+            :id="
+              machineSetIndex !== undefined
+                ? `extensions-${options?.[machineSetIndex]?.id}`
+                : undefined
+            "
+            class="my-auto text-naturals-n14"
+            :disabled="machineSetIndex === undefined || options?.[machineSetIndex]?.disabled"
+            :icon="systemExtensions ? 'extensions-toggle' : 'extensions'"
+            @click="openExtensionConfig"
+          />
+          <IconButton
+            :id="machineSetIndex !== undefined ? options?.[machineSetIndex]?.id : undefined"
+            class="my-auto text-naturals-n14"
+            :disabled="machineSetIndex === undefined || options?.[machineSetIndex]?.disabled"
+            :icon="
+              machineSetNode.patches[machinePatchID] && machineSetIndex !== undefined
+                ? 'settings-toggle'
+                : 'settings'
+            "
+            @click="openPatchConfig"
+          />
         </div>
       </div>
     </template>
+
+    <template #secondary>
+      <MachineItemLabels
+        :resource="item"
+        :add-label-func="addMachineLabels"
+        :remove-label-func="removeMachineLabels"
+        @filter-label="(label) => $emit('filterLabel', label)"
+      />
+    </template>
+
     <template #details>
       <div class="grid grid-cols-5 pl-6">
         <div class="mt-4 mb-2">Processors</div>


### PR DESCRIPTION
When creating or scaling a cluster, for the list of machines keep the labels on a new line, as in the main machines page.

Before:
<img width="950" height="645" alt="image" src="https://github.com/user-attachments/assets/4bebad1f-0c02-4354-8e39-5a8a08c47181" />

After:
<img width="942" height="619" alt="image" src="https://github.com/user-attachments/assets/0cd33a8e-73ae-4dbe-a824-e49edfdb459a" />
