### PR TITLE
feat(frontend): allow re-saving omni support bundle

### DIFF
--- a/frontend/src/views/Overview/components/OverviewRightPanel/DownloadSupportBundleModal.vue
+++ b/frontend/src/views/Overview/components/OverviewRightPanel/DownloadSupportBundleModal.vue
@@ -61,10 +61,10 @@ const { data } = useResourceWatch<ClusterMachineIdentitySpec>(() => ({
 }))
 
 const downloading = ref(false)
-const done = ref(false)
+const downloadedURL = ref<string>()
 
 const closeText = computed(() => {
-  return done.value ? 'Close' : 'Cancel'
+  return downloadedURL.value ? 'Close' : 'Cancel'
 })
 
 let abortController: AbortController
@@ -76,6 +76,11 @@ onUnmounted(() => {
 watchEffect(() => {
   if (!open.value) {
     abortController?.abort()
+
+    if (downloadedURL.value) {
+      window.URL.revokeObjectURL(downloadedURL.value)
+    }
+
     return
   }
 
@@ -83,7 +88,7 @@ watchEffect(() => {
   sourceToProgress.value = {}
   expanded.value = {}
   downloading.value = false
-  done.value = false
+  downloadedURL.value = undefined
 })
 
 const download = async () => {
@@ -144,13 +149,7 @@ const download = async () => {
           const rawData = b64Decode(data) as Uint8Array<ArrayBuffer>
           const blob = new Blob([rawData], { type: 'application/zip' })
 
-          const url = window.URL.createObjectURL(blob)
-          downloadURL(url, 'support.zip')
-          window.URL.revokeObjectURL(url)
-
-          done.value = true
-
-          return
+          downloadedURL.value = window.URL.createObjectURL(blob)
         }
       },
       withAbortController(abortController),
@@ -174,6 +173,16 @@ const downloadURL = (data: string, fileName: string) => {
   a.remove()
 }
 
+async function confirm() {
+  if (!downloadedURL.value) {
+    await download()
+  }
+
+  if (downloadedURL.value) {
+    downloadURL(downloadedURL.value, 'support.zip')
+  }
+}
+
 const { canDownloadSupportBundle } = useClusterPermissions(computed(() => clusterId))
 </script>
 
@@ -182,10 +191,10 @@ const { canDownloadSupportBundle } = useClusterPermissions(computed(() => cluste
     v-model:open="open"
     title="Download Support Bundle"
     :cancel-label="closeText"
-    action-label="Download"
+    :action-label="downloadedURL ? 'Save' : 'Download'"
     :action-disabled="!canDownloadSupportBundle"
     :loading="downloading"
-    @confirm="download"
+    @confirm="confirm"
   >
     <template #description>Cluster: {{ clusterId }}</template>
 


### PR DESCRIPTION
After download completes on the Omni support bundle, the user may click save again to save the bundle again without having to initiate the download again. This helps incase you accidentally click out of the first save, or deleted it, or anything like that. If you want a fresh bundle, you can still get that when you close & re-open the modal.

https://github.com/user-attachments/assets/6e158c90-8a0a-4be0-9986-6fcd949b2629

Closes #2680 
