### PR TITLE
fix(frontend): open external eula link in a new tab

### DIFF
--- a/frontend/src/pages/eula.vue
+++ b/frontend/src/pages/eula.vue
@@ -80,7 +80,12 @@ const accept = async () => {
       >
         <p>
           Before using Sidero Omni, please review the End User License Agreement ("Agreement") at:
-          <a href="https://siderolabs.com/eula/" class="link-primary">
+          <a
+            href="https://siderolabs.com/eula/"
+            class="link-primary"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             https://siderolabs.com/eula/
           </a>
         </p>


### PR DESCRIPTION
Open external EULA link in a new tab with _blank


(cherry picked from commit 9fd6e9e14bbdbf3fa5a3c13959b3c1ee29e44d50)