### PR TITLE
chore: extract sqlite metrics collector into a separate goroutine

### DIFF
--- a/internal/backend/runtime/omni/sqlite/metrics.go
+++ b/internal/backend/runtime/omni/sqlite/metrics.go
@@ -144,10 +144,6 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if time.Since(m.lastRefresh) > m.refreshInterval {
-		m.refresh()
-	}
-
 	ch <- prometheus.MustNewConstMetric(m.dbSizeDesc, prometheus.GaugeValue, m.cachedDBSize)
 
 	ch <- prometheus.MustNewConstMetric(m.dbFreelistSizeDesc, prometheus.GaugeValue, m.cachedFreelistSize)
@@ -163,13 +159,35 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 	m.cleanupRowsDeleted.Collect(ch)
 }
 
+// Run starts a loop that periodically refreshes metrics by querying the database.
+func (m *Metrics) Run(ctx context.Context) {
+	ticker := time.NewTicker(m.refreshInterval)
+	defer ticker.Stop()
+
+	m.mu.Lock()
+	// Initial refresh before the first tick.
+	m.refresh(ctx)
+	m.mu.Unlock()
+
+	for {
+		select {
+		case <-ticker.C:
+			m.mu.Lock()
+			m.refresh(ctx)
+			m.mu.Unlock()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 // refresh queries the database and updates cached values.
 // On failure, lastRefresh is still updated to avoid retrying on every scrape.
-func (m *Metrics) refresh() {
+func (m *Metrics) refresh(ctx context.Context) {
 	// Always update lastRefresh to prevent tight retry loops when the DB is unavailable.
 	defer func() { m.lastRefresh = time.Now() }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
 	defer cancel()
 
 	conn, err := m.db.Take(ctx)

--- a/internal/backend/runtime/omni/sqlite/metrics_test.go
+++ b/internal/backend/runtime/omni/sqlite/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
@@ -51,13 +52,21 @@ func (f *fakeSQLState) DBSize(context.Context) (int64, error) {
 	return f.size, nil
 }
 
-func setupMetrics(t *testing.T, db *sqlitexx.Pool, cosiState state.CoreState, opts ...sqlite.MetricsOption) *prometheus.Registry {
+func setupMetrics(t *testing.T, db *sqlitexx.Pool, cosiState state.CoreState) *prometheus.Registry {
 	t.Helper()
 
 	logger := zaptest.NewLogger(t)
 	registry := prometheus.NewRegistry()
 
-	registry.MustRegister(sqlite.NewMetrics(db, cosiState, logger, opts...))
+	metrics := sqlite.NewMetrics(db, cosiState, logger)
+
+	registry.MustRegister(metrics)
+
+	go func() {
+		metrics.Run(t.Context())
+	}()
+
+	time.Sleep(time.Second)
 
 	return registry
 }
@@ -145,7 +154,9 @@ func TestMetricsCaching(t *testing.T) {
 	assert.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(expected), "omni_sqlite_subsystem_row_count"))
 
 	// A new metrics instance with zero interval should see the new row.
-	registry2 := setupMetrics(t, db, &fakeSQLState{CoreState: st}, sqlite.WithRefreshInterval(0))
+	registry2 := setupMetrics(t, db, &fakeSQLState{CoreState: st})
+
+	time.Sleep(time.Second)
 
 	expected2 := `
 		# HELP omni_sqlite_subsystem_row_count Total number of rows across a subsystem's tables.
@@ -259,7 +270,7 @@ func TestMetricsSubsystemSizeIncludesIndexes(t *testing.T) {
 		INSERT INTO machine_logs (machine_id, message) VALUES ('m1', 'log1');
 	`)
 
-	registry := setupMetrics(t, db, &fakeSQLState{CoreState: st}, sqlite.WithRefreshInterval(0))
+	registry := setupMetrics(t, db, &fakeSQLState{CoreState: st})
 
 	families, err := registry.Gather()
 	require.NoError(t, err)
@@ -285,7 +296,7 @@ func TestMetricsSubsystemSizeIncludesIndexes(t *testing.T) {
 	// Add an index — the subsystem size should grow.
 	execSQL(t, db, `CREATE INDEX idx_machine_logs_machine_id ON machine_logs (machine_id)`)
 
-	registry2 := setupMetrics(t, db, &fakeSQLState{CoreState: st}, sqlite.WithRefreshInterval(0))
+	registry2 := setupMetrics(t, db, &fakeSQLState{CoreState: st})
 
 	families, err = registry2.Gather()
 	require.NoError(t, err)

--- a/internal/backend/runtime/omni/state.go
+++ b/internal/backend/runtime/omni/state.go
@@ -102,6 +102,13 @@ func (s *State) RunAuditCleanup(ctx context.Context) error {
 	return s.auditWrap.RunCleanup(ctx)
 }
 
+// RunSQLiteMetrics runs the SQLite metrics collector.
+func (s *State) RunSQLiteMetrics(ctx context.Context) error {
+	s.sqliteMetrics.Run(ctx)
+
+	return nil
+}
+
 // DefaultCore returns the default core state.
 func (s *State) DefaultCore() state.CoreState {
 	return s.defaultPersistentState.State

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -282,6 +282,7 @@ func (s *Server) Run(ctx context.Context) error {
 		newSubsystem("frontend dev proxy server", func() error { return s.runDevProxyServer(ctx, apiSrv.Handler()) }),
 		newSubsystem("log handler", func() error { return s.logHandler.Start(ctx) }),
 		newSubsystem("machine API", func() error { return s.runMachineAPI(ctx) }),
+		newSubsystem("SQLite metrics", func() error { return s.state.RunSQLiteMetrics(ctx) }),
 		newSubsystem("audit cleanup", func() error { return s.state.RunAuditCleanup(ctx) }),
 		newSubsystem("state error handler", func() error { return s.state.HandleErrors(ctx) }),
 	}


### PR DESCRIPTION
Instead of collect it on demand, when the metrics API is called, run it in a separate goroutine.
Otherwise if collecting the stats takes too long it makes the `/metrics` API to time out.