### PR TITLE
chore: make Omni use join tokens mode `legacyAllowed` by default

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -6,64 +6,13 @@ github_repo = "siderolabs/omni"
 match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 
 pre_release = true
-previous = "v1.6.0"
+previous = "v1.7.0"
 
-[notes.aaa-eula-flags]
+# IMPORTANT: These upgrade notes are for 1.8.x, keep them when updating the file for the next release
+
+[notes.aaa-upgrade-nodes]
 title = "Urgent Upgrade Notes **(No, really, you MUST read this before you upgrade)**"
 description = """\
-A [EULA](https://siderolabs.com/eula/) agreement has been added to Omni which must be accepted in order to continue using it.
-
-This agreement can be accepted through UI or programmatically either by adding the below flags:
-```sh
---eula-accept-name=Your Name
---eula-accept-email=your@email.com
-```
-
-Or if using `--config-path` with the below configuration:
-```yaml
-eulaAccept:
-  name: Your Name
-  email: your@email.com
-```
-"""
-
-[notes.kubernetes-manifests-sync]
-title = "Kubernetes Manifests Sync"
-description = """\
-Omni now supports syncing Kubernetes manifests directly to managed clusters. \
-Manifests can be defined in cluster templates, allowing declarative management of Kubernetes resources alongside cluster configuration.
-"""
-
-[notes.omnictl-edit]
-title = "`omnictl edit` Command"
-description = """\
-A new `omnictl edit` command has been added, allowing users to edit Omni resources interactively from the CLI.
-"""
-
-[notes.browsable-audit-logs]
-title = "Browsable Audit Logs in the UI"
-description = """\
-Audit logs are now browsable directly in the Omni UI, making it easier to review audit events without CLI access.
-"""
-
-[notes.workload-proxy-subdomain]
-title = "Workload Proxy Subdomain Options"
-description = """\
-The workload proxy now supports an empty subdomain configuration and a new `useOmniSubdomain` option, \
-providing more flexibility in how workload proxy URLs are structured.
-"""
-
-[notes.config-validation-errors]
-title = "Human-Readable Config Validation Errors"
-description = """\
-Configuration validation errors are now presented in a human-readable format, \
-making it easier to diagnose and fix configuration issues.
-"""
-
-[notes.direct-talos-node-access]
-title = "Direct Talos Node Access via SideroLink"
-description = """\
-All Talos nodes can now be accessed directly via their SideroLink endpoint, \
-removing the need to route through the load balancer for Talos API calls. \
-Allowing direct access to worker nodes when control plane nodes are unavailable.
+As Omni is now using `--join-tokens-mode=legacyAllowed` by default it won't start if there are any nodes running Talos below 1.6 connected to the instance.
+If you want to keep using Omni with the outdated Talos you will need to set the flag to `legacy`. But of course we strongly recommend you to update Talos ASAP.
 """

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -467,7 +467,7 @@ func TestSchemaDefaults(t *testing.T) {
 	assert.Equal(t, "https://localhost:8095", p.Services.KubernetesProxy.GetAdvertisedURL())
 
 	// services.siderolink
-	assert.Equal(t, config.SiderolinkServiceJoinTokensModeLegacy, p.Services.Siderolink.GetJoinTokensMode())
+	assert.Equal(t, config.SiderolinkServiceJoinTokensModeLegacyAllowed, p.Services.Siderolink.GetJoinTokensMode())
 	assert.Equal(t, 8090, p.Services.Siderolink.GetEventSinkPort())
 	assert.Equal(t, 8092, p.Services.Siderolink.GetLogServerPort())
 

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -357,7 +357,7 @@
           "description": "JoinTokensMode configures how machine join tokens are generated and used. Set to strict to use the secure join tokens mode.",
           "x-cli-flag": "join-tokens-mode",
           "type": "string",
-          "default": "legacy",
+          "default": "legacyAllowed",
           "enum": [
             "strict",
             "legacyAllowed",


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/omni/issues/1591