### PR TITLE
fix: batch SQLite cleanup deletes to reduce write lock contention

### DIFF
--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
@@ -28,9 +28,8 @@ import (
 )
 
 const (
-	// removeBySizeBatchCap is the maximum number of rows deleted per removeBySize invocation.
-	// The probabilistic trigger ensures convergence over multiple writes.
-	removeBySizeBatchCap = 1000
+	// removeBatchSize is the maximum number of rows deleted per batch in Remove and removeBySize.
+	removeBatchSize = 1000
 
 	// TableName is the SQLite table name used by the audit log store.
 	TableName           = "audit_logs"
@@ -222,8 +221,15 @@ func (s *Store) Write(ctx context.Context, event auditlog.Event) error {
 	return nil
 }
 
+// Remove deletes audit log events in the given time range in batches of removeBatchSize.
+// Batching keeps each autocommit DELETE small, releasing the SQLite write lock between
+// statements so other writers sharing the same database are not blocked for long.
 func (s *Store) Remove(ctx context.Context, start, end time.Time) error {
-	query := fmt.Sprintf(`DELETE FROM %s WHERE %s >= $start AND %s <= $end`, TableName, eventTSMillisColumn, eventTSMillisColumn)
+	// DELETE ... LIMIT is not supported (requires SQLITE_ENABLE_UPDATE_DELETE_LIMIT), so we use a subquery to select the IDs to delete.
+	query := fmt.Sprintf(
+		`DELETE FROM %s WHERE %s IN (SELECT %s FROM %s WHERE %s >= $start AND %s <= $end LIMIT $limit)`,
+		TableName, idColumn, idColumn, TableName, eventTSMillisColumn, eventTSMillisColumn,
+	)
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
@@ -235,21 +241,33 @@ func (s *Store) Remove(ctx context.Context, start, end time.Time) error {
 
 	defer s.db.Put(conn)
 
-	q, err := sqlitexx.NewQuery(conn, query)
-	if err != nil {
-		return fmt.Errorf("failed to prepare sqlite statement: %w", err)
+	var totalDeleted int
+
+	for {
+		q, qErr := sqlitexx.NewQuery(conn, query)
+		if qErr != nil {
+			return fmt.Errorf("failed to prepare sqlite statement: %w", qErr)
+		}
+
+		qErr = q.
+			BindInt64("$start", start.UnixMilli()).
+			BindInt64("$end", end.UnixMilli()).
+			BindInt64("$limit", removeBatchSize).
+			Exec()
+		if qErr != nil {
+			return fmt.Errorf("failed to remove audit log events: %w", qErr)
+		}
+
+		deleted := conn.Changes()
+		totalDeleted += deleted
+
+		if deleted == 0 || ctx.Err() != nil {
+			break
+		}
 	}
 
-	err = q.
-		BindInt64("$start", start.UnixMilli()).
-		BindInt64("$end", end.UnixMilli()).
-		Exec()
-	if err != nil {
-		return fmt.Errorf("failed to remove audit log events: %w", err)
-	}
-
-	if s.onCleanup != nil {
-		s.onCleanup(conn.Changes())
+	if s.onCleanup != nil && totalDeleted > 0 {
+		s.onCleanup(totalDeleted)
 	}
 
 	return nil
@@ -317,8 +335,8 @@ func (s *Store) removeBySize(conn *zombiesqlite.Conn) error {
 
 	// Cap per invocation to keep each cleanup fast. The probabilistic trigger
 	// on each Write ensures we converge to the target size over time.
-	if rowsToDelete > removeBySizeBatchCap {
-		rowsToDelete = removeBySizeBatchCap
+	if rowsToDelete > removeBatchSize {
+		rowsToDelete = removeBatchSize
 	}
 
 	// Compute cutoff ID from the min ID, then range-delete everything at or

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
@@ -366,6 +366,72 @@ func TestRemoveByMaxSizeBatchCap(t *testing.T) {
 	}
 }
 
+func TestRemoveBatching(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+
+	var totalCleaned int
+
+	store, db := setupStoreWithOpts(ctx, t, logger, 0, 0, auditlogsqlite.WithCleanupCallback(func(n int) { totalCleaned += n }))
+
+	const (
+		inRangeCount  = 1500
+		outRangeCount = 10
+	)
+
+	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rangeEnd := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	conn, err := db.Take(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Put(conn)
+	})
+
+	for i := range inRangeCount {
+		ts := rangeStart.Add(time.Duration(i) * time.Second).UnixMilli()
+
+		q, qErr := sqlitexx.NewQuery(conn,
+			fmt.Sprintf("INSERT INTO %s (%s, %s) VALUES ($ts, $data)", auditlogsqlite.TableName, "event_ts_ms", "event_data"))
+		require.NoError(t, qErr)
+		require.NoError(t, q.BindInt64("$ts", ts).BindBytes("$data", []byte(`{}`)).Exec())
+	}
+
+	for i := range outRangeCount {
+		ts := rangeEnd.Add(time.Duration(i+1) * time.Hour).UnixMilli()
+
+		q, qErr := sqlitexx.NewQuery(conn,
+			fmt.Sprintf("INSERT INTO %s (%s, %s) VALUES ($ts, $data)", auditlogsqlite.TableName, "event_ts_ms", "event_data"))
+		require.NoError(t, qErr)
+		require.NoError(t, q.BindInt64("$ts", ts).BindBytes("$data", []byte(`{}`)).Exec())
+	}
+
+	// Remove all events in range — requires multiple batches (1000 + 500).
+	require.NoError(t, store.Remove(ctx, rangeStart, rangeEnd))
+
+	// Verify only out-of-range events remain.
+	rdr, err := store.Reader(ctx, time.Time{}, time.Now().Add(24*time.Hour))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, rdr.Close())
+	})
+
+	events := readAllEvents(t, rdr)
+	assert.Len(t, events, outRangeCount, "only out-of-range events should remain")
+	assert.Equal(t, inRangeCount, totalCleaned, "cleanup callback should report all in-range rows deleted")
+
+	// Verify remaining events are all after the range.
+	for _, evt := range events {
+		assert.Greater(t, evt.TimeMillis, rangeEnd.UnixMilli(), "remaining events should be after the removal range")
+	}
+}
+
 func TestReaderParameters(t *testing.T) {
 	t.Parallel()
 
@@ -538,7 +604,7 @@ func setupStore(ctx context.Context, t *testing.T, logger *zap.Logger) (*auditlo
 	return setupStoreWithOpts(ctx, t, logger, 0, 0)
 }
 
-func setupStoreWithOpts(ctx context.Context, t *testing.T, logger *zap.Logger, maxSize uint64, cleanupProbability float64) (*auditlogsqlite.Store, *sqlitexx.Pool) {
+func setupStoreWithOpts(ctx context.Context, t *testing.T, logger *zap.Logger, maxSize uint64, cleanupProbability float64, opts ...auditlogsqlite.Option) (*auditlogsqlite.Store, *sqlitexx.Pool) {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "test.db")
@@ -553,7 +619,7 @@ func setupStoreWithOpts(ctx context.Context, t *testing.T, logger *zap.Logger, m
 		require.NoError(t, db.Close())
 	})
 
-	store, err := auditlogsqlite.NewStore(ctx, db, 5*time.Second, maxSize, cleanupProbability, logger)
+	store, err := auditlogsqlite.NewStore(ctx, db, 5*time.Second, maxSize, cleanupProbability, logger, opts...)
 	require.NoError(t, err)
 
 	return store, db

--- a/internal/pkg/siderolink/logstore/sqlitelog/manager.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/manager.go
@@ -32,9 +32,8 @@ const (
 	createdAtColumn = "created_at"
 	messageColumn   = "message"
 
-	// removeBySizeBatchSize is the maximum number of rows deleted per batch in removeBySize.
-	// The method loops until the table is under maxSize, deleting up to this many rows each iteration.
-	removeBySizeBatchSize = 1000
+	// cleanupBatchSize is the maximum number of rows deleted per batch in cleanup operations.
+	cleanupBatchSize = 1000
 )
 
 // StoreManagerOption configures optional StoreManager behavior.
@@ -68,9 +67,11 @@ func (m *StoreManager) Run(ctx context.Context) error {
 		defer ticker.Stop()
 
 		tickerCh = ticker.C
-		// Do the initial cleanup immediately
+
+		// Run the first cleanup immediately but non-fatally.
+		// This avoids blocking startup if another writer holds the SQLite lock.
 		if err := m.DoCleanup(ctx); err != nil {
-			return err
+			m.logger.Warn("initial log cleanup failed, will retry on next tick", zap.Error(err))
 		}
 	}
 
@@ -93,7 +94,8 @@ func (m *StoreManager) Run(ctx context.Context) error {
 
 // DoCleanup performs the actual cleanup of old and orphaned logs.
 //
-//nolint:gocognit
+// Each batch deletes up to cleanupBatchSize rows in its own implicit autocommit statement,
+// releasing the SQLite write lock between statements so other writers are not blocked for long.
 func (m *StoreManager) DoCleanup(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, m.config.GetSqliteTimeout())
 	defer cancel()
@@ -109,85 +111,24 @@ func (m *StoreManager) DoCleanup(ctx context.Context) error {
 		machineIDs = append(machineIDs, truncateMachineID(machine.Metadata().ID()))
 	}
 
-	var rowsDeleted int
-
 	cutoff := time.Now().Add(-m.config.GetCleanupOlderThan())
 
-	// Temporary table lives in a single transaction, so we need to do everything in one transaction
-	err = func() (err error) {
-		var conn *sqlite.Conn
-
-		conn, err = m.db.Take(ctx)
-		if err != nil {
-			return fmt.Errorf("error taking connection for cleanup: %w", err)
-		}
-
-		defer m.db.Put(conn)
-
-		doneFn, transErr := sqlitex.ImmediateTransaction(conn)
-		if transErr != nil {
-			return fmt.Errorf("starting transaction for cleanup: %w", transErr)
-		}
-		defer doneFn(&err)
-
-		// Create a temporary table to store active machine IDs - it is used in the join query to delete orphaned logs
-		err = sqlitex.ExecScript(conn, `CREATE TEMPORARY TABLE machine_ids (machine_id TEXT PRIMARY KEY) STRICT`)
-		if err != nil {
-			return fmt.Errorf("failed to create temporary table: %w", err)
-		}
-
-		// Populate the temporary table with active machine IDs
-		for _, id := range machineIDs {
-			var q *sqlitexx.Query
-
-			q, err = sqlitexx.NewQuery(conn, "INSERT INTO machine_ids (machine_id) VALUES ($machine_id)")
-			if err != nil {
-				return fmt.Errorf("failed to prepare statement: %w", err)
-			}
-
-			err = q.
-				BindString("$machine_id", id).
-				Exec()
-			if err != nil {
-				return fmt.Errorf("failed to insert machine ID %q: %w", id, err)
-			}
-		}
-
-		// Delete if:
-		//   (A) Log is older than cutoff (Time-based cleanup)
-		//   OR
-		//   (B) Machine ID is NOT in the active list (Orphan cleanup)
-		deleteSQL := fmt.Sprintf(`DELETE FROM %s WHERE %s < $cutoff OR %s NOT IN (SELECT machine_id FROM machine_ids)`, TableName, createdAtColumn, machineIDColumn)
-
-		var q *sqlitexx.Query
-
-		q, err = sqlitexx.NewQuery(conn, deleteSQL)
-		if err != nil {
-			return fmt.Errorf("failed to prepare cleanup statement: %w", err)
-		}
-
-		err = q.
-			BindInt64("$cutoff", cutoff.Unix()).
-			Exec()
-		if err != nil {
-			return fmt.Errorf("failed to execute unified cleanup: %w", err)
-		}
-
-		rowsDeleted = conn.Changes()
-
-		if m.onCleanup != nil {
-			m.onCleanup(rowsDeleted)
-		}
-
-		err = sqlitex.ExecScript(conn, `DROP TABLE IF EXISTS machine_ids`)
-		if err != nil {
-			return fmt.Errorf("failed to drop temporary table: %w", err)
-		}
-
-		return nil
-	}()
+	// Phase 1: Time-based cleanup in batches
+	timeDeleted, err := m.cleanupByTime(ctx, cutoff)
 	if err != nil {
-		return err
+		return fmt.Errorf("time-based cleanup: %w", err)
+	}
+
+	// Phase 2: Orphan cleanup in batches
+	orphanDeleted, err := m.cleanupOrphans(ctx, machineIDs)
+	if err != nil {
+		return fmt.Errorf("orphan cleanup: %w", err)
+	}
+
+	rowsDeleted := timeDeleted + orphanDeleted
+
+	if m.onCleanup != nil && rowsDeleted > 0 {
+		m.onCleanup(rowsDeleted)
 	}
 
 	if rowsDeleted > 0 {
@@ -200,6 +141,7 @@ func (m *StoreManager) DoCleanup(ctx context.Context) error {
 		m.logger.Debug("completed logs cleanup", zap.Int64("rows_deleted", 0))
 	}
 
+	// Phase 3: Size-based cleanup (already batched)
 	if m.config.GetMaxSize() > 0 {
 		sizeRowsDeleted, sizeErr := m.removeBySize(ctx)
 		if sizeErr != nil {
@@ -213,9 +155,117 @@ func (m *StoreManager) DoCleanup(ctx context.Context) error {
 	return nil
 }
 
+// cleanupByTime deletes log rows older than cutoff in batches of cleanupBatchSize.
+func (m *StoreManager) cleanupByTime(ctx context.Context, cutoff time.Time) (int, error) {
+	// DELETE ... LIMIT is not supported (requires SQLITE_ENABLE_UPDATE_DELETE_LIMIT), so we use a subquery to select the IDs to delete.
+	deleteSQL := fmt.Sprintf(
+		`DELETE FROM %s WHERE %s IN (SELECT %s FROM %s WHERE %s < $cutoff LIMIT $limit)`,
+		TableName, idColumn, idColumn, TableName, createdAtColumn,
+	)
+
+	conn, err := m.db.Take(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("error taking connection: %w", err)
+	}
+
+	defer m.db.Put(conn)
+
+	var totalDeleted int
+
+	for {
+		q, qErr := sqlitexx.NewQuery(conn, deleteSQL)
+		if qErr != nil {
+			return totalDeleted, fmt.Errorf("failed to prepare statement: %w", qErr)
+		}
+
+		qErr = q.
+			BindInt64("$cutoff", cutoff.Unix()).
+			BindInt64("$limit", cleanupBatchSize).
+			Exec()
+		if qErr != nil {
+			return totalDeleted, fmt.Errorf("failed to execute delete: %w", qErr)
+		}
+
+		deleted := conn.Changes()
+		totalDeleted += deleted
+
+		if deleted == 0 || ctx.Err() != nil {
+			break
+		}
+	}
+
+	return totalDeleted, nil
+}
+
+// cleanupOrphans deletes log rows for machines that no longer exist, in batches of cleanupBatchSize.
+// It creates a temp table with active machine IDs for efficient indexed lookups.
+func (m *StoreManager) cleanupOrphans(ctx context.Context, activeMachineIDs []string) (int, error) {
+	conn, err := m.db.Take(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("error taking connection: %w", err)
+	}
+
+	defer m.db.Put(conn)
+
+	// Temp table lives on the connection (not tied to a transaction) and doesn't lock the main DB.
+	if err = sqlitex.ExecScript(conn, `CREATE TEMPORARY TABLE IF NOT EXISTS cleanup_machine_ids (machine_id TEXT PRIMARY KEY) STRICT`); err != nil {
+		return 0, fmt.Errorf("failed to create temporary table: %w", err)
+	}
+
+	// Clear any stale data from a previous run if the table already existed on this pooled connection.
+	if err = sqlitex.ExecScript(conn, `DELETE FROM cleanup_machine_ids`); err != nil {
+		return 0, fmt.Errorf("failed to clear temporary table: %w", err)
+	}
+
+	defer func() {
+		if dropErr := sqlitex.ExecScript(conn, `DROP TABLE IF EXISTS cleanup_machine_ids`); dropErr != nil {
+			m.logger.Warn("failed to drop temporary table", zap.Error(dropErr))
+		}
+	}()
+
+	for _, id := range activeMachineIDs {
+		q, qErr := sqlitexx.NewQuery(conn, "INSERT OR IGNORE INTO cleanup_machine_ids (machine_id) VALUES ($machine_id)")
+		if qErr != nil {
+			return 0, fmt.Errorf("failed to prepare insert statement: %w", qErr)
+		}
+
+		if qErr = q.BindString("$machine_id", id).Exec(); qErr != nil {
+			return 0, fmt.Errorf("failed to insert machine ID %q: %w", id, qErr)
+		}
+	}
+
+	// DELETE ... LIMIT is not supported (requires SQLITE_ENABLE_UPDATE_DELETE_LIMIT), so we use a subquery to select the IDs to delete.
+	deleteSQL := fmt.Sprintf(
+		`DELETE FROM %s WHERE %s IN (SELECT %s FROM %s WHERE %s NOT IN (SELECT machine_id FROM cleanup_machine_ids) LIMIT $limit)`,
+		TableName, idColumn, idColumn, TableName, machineIDColumn,
+	)
+
+	var totalDeleted int
+
+	for {
+		q, qErr := sqlitexx.NewQuery(conn, deleteSQL)
+		if qErr != nil {
+			return totalDeleted, fmt.Errorf("failed to prepare statement: %w", qErr)
+		}
+
+		if qErr = q.BindInt64("$limit", cleanupBatchSize).Exec(); qErr != nil {
+			return totalDeleted, fmt.Errorf("failed to execute delete: %w", qErr)
+		}
+
+		deleted := conn.Changes()
+		totalDeleted += deleted
+
+		if deleted == 0 || ctx.Err() != nil {
+			break
+		}
+	}
+
+	return totalDeleted, nil
+}
+
 // removeBySize deletes the oldest log rows globally across all machines to bring the table under maxSize bytes.
 // It estimates the number of rows to delete based on average row size, then deletes in batches of
-// removeBySizeBatchSize. The estimate may slightly overshoot; any remaining excess is handled on the next cycle.
+// cleanupBatchSize. The estimate may slightly overshoot; any remaining excess is handled on the next cycle.
 func (m *StoreManager) removeBySize(ctx context.Context) (int, error) {
 	conn, err := m.db.Take(ctx)
 	if err != nil {
@@ -236,7 +286,7 @@ func (m *StoreManager) removeBySize(ctx context.Context) (int, error) {
 	var totalDeleted int
 
 	for rowsToDelete > 0 {
-		batchSize := min(rowsToDelete, removeBySizeBatchSize)
+		batchSize := min(rowsToDelete, cleanupBatchSize)
 
 		deleted, batchErr := m.deleteOldestBatch(conn, batchSize)
 		if batchErr != nil {

--- a/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -665,6 +666,83 @@ func countTotalRows(ctx context.Context, t *testing.T, mgr *sqlitelog.StoreManag
 	}
 
 	return total
+}
+
+func TestTimeBasedCleanupBatching(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	logger := zaptest.NewLogger(t)
+
+	storageConf := config.Default().Logs.Machine.Storage
+	storageConf.SetCleanupProbability(0)
+	storageConf.SetCleanupOlderThan(24 * time.Hour)
+
+	path := filepath.Join(t.TempDir(), "time-batch.db")
+	dbConf := config.Default().Storage.Sqlite
+	dbConf.SetPath(path)
+
+	db, err := sqlite.OpenDB(dbConf)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	omniState := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var totalCleaned int
+
+	storeManager, err := sqlitelog.NewStoreManager(ctx, db, storageConf, omniState, logger,
+		sqlitelog.WithCleanupCallback(func(n int) { totalCleaned += n }),
+	)
+	require.NoError(t, err)
+
+	machineID := "time-batch-m1"
+	require.NoError(t, omniState.Create(ctx, omni.NewMachine(machineID)))
+
+	// Insert rows directly to control timestamps.
+	// 1500 old rows (2 days ago) + 200 recent rows (1 hour ago).
+	conn, err := db.Take(ctx)
+	require.NoError(t, err)
+
+	oldTimestamp := time.Now().Add(-48 * time.Hour).Unix()
+	recentTimestamp := time.Now().Add(-1 * time.Hour).Unix()
+
+	const (
+		oldRows    = 1500
+		recentRows = 200
+	)
+
+	for range oldRows {
+		q, qErr := sqlitexx.NewQuery(conn, fmt.Sprintf(
+			"INSERT INTO %s (%s, %s, %s) VALUES ($mid, $msg, $ts)",
+			sqlitelog.TableName, "machine_id", "message", "created_at",
+		))
+		require.NoError(t, qErr)
+		require.NoError(t, q.BindString("$mid", machineID).BindBytes("$msg", []byte("old")).BindInt64("$ts", oldTimestamp).Exec())
+	}
+
+	for range recentRows {
+		q, qErr := sqlitexx.NewQuery(conn, fmt.Sprintf(
+			"INSERT INTO %s (%s, %s, %s) VALUES ($mid, $msg, $ts)",
+			sqlitelog.TableName, "machine_id", "message", "created_at",
+		))
+		require.NoError(t, qErr)
+		require.NoError(t, q.BindString("$mid", machineID).BindBytes("$msg", []byte("recent")).BindInt64("$ts", recentTimestamp).Exec())
+	}
+
+	db.Put(conn)
+
+	// Verify all rows exist before cleanup.
+	totalBefore := countTotalRows(ctx, t, storeManager, []string{machineID})
+	require.Equal(t, oldRows+recentRows, totalBefore)
+
+	// DoCleanup should delete all 1500 old rows across multiple batches (1000 + 500).
+	require.NoError(t, storeManager.DoCleanup(ctx))
+
+	totalAfter := countTotalRows(ctx, t, storeManager, []string{machineID})
+	assert.Equal(t, recentRows, totalAfter, "only recent rows should remain after time-based cleanup")
+	assert.Equal(t, oldRows, totalCleaned, "cleanup callback should report all old rows deleted")
 }
 
 func TestOrphanLogsCleanup(t *testing.T) {


### PR DESCRIPTION
Break large DELETE operations in audit log and machine log cleanup into batches of 1000 rows. Each statement releases the SQLite write lock on completion, preventing long-held locks from blocking concurrent writers.

- Audit log Remove() now deletes in batched subquery loops
- Machine log DoCleanup() split into cleanupByTime() and cleanupOrphans() phases, each batched independently
- Initial cleanup failure in log manager is now non-fatal (warns and retries on next tick) to avoid blocking startup

Fixes: #2628
