### PR TITLE
fix: attribute SA audit events to the performing admin

### DIFF
--- a/internal/backend/runtime/omni/audit/hooks/hooks.go
+++ b/internal/backend/runtime/omni/audit/hooks/hooks.go
@@ -135,10 +135,17 @@ func handlePublicKey(data *auditlog.Data, res resource.Resource) error {
 	}
 
 	data.Session.Fingerprint = res.Metadata().ID()
-	data.Session.UserID = userID
-	data.Session.Email = publicKey.TypedSpec().Value.GetIdentity().GetEmail()
-	data.Session.Role = r
 	data.Session.PublicKeyExpiration = publicKey.TypedSpec().Value.GetExpiration().Seconds
+
+	// Only set actor identity fields if not already populated by the auth interceptor.
+	// When an admin manages a service account, the interceptor has already set these
+	// to the admin's identity; overwriting them would incorrectly attribute the action
+	// to the service account being managed.
+	if data.Session.Email == "" {
+		data.Session.UserID = userID
+		data.Session.Email = publicKey.TypedSpec().Value.GetIdentity().GetEmail()
+		data.Session.Role = r
+	}
 
 	return nil
 }

--- a/internal/backend/runtime/omni/audit/hooks/hooks_test.go
+++ b/internal/backend/runtime/omni/audit/hooks/hooks_test.go
@@ -15,12 +15,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/common"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/hooks"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
 	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 
 func TestUserManagedResourceTypes(t *testing.T) {
@@ -45,6 +50,67 @@ func TestUserManagedResourceTypes(t *testing.T) {
 	assert.Subset(t, createHooksResourceTypes, userManagedResourceTypes, "all user managed resource types should have create hooks")
 	assert.Subset(t, updateHooksResourceTypes, userManagedResourceTypes, "all user managed resource types should have update hooks")
 	assert.Subset(t, destroyHooksResourceTypes, userManagedResourceTypes, "all user managed resource types should have destroy hooks")
+}
+
+func TestPublicKeyCreatePreservesActorSession(t *testing.T) {
+	t.Parallel()
+
+	db := testDB(t)
+
+	cfg := config.LogsAudit{Enabled: new(true)}
+	l, err := audit.NewLog(t.Context(), cfg, db, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	hooks.Init(l)
+
+	saPublicKey := authres.NewPublicKey("sa-key-fingerprint")
+	saPublicKey.Metadata().Labels().Set(authres.LabelPublicKeyUserID, "sa-user-id")
+	saPublicKey.TypedSpec().Value.Identity = &specs.Identity{Email: "my-sa@serviceaccount.omni.sidero.dev"}
+	saPublicKey.TypedSpec().Value.Role = "Operator"
+	saPublicKey.TypedSpec().Value.Expiration = timestamppb.New(time.Unix(1700000000, 0))
+
+	t.Run("admin managing service account preserves admin session", func(t *testing.T) {
+		t.Parallel()
+
+		ad := auditlog.Data{
+			Session: auditlog.Session{
+				UserAgent: "grpc-go/1.80.0",
+				UserID:    "admin-user-id",
+				Email:     "admin@siderolabs.com",
+				Role:      "Admin",
+			},
+		}
+
+		ctx := ctxstore.WithValue(t.Context(), &ad)
+
+		fn := l.LogCreate(saPublicKey)
+		require.NoError(t, fn(ctx, saPublicKey))
+
+		assert.Equal(t, "admin@siderolabs.com", ad.Session.Email, "Session.Email must remain the admin's email")
+		assert.Equal(t, "admin-user-id", ad.Session.UserID, "Session.UserID must remain the admin's user ID")
+		assert.Equal(t, "Admin", string(ad.Session.Role), "Session.Role must remain the admin's role")
+		assert.Equal(t, "sa-key-fingerprint", ad.Session.Fingerprint, "Session.Fingerprint should be set to the new public key ID")
+	})
+
+	t.Run("empty session gets populated from public key", func(t *testing.T) {
+		t.Parallel()
+
+		ad := auditlog.Data{
+			Session: auditlog.Session{
+				UserAgent: "Mozilla/5.0",
+			},
+		}
+
+		ctx := ctxstore.WithValue(t.Context(), &ad)
+
+		fn := l.LogCreate(saPublicKey)
+		require.NoError(t, fn(ctx, saPublicKey))
+
+		assert.Equal(t, "my-sa@serviceaccount.omni.sidero.dev", ad.Session.Email, "Session.Email should be set from the public key")
+		assert.Equal(t, "sa-user-id", ad.Session.UserID, "Session.UserID should be set from the public key")
+		assert.Equal(t, "Operator", string(ad.Session.Role), "Session.Role should be set from the public key")
+		assert.Equal(t, "sa-key-fingerprint", ad.Session.Fingerprint, "Session.Fingerprint should be set to the public key ID")
+	})
 }
 
 func testDB(t *testing.T) *sqlitexx.Pool {


### PR DESCRIPTION
When an admin creates, renews, or destroys a service account, audit logs incorrectly recorded the service account itself as the actor instead of the admin. The audit hook for public key operations was overwriting the session identity that the auth interceptor had already set to the admin's identity.

Preserve the actor session fields when they are already populated by the auth interceptor, so that service account management events are correctly attributed to the admin who performed them.

Fixes: siderolabs/omni#2662