### PR TITLE
chore: collect metrics on the initial `Collect` call to avoid empty data

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -4,6 +4,11 @@ name: omnictl
 spec:
   disableImage: true
 ---
+kind: golang.GoVulnCheck
+spec:
+  ignore:
+    - GO-2026-4923 # not fixed yet
+---
 kind: auto.CommandConfig
 name: acompat
 spec:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-03-23T13:14:08Z by kres 3675077.
+# Generated on 2026-04-07T12:09:10Z by kres 3675077.
 
 ARG JS_TOOLCHAIN
 ARG TOOLCHAIN=scratch
@@ -322,13 +322,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build
 FROM base AS lint-govulncheck
 WORKDIR /src
 COPY --chmod=0755 hack/govulncheck.sh ./hack/govulncheck.sh
-RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg ./hack/govulncheck.sh ./...
+RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg ./hack/govulncheck.sh -exclude 'GO-2026-4923' ./...
 
 # runs govulncheck
 FROM base AS lint-govulncheck-client
 WORKDIR /src/client
 COPY --chmod=0755 hack/govulncheck.sh ./hack/govulncheck.sh
-RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg ./hack/govulncheck.sh ./...
+RUN --mount=type=cache,target=/root/.cache/go-build,id=omni/root/.cache/go-build --mount=type=cache,target=/go/pkg,id=omni/go/pkg ./hack/govulncheck.sh -exclude 'GO-2026-4923' ./...
 
 # runs unit-tests with race detector
 FROM base AS unit-tests-client-race

--- a/internal/backend/runtime/omni/sqlite/metrics.go
+++ b/internal/backend/runtime/omni/sqlite/metrics.go
@@ -153,6 +153,10 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if m.lastRefresh.IsZero() {
+		m.refresh(context.Background())
+	}
+
 	ch <- prometheus.MustNewConstMetric(m.dbSizeDesc, prometheus.GaugeValue, m.cachedDBSize)
 
 	ch <- prometheus.MustNewConstMetric(m.dbFreelistSizeDesc, prometheus.GaugeValue, m.cachedFreelistSize)

--- a/internal/backend/runtime/omni/sqlite/metrics_test.go
+++ b/internal/backend/runtime/omni/sqlite/metrics_test.go
@@ -156,8 +156,6 @@ func TestMetricsCaching(t *testing.T) {
 	// A new metrics instance with zero interval should see the new row.
 	registry2 := setupMetrics(t, db, &fakeSQLState{CoreState: st})
 
-	time.Sleep(time.Second)
-
 	expected2 := `
 		# HELP omni_sqlite_subsystem_row_count Total number of rows across a subsystem's tables.
 		# TYPE omni_sqlite_subsystem_row_count gauge


### PR DESCRIPTION
This was found by the Copilot review, but only from the second attempt. Will do the same in the backport PR.