### PR TITLE
feat: allow force destroying machine requests

### DIFF
--- a/frontend/src/components/ActionsBox/TActionsBoxItem.vue
+++ b/frontend/src/components/ActionsBox/TActionsBoxItem.vue
@@ -28,8 +28,12 @@ const emitsAsProps = useEmitAsProps(emit)
 
 <template>
   <DropdownMenuItem
-    class="flex w-full cursor-pointer items-center gap-2 px-3 py-2"
-    :class="danger ? 'text-red-r1 hover:text-primary-p1' : 'hover:text-naturals-n12'"
+    class="flex w-full items-center gap-2 px-3 py-2 not-data-disabled:cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-50"
+    :class="
+      danger
+        ? 'text-red-r1 not-data-disabled:hover:text-primary-p1'
+        : 'not-data-disabled:hover:text-naturals-n12'
+    "
     v-bind="{ ...props, ...emitsAsProps }"
   >
     <TIcon v-if="icon" class="h-4 w-4 transition-colors" :icon />

--- a/frontend/src/views/ClusterMachines/MachineRequest.vue
+++ b/frontend/src/views/ClusterMachines/MachineRequest.vue
@@ -5,21 +5,31 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, toRefs } from 'vue'
+import { computed, ref, toRefs } from 'vue'
 
+import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
+import { ResourceService } from '@/api/grpc'
 import type { ClusterMachineRequestStatusSpec } from '@/api/omni/specs/omni.pb'
 import { ClusterMachineRequestStatusSpecStage } from '@/api/omni/specs/omni.pb'
+import { withRuntime } from '@/api/options'
+import { InfraProviderNamespace, MachineRequestType } from '@/api/resources'
+import TActionsBox from '@/components/ActionsBox/TActionsBox.vue'
+import TActionsBoxItem from '@/components/ActionsBox/TActionsBoxItem.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
 import IconHeaderDropdownLoading from '@/components/icons/IconHeaderDropdownLoading.vue'
 import TStatus from '@/components/Status/TStatus.vue'
+import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { TCommonStatuses } from '@/constants'
+import { showError, showSuccess } from '@/notification'
 
 const props = defineProps<{
   requestStatus: Resource<ClusterMachineRequestStatusSpec>
+  canDestroy: boolean
 }>()
 
 const { requestStatus } = toRefs(props)
+const destroying = ref(false)
 
 const stage = computed(() => {
   switch (requestStatus.value.spec.stage) {
@@ -37,6 +47,45 @@ const stage = computed(() => {
 
   return TCommonStatuses.UNKNOWN
 })
+
+const isDestroyableStage = computed(() => {
+  return (
+    stage.value === TCommonStatuses.PROVISION_FAILED ||
+    stage.value === TCommonStatuses.PROVISIONING ||
+    stage.value === TCommonStatuses.PROVISIONED ||
+    stage.value === TCommonStatuses.PENDING
+  )
+})
+
+const destroyDisabled = computed(() => {
+  if (!props.canDestroy) return 'Insufficient permissions to destroy machine requests'
+  if (!isDestroyableStage.value) return 'Cannot destroy a machine request in this stage'
+
+  return undefined
+})
+
+const forceDestroy = async () => {
+  const id = requestStatus.value.metadata.id!
+
+  destroying.value = true
+
+  try {
+    await ResourceService.Teardown(
+      {
+        type: MachineRequestType,
+        namespace: InfraProviderNamespace,
+        id: id,
+      },
+      withRuntime(Runtime.Omni),
+    )
+
+    showSuccess('Machine Request Destroyed', `Machine request ${id} is being torn down.`)
+  } catch (e) {
+    showError('Failed to Destroy Machine Request', (e as Error).message)
+  } finally {
+    destroying.value = false
+  }
+}
 </script>
 
 <template>
@@ -57,6 +106,21 @@ const stage = computed(() => {
 
     <div class="truncate text-xs" :title="requestStatus.spec.status">
       {{ requestStatus.spec.status }}
+    </div>
+
+    <div class="flex items-center justify-end">
+      <TActionsBox>
+        <Tooltip :description="destroyDisabled" placement="left">
+          <TActionsBoxItem
+            :icon="destroying ? 'loading' : 'delete'"
+            danger
+            :disabled="!!destroyDisabled || destroying"
+            @select="forceDestroy"
+          >
+            {{ destroying ? 'Destroying...' : 'Destroy' }}
+          </TActionsBoxItem>
+        </Tooltip>
+      </TActionsBox>
     </div>
   </div>
 </template>

--- a/frontend/src/views/ClusterMachines/MachineSet.vue
+++ b/frontend/src/views/ClusterMachines/MachineSet.vue
@@ -254,6 +254,7 @@ function isMachineSetScalable(
         :key="itemID(request)"
         class="border-t border-naturals-n4 last-of-type:rounded-b-md"
         :request-status="request"
+        :can-destroy="canRemoveClusterMachines"
       />
 
       <div

--- a/internal/backend/runtime/omni/controllers/omni/machine_request_set_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_request_set_status.go
@@ -155,22 +155,19 @@ func (h *machineRequestSetStatusHandler) scaleUp(ctx context.Context, r controll
 		for range 100 {
 			alias := rand.String(6)
 
-			if err := safe.WriterModify(ctx, r, infra.NewMachineRequest(machineRequestSet.Metadata().ID()+"-"+alias), func(request *infra.MachineRequest) error {
-				var err error
+			request := infra.NewMachineRequest(machineRequestSet.Metadata().ID() + "-" + alias)
 
-				request.TypedSpec().Value.TalosVersion = machineRequestSet.TypedSpec().Value.TalosVersion
+			request.TypedSpec().Value.TalosVersion = machineRequestSet.TypedSpec().Value.TalosVersion
+			request.TypedSpec().Value.Extensions = machineRequestSet.TypedSpec().Value.Extensions
+			request.TypedSpec().Value.KernelArgs = machineRequestSet.TypedSpec().Value.KernelArgs
+			request.TypedSpec().Value.MetaValues = machineRequestSet.TypedSpec().Value.MetaValues
+			request.TypedSpec().Value.ProviderData = machineRequestSet.TypedSpec().Value.ProviderData
+			request.TypedSpec().Value.GrpcTunnel = machineRequestSet.TypedSpec().Value.GrpcTunnel
 
-				request.TypedSpec().Value.Extensions = machineRequestSet.TypedSpec().Value.Extensions
-				request.TypedSpec().Value.KernelArgs = machineRequestSet.TypedSpec().Value.KernelArgs
-				request.TypedSpec().Value.MetaValues = machineRequestSet.TypedSpec().Value.MetaValues
-				request.TypedSpec().Value.ProviderData = machineRequestSet.TypedSpec().Value.ProviderData
-				request.TypedSpec().Value.GrpcTunnel = machineRequestSet.TypedSpec().Value.GrpcTunnel
+			request.Metadata().Labels().Set(omni.LabelInfraProviderID, machineRequestSet.TypedSpec().Value.ProviderId)
+			request.Metadata().Labels().Set(omni.LabelMachineRequestSet, machineRequestSet.Metadata().ID())
 
-				request.Metadata().Labels().Set(omni.LabelInfraProviderID, machineRequestSet.TypedSpec().Value.ProviderId)
-				request.Metadata().Labels().Set(omni.LabelMachineRequestSet, machineRequestSet.Metadata().ID())
-
-				return err
-			}); err != nil {
+			if err := r.Create(ctx, request, controller.WithCreateNoOwner()); err != nil {
 				if state.IsConflictError(err) {
 					continue
 				}
@@ -262,7 +259,7 @@ func scaleDown(ctx context.Context, r controller.ReaderWriter, machineRequests [
 }
 
 func deleteMachineRequest(ctx context.Context, r controller.ReaderWriter, request *infra.MachineRequest, machine *machineStatusLabels) error {
-	deleted, err := helpers.TeardownAndDestroy(ctx, r, request.Metadata())
+	deleted, err := helpers.TeardownAndDestroy(ctx, r, request.Metadata(), controller.WithOwner(""))
 	if err != nil {
 		return err
 	}
@@ -290,7 +287,7 @@ func (h *machineRequestSetStatusHandler) reconcileTearingDown(ctx context.Contex
 		}
 	}
 
-	destroyReady, err := helpers.TeardownAndDestroyAll(ctx, r, machineRequests.Pointers())
+	destroyReady, err := helpers.TeardownAndDestroyAll(ctx, r, machineRequests.Pointers(), controller.WithOwner(""))
 	if err != nil {
 		return err
 	}
@@ -338,7 +335,7 @@ func (h *machineRequestSetStatusHandler) handleInfraProviderDeletion(ctx context
 		}
 
 		return nil
-	}, controller.WithExpectedPhaseAny()); err != nil {
+	}, controller.WithExpectedPhaseAny(), controller.WithModifyNoOwner()); err != nil {
 		return err
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_request_set_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_request_set_status_test.go
@@ -302,6 +302,112 @@ func reconcileLabels(ctx context.Context, st state.State, ready chan<- struct{})
 	}
 }
 
+func TestMachineRequestForceDestroy(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterQController(omnictrl.NewMachineRequestSetStatusController()))
+			require.NoError(t, tc.Runtime.RegisterQController(newTestInfraProvider()))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			testMachineRequestForceDestroy(ctx, t, tc.State)
+		},
+	)
+}
+
+func testMachineRequestForceDestroy(ctx context.Context, t *testing.T, st state.State) {
+	var eg errgroup.Group
+
+	reconcilerCtx, reconcilerCancel := context.WithCancel(ctx)
+
+	defer func() {
+		reconcilerCancel()
+
+		require.NoError(t, eg.Wait())
+	}()
+
+	watchReady := make(chan struct{})
+	errCh := make(chan error, 1)
+
+	eg.Go(func() error {
+		err := reconcileLabels(reconcilerCtx, st, watchReady)
+		if err != nil {
+			t.Logf("machine status labels reconciler crashed with error %s", err)
+
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
+
+		return err
+	})
+
+	select {
+	case <-watchReady:
+	case err := <-errCh:
+		require.FailNow(t, "reconcileLabels failed before watch was established", err)
+	case <-ctx.Done():
+		require.FailNow(t, "context canceled waiting for reconcileLabels watch to be established")
+	}
+
+	machineRequestSet := rmock.Mock[*omni.MachineRequestSet](ctx, t, st,
+		options.WithID("test-force-destroy"),
+		options.Modify(func(r *omni.MachineRequestSet) error {
+			r.TypedSpec().Value.ProviderId = "test"
+			r.TypedSpec().Value.TalosVersion = "v1.7.5"
+			r.TypedSpec().Value.MachineCount = 2
+
+			return nil
+		}),
+	)
+
+	// wait for the requests to be created
+	var ids []resource.ID
+
+	err := retry.Constant(time.Second*5).RetryWithContext(ctx, func(ctx context.Context) error {
+		ids = rtestutils.ResourceIDs[*infra.MachineRequest](ctx, t, st, state.WithLabelQuery(resource.LabelEqual(omni.LabelMachineRequestSet, machineRequestSet.Metadata().ID())))
+
+		if len(ids) != int(machineRequestSet.TypedSpec().Value.MachineCount) {
+			return retry.ExpectedErrorf("expected %d requests got %d", machineRequestSet.TypedSpec().Value.MachineCount, len(ids))
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	targetRequestID := ids[0]
+
+	// force destroy the ownerless machine request by tearing it down directly
+	_, err = st.Teardown(ctx, infra.NewMachineRequest(targetRequestID).Metadata())
+
+	require.NoError(t, err)
+
+	// the original request should be destroyed
+	rtestutils.AssertNoResource[*infra.MachineRequest](ctx, t, st, targetRequestID)
+
+	// a replacement request should be created, so total count is still 2
+	err = retry.Constant(time.Second*5).RetryWithContext(ctx, func(ctx context.Context) error {
+		ids = rtestutils.ResourceIDs[*infra.MachineRequest](ctx, t, st, state.WithLabelQuery(resource.LabelEqual(omni.LabelMachineRequestSet, machineRequestSet.Metadata().ID())))
+
+		if len(ids) != int(machineRequestSet.TypedSpec().Value.MachineCount) {
+			return retry.ExpectedErrorf("expected %d requests got %d", machineRequestSet.TypedSpec().Value.MachineCount, len(ids))
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	// the replacement should be a new request, not the original
+	assert.NotContains(t, ids, targetRequestID)
+}
+
 func TestInfraProviderDeletion(t *testing.T) {
 	t.Parallel()
 
@@ -363,9 +469,7 @@ func TestInfraProviderDeletion(t *testing.T) {
 
 		machineRequest := machineRequests.Get(0)
 		machineRequest.Metadata().Finalizers().Add(providerID)
-		require.NoError(t, st.Update(ctx, machineRequest, func(updateOptions *state.UpdateOptions) {
-			updateOptions.Owner = omnictrl.MachineRequestSetStatusControllerName
-		}))
+		require.NoError(t, st.Update(ctx, machineRequest))
 
 		rtestutils.AssertResources(ctx, t, st, ids, func(r *infra.MachineRequest, assert *assert.Assertions) {
 			require.True(t, r.Metadata().Finalizers().Has(providerID))

--- a/internal/backend/runtime/omni/infraprovider/state.go
+++ b/internal/backend/runtime/omni/infraprovider/state.go
@@ -339,8 +339,12 @@ func (st *State) checkAccess(ctx context.Context, ns resource.Namespace, resType
 
 	// not an infra provider, run regular user checks
 
-	if !isReadAccess && resType != infra.ProviderType { // not an infra provider, check for the read-only access
+	if !isReadAccess && resType != infra.ProviderType && resType != infra.MachineRequestType {
 		return accessCheckResult{}, status.Errorf(codes.PermissionDenied, "users are not allowed to modify %q resources", resType)
+	}
+
+	if !isReadAccess && resType == infra.MachineRequestType && checkResult.Role.Check(role.Operator) != nil {
+		return accessCheckResult{}, status.Errorf(codes.PermissionDenied, "only operators and admins are allowed to modify %q resources", resType)
 	}
 
 	if config.onlyAdminCanRead && checkResult.Role != role.Admin {

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -297,6 +297,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: removeStaleIdentityLastActiveResources,
 				name:     "removeStaleIdentityLastActiveResources",
 			},
+			{
+				callback: makeMachineRequestsOwnerEmpty,
+				name:     "makeMachineRequestsOwnerEmpty",
+			},
 		},
 	}
 }

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -386,3 +386,22 @@ func dropWorkloadProxyConfigPatches(ctx context.Context, st state.State, _ *zap.
 
 	return nil
 }
+
+func makeMachineRequestsOwnerEmpty(ctx context.Context, st state.State, _ *zap.Logger, _ migrationContext) error {
+	machineRequests, err := safe.ReaderListAll[*infra.MachineRequest](ctx, st)
+	if err != nil {
+		return err
+	}
+
+	for machineRequest := range machineRequests.All() {
+		if machineRequest.Metadata().Owner() == "" {
+			continue
+		}
+
+		if err = changeOwner(ctx, st, machineRequest, ""); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Machine requests are now created without a controller owner, allowing operators and admins to teardown stuck or unwanted requests directly. The controller replaces destroyed requests automatically to maintain the desired machine count. Includes a migration to clear ownership on existing requests.

Fixes: #2642
