### PR TITLE
feat(frontend): update talos version text on installation media wizard

### DIFF
--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/talos-version.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/talos-version.vue
@@ -78,9 +78,7 @@ watch(joinTokens, (v) => (formState.value.joinToken ??= v[0]?.value))
     />
 
     <p class="text-xs">
-      We strongly recommend using the latest stable version of Talos Linux ({{
-        DefaultTalosVersion
-      }}).
+      Latest recommended version of Talos Linux ({{ DefaultTalosVersion }}).
       <template v-if="features?.spec.talos_pre_release_versions_enabled">
         <br />
         Pre-release versions are suitable for testing purposes but are not advised for production


### PR DESCRIPTION
Update the text shown when selecting the Talos version on the Installation Media wizard to be the latest recommended version, rather than the latest.