### PR TITLE
feat: introduce powered off machine state and power on support

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -2527,6 +2527,168 @@ func (x *DestroyUserRequest) GetEmail() string {
 	return ""
 }
 
+type MachinePowerOffRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// MachineId is the ID of the machine to power off (shutdown).
+	MachineId     string `protobuf:"bytes,1,opt,name=machine_id,json=machineId,proto3" json:"machine_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MachinePowerOffRequest) Reset() {
+	*x = MachinePowerOffRequest{}
+	mi := &file_omni_management_management_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MachinePowerOffRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MachinePowerOffRequest) ProtoMessage() {}
+
+func (x *MachinePowerOffRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MachinePowerOffRequest.ProtoReflect.Descriptor instead.
+func (*MachinePowerOffRequest) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *MachinePowerOffRequest) GetMachineId() string {
+	if x != nil {
+		return x.MachineId
+	}
+	return ""
+}
+
+type MachinePowerOffResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MachinePowerOffResponse) Reset() {
+	*x = MachinePowerOffResponse{}
+	mi := &file_omni_management_management_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MachinePowerOffResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MachinePowerOffResponse) ProtoMessage() {}
+
+func (x *MachinePowerOffResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MachinePowerOffResponse.ProtoReflect.Descriptor instead.
+func (*MachinePowerOffResponse) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{40}
+}
+
+type MachinePowerOnRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// MachineId is the ID of the machine to power on.
+	MachineId     string `protobuf:"bytes,1,opt,name=machine_id,json=machineId,proto3" json:"machine_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MachinePowerOnRequest) Reset() {
+	*x = MachinePowerOnRequest{}
+	mi := &file_omni_management_management_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MachinePowerOnRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MachinePowerOnRequest) ProtoMessage() {}
+
+func (x *MachinePowerOnRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MachinePowerOnRequest.ProtoReflect.Descriptor instead.
+func (*MachinePowerOnRequest) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *MachinePowerOnRequest) GetMachineId() string {
+	if x != nil {
+		return x.MachineId
+	}
+	return ""
+}
+
+type MachinePowerOnResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MachinePowerOnResponse) Reset() {
+	*x = MachinePowerOnResponse{}
+	mi := &file_omni_management_management_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MachinePowerOnResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MachinePowerOnResponse) ProtoMessage() {}
+
+func (x *MachinePowerOnResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_management_management_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MachinePowerOnResponse.ProtoReflect.Descriptor instead.
+func (*MachinePowerOnResponse) Descriptor() ([]byte, []int) {
+	return file_omni_management_management_proto_rawDescGZIP(), []int{42}
+}
+
 type ListUsersResponse struct {
 	state         protoimpl.MessageState    `protogen:"open.v1"`
 	Users         []*ListUsersResponse_User `protobuf:"bytes,1,rep,name=users,proto3" json:"users,omitempty"`
@@ -2536,7 +2698,7 @@ type ListUsersResponse struct {
 
 func (x *ListUsersResponse) Reset() {
 	*x = ListUsersResponse{}
-	mi := &file_omni_management_management_proto_msgTypes[39]
+	mi := &file_omni_management_management_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2548,7 +2710,7 @@ func (x *ListUsersResponse) String() string {
 func (*ListUsersResponse) ProtoMessage() {}
 
 func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[39]
+	mi := &file_omni_management_management_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2561,7 +2723,7 @@ func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersResponse.ProtoReflect.Descriptor instead.
 func (*ListUsersResponse) Descriptor() ([]byte, []int) {
-	return file_omni_management_management_proto_rawDescGZIP(), []int{39}
+	return file_omni_management_management_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ListUsersResponse) GetUsers() []*ListUsersResponse_User {
@@ -2583,7 +2745,7 @@ type ListServiceAccountsResponse_ServiceAccount struct {
 
 func (x *ListServiceAccountsResponse_ServiceAccount) Reset() {
 	*x = ListServiceAccountsResponse_ServiceAccount{}
-	mi := &file_omni_management_management_proto_msgTypes[40]
+	mi := &file_omni_management_management_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2595,7 +2757,7 @@ func (x *ListServiceAccountsResponse_ServiceAccount) String() string {
 func (*ListServiceAccountsResponse_ServiceAccount) ProtoMessage() {}
 
 func (x *ListServiceAccountsResponse_ServiceAccount) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[40]
+	mi := &file_omni_management_management_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2652,7 +2814,7 @@ type ListServiceAccountsResponse_ServiceAccount_PgpPublicKey struct {
 
 func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) Reset() {
 	*x = ListServiceAccountsResponse_ServiceAccount_PgpPublicKey{}
-	mi := &file_omni_management_management_proto_msgTypes[41]
+	mi := &file_omni_management_management_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2664,7 +2826,7 @@ func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) String() strin
 func (*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) ProtoMessage() {}
 
 func (x *ListServiceAccountsResponse_ServiceAccount_PgpPublicKey) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[41]
+	mi := &file_omni_management_management_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2726,7 +2888,7 @@ type CreateSchematicRequest_Overlay struct {
 
 func (x *CreateSchematicRequest_Overlay) Reset() {
 	*x = CreateSchematicRequest_Overlay{}
-	mi := &file_omni_management_management_proto_msgTypes[42]
+	mi := &file_omni_management_management_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2738,7 +2900,7 @@ func (x *CreateSchematicRequest_Overlay) String() string {
 func (*CreateSchematicRequest_Overlay) ProtoMessage() {}
 
 func (x *CreateSchematicRequest_Overlay) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[42]
+	mi := &file_omni_management_management_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2788,7 +2950,7 @@ type GetSupportBundleResponse_Progress struct {
 
 func (x *GetSupportBundleResponse_Progress) Reset() {
 	*x = GetSupportBundleResponse_Progress{}
-	mi := &file_omni_management_management_proto_msgTypes[44]
+	mi := &file_omni_management_management_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2800,7 +2962,7 @@ func (x *GetSupportBundleResponse_Progress) String() string {
 func (*GetSupportBundleResponse_Progress) ProtoMessage() {}
 
 func (x *GetSupportBundleResponse_Progress) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[44]
+	mi := &file_omni_management_management_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2863,7 +3025,7 @@ type ValidateJsonSchemaResponse_Error struct {
 
 func (x *ValidateJsonSchemaResponse_Error) Reset() {
 	*x = ValidateJsonSchemaResponse_Error{}
-	mi := &file_omni_management_management_proto_msgTypes[45]
+	mi := &file_omni_management_management_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2875,7 +3037,7 @@ func (x *ValidateJsonSchemaResponse_Error) String() string {
 func (*ValidateJsonSchemaResponse_Error) ProtoMessage() {}
 
 func (x *ValidateJsonSchemaResponse_Error) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[45]
+	mi := &file_omni_management_management_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2932,7 +3094,7 @@ type ListUsersResponse_User struct {
 
 func (x *ListUsersResponse_User) Reset() {
 	*x = ListUsersResponse_User{}
-	mi := &file_omni_management_management_proto_msgTypes[46]
+	mi := &file_omni_management_management_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2944,7 +3106,7 @@ func (x *ListUsersResponse_User) String() string {
 func (*ListUsersResponse_User) ProtoMessage() {}
 
 func (x *ListUsersResponse_User) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_management_management_proto_msgTypes[46]
+	mi := &file_omni_management_management_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2957,7 +3119,7 @@ func (x *ListUsersResponse_User) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersResponse_User.ProtoReflect.Descriptor instead.
 func (*ListUsersResponse_User) Descriptor() ([]byte, []int) {
-	return file_omni_management_management_proto_rawDescGZIP(), []int{39, 0}
+	return file_omni_management_management_proto_rawDescGZIP(), []int{43, 0}
 }
 
 func (x *ListUsersResponse_User) GetId() string {
@@ -3202,7 +3364,15 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x05email\x18\x01 \x01(\tR\x05email\x12\x12\n" +
 	"\x04role\x18\x02 \x01(\tR\x04role\"*\n" +
 	"\x12DestroyUserRequest\x12\x14\n" +
-	"\x05email\x18\x01 \x01(\tR\x05email\"\xc5\x02\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\"7\n" +
+	"\x16MachinePowerOffRequest\x12\x1d\n" +
+	"\n" +
+	"machine_id\x18\x01 \x01(\tR\tmachineId\"\x19\n" +
+	"\x17MachinePowerOffResponse\"6\n" +
+	"\x15MachinePowerOnRequest\x12\x1d\n" +
+	"\n" +
+	"machine_id\x18\x01 \x01(\tR\tmachineId\"\x18\n" +
+	"\x16MachinePowerOnResponse\"\xc5\x02\n" +
 	"\x11ListUsersResponse\x128\n" +
 	"\x05users\x18\x01 \x03(\v2\".management.ListUsersResponse.UserR\x05users\x1a\xf5\x01\n" +
 	"\x04User\x12\x0e\n" +
@@ -3241,7 +3411,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x12AuditLogOrderByDir\x12&\n" +
 	"\"AUDIT_LOG_ORDER_BY_DIR_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aAUDIT_LOG_ORDER_BY_DIR_ASC\x10\x01\x12\x1f\n" +
-	"\x1bAUDIT_LOG_ORDER_BY_DIR_DESC\x10\x022\xa4\x10\n" +
+	"\x1bAUDIT_LOG_ORDER_BY_DIR_DESC\x10\x022\xd9\x11\n" +
 	"\x11ManagementService\x12K\n" +
 	"\n" +
 	"Kubeconfig\x12\x1d.management.KubeconfigRequest\x1a\x1e.management.KubeconfigResponse\x12N\n" +
@@ -3269,7 +3439,9 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\tListUsers\x12\x16.google.protobuf.Empty\x1a\x1d.management.ListUsersResponse\x12C\n" +
 	"\n" +
 	"UpdateUser\x12\x1d.management.UpdateUserRequest\x1a\x16.google.protobuf.Empty\x12E\n" +
-	"\vDestroyUser\x12\x1e.management.DestroyUserRequest\x1a\x16.google.protobuf.EmptyB7Z5github.com/siderolabs/omni/client/api/omni/managementb\x06proto3"
+	"\vDestroyUser\x12\x1e.management.DestroyUserRequest\x1a\x16.google.protobuf.Empty\x12Z\n" +
+	"\x0fMachinePowerOff\x12\".management.MachinePowerOffRequest\x1a#.management.MachinePowerOffResponse\x12W\n" +
+	"\x0eMachinePowerOn\x12!.management.MachinePowerOnRequest\x1a\".management.MachinePowerOnResponseB7Z5github.com/siderolabs/omni/client/api/omni/managementb\x06proto3"
 
 var (
 	file_omni_management_management_proto_rawDescOnce sync.Once
@@ -3284,7 +3456,7 @@ func file_omni_management_management_proto_rawDescGZIP() []byte {
 }
 
 var file_omni_management_management_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_omni_management_management_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_omni_management_management_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
 var file_omni_management_management_proto_goTypes = []any{
 	(SchematicBootloader)(0),                                        // 0: management.SchematicBootloader
 	(AuditLogEventType)(0),                                          // 1: management.AuditLogEventType
@@ -3332,53 +3504,57 @@ var file_omni_management_management_proto_goTypes = []any{
 	(*CreateUserResponse)(nil),                                      // 43: management.CreateUserResponse
 	(*UpdateUserRequest)(nil),                                       // 44: management.UpdateUserRequest
 	(*DestroyUserRequest)(nil),                                      // 45: management.DestroyUserRequest
-	(*ListUsersResponse)(nil),                                       // 46: management.ListUsersResponse
-	(*ListServiceAccountsResponse_ServiceAccount)(nil),              // 47: management.ListServiceAccountsResponse.ServiceAccount
-	(*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey)(nil), // 48: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	(*CreateSchematicRequest_Overlay)(nil),                          // 49: management.CreateSchematicRequest.Overlay
-	nil,                                                             // 50: management.CreateSchematicRequest.MetaValuesEntry
-	(*GetSupportBundleResponse_Progress)(nil),                       // 51: management.GetSupportBundleResponse.Progress
-	(*ValidateJsonSchemaResponse_Error)(nil),                        // 52: management.ValidateJsonSchemaResponse.Error
-	(*ListUsersResponse_User)(nil),                                  // 53: management.ListUsersResponse.User
-	nil,                                                             // 54: management.ListUsersResponse.User.SamlLabelsEntry
-	(*durationpb.Duration)(nil),                                     // 55: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),                                   // 56: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                                           // 57: google.protobuf.Empty
-	(*common.Data)(nil),                                             // 58: common.Data
+	(*MachinePowerOffRequest)(nil),                                  // 46: management.MachinePowerOffRequest
+	(*MachinePowerOffResponse)(nil),                                 // 47: management.MachinePowerOffResponse
+	(*MachinePowerOnRequest)(nil),                                   // 48: management.MachinePowerOnRequest
+	(*MachinePowerOnResponse)(nil),                                  // 49: management.MachinePowerOnResponse
+	(*ListUsersResponse)(nil),                                       // 50: management.ListUsersResponse
+	(*ListServiceAccountsResponse_ServiceAccount)(nil),              // 51: management.ListServiceAccountsResponse.ServiceAccount
+	(*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey)(nil), // 52: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
+	(*CreateSchematicRequest_Overlay)(nil),                          // 53: management.CreateSchematicRequest.Overlay
+	nil,                                                             // 54: management.CreateSchematicRequest.MetaValuesEntry
+	(*GetSupportBundleResponse_Progress)(nil),                       // 55: management.GetSupportBundleResponse.Progress
+	(*ValidateJsonSchemaResponse_Error)(nil),                        // 56: management.ValidateJsonSchemaResponse.Error
+	(*ListUsersResponse_User)(nil),                                  // 57: management.ListUsersResponse.User
+	nil,                                                             // 58: management.ListUsersResponse.User.SamlLabelsEntry
+	(*durationpb.Duration)(nil),                                     // 59: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),                                   // 60: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),                                           // 61: google.protobuf.Empty
+	(*common.Data)(nil),                                             // 62: common.Data
 }
 var file_omni_management_management_proto_depIdxs = []int32{
-	47, // 0: management.ListServiceAccountsResponse.service_accounts:type_name -> management.ListServiceAccountsResponse.ServiceAccount
-	55, // 1: management.KubeconfigRequest.service_account_ttl:type_name -> google.protobuf.Duration
+	51, // 0: management.ListServiceAccountsResponse.service_accounts:type_name -> management.ListServiceAccountsResponse.ServiceAccount
+	59, // 1: management.KubeconfigRequest.service_account_ttl:type_name -> google.protobuf.Duration
 	4,  // 2: management.KubernetesSSAOptions.inventory_policy:type_name -> management.KubernetesSSAOptions.InventoryPolicy
-	55, // 3: management.KubernetesSSAOptions.reconcile_timeout:type_name -> google.protobuf.Duration
+	59, // 3: management.KubernetesSSAOptions.reconcile_timeout:type_name -> google.protobuf.Duration
 	22, // 4: management.KubernetesSyncManifestRequest.ssa:type_name -> management.KubernetesSSAOptions
 	5,  // 5: management.KubernetesSyncManifestResponse.response_type:type_name -> management.KubernetesSyncManifestResponse.ResponseType
-	50, // 6: management.CreateSchematicRequest.meta_values:type_name -> management.CreateSchematicRequest.MetaValuesEntry
+	54, // 6: management.CreateSchematicRequest.meta_values:type_name -> management.CreateSchematicRequest.MetaValuesEntry
 	6,  // 7: management.CreateSchematicRequest.siderolink_grpc_tunnel_mode:type_name -> management.CreateSchematicRequest.SiderolinkGRPCTunnelMode
-	49, // 8: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
+	53, // 8: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
 	0,  // 9: management.CreateSchematicRequest.bootloader:type_name -> management.SchematicBootloader
-	51, // 10: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
+	55, // 10: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
 	2,  // 11: management.ReadAuditLogRequest.order_by_field:type_name -> management.AuditLogOrderByField
 	3,  // 12: management.ReadAuditLogRequest.order_by_dir:type_name -> management.AuditLogOrderByDir
 	1,  // 13: management.ReadAuditLogRequest.event_type:type_name -> management.AuditLogEventType
-	52, // 14: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	56, // 15: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
-	53, // 16: management.ListUsersResponse.users:type_name -> management.ListUsersResponse.User
-	48, // 17: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	56, // 18: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
-	56, // 19: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.created:type_name -> google.protobuf.Timestamp
-	56, // 20: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.last_used:type_name -> google.protobuf.Timestamp
-	52, // 21: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	54, // 22: management.ListUsersResponse.User.saml_labels:type_name -> management.ListUsersResponse.User.SamlLabelsEntry
+	56, // 14: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	60, // 15: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
+	57, // 16: management.ListUsersResponse.users:type_name -> management.ListUsersResponse.User
+	52, // 17: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
+	60, // 18: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
+	60, // 19: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.created:type_name -> google.protobuf.Timestamp
+	60, // 20: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.last_used:type_name -> google.protobuf.Timestamp
+	56, // 21: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	58, // 22: management.ListUsersResponse.User.saml_labels:type_name -> management.ListUsersResponse.User.SamlLabelsEntry
 	19, // 23: management.ManagementService.Kubeconfig:input_type -> management.KubeconfigRequest
 	12, // 24: management.ManagementService.Talosconfig:input_type -> management.TalosconfigRequest
-	57, // 25: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
+	61, // 25: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
 	10, // 26: management.ManagementService.MachineLogs:input_type -> management.MachineLogsRequest
 	11, // 27: management.ManagementService.ValidateConfig:input_type -> management.ValidateConfigRequest
 	31, // 28: management.ManagementService.ValidateJSONSchema:input_type -> management.ValidateJsonSchemaRequest
 	13, // 29: management.ManagementService.CreateServiceAccount:input_type -> management.CreateServiceAccountRequest
 	15, // 30: management.ManagementService.RenewServiceAccount:input_type -> management.RenewServiceAccountRequest
-	57, // 31: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
+	61, // 31: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
 	17, // 32: management.ManagementService.DestroyServiceAccount:input_type -> management.DestroyServiceAccountRequest
 	20, // 33: management.ManagementService.KubernetesUpgradePreChecks:input_type -> management.KubernetesUpgradePreChecksRequest
 	23, // 34: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
@@ -3390,34 +3566,38 @@ var file_omni_management_management_proto_depIdxs = []int32{
 	38, // 40: management.ManagementService.CreateJoinToken:input_type -> management.CreateJoinTokenRequest
 	40, // 41: management.ManagementService.ResetNodeUniqueToken:input_type -> management.ResetNodeUniqueTokenRequest
 	42, // 42: management.ManagementService.CreateUser:input_type -> management.CreateUserRequest
-	57, // 43: management.ManagementService.ListUsers:input_type -> google.protobuf.Empty
+	61, // 43: management.ManagementService.ListUsers:input_type -> google.protobuf.Empty
 	44, // 44: management.ManagementService.UpdateUser:input_type -> management.UpdateUserRequest
 	45, // 45: management.ManagementService.DestroyUser:input_type -> management.DestroyUserRequest
-	7,  // 46: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
-	8,  // 47: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
-	9,  // 48: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
-	58, // 49: management.ManagementService.MachineLogs:output_type -> common.Data
-	57, // 50: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
-	32, // 51: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
-	14, // 52: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
-	16, // 53: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
-	18, // 54: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
-	57, // 55: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
-	21, // 56: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
-	24, // 57: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
-	26, // 58: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
-	28, // 59: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
-	30, // 60: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
-	34, // 61: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
-	36, // 62: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
-	39, // 63: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
-	41, // 64: management.ManagementService.ResetNodeUniqueToken:output_type -> management.ResetNodeUniqueTokenResponse
-	43, // 65: management.ManagementService.CreateUser:output_type -> management.CreateUserResponse
-	46, // 66: management.ManagementService.ListUsers:output_type -> management.ListUsersResponse
-	57, // 67: management.ManagementService.UpdateUser:output_type -> google.protobuf.Empty
-	57, // 68: management.ManagementService.DestroyUser:output_type -> google.protobuf.Empty
-	46, // [46:69] is the sub-list for method output_type
-	23, // [23:46] is the sub-list for method input_type
+	46, // 46: management.ManagementService.MachinePowerOff:input_type -> management.MachinePowerOffRequest
+	48, // 47: management.ManagementService.MachinePowerOn:input_type -> management.MachinePowerOnRequest
+	7,  // 48: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
+	8,  // 49: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
+	9,  // 50: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
+	62, // 51: management.ManagementService.MachineLogs:output_type -> common.Data
+	61, // 52: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
+	32, // 53: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
+	14, // 54: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
+	16, // 55: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
+	18, // 56: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
+	61, // 57: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
+	21, // 58: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
+	24, // 59: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
+	26, // 60: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
+	28, // 61: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
+	30, // 62: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
+	34, // 63: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
+	36, // 64: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
+	39, // 65: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
+	41, // 66: management.ManagementService.ResetNodeUniqueToken:output_type -> management.ResetNodeUniqueTokenResponse
+	43, // 67: management.ManagementService.CreateUser:output_type -> management.CreateUserResponse
+	50, // 68: management.ManagementService.ListUsers:output_type -> management.ListUsersResponse
+	61, // 69: management.ManagementService.UpdateUser:output_type -> google.protobuf.Empty
+	61, // 70: management.ManagementService.DestroyUser:output_type -> google.protobuf.Empty
+	47, // 71: management.ManagementService.MachinePowerOff:output_type -> management.MachinePowerOffResponse
+	49, // 72: management.ManagementService.MachinePowerOn:output_type -> management.MachinePowerOnResponse
+	48, // [48:73] is the sub-list for method output_type
+	23, // [23:48] is the sub-list for method input_type
 	23, // [23:23] is the sub-list for extension type_name
 	23, // [23:23] is the sub-list for extension extendee
 	0,  // [0:23] is the sub-list for field type_name
@@ -3434,7 +3614,7 @@ func file_omni_management_management_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_omni_management_management_proto_rawDesc), len(file_omni_management_management_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   48,
+			NumMessages:   52,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/client/api/omni/management/management.pb.gw.go
+++ b/client/api/omni/management/management.pb.gw.go
@@ -641,6 +641,60 @@ func local_request_ManagementService_DestroyUser_0(ctx context.Context, marshale
 	return msg, metadata, err
 }
 
+func request_ManagementService_MachinePowerOff_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq MachinePowerOffRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.MachinePowerOff(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ManagementService_MachinePowerOff_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq MachinePowerOffRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.MachinePowerOff(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ManagementService_MachinePowerOn_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq MachinePowerOnRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.MachinePowerOn(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ManagementService_MachinePowerOn_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq MachinePowerOnRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.MachinePowerOn(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterManagementServiceHandlerServer registers the http handlers for service ManagementService to "mux".
 // UnaryRPC     :call ManagementServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -1054,6 +1108,46 @@ func RegisterManagementServiceHandlerServer(ctx context.Context, mux *runtime.Se
 			return
 		}
 		forward_ManagementService_DestroyUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_MachinePowerOff_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/MachinePowerOff", runtime.WithHTTPPathPattern("/management.ManagementService/MachinePowerOff"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ManagementService_MachinePowerOff_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_MachinePowerOff_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_MachinePowerOn_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/MachinePowerOn", runtime.WithHTTPPathPattern("/management.ManagementService/MachinePowerOn"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ManagementService_MachinePowerOn_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_MachinePowerOn_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -1486,6 +1580,40 @@ func RegisterManagementServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_ManagementService_DestroyUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_MachinePowerOff_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/MachinePowerOff", runtime.WithHTTPPathPattern("/management.ManagementService/MachinePowerOff"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ManagementService_MachinePowerOff_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_MachinePowerOff_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ManagementService_MachinePowerOn_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/MachinePowerOn", runtime.WithHTTPPathPattern("/management.ManagementService/MachinePowerOn"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ManagementService_MachinePowerOn_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ManagementService_MachinePowerOn_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1513,6 +1641,8 @@ var (
 	pattern_ManagementService_ListUsers_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "ListUsers"}, ""))
 	pattern_ManagementService_UpdateUser_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "UpdateUser"}, ""))
 	pattern_ManagementService_DestroyUser_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "DestroyUser"}, ""))
+	pattern_ManagementService_MachinePowerOff_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "MachinePowerOff"}, ""))
+	pattern_ManagementService_MachinePowerOn_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "MachinePowerOn"}, ""))
 )
 
 var (
@@ -1539,4 +1669,6 @@ var (
 	forward_ManagementService_ListUsers_0                  = runtime.ForwardResponseMessage
 	forward_ManagementService_UpdateUser_0                 = runtime.ForwardResponseMessage
 	forward_ManagementService_DestroyUser_0                = runtime.ForwardResponseMessage
+	forward_ManagementService_MachinePowerOff_0            = runtime.ForwardResponseMessage
+	forward_ManagementService_MachinePowerOn_0             = runtime.ForwardResponseMessage
 )

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -316,6 +316,20 @@ message DestroyUserRequest {
   string email = 1;
 }
 
+message MachinePowerOffRequest {
+  // MachineId is the ID of the machine to power off (shutdown).
+  string machine_id = 1;
+}
+
+message MachinePowerOffResponse {}
+
+message MachinePowerOnRequest {
+  // MachineId is the ID of the machine to power on.
+  string machine_id = 1;
+}
+
+message MachinePowerOnResponse {}
+
 message ListUsersResponse {
   message User {
     string id = 1;
@@ -352,4 +366,6 @@ service ManagementService {
   rpc ListUsers(google.protobuf.Empty) returns (ListUsersResponse);
   rpc UpdateUser(UpdateUserRequest) returns (google.protobuf.Empty);
   rpc DestroyUser(DestroyUserRequest) returns (google.protobuf.Empty);
+  rpc MachinePowerOff(MachinePowerOffRequest) returns (MachinePowerOffResponse);
+  rpc MachinePowerOn(MachinePowerOnRequest) returns (MachinePowerOnResponse);
 }

--- a/client/api/omni/management/management_grpc.pb.go
+++ b/client/api/omni/management/management_grpc.pb.go
@@ -45,6 +45,8 @@ const (
 	ManagementService_ListUsers_FullMethodName                  = "/management.ManagementService/ListUsers"
 	ManagementService_UpdateUser_FullMethodName                 = "/management.ManagementService/UpdateUser"
 	ManagementService_DestroyUser_FullMethodName                = "/management.ManagementService/DestroyUser"
+	ManagementService_MachinePowerOff_FullMethodName            = "/management.ManagementService/MachinePowerOff"
+	ManagementService_MachinePowerOn_FullMethodName             = "/management.ManagementService/MachinePowerOn"
 )
 
 // ManagementServiceClient is the client API for ManagementService service.
@@ -74,6 +76,8 @@ type ManagementServiceClient interface {
 	ListUsers(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListUsersResponse, error)
 	UpdateUser(ctx context.Context, in *UpdateUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	DestroyUser(ctx context.Context, in *DestroyUserRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	MachinePowerOff(ctx context.Context, in *MachinePowerOffRequest, opts ...grpc.CallOption) (*MachinePowerOffResponse, error)
+	MachinePowerOn(ctx context.Context, in *MachinePowerOnRequest, opts ...grpc.CallOption) (*MachinePowerOnResponse, error)
 }
 
 type managementServiceClient struct {
@@ -350,6 +354,26 @@ func (c *managementServiceClient) DestroyUser(ctx context.Context, in *DestroyUs
 	return out, nil
 }
 
+func (c *managementServiceClient) MachinePowerOff(ctx context.Context, in *MachinePowerOffRequest, opts ...grpc.CallOption) (*MachinePowerOffResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MachinePowerOffResponse)
+	err := c.cc.Invoke(ctx, ManagementService_MachinePowerOff_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *managementServiceClient) MachinePowerOn(ctx context.Context, in *MachinePowerOnRequest, opts ...grpc.CallOption) (*MachinePowerOnResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MachinePowerOnResponse)
+	err := c.cc.Invoke(ctx, ManagementService_MachinePowerOn_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ManagementServiceServer is the server API for ManagementService service.
 // All implementations must embed UnimplementedManagementServiceServer
 // for forward compatibility.
@@ -377,6 +401,8 @@ type ManagementServiceServer interface {
 	ListUsers(context.Context, *emptypb.Empty) (*ListUsersResponse, error)
 	UpdateUser(context.Context, *UpdateUserRequest) (*emptypb.Empty, error)
 	DestroyUser(context.Context, *DestroyUserRequest) (*emptypb.Empty, error)
+	MachinePowerOff(context.Context, *MachinePowerOffRequest) (*MachinePowerOffResponse, error)
+	MachinePowerOn(context.Context, *MachinePowerOnRequest) (*MachinePowerOnResponse, error)
 	mustEmbedUnimplementedManagementServiceServer()
 }
 
@@ -455,6 +481,12 @@ func (UnimplementedManagementServiceServer) UpdateUser(context.Context, *UpdateU
 }
 func (UnimplementedManagementServiceServer) DestroyUser(context.Context, *DestroyUserRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method DestroyUser not implemented")
+}
+func (UnimplementedManagementServiceServer) MachinePowerOff(context.Context, *MachinePowerOffRequest) (*MachinePowerOffResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method MachinePowerOff not implemented")
+}
+func (UnimplementedManagementServiceServer) MachinePowerOn(context.Context, *MachinePowerOnRequest) (*MachinePowerOnResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method MachinePowerOn not implemented")
 }
 func (UnimplementedManagementServiceServer) mustEmbedUnimplementedManagementServiceServer() {}
 func (UnimplementedManagementServiceServer) testEmbeddedByValue()                           {}
@@ -863,6 +895,42 @@ func _ManagementService_DestroyUser_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ManagementService_MachinePowerOff_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MachinePowerOffRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).MachinePowerOff(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_MachinePowerOff_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).MachinePowerOff(ctx, req.(*MachinePowerOffRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ManagementService_MachinePowerOn_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MachinePowerOnRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ManagementServiceServer).MachinePowerOn(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ManagementService_MachinePowerOn_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ManagementServiceServer).MachinePowerOn(ctx, req.(*MachinePowerOnRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ManagementService_ServiceDesc is the grpc.ServiceDesc for ManagementService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -945,6 +1013,14 @@ var ManagementService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DestroyUser",
 			Handler:    _ManagementService_DestroyUser_Handler,
+		},
+		{
+			MethodName: "MachinePowerOff",
+			Handler:    _ManagementService_MachinePowerOff_Handler,
+		},
+		{
+			MethodName: "MachinePowerOn",
+			Handler:    _ManagementService_MachinePowerOn_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -908,6 +908,72 @@ func (m *DestroyUserRequest) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *MachinePowerOffRequest) CloneVT() *MachinePowerOffRequest {
+	if m == nil {
+		return (*MachinePowerOffRequest)(nil)
+	}
+	r := new(MachinePowerOffRequest)
+	r.MachineId = m.MachineId
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *MachinePowerOffRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *MachinePowerOffResponse) CloneVT() *MachinePowerOffResponse {
+	if m == nil {
+		return (*MachinePowerOffResponse)(nil)
+	}
+	r := new(MachinePowerOffResponse)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *MachinePowerOffResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *MachinePowerOnRequest) CloneVT() *MachinePowerOnRequest {
+	if m == nil {
+		return (*MachinePowerOnRequest)(nil)
+	}
+	r := new(MachinePowerOnRequest)
+	r.MachineId = m.MachineId
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *MachinePowerOnRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *MachinePowerOnResponse) CloneVT() *MachinePowerOnResponse {
+	if m == nil {
+		return (*MachinePowerOnResponse)(nil)
+	}
+	r := new(MachinePowerOnResponse)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *MachinePowerOnResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ListUsersResponse_User) CloneVT() *ListUsersResponse_User {
 	if m == nil {
 		return (*ListUsersResponse_User)(nil)
@@ -2076,6 +2142,76 @@ func (this *DestroyUserRequest) EqualVT(that *DestroyUserRequest) bool {
 
 func (this *DestroyUserRequest) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*DestroyUserRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *MachinePowerOffRequest) EqualVT(that *MachinePowerOffRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.MachineId != that.MachineId {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *MachinePowerOffRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*MachinePowerOffRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *MachinePowerOffResponse) EqualVT(that *MachinePowerOffResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *MachinePowerOffResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*MachinePowerOffResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *MachinePowerOnRequest) EqualVT(that *MachinePowerOnRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.MachineId != that.MachineId {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *MachinePowerOnRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*MachinePowerOnRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *MachinePowerOnResponse) EqualVT(that *MachinePowerOnResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *MachinePowerOnResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*MachinePowerOnResponse)
 	if !ok {
 		return false
 	}
@@ -4466,6 +4602,152 @@ func (m *DestroyUserRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *MachinePowerOffRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MachinePowerOffRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *MachinePowerOffRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.MachineId) > 0 {
+		i -= len(m.MachineId)
+		copy(dAtA[i:], m.MachineId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MachineId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MachinePowerOffResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MachinePowerOffResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *MachinePowerOffResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MachinePowerOnRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MachinePowerOnRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *MachinePowerOnRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.MachineId) > 0 {
+		i -= len(m.MachineId)
+		copy(dAtA[i:], m.MachineId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MachineId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MachinePowerOnResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MachinePowerOnResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *MachinePowerOnResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ListUsersResponse_User) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -5462,6 +5744,54 @@ func (m *DestroyUserRequest) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *MachinePowerOffRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.MachineId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *MachinePowerOffResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *MachinePowerOnRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.MachineId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *MachinePowerOnResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
 	n += len(m.unknownFields)
 	return n
 }
@@ -11085,6 +11415,274 @@ func (m *DestroyUserRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Email = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MachinePowerOffRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MachinePowerOffRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MachinePowerOffRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MachineId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MachineId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MachinePowerOffResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MachinePowerOffResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MachinePowerOffResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MachinePowerOnRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MachinePowerOnRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MachinePowerOnRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MachineId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MachineId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MachinePowerOnResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MachinePowerOnResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MachinePowerOnResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/api/omni/specs/infra.pb.go
+++ b/client/api/omni/specs/infra.pb.go
@@ -353,8 +353,15 @@ type InfraMachineSpec struct {
 	InstallEventId uint64 `protobuf:"varint,9,opt,name=install_event_id,json=installEventId,proto3" json:"install_event_id,omitempty"`
 	// NodeUniqueToken is copied from the corresponding siderolink.Link resource.
 	NodeUniqueToken string `protobuf:"bytes,10,opt,name=node_unique_token,json=nodeUniqueToken,proto3" json:"node_unique_token,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// PowerOffRequestId is generally copied from InfraMachineConfig. Omni may clear this field on the
+	// InfraMachine spec when the machine is unallocated or being deallocated, even if the config field
+	// remains set. When non-empty, the infra provider should not power on the machine due to cluster
+	// allocation alone. The provider determines if the request is still valid by comparing the wipe_id at
+	// the time of acknowledgment with the current one: if the machine went through a deallocation cycle
+	// (wipe_id changed), the request is considered stale.
+	PowerOffRequestId string `protobuf:"bytes,11,opt,name=power_off_request_id,json=powerOffRequestId,proto3" json:"power_off_request_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *InfraMachineSpec) Reset() {
@@ -457,6 +464,13 @@ func (x *InfraMachineSpec) GetNodeUniqueToken() string {
 	return ""
 }
 
+func (x *InfraMachineSpec) GetPowerOffRequestId() string {
+	if x != nil {
+		return x.PowerOffRequestId
+	}
+	return ""
+}
+
 type InfraMachineStateSpec struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Installed     bool                   `protobuf:"varint,1,opt,name=installed,proto3" json:"installed,omitempty"`
@@ -512,8 +526,13 @@ type InfraMachineStatusSpec struct {
 	// WipedNodeUniqueToken is updated when the bare metal infra provider wipes the machine.
 	// It reads the current token from the infra.Machine resource and updates it here.
 	WipedNodeUniqueToken string `protobuf:"bytes,6,opt,name=wiped_node_unique_token,json=wipedNodeUniqueToken,proto3" json:"wiped_node_unique_token,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// LastPowerOffId is the power-off request ID that the infra provider is currently honoring.
+	// It is empty if the provider is not honoring any power-off request, either because there is no
+	// active request or because the provider considers the current request stale (e.g., due to the
+	// machine going through a deallocation cycle since the request was acknowledged).
+	LastPowerOffId string `protobuf:"bytes,7,opt,name=last_power_off_id,json=lastPowerOffId,proto3" json:"last_power_off_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *InfraMachineStatusSpec) Reset() {
@@ -584,6 +603,13 @@ func (x *InfraMachineStatusSpec) GetInstalled() bool {
 func (x *InfraMachineStatusSpec) GetWipedNodeUniqueToken() string {
 	if x != nil {
 		return x.WipedNodeUniqueToken
+	}
+	return ""
+}
+
+func (x *InfraMachineStatusSpec) GetLastPowerOffId() string {
+	if x != nil {
+		return x.LastPowerOffId
 	}
 	return ""
 }
@@ -852,7 +878,7 @@ const file_omni_specs_infra_proto_rawDesc = "" +
 	"\fPROVISIONING\x10\x01\x12\x0f\n" +
 	"\vPROVISIONED\x10\x02\x12\n" +
 	"\n" +
-	"\x06FAILED\x10\x03\"\xc7\x04\n" +
+	"\x06FAILED\x10\x03\"\xf8\x04\n" +
 	"\x10InfraMachineSpec\x12]\n" +
 	"\x15preferred_power_state\x18\x01 \x01(\x0e2).specs.InfraMachineSpec.MachinePowerStateR\x13preferredPowerState\x12[\n" +
 	"\x11acceptance_status\x18\x02 \x01(\x0e2..specs.InfraMachineConfigSpec.AcceptanceStatusR\x10acceptanceStatus\x122\n" +
@@ -866,12 +892,13 @@ const file_omni_specs_infra_proto_rawDesc = "" +
 	"\bcordoned\x18\b \x01(\bR\bcordoned\x12(\n" +
 	"\x10install_event_id\x18\t \x01(\x04R\x0einstallEventId\x12*\n" +
 	"\x11node_unique_token\x18\n" +
-	" \x01(\tR\x0fnodeUniqueToken\"<\n" +
+	" \x01(\tR\x0fnodeUniqueToken\x12/\n" +
+	"\x14power_off_request_id\x18\v \x01(\tR\x11powerOffRequestId\"<\n" +
 	"\x11MachinePowerState\x12\x13\n" +
 	"\x0fPOWER_STATE_OFF\x10\x00\x12\x12\n" +
 	"\x0ePOWER_STATE_ON\x10\x01\"5\n" +
 	"\x15InfraMachineStateSpec\x12\x1c\n" +
-	"\tinstalled\x18\x01 \x01(\bR\tinstalled\"\xae\x03\n" +
+	"\tinstalled\x18\x01 \x01(\bR\tinstalled\"\xd9\x03\n" +
 	"\x16InfraMachineStatusSpec\x12P\n" +
 	"\vpower_state\x18\x01 \x01(\x0e2/.specs.InfraMachineStatusSpec.MachinePowerStateR\n" +
 	"powerState\x12 \n" +
@@ -880,7 +907,8 @@ const file_omni_specs_infra_proto_rawDesc = "" +
 	"\x0elast_reboot_id\x18\x03 \x01(\tR\flastRebootId\x12N\n" +
 	"\x15last_reboot_timestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x13lastRebootTimestamp\x12\x1c\n" +
 	"\tinstalled\x18\x05 \x01(\bR\tinstalled\x125\n" +
-	"\x17wiped_node_unique_token\x18\x06 \x01(\tR\x14wipedNodeUniqueToken\"U\n" +
+	"\x17wiped_node_unique_token\x18\x06 \x01(\tR\x14wipedNodeUniqueToken\x12)\n" +
+	"\x11last_power_off_id\x18\a \x01(\tR\x0elastPowerOffId\"U\n" +
 	"\x11MachinePowerState\x12\x17\n" +
 	"\x13POWER_STATE_UNKNOWN\x10\x00\x12\x13\n" +
 	"\x0fPOWER_STATE_OFF\x10\x01\x12\x12\n" +

--- a/client/api/omni/specs/infra.proto
+++ b/client/api/omni/specs/infra.proto
@@ -61,6 +61,14 @@ message InfraMachineSpec {
 
   // NodeUniqueToken is copied from the corresponding siderolink.Link resource.
   string node_unique_token = 10;
+
+  // PowerOffRequestId is generally copied from InfraMachineConfig. Omni may clear this field on the
+  // InfraMachine spec when the machine is unallocated or being deallocated, even if the config field
+  // remains set. When non-empty, the infra provider should not power on the machine due to cluster
+  // allocation alone. The provider determines if the request is still valid by comparing the wipe_id at
+  // the time of acknowledgment with the current one: if the machine went through a deallocation cycle
+  // (wipe_id changed), the request is considered stale.
+  string power_off_request_id = 11;
 }
 
 message InfraMachineStateSpec {
@@ -84,6 +92,12 @@ message InfraMachineStatusSpec {
   // WipedNodeUniqueToken is updated when the bare metal infra provider wipes the machine.
   // It reads the current token from the infra.Machine resource and updates it here.
   string wiped_node_unique_token = 6;
+
+  // LastPowerOffId is the power-off request ID that the infra provider is currently honoring.
+  // It is empty if the provider is not honoring any power-off request, either because there is no
+  // active request or because the provider considers the current request stale (e.g., due to the
+  // machine going through a deallocation cycle since the request was acknowledged).
+  string last_power_off_id = 7;
 }
 
 message InfraProviderSpec {}

--- a/client/api/omni/specs/infra_vtproto.pb.go
+++ b/client/api/omni/specs/infra_vtproto.pb.go
@@ -93,6 +93,7 @@ func (m *InfraMachineSpec) CloneVT() *InfraMachineSpec {
 	r.Cordoned = m.Cordoned
 	r.InstallEventId = m.InstallEventId
 	r.NodeUniqueToken = m.NodeUniqueToken
+	r.PowerOffRequestId = m.PowerOffRequestId
 	if rhs := m.Extensions; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -137,6 +138,7 @@ func (m *InfraMachineStatusSpec) CloneVT() *InfraMachineStatusSpec {
 	r.LastRebootTimestamp = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.LastRebootTimestamp).CloneVT())
 	r.Installed = m.Installed
 	r.WipedNodeUniqueToken = m.WipedNodeUniqueToken
+	r.LastPowerOffId = m.LastPowerOffId
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -368,6 +370,9 @@ func (this *InfraMachineSpec) EqualVT(that *InfraMachineSpec) bool {
 	if this.NodeUniqueToken != that.NodeUniqueToken {
 		return false
 	}
+	if this.PowerOffRequestId != that.PowerOffRequestId {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -419,6 +424,9 @@ func (this *InfraMachineStatusSpec) EqualVT(that *InfraMachineStatusSpec) bool {
 		return false
 	}
 	if this.WipedNodeUniqueToken != that.WipedNodeUniqueToken {
+		return false
+	}
+	if this.LastPowerOffId != that.LastPowerOffId {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -713,6 +721,13 @@ func (m *InfraMachineSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.PowerOffRequestId) > 0 {
+		i -= len(m.PowerOffRequestId)
+		copy(dAtA[i:], m.PowerOffRequestId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PowerOffRequestId)))
+		i--
+		dAtA[i] = 0x5a
+	}
 	if len(m.NodeUniqueToken) > 0 {
 		i -= len(m.NodeUniqueToken)
 		copy(dAtA[i:], m.NodeUniqueToken)
@@ -857,6 +872,13 @@ func (m *InfraMachineStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.LastPowerOffId) > 0 {
+		i -= len(m.LastPowerOffId)
+		copy(dAtA[i:], m.LastPowerOffId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.LastPowerOffId)))
+		i--
+		dAtA[i] = 0x3a
 	}
 	if len(m.WipedNodeUniqueToken) > 0 {
 		i -= len(m.WipedNodeUniqueToken)
@@ -1242,6 +1264,10 @@ func (m *InfraMachineSpec) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.PowerOffRequestId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1283,6 +1309,10 @@ func (m *InfraMachineStatusSpec) SizeVT() (n int) {
 		n += 2
 	}
 	l = len(m.WipedNodeUniqueToken)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.LastPowerOffId)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -2100,6 +2130,38 @@ func (m *InfraMachineSpec) UnmarshalVT(dAtA []byte) error {
 			}
 			m.NodeUniqueToken = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PowerOffRequestId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PowerOffRequestId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2380,6 +2442,38 @@ func (m *InfraMachineStatusSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.WipedNodeUniqueToken = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastPowerOffId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.LastPowerOffId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -7312,6 +7312,11 @@ type InfraMachineConfigSpec struct {
 	ExtraKernelArgs   string                                   `protobuf:"bytes,3,opt,name=extra_kernel_args,json=extraKernelArgs,proto3" json:"extra_kernel_args,omitempty"`
 	RequestedRebootId string                                   `protobuf:"bytes,4,opt,name=requested_reboot_id,json=requestedRebootId,proto3" json:"requested_reboot_id,omitempty"`
 	Cordoned          bool                                     `protobuf:"varint,5,opt,name=cordoned,proto3" json:"cordoned,omitempty"`
+	// PowerOffRequestId is set to a new UUID each time the user requests the machine to be powered off (shutdown).
+	//
+	// This is used by Omni to signal the infra provider to not power the machine back on after a shutdown,
+	// even when the machine is allocated to a cluster.
+	PowerOffRequestId string `protobuf:"bytes,6,opt,name=power_off_request_id,json=powerOffRequestId,proto3" json:"power_off_request_id,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -7379,6 +7384,13 @@ func (x *InfraMachineConfigSpec) GetCordoned() bool {
 		return x.Cordoned
 	}
 	return false
+}
+
+func (x *InfraMachineConfigSpec) GetPowerOffRequestId() string {
+	if x != nil {
+		return x.PowerOffRequestId
+	}
+	return ""
 }
 
 type InfraMachineBMCConfigSpec struct {
@@ -11757,14 +11769,15 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\vPROVISIONED\x10\x03\x12\x12\n" +
 	"\x0eDEPROVISIONING\x10\x04\x12\n" +
 	"\n" +
-	"\x06FAILED\x10\x05\"\xd3\x03\n" +
+	"\x06FAILED\x10\x05\"\x84\x04\n" +
 	"\x16InfraMachineConfigSpec\x12P\n" +
 	"\vpower_state\x18\x01 \x01(\x0e2/.specs.InfraMachineConfigSpec.MachinePowerStateR\n" +
 	"powerState\x12[\n" +
 	"\x11acceptance_status\x18\x02 \x01(\x0e2..specs.InfraMachineConfigSpec.AcceptanceStatusR\x10acceptanceStatus\x12*\n" +
 	"\x11extra_kernel_args\x18\x03 \x01(\tR\x0fextraKernelArgs\x12.\n" +
 	"\x13requested_reboot_id\x18\x04 \x01(\tR\x11requestedRebootId\x12\x1a\n" +
-	"\bcordoned\x18\x05 \x01(\bR\bcordoned\";\n" +
+	"\bcordoned\x18\x05 \x01(\bR\bcordoned\x12/\n" +
+	"\x14power_off_request_id\x18\x06 \x01(\tR\x11powerOffRequestId\";\n" +
 	"\x10AcceptanceStatus\x12\v\n" +
 	"\aPENDING\x10\x00\x12\f\n" +
 	"\bACCEPTED\x10\x01\x12\f\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1467,6 +1467,12 @@ message InfraMachineConfigSpec {
   string extra_kernel_args = 3;
   string requested_reboot_id = 4;
   bool cordoned = 5;
+
+  // PowerOffRequestId is set to a new UUID each time the user requests the machine to be powered off (shutdown).
+  //
+  // This is used by Omni to signal the infra provider to not power the machine back on after a shutdown,
+  // even when the machine is allocated to a cluster.
+  string power_off_request_id = 6;
 }
 
 message InfraMachineBMCConfigSpec {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -2715,6 +2715,7 @@ func (m *InfraMachineConfigSpec) CloneVT() *InfraMachineConfigSpec {
 	r.ExtraKernelArgs = m.ExtraKernelArgs
 	r.RequestedRebootId = m.RequestedRebootId
 	r.Cordoned = m.Cordoned
+	r.PowerOffRequestId = m.PowerOffRequestId
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -6956,6 +6957,9 @@ func (this *InfraMachineConfigSpec) EqualVT(that *InfraMachineConfigSpec) bool {
 		return false
 	}
 	if this.Cordoned != that.Cordoned {
+		return false
+	}
+	if this.PowerOffRequestId != that.PowerOffRequestId {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -14923,6 +14927,13 @@ func (m *InfraMachineConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.PowerOffRequestId) > 0 {
+		i -= len(m.PowerOffRequestId)
+		copy(dAtA[i:], m.PowerOffRequestId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PowerOffRequestId)))
+		i--
+		dAtA[i] = 0x32
+	}
 	if m.Cordoned {
 		i--
 		if m.Cordoned {
@@ -19187,6 +19198,10 @@ func (m *InfraMachineConfigSpec) SizeVT() (n int) {
 	}
 	if m.Cordoned {
 		n += 2
+	}
+	l = len(m.PowerOffRequestId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -38247,6 +38262,38 @@ func (m *InfraMachineConfigSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Cordoned = bool(v != 0)
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PowerOffRequestId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PowerOffRequestId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/client/management/management.go
+++ b/client/pkg/client/management/management.go
@@ -312,6 +312,25 @@ func (client *Client) ResetNodeUniqueToken(ctx context.Context, machineID string
 	return err
 }
 
+// MachinePowerOff powers off (shuts down) a machine. For machines managed by a static infra provider,
+// it also updates the infra machine config to prevent the provider from powering the machine back on.
+func (client *Client) MachinePowerOff(ctx context.Context, machineID string) error {
+	_, err := client.conn.MachinePowerOff(ctx, &management.MachinePowerOffRequest{
+		MachineId: machineID,
+	})
+
+	return err
+}
+
+// MachinePowerOn powers on a machine managed by a static infra provider by clearing the power off request.
+func (client *Client) MachinePowerOn(ctx context.Context, machineID string) error {
+	_, err := client.conn.MachinePowerOn(ctx, &management.MachinePowerOnRequest{
+		MachineId: machineID,
+	})
+
+	return err
+}
+
 // LogReader is a log client reader which implements io.Reader.
 type LogReader struct {
 	ctx    context.Context //nolint:containedctx

--- a/client/pkg/omnictl/machine.go
+++ b/client/pkg/omnictl/machine.go
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package omnictl
+
+import "github.com/siderolabs/omni/client/pkg/omnictl/machine"
+
+func init() {
+	RootCmd.AddCommand(machine.RootCmd())
+}

--- a/client/pkg/omnictl/machine/machine.go
+++ b/client/pkg/omnictl/machine/machine.go
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package machine contains machine-level commands for omnictl.
+package machine
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/siderolabs/omni/client/pkg/client"
+	"github.com/siderolabs/omni/client/pkg/omnictl/internal/access"
+)
+
+var shutdownCmd = &cobra.Command{
+	Use:   "shutdown machine-id",
+	Short: "Shut down a machine",
+	Long: `Shut down a machine. For machines managed by an infra provider, this also prevents
+the provider from automatically powering the machine back on.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		return access.WithClient(func(ctx context.Context, client *client.Client, _ access.ServerInfo) error {
+			if err := client.Management().MachinePowerOff(ctx, args[0]); err != nil {
+				return fmt.Errorf("failed to shut down machine %q: %w", args[0], err)
+			}
+
+			fmt.Fprintf(os.Stderr, "machine %q is shutting down\n", args[0])
+
+			return nil
+		})
+	},
+}
+
+var powerOnCmd = &cobra.Command{
+	Use:   "power-on machine-id",
+	Short: "Power on a machine",
+	Long: `Power on a machine managed by an infra provider. This clears the power off request
+and allows the provider to power the machine on.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		return access.WithClient(func(ctx context.Context, client *client.Client, _ access.ServerInfo) error {
+			if err := client.Management().MachinePowerOn(ctx, args[0]); err != nil {
+				return fmt.Errorf("failed to power on machine %q: %w", args[0], err)
+			}
+
+			fmt.Fprintf(os.Stderr, "machine %q power on requested\n", args[0])
+
+			return nil
+		})
+	},
+}
+
+// RootCmd returns the root machine command.
+func RootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:     "machine",
+		Short:   "Machine related commands.",
+		Long:    `Commands to manage machines.`,
+		Example: "",
+	}
+
+	rootCmd.AddCommand(shutdownCmd)
+	rootCmd.AddCommand(powerOnCmd)
+
+	return rootCmd
+}

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -304,6 +304,20 @@ export type DestroyUserRequest = {
   email?: string
 }
 
+export type MachinePowerOffRequest = {
+  machine_id?: string
+}
+
+export type MachinePowerOffResponse = {
+}
+
+export type MachinePowerOnRequest = {
+  machine_id?: string
+}
+
+export type MachinePowerOnResponse = {
+}
+
 export type ListUsersResponseUser = {
   id?: string
   email?: string
@@ -385,5 +399,11 @@ export class ManagementService {
   }
   static DestroyUser(req: DestroyUserRequest, ...options: fm.fetchOption[]): Promise<GoogleProtobufEmpty.Empty> {
     return fm.fetchReq<DestroyUserRequest, GoogleProtobufEmpty.Empty>("POST", `/management.ManagementService/DestroyUser`, req, ...options)
+  }
+  static MachinePowerOff(req: MachinePowerOffRequest, ...options: fm.fetchOption[]): Promise<MachinePowerOffResponse> {
+    return fm.fetchReq<MachinePowerOffRequest, MachinePowerOffResponse>("POST", `/management.ManagementService/MachinePowerOff`, req, ...options)
+  }
+  static MachinePowerOn(req: MachinePowerOnRequest, ...options: fm.fetchOption[]): Promise<MachinePowerOnResponse> {
+    return fm.fetchReq<MachinePowerOnRequest, MachinePowerOnResponse>("POST", `/management.ManagementService/MachinePowerOn`, req, ...options)
   }
 }

--- a/frontend/src/api/omni/specs/infra.pb.ts
+++ b/frontend/src/api/omni/specs/infra.pb.ts
@@ -53,6 +53,7 @@ export type InfraMachineSpec = {
   cordoned?: boolean
   install_event_id?: string
   node_unique_token?: string
+  power_off_request_id?: string
 }
 
 export type InfraMachineStateSpec = {
@@ -66,6 +67,7 @@ export type InfraMachineStatusSpec = {
   last_reboot_timestamp?: GoogleProtobufTimestamp.Timestamp
   installed?: boolean
   wiped_node_unique_token?: string
+  last_power_off_id?: string
 }
 
 export type InfraProviderSpec = {

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -989,6 +989,7 @@ export type InfraMachineConfigSpec = {
   extra_kernel_args?: string
   requested_reboot_id?: string
   cordoned?: boolean
+  power_off_request_id?: string
 }
 
 export type InfraMachineBMCConfigSpecIPMI = {

--- a/frontend/src/components/Modals/ConfirmModal.vue
+++ b/frontend/src/components/Modals/ConfirmModal.vue
@@ -29,6 +29,7 @@ const props = withDefaults(
       title?: string
       actionLabel?: string
       loading?: boolean
+      disabled?: boolean
     }
   >(),
   {
@@ -39,7 +40,7 @@ const props = withDefaults(
 
 const emit = defineEmits<AlertDialogEmits & { confirm: [] }>()
 
-const alertDialogRootProps = reactiveOmit(props, 'title', 'actionLabel', 'loading')
+const alertDialogRootProps = reactiveOmit(props, 'title', 'actionLabel', 'loading', 'disabled')
 const forwarded = useForwardPropsEmits(alertDialogRootProps, emit)
 </script>
 
@@ -67,7 +68,7 @@ const forwarded = useForwardPropsEmits(alertDialogRootProps, emit)
             <TButton variant="secondary">Cancel</TButton>
           </AlertDialogCancel>
 
-          <TButton :disabled="loading" variant="highlighted" @click="$emit('confirm')">
+          <TButton :disabled="loading || disabled" variant="highlighted" @click="$emit('confirm')">
             <TSpinner v-if="loading" class="size-5" />
             <template v-else>{{ actionLabel }}</template>
           </TButton>

--- a/frontend/src/views/ClusterMachines/ClusterMachinePhase.vue
+++ b/frontend/src/views/ClusterMachines/ClusterMachinePhase.vue
@@ -14,7 +14,10 @@ import TIcon from '@/components/Icon/TIcon.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 
 const connected = (machine: Resource<ClusterMachineStatusSpec>): boolean => {
-  if (machine.spec.stage === ClusterMachineStatusSpecStage.POWERING_ON) {
+  if (
+    machine.spec.stage === ClusterMachineStatusSpecStage.POWERING_ON ||
+    machine.spec.stage === ClusterMachineStatusSpecStage.POWERED_OFF
+  ) {
     return true
   }
 
@@ -47,6 +50,8 @@ const stageName = (machine: Resource<ClusterMachineStatusSpec>): string => {
       return 'Preparing to Destroy'
     case ClusterMachineStatusSpecStage.POWERING_ON:
       return 'Powering On'
+    case ClusterMachineStatusSpecStage.POWERED_OFF:
+      return 'Powered Off'
     default:
       return 'Unknown'
   }
@@ -66,6 +71,8 @@ const stageIcon = (machine: Resource<ClusterMachineStatusSpec>): IconType => {
     case ClusterMachineStatusSpecStage.SHUTTING_DOWN:
       return 'loading'
     case ClusterMachineStatusSpecStage.POWERING_ON:
+      return 'power'
+    case ClusterMachineStatusSpecStage.POWERED_OFF:
       return 'power'
     case ClusterMachineStatusSpecStage.RUNNING:
       if (machine?.spec.ready) {
@@ -97,6 +104,8 @@ const stageClass = (machine: Resource<ClusterMachineStatusSpec>): string => {
       } else {
         return 'text-red-r1'
       }
+    case ClusterMachineStatusSpecStage.POWERED_OFF:
+      return 'text-naturals-n10'
     case ClusterMachineStatusSpecStage.SHUTTING_DOWN:
     case ClusterMachineStatusSpecStage.BEFORE_DESTROY:
     case ClusterMachineStatusSpecStage.DESTROYING:

--- a/frontend/src/views/Modals/NodePowerOn.vue
+++ b/frontend/src/views/Modals/NodePowerOn.vue
@@ -1,0 +1,84 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import { ManagementService } from '@/api/omni/management/management.pb'
+import type { ClusterMachineStatusSpec } from '@/api/omni/specs/omni.pb'
+import {
+  ClusterMachineStatusLabelNodeName,
+  ClusterMachineStatusType,
+  DefaultNamespace,
+} from '@/api/resources'
+import ConfirmModal from '@/components/Modals/ConfirmModal.vue'
+import { useClusterPermissions } from '@/methods/auth'
+import { useResourceWatch } from '@/methods/useResourceWatch'
+import { showError, showSuccess } from '@/notification'
+
+const { clusterId, machineId } = defineProps<{
+  clusterId: string
+  machineId: string
+}>()
+
+const open = defineModel<boolean>('open', { default: false })
+const loading = ref(false)
+
+const { data: clusterMachineStatus } = useResourceWatch<ClusterMachineStatusSpec>(() => ({
+  skip: !open.value,
+  resource: {
+    namespace: DefaultNamespace,
+    type: ClusterMachineStatusType,
+    id: machineId,
+  },
+  runtime: Runtime.Omni,
+}))
+
+const nodeName = computed(
+  () =>
+    clusterMachineStatus.value?.metadata.labels?.[ClusterMachineStatusLabelNodeName] ?? machineId,
+)
+
+const close = () => {
+  open.value = false
+}
+
+const { canRebootMachines } = useClusterPermissions(computed(() => clusterId))
+
+const powerOn = async () => {
+  loading.value = true
+
+  try {
+    await ManagementService.MachinePowerOn({ machine_id: machineId })
+  } catch (e) {
+    close()
+
+    showError('Failed to Issue Power On', e instanceof Error ? e.message : String(e))
+
+    return
+  } finally {
+    loading.value = false
+  }
+
+  close()
+
+  showSuccess('Machine Power On', `Power on request sent for machine ${nodeName.value}.`)
+}
+</script>
+
+<template>
+  <ConfirmModal
+    v-model:open="open"
+    :title="`Power on the Machine ${nodeName} ?`"
+    action-label="Power On"
+    :disabled="!canRebootMachines"
+    :loading="loading"
+    @confirm="powerOn"
+  >
+    <p class="text-xs">Please confirm the action.</p>
+  </ConfirmModal>
+</template>

--- a/frontend/src/views/Modals/NodeShutdown.vue
+++ b/frontend/src/views/Modals/NodeShutdown.vue
@@ -8,9 +8,7 @@ included in the LICENSE file.
 import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import { Runtime } from '@/api/common/omni.pb'
-import { withContext, withRuntime } from '@/api/options'
-import { MachineService } from '@/api/talos/machine/machine.pb'
+import { ManagementService } from '@/api/omni/management/management.pb'
 import TButton from '@/components/Button/TButton.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
 import { getContext } from '@/context'
@@ -22,7 +20,8 @@ const route = useRoute()
 const router = useRouter()
 const state = ref('Shutdown')
 
-const node = setupNodenameWatch(route.query.machine as string)
+const machineId = route.query.machine as string
+const node = setupNodenameWatch(machineId)
 
 const close = () => {
   router.go(-1)
@@ -35,17 +34,10 @@ const { canRebootMachines } = useClusterPermissions(computed(() => context.clust
 const shutdown = async () => {
   state.value = 'Shutdown in progress'
 
-  const nodeName = node.value ?? (route.query.machine as string)
+  const nodeName = node.value ?? machineId
 
   try {
-    const res = await MachineService.Shutdown({}, withRuntime(Runtime.Talos), withContext(context))
-
-    const errors: string[] = []
-    for (const message of res.messages || []) {
-      if (message?.metadata?.error)
-        errors.push(`${message.metadata.hostname || nodeName} ${message.metadata.error}`)
-    }
-    if (errors.length > 0) throw new Error(errors.join(', '))
+    await ManagementService.MachinePowerOff({ machine_id: machineId })
   } catch (e) {
     close()
 
@@ -60,7 +52,7 @@ const shutdown = async () => {
     await router.push({ name: 'ClusterOverview', params: { cluster: context.cluster! } })
   }
 
-  showSuccess('Machine Shutdown', `Machine ${nodeName} is shutting down now.`)
+  showSuccess('Machine Shutdown', `Shutdown request sent for machine ${nodeName}.`)
 }
 </script>
 

--- a/frontend/src/views/Nodes/NodesHeader.vue
+++ b/frontend/src/views/Nodes/NodesHeader.vue
@@ -5,15 +5,22 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { MachineSetNodeSpec } from '@/api/omni/specs/omni.pb'
-import { DefaultNamespace, MachineSetNodeType } from '@/api/resources'
+import type { MachineSetNodeSpec, MachineSpec } from '@/api/omni/specs/omni.pb'
+import {
+  DefaultNamespace,
+  LabelIsManagedByStaticInfraProvider,
+  MachineSetNodeType,
+  MachineType,
+} from '@/api/resources'
 import TButton from '@/components/Button/TButton.vue'
+import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { useClusterPermissions } from '@/methods/auth'
 import { useResourceWatch } from '@/methods/useResourceWatch'
+import NodePowerOn from '@/views/Modals/NodePowerOn.vue'
 import NodesBreadcrumbs from '@/views/Nodes/NodesBreadcrumbs.vue'
 
 const { clusterId, machineId } = defineProps<{
@@ -23,6 +30,7 @@ const { clusterId, machineId } = defineProps<{
 
 const route = useRoute()
 const router = useRouter()
+const powerOnModalOpen = ref(false)
 
 const shutdownNode = () => {
   router.push({
@@ -32,6 +40,10 @@ const shutdownNode = () => {
       ...route.query,
     },
   })
+}
+
+const powerOnNode = () => {
+  powerOnModalOpen.value = true
 }
 
 const rebootNode = () => {
@@ -52,6 +64,19 @@ const { data: machineSetNode, loading } = useResourceWatch<MachineSetNodeSpec>((
   },
   runtime: Runtime.Omni,
 }))
+
+const { data: machine } = useResourceWatch<MachineSpec>(() => ({
+  resource: {
+    type: MachineType,
+    id: machineId,
+    namespace: DefaultNamespace,
+  },
+  runtime: Runtime.Omni,
+}))
+
+const isManagedByStaticInfraProvider = computed(
+  () => machine.value?.metadata.labels?.[LabelIsManagedByStaticInfraProvider] !== undefined,
+)
 
 const destroyNode = async () => {
   router.push({
@@ -83,6 +108,24 @@ const { canRebootMachines, canRemoveMachines, canAddClusterMachines } = useClust
     <NodesBreadcrumbs :cluster-id :machine-id />
 
     <div class="flex">
+      <Tooltip
+        :description="
+          isManagedByStaticInfraProvider
+            ? undefined
+            : 'Power on is only available for machines managed by a static infra provider. For other machines, power on the machine manually.'
+        "
+      >
+        <TButton
+          class="header-button"
+          icon="power"
+          icon-position="left"
+          variant="secondary"
+          :disabled="!canRebootMachines || !isManagedByStaticInfraProvider"
+          @click="powerOnNode"
+        >
+          Power On
+        </TButton>
+      </Tooltip>
       <TButton
         class="header-button"
         icon="power"
@@ -126,6 +169,8 @@ const { canRebootMachines, canRemoveMachines, canAddClusterMachines } = useClust
         Cancel Destroy
       </TButton>
     </div>
+
+    <NodePowerOn v-model:open="powerOnModalOpen" :cluster-id="clusterId" :machine-id="machineId" />
   </div>
 </template>
 

--- a/internal/backend/grpc/export_test.go
+++ b/internal/backend/grpc/export_test.go
@@ -18,17 +18,41 @@ type ManagementServer = managementServer
 
 type AuthServer = authServer
 
+// ManagementServerOption configures a test management server.
+type ManagementServerOption func(*ManagementServer)
+
 //nolint:revive
 func NewManagementServer(st state.State, imageFactoryClient *imagefactory.Client, logger *zap.Logger,
 	enableBreakGlassConfigs bool, kubernetesRuntime KubernetesRuntime, talosconfigProvider TalosconfigProvider,
+	opts ...ManagementServerOption,
 ) *ManagementServer {
-	return &ManagementServer{
+	server := &ManagementServer{
 		omniState:           st,
 		imageFactoryClient:  imageFactoryClient,
 		logger:              logger,
 		cfg:                 &config.Params{Features: config.Features{EnableBreakGlassConfigs: new(enableBreakGlassConfigs)}},
 		kubernetesRuntime:   kubernetesRuntime,
 		talosconfigProvider: talosconfigProvider,
+	}
+
+	for _, opt := range opts {
+		opt(server)
+	}
+
+	return server
+}
+
+// WithTalosRuntime configures the Talos runtime on a test management server.
+func WithTalosRuntime(talosRuntime TalosRuntime) ManagementServerOption {
+	return func(server *ManagementServer) {
+		server.talosRuntime = talosRuntime
+	}
+}
+
+// WithAuditLogger configures the audit logger on a test management server.
+func WithAuditLogger(auditor AuditLogger) ManagementServerOption {
+	return func(server *ManagementServer) {
+		server.auditor = auditor
 	}
 }
 
@@ -38,8 +62,4 @@ func NewAuthServer(st state.State, services config.Services, logger *zap.Logger)
 
 func NewResourceServer(st state.State, runtimes map[string]runtime.Runtime, depGrapher DependencyGrapher) *ResourceServer {
 	return newResourceServer(st, runtimes, depGrapher)
-}
-
-func GenerateDest(apiurl string) (string, error) {
-	return generateDest(apiurl)
 }

--- a/internal/backend/grpc/kubernetes_manifests.go
+++ b/internal/backend/grpc/kubernetes_manifests.go
@@ -35,7 +35,6 @@ import (
 	"github.com/siderolabs/omni/client/pkg/panichandler"
 	"github.com/siderolabs/omni/internal/backend/grpc/router"
 	"github.com/siderolabs/omni/internal/backend/runtime/kubernetes"
-	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
@@ -46,13 +45,19 @@ func (s *managementServer) KubernetesSyncManifests(
 ) error {
 	ctx := srv.Context()
 
-	if _, err := s.authCheckGRPC(ctx, auth.WithRole(role.Operator)); err != nil {
+	requestContext := router.ExtractContext(ctx)
+	if requestContext == nil {
+		return status.Error(codes.InvalidArgument, "unable to extract request context")
+	}
+
+	authCtx, _, err := s.checkClusterAuthorization(ctx, requestContext.Name, role.Operator)
+	if err != nil {
 		return err
 	}
 
-	ctx = actor.MarkContextAsInternalActor(ctx)
+	ctx = actor.MarkContextAsInternalActor(authCtx)
 
-	sync, err := s.prepareKubernetesSyncHelpers(ctx)
+	sync, err := s.prepareKubernetesSyncHelpers(ctx, authCtx, requestContext)
 	if err != nil {
 		return err
 	}
@@ -341,15 +346,14 @@ type kubernetesSyncHelpers struct {
 	manifests      []manifests.Manifest
 }
 
-func (s *managementServer) prepareKubernetesSyncHelpers(ctx context.Context) (*kubernetesSyncHelpers, error) {
-	requestContext := router.ExtractContext(ctx)
-	if requestContext == nil {
-		return nil, status.Error(codes.InvalidArgument, "unable to extract request context")
-	}
-
+func (s *managementServer) prepareKubernetesSyncHelpers(ctx, authCtx context.Context, requestContext *common.Context) (*kubernetesSyncHelpers, error) {
 	cfg, err := s.kubernetesRuntime.GetKubeconfig(ctx, requestContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+
+	if err = s.auditTalosAccess(authCtx, management.ManagementService_KubernetesSyncManifests_FullMethodName, requestContext.Name, ""); err != nil {
+		return nil, err
 	}
 
 	talosClient, err := s.talosRuntime.GetClientForCluster(ctx, requestContext.Name)

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -21,10 +21,12 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/google/uuid"
 	gateway "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/siderolabs/gen/optional"
 	"github.com/siderolabs/go-kubernetes/kubernetes/upgrade"
 	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/zitadel/oidc/v3/pkg/op"
 	"go.uber.org/zap"
@@ -40,6 +42,7 @@ import (
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/jointoken"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	ctlcfg "github.com/siderolabs/omni/client/pkg/omnictl/config"
@@ -144,7 +147,7 @@ func (s *managementServer) Kubeconfig(ctx context.Context, req *management.Kubec
 		clusterName = commonContext.Name
 	}
 
-	ctx, err := accesspolicy.ApplyClusterAccessPolicy(ctx, clusterName, s.omniState)
+	ctx, authResult, err := s.checkClusterAuthorization(ctx, clusterName, role.Reader)
 	if err != nil {
 		return nil, err
 	}
@@ -154,11 +157,6 @@ func (s *managementServer) Kubeconfig(ctx context.Context, req *management.Kubec
 	}
 
 	// not a service account, generate OIDC (user) or admin kubeconfig
-
-	authResult, err := auth.CheckGRPC(ctx, auth.WithRole(role.Reader))
-	if err != nil {
-		return nil, err
-	}
 
 	var extraOptions []string
 
@@ -193,7 +191,7 @@ func (s *managementServer) Kubeconfig(ctx context.Context, req *management.Kubec
 			cacheDir = filepath.Join("~", ".kube", "cache", "oidc-login")
 		}
 
-		cacheDir = filepath.Join(cacheDir, s.cfg.Account.GetName()+"-"+commonContext.Name+"-"+authResult.Identity)
+		cacheDir = filepath.Join(cacheDir, s.cfg.Account.GetName()+"-"+clusterName+"-"+authResult.Identity)
 	}
 
 	if cacheDir != "" {
@@ -216,6 +214,22 @@ func (s *managementServer) Talosconfig(ctx context.Context, request *management.
 		r = role.Admin
 	}
 
+	routerContext := router.ExtractContext(ctx)
+
+	clusterName := ""
+	if routerContext != nil {
+		clusterName = routerContext.Name
+	}
+
+	if !request.BreakGlass {
+		var err error
+
+		ctx, _, err = s.checkClusterAuthorization(ctx, clusterName, r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// getting talosconfig is low risk, as it doesn't contain any sensitive data
 	// real check for authentication happens in the Talos API gRPC proxy
 	authResult, err := auth.CheckGRPC(ctx, auth.WithRole(r))
@@ -231,7 +245,7 @@ func (s *managementServer) Talosconfig(ctx context.Context, request *management.
 		return s.breakGlassTalosconfig(ctx, false)
 	}
 
-	talosconfig, err := s.talosRuntime.GetTalosconfigRaw(router.ExtractContext(ctx), authResult.Identity)
+	talosconfig, err := s.talosRuntime.GetTalosconfigRaw(routerContext, authResult.Identity)
 	if err != nil {
 		return nil, err
 	}
@@ -261,14 +275,15 @@ func (s *managementServer) Omniconfig(ctx context.Context, _ *emptypb.Empty) (*m
 func (s *managementServer) MachineLogs(request *management.MachineLogsRequest, serv grpc.ServerStreamingServer[common.Data]) error {
 	ctx := serv.Context()
 
-	// getting machine logs is equivalent to reading machine resource
-	if _, err := auth.CheckGRPC(ctx, auth.WithRole(role.Reader)); err != nil {
-		return err
-	}
-
 	machineID := request.GetMachineId()
 	if machineID == "" {
 		return status.Error(codes.InvalidArgument, "machine id is required")
+	}
+
+	// getting machine logs is equivalent to reading machine resource
+	authCtx, _, err := s.checkAuthorization(ctx, machineID, role.Reader)
+	if err != nil {
+		return err
 	}
 
 	tailLines := optional.None[int32]()
@@ -276,7 +291,7 @@ func (s *managementServer) MachineLogs(request *management.MachineLogsRequest, s
 		tailLines = optional.Some(request.TailLines)
 	}
 
-	logReader, err := s.logHandler.GetReader(ctx, siderolinkinternal.MachineID(machineID), request.Follow, tailLines)
+	logReader, err := s.logHandler.GetReader(authCtx, siderolinkinternal.MachineID(machineID), request.Follow, tailLines)
 	if err != nil {
 		return handleError(err)
 	}
@@ -284,7 +299,7 @@ func (s *managementServer) MachineLogs(request *management.MachineLogsRequest, s
 	defer logReader.Close() //nolint:errcheck
 
 	for {
-		line, err := logReader.ReadLine(ctx)
+		line, err := logReader.ReadLine(authCtx)
 		if err != nil {
 			return handleError(err)
 		}
@@ -371,6 +386,10 @@ func (s *managementServer) breakGlassTalosconfig(ctx context.Context, raw bool) 
 		return nil, err
 	}
 
+	if err = s.auditTalosAccess(ctx, management.ManagementService_Talosconfig_FullMethodName, clusterName, ""); err != nil {
+		return nil, err
+	}
+
 	if err = s.markClusterAsTainted(ctx, clusterName); err != nil {
 		return nil, err
 	}
@@ -413,16 +432,17 @@ func (s *managementServer) breakGlassKubeconfig(ctx context.Context) (*managemen
 }
 
 func (s *managementServer) KubernetesUpgradePreChecks(ctx context.Context, req *management.KubernetesUpgradePreChecksRequest) (*management.KubernetesUpgradePreChecksResponse, error) {
-	if _, err := s.authCheckGRPC(ctx, auth.WithRole(role.Operator)); err != nil {
-		return nil, err
-	}
-
-	ctx = actor.MarkContextAsInternalActor(ctx)
-
 	requestContext := router.ExtractContext(ctx)
 	if requestContext == nil {
 		return nil, status.Error(codes.InvalidArgument, "unable to extract request context")
 	}
+
+	authCtx, _, err := s.checkClusterAuthorization(ctx, requestContext.Name, role.Operator)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx = actor.MarkContextAsInternalActor(authCtx)
 
 	upgradeStatus, err := safe.StateGet[*omnires.KubernetesUpgradeStatus](ctx, s.omniState, omnires.NewKubernetesUpgradeStatus(requestContext.Name).Metadata())
 	if err != nil {
@@ -464,6 +484,10 @@ func (s *managementServer) KubernetesUpgradePreChecks(ctx context.Context, req *
 
 	for cm := range cms.All() {
 		controlplaneMachines = append(controlplaneMachines, cm.Metadata().ID())
+	}
+
+	if err = s.auditTalosAccessForNodes(authCtx, management.ManagementService_KubernetesUpgradePreChecks_FullMethodName, requestContext.Name, controlplaneMachines); err != nil {
+		return nil, err
 	}
 
 	s.logger.Debug("running k8s upgrade pre-checks", zap.Strings("controlplane_machines", controlplaneMachines), zap.String("cluster", requestContext.Name))
@@ -565,15 +589,16 @@ func (s *managementServer) ReadAuditLog(req *management.ReadAuditLogRequest, srv
 func (s *managementServer) MaintenanceUpgrade(ctx context.Context, req *management.MaintenanceUpgradeRequest) (*management.MaintenanceUpgradeResponse, error) {
 	s.logger.Info("maintenance upgrade request received", zap.String("machine_id", req.MachineId), zap.String("version", req.Version))
 
-	if _, err := s.authCheckGRPC(ctx, auth.WithRole(role.Operator)); err != nil {
-		return nil, err
-	}
-
 	if req.MachineId == "" {
 		return nil, status.Error(codes.InvalidArgument, "machine id is required")
 	}
 
-	ctx = actor.MarkContextAsInternalActor(ctx)
+	authCtx, clusterName, err := s.checkAuthorization(ctx, req.MachineId, role.Operator)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx = actor.MarkContextAsInternalActor(authCtx)
 
 	machineStatus, err := safe.StateGetByID[*omnires.MachineStatus](ctx, s.omniState, req.MachineId)
 	if err != nil {
@@ -621,13 +646,17 @@ func (s *managementServer) MaintenanceUpgrade(ctx context.Context, req *manageme
 	opts := talos.GetSocketOptions(address)
 	opts = append(opts, client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}), client.WithEndpoints(address))
 
-	talosClient, err := client.New(ctx, opts...)
+	talosClient, err := client.New(authCtx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create talos client: %w", err)
 	}
 
+	if err = s.auditTalosAccess(authCtx, machineapi.MachineService_Upgrade_FullMethodName, clusterName, req.MachineId); err != nil {
+		return nil, err
+	}
+
 	//nolint:staticcheck
-	if _, err = talosClient.UpgradeWithOptions(ctx, client.WithUpgradeImage(installImageStr)); err != nil {
+	if _, err = talosClient.UpgradeWithOptions(authCtx, client.WithUpgradeImage(installImageStr)); err != nil {
 		return nil, fmt.Errorf("failed to upgrade machine: %w", err)
 	}
 
@@ -729,6 +758,221 @@ func (s *managementServer) ResetNodeUniqueToken(ctx context.Context, request *ma
 	}
 
 	return &management.ResetNodeUniqueTokenResponse{}, nil
+}
+
+func (s *managementServer) MachinePowerOff(ctx context.Context, request *management.MachinePowerOffRequest) (*management.MachinePowerOffResponse, error) {
+	if request.MachineId == "" {
+		return nil, status.Error(codes.InvalidArgument, "machine id is required")
+	}
+
+	authCtx, clusterName, err := s.checkAuthorization(ctx, request.MachineId, role.Operator)
+	if err != nil {
+		return nil, err
+	}
+
+	internalCtx := actor.MarkContextAsInternalActor(authCtx)
+
+	isManagedByStaticInfraProvider, err := s.isManagedByStaticInfraProvider(internalCtx, request.MachineId)
+	if err != nil {
+		return nil, err
+	}
+
+	// For machines managed by a static infra provider, update InfraMachineConfig with a new power off request ID.
+	if isManagedByStaticInfraProvider {
+		if err = s.setMachinePowerOffRequestID(internalCtx, request.MachineId); err != nil {
+			return nil, err
+		}
+	}
+
+	// Call Talos Shutdown API.
+	talosClient, err := s.talosRuntime.GetClientForMachine(internalCtx, request.MachineId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get talos client: %w", err)
+	}
+
+	if err = s.auditTalosAccess(authCtx, machineapi.MachineService_Shutdown_FullMethodName, clusterName, request.MachineId); err != nil {
+		return nil, err
+	}
+
+	if err = talosClient.Shutdown(authCtx); err != nil {
+		return nil, fmt.Errorf("failed to shutdown machine: %w", err)
+	}
+
+	return &management.MachinePowerOffResponse{}, nil
+}
+
+func (s *managementServer) MachinePowerOn(ctx context.Context, request *management.MachinePowerOnRequest) (*management.MachinePowerOnResponse, error) {
+	if request.MachineId == "" {
+		return nil, status.Error(codes.InvalidArgument, "machine id is required")
+	}
+
+	authCtx, _, err := s.checkAuthorization(ctx, request.MachineId, role.Operator)
+	if err != nil {
+		return nil, err
+	}
+
+	internalCtx := actor.MarkContextAsInternalActor(authCtx)
+
+	isManagedByStaticInfraProvider, err := s.isManagedByStaticInfraProvider(internalCtx, request.MachineId)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isManagedByStaticInfraProvider {
+		return nil, status.Error(codes.FailedPrecondition, "machine is not managed by a static infra provider, power on the machine manually")
+	}
+
+	if err = s.clearMachinePowerOffRequestID(internalCtx, request.MachineId); err != nil {
+		return nil, err
+	}
+
+	return &management.MachinePowerOnResponse{}, nil
+}
+
+// checkAuthorization checks if the user has the required role to perform an action on a machine.
+//
+// It also returns the authorized context and the cluster name the machine belongs to, if available.
+func (s *managementServer) checkAuthorization(ctx context.Context, machineID string, checkRole role.Role) (context.Context, string, error) {
+	cm, err := s.omniState.Get(actor.MarkContextAsInternalActor(ctx), omnires.NewClusterMachine(machineID).Metadata())
+	if err != nil && !state.IsNotFoundError(err) {
+		return nil, "", err
+	}
+
+	cluster := ""
+
+	if cm != nil {
+		var ok bool
+
+		if cluster, ok = cm.Metadata().Labels().Get(omnires.LabelCluster); !ok {
+			return nil, "", status.Errorf(codes.FailedPrecondition, "cluster label not found on cluster machine %q", machineID)
+		}
+	}
+
+	authCtx, _, err := s.checkClusterAuthorization(ctx, cluster, checkRole)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return authCtx, cluster, nil
+}
+
+func (s *managementServer) checkClusterAuthorization(ctx context.Context, cluster string, checkRole role.Role) (context.Context, auth.CheckResult, error) {
+	authCtx := ctx
+
+	var err error
+
+	if cluster != "" {
+		authCtx, err = accesspolicy.ApplyClusterAccessPolicy(ctx, cluster, s.omniState)
+		if err != nil {
+			return nil, auth.CheckResult{}, err
+		}
+	}
+
+	authResult, err := auth.CheckGRPC(authCtx, auth.WithRole(checkRole))
+	if err != nil {
+		return nil, auth.CheckResult{}, err
+	}
+
+	return authCtx, authResult, nil
+}
+
+func (s *managementServer) auditTalosAccess(ctx context.Context, fullMethodName, clusterID, nodeID string) error {
+	if s.auditor == nil {
+		return nil
+	}
+
+	fullMethodName = strings.TrimLeft(fullMethodName, "/")
+
+	if err := s.auditor.AuditTalosAccess(ctx, fullMethodName, clusterID, nodeID); err != nil {
+		return fmt.Errorf("failed to audit talos access: %w", err)
+	}
+
+	return nil
+}
+
+func (s *managementServer) auditTalosAccessForNodes(ctx context.Context, fullMethodName, clusterID string, nodeIDs []string) error {
+	for _, nodeID := range nodeIDs {
+		if err := s.auditTalosAccess(ctx, fullMethodName, clusterID, nodeID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *managementServer) setMachinePowerOffRequestID(ctx context.Context, machineID string) error {
+	ctx = actor.MarkContextAsInternalActor(ctx)
+
+	_, err := safe.StateUpdateWithConflicts(ctx, s.omniState, omnires.NewInfraMachineConfig(machineID).Metadata(),
+		func(config *omnires.InfraMachineConfig) error {
+			if config.TypedSpec().Value.AcceptanceStatus != specs.InfraMachineConfigSpec_ACCEPTED {
+				return fmt.Errorf("infra machine config is not accepted yet, cannot set machine power-off request")
+			}
+
+			config.TypedSpec().Value.PowerOffRequestId = uuid.NewString()
+
+			return nil
+		},
+	)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return status.Error(codes.FailedPrecondition, "infra machine config not found, cannot set machine power-off request")
+		}
+
+		return fmt.Errorf("failed to update infra machine config: %w", err)
+	}
+
+	return nil
+}
+
+func (s *managementServer) isManagedByStaticInfraProvider(ctx context.Context, machineID string) (bool, error) {
+	link, err := safe.StateGetByID[*siderolinkres.Link](ctx, s.omniState, machineID)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return false, status.Error(codes.NotFound, "machine not found")
+		}
+
+		return false, fmt.Errorf("failed to get machine link: %w", err)
+	}
+
+	infraProviderID, ok := link.Metadata().Labels().Get(omnires.LabelInfraProviderID)
+	if !ok {
+		return false, nil
+	}
+
+	providerStatus, err := safe.StateGetByID[*infra.ProviderStatus](ctx, s.omniState, infraProviderID)
+	if err != nil {
+		return false, status.Error(codes.FailedPrecondition, "failed to get infra provider status")
+	}
+
+	_, isStaticInfraProvider := providerStatus.Metadata().Labels().Get(omnires.LabelIsStaticInfraProvider)
+
+	return isStaticInfraProvider, nil
+}
+
+func (s *managementServer) clearMachinePowerOffRequestID(ctx context.Context, machineID string) error {
+	ctx = actor.MarkContextAsInternalActor(ctx)
+
+	_, err := safe.StateUpdateWithConflicts(ctx, s.omniState, omnires.NewInfraMachineConfig(machineID).Metadata(),
+		func(config *omnires.InfraMachineConfig) error {
+			if config.TypedSpec().Value.AcceptanceStatus != specs.InfraMachineConfigSpec_ACCEPTED {
+				return fmt.Errorf("infra machine config is not accepted yet, cannot clear machine power-off request")
+			}
+
+			config.TypedSpec().Value.PowerOffRequestId = ""
+
+			return nil
+		},
+	)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return status.Error(codes.FailedPrecondition, "infra machine config not found, cannot clear machine power-off request")
+		}
+
+		return fmt.Errorf("failed to update infra machine config: %w", err)
+	}
+
+	return nil
 }
 
 func parseTime(date string, fallback time.Time) (time.Time, error) {
@@ -833,9 +1077,10 @@ func generateDest(apiurl string) (string, error) {
 	return result, nil
 }
 
-// AuditLogger is an interface for reading the audit log.
+// AuditLogger is an interface for reading the audit log and logging Talos access events.
 type AuditLogger interface {
 	Reader(ctx context.Context, filters auditlog.ReadFilters) (auditlog.Reader, error)
+	AuditTalosAccess(ctx context.Context, fullMethodName, clusterID, nodeID string) error
 }
 
 func auditLogOrderByField(f management.AuditLogOrderByField) auditlog.OrderByField {

--- a/internal/backend/grpc/management_power_test.go
+++ b/internal/backend/grpc/management_power_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package grpc_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	commonOmni "github.com/siderolabs/omni/client/api/common"
+	"github.com/siderolabs/omni/client/api/omni/management"
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
+	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
+	grpcomni "github.com/siderolabs/omni/internal/backend/grpc"
+	omniruntime "github.com/siderolabs/omni/internal/backend/runtime/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
+	talosruntime "github.com/siderolabs/omni/internal/backend/runtime/talos"
+	"github.com/siderolabs/omni/internal/pkg/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/actor"
+	"github.com/siderolabs/omni/internal/pkg/auth/role"
+	"github.com/siderolabs/omni/internal/pkg/ctxstore"
+)
+
+func TestMachinePowerOffUsesInternalContextAfterACLAuthorization(t *testing.T) {
+	const (
+		clusterID  = "cluster-1"
+		identityID = "user@example.com"
+		machineID  = "machine-1"
+	)
+
+	st := newManagementPowerTestState(t, clusterID, identityID, machineID)
+	ctx := managementPowerTestContext(t.Context(), identityID, role.Reader)
+
+	talosRuntime := &capturingTalosRuntime{}
+	auditor := &capturingAuditLogger{err: errors.New("stop before shutdown")}
+
+	server := grpcomni.NewManagementServer(
+		st,
+		nil,
+		zaptest.NewLogger(t),
+		false,
+		nil,
+		nil,
+		grpcomni.WithTalosRuntime(talosRuntime),
+		grpcomni.WithAuditLogger(auditor),
+	)
+
+	_, err := server.MachinePowerOff(ctx, &management.MachinePowerOffRequest{MachineId: machineID})
+	require.ErrorIs(t, err, auditor.err)
+
+	require.True(t, talosRuntime.machineCtx.captured)
+	require.True(t, talosRuntime.machineCtx.internal)
+	require.True(t, talosRuntime.machineCtx.hasRole)
+	require.Equal(t, role.Operator, talosRuntime.machineCtx.role)
+
+	require.True(t, auditor.ctx.captured)
+	require.False(t, auditor.ctx.internal)
+	require.True(t, auditor.ctx.hasRole)
+	require.Equal(t, role.Operator, auditor.ctx.role)
+	require.Equal(t, "machine.MachineService/Shutdown", auditor.fullMethod)
+	require.Equal(t, clusterID, auditor.clusterID)
+	require.Equal(t, machineID, auditor.nodeID)
+}
+
+func newManagementPowerTestState(t *testing.T, clusterID, identityID, machineID string) state.State {
+	runtimeState, err := omniruntime.NewTestState(zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	st := runtimeState.Default()
+	ctx := actor.MarkContextAsInternalActor(t.Context())
+
+	clusterMachine := omnires.NewClusterMachine(machineID)
+	clusterMachine.Metadata().Labels().Set(omnires.LabelCluster, clusterID)
+	require.NoError(t, st.Create(ctx, clusterMachine))
+
+	require.NoError(t, st.Create(ctx, siderolinkres.NewLink(machineID, &specs.SiderolinkSpec{})))
+	require.NoError(t, st.Create(ctx, authres.NewIdentity(identityID)))
+
+	accessPolicy := authres.NewAccessPolicy()
+	accessPolicy.TypedSpec().Value.Rules = []*specs.AccessPolicyRule{
+		{
+			Users:    []string{identityID},
+			Clusters: []string{clusterID},
+			Role:     string(role.Operator),
+		},
+	}
+
+	require.NoError(t, st.Create(ctx, accessPolicy))
+
+	return st
+}
+
+func managementPowerTestContext(ctx context.Context, identityID string, r role.Role) context.Context {
+	ctx = ctxstore.WithValue(ctx, auth.EnabledAuthContextKey{Enabled: true})
+	ctx = ctxstore.WithValue(ctx, auth.IdentityContextKey{Identity: identityID})
+	ctx = ctxstore.WithValue(ctx, auth.RoleContextKey{Role: r})
+
+	return ctx
+}
+
+type capturingTalosRuntime struct {
+	machineCtx capturedContext
+}
+
+func (c *capturingTalosRuntime) GetTalosconfigRaw(*commonOmni.Context, string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (c *capturingTalosRuntime) GetClientForCluster(context.Context, string) (*talosruntime.Client, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *capturingTalosRuntime) GetClientForMachine(ctx context.Context, _ string) (*talosruntime.Client, error) {
+	c.machineCtx = captureContext(ctx)
+
+	return talosruntime.NewClient(nil, "", ""), nil
+}
+
+type capturingAuditLogger struct {
+	err        error
+	fullMethod string
+	clusterID  string
+	nodeID     string
+	ctx        capturedContext
+}
+
+func (c *capturingAuditLogger) Reader(context.Context, auditlog.ReadFilters) (auditlog.Reader, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *capturingAuditLogger) AuditTalosAccess(ctx context.Context, fullMethodName, clusterID, nodeID string) error {
+	c.ctx = captureContext(ctx)
+	c.fullMethod = fullMethodName
+	c.clusterID = clusterID
+	c.nodeID = nodeID
+
+	return c.err
+}
+
+type capturedContext struct {
+	role     role.Role
+	captured bool
+	internal bool
+	hasRole  bool
+}
+
+func captureContext(ctx context.Context) capturedContext {
+	roleVal, ok := ctxstore.Value[auth.RoleContextKey](ctx)
+
+	return capturedContext{
+		captured: true,
+		internal: actor.ContextIsInternalActor(ctx),
+		hasRole:  ok,
+		role:     roleVal.Role,
+	}
+}

--- a/internal/backend/grpc/router/router.go
+++ b/internal/backend/grpc/router/router.go
@@ -193,10 +193,6 @@ func (r *Router) Director(ctx context.Context, fullMethodName string) (proxy.Mod
 			return proxy.One2One, nil, err
 		}
 
-		if err = r.talosAuditor.AuditTalosAccess(ctx, fullMethodName, getClusterName(md), getNodeID(md)); err != nil {
-			return proxy.One2One, nil, err
-		}
-
 		return proxy.One2One, []proxy.Backend{backend}, nil
 	}
 
@@ -267,7 +263,7 @@ func (r *Router) getForCluster(ctx context.Context, clusterID string) (proxy.Bac
 		activeGauge := r.metricActiveClients.WithLabelValues(typ)
 		activeGauge.Inc()
 
-		backend := NewTalosBackend(cacheKey, clusterID, r.nodeResolver, conn, r.authEnabled, r.verifier, r.cosiState)
+		backend := NewTalosBackend(cacheKey, clusterID, r.nodeResolver, conn, r.authEnabled, r.verifier, r.cosiState, r.talosAuditor)
 		r.talosBackends.Add(cacheKey, backend)
 
 		r.metricCacheSize.WithLabelValues(typ).Inc()
@@ -318,7 +314,7 @@ func (r *Router) getForMachine(ctx context.Context, clusterID string, node dns.I
 		activeGauge := r.metricActiveClients.WithLabelValues(typ)
 		activeGauge.Inc()
 
-		backend := NewTalosBackend(cacheKey, clusterID, r.nodeResolver, conn, r.authEnabled, r.verifier, r.cosiState)
+		backend := NewTalosBackend(cacheKey, clusterID, r.nodeResolver, conn, r.authEnabled, r.verifier, r.cosiState, r.talosAuditor)
 		r.talosBackends.Add(cacheKey, backend)
 
 		r.metricCacheSize.WithLabelValues(typ).Inc()

--- a/internal/backend/grpc/router/talos_backend.go
+++ b/internal/backend/grpc/router/talos_backend.go
@@ -7,6 +7,7 @@ package router
 
 import (
 	"context"
+	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -70,13 +71,22 @@ type TalosBackend struct {
 	omniState    state.State
 	conn         *grpc.ClientConn
 	verifier     grpc.UnaryServerInterceptor
+	talosAuditor TalosAuditor
 	name         string
 	clusterID    string
 	authEnabled  bool
 }
 
 // NewTalosBackend builds new Talos API backend.
-func NewTalosBackend(name, clusterID string, nodeResolver NodeResolver, conn *grpc.ClientConn, authEnabled bool, verifier grpc.UnaryServerInterceptor, st state.State) *TalosBackend {
+func NewTalosBackend(
+	name, clusterID string,
+	nodeResolver NodeResolver,
+	conn *grpc.ClientConn,
+	authEnabled bool,
+	verifier grpc.UnaryServerInterceptor,
+	st state.State,
+	talosAuditor TalosAuditor,
+) *TalosBackend {
 	return &TalosBackend{
 		name:         name,
 		clusterID:    clusterID,
@@ -85,6 +95,7 @@ func NewTalosBackend(name, clusterID string, nodeResolver NodeResolver, conn *gr
 		authEnabled:  authEnabled,
 		verifier:     verifier,
 		omniState:    st,
+		talosAuditor: talosAuditor,
 	}
 }
 
@@ -131,6 +142,17 @@ func (backend *TalosBackend) GetConnection(ctx context.Context, fullMethodName s
 		return ctx, nil, err
 	}
 
+	nodes, err := resolveNodes(backend.nodeResolver, md)
+	if err != nil {
+		return ctx, nil, err
+	}
+
+	if backend.talosAuditor != nil {
+		if err = backend.talosAuditor.AuditTalosAccess(ctx, strings.TrimLeft(fullMethodName, "/"), backend.clusterID, getNodeID(md)); err != nil {
+			return ctx, nil, err
+		}
+	}
+
 	hasModifyAccess := false
 
 	_, authErr := auth.Check(ctx, auth.WithRole(role.Operator))
@@ -148,11 +170,6 @@ func (backend *TalosBackend) GetConnection(ctx context.Context, fullMethodName s
 		if _, err = auth.CheckGRPC(ctx, auth.WithRole(role.Reader)); err != nil {
 			return ctx, nil, err
 		}
-	}
-
-	nodes, err := resolveNodes(backend.nodeResolver, md)
-	if err != nil {
-		return ctx, nil, err
 	}
 
 	md = md.Copy()

--- a/internal/backend/grpc/router/talos_backend_test.go
+++ b/internal/backend/grpc/router/talos_backend_test.go
@@ -95,6 +95,7 @@ func TestTalosBackendHeaderDeletion(t *testing.T) {
 				return handler(ctx, req)
 			},
 			st.Default(),
+			nil,
 		)
 	}
 
@@ -144,6 +145,42 @@ func TestTalosBackendHeaderDeletion(t *testing.T) {
 	})
 }
 
+func TestTalosBackendAuditsAfterVerifier(t *testing.T) {
+	t.Parallel()
+
+	logger := zaptest.NewLogger(t)
+	st, err := omniruntime.NewTestState(logger)
+	require.NoError(t, err)
+
+	conn, err := dial("127.0.0.1:10501")
+	require.NoError(t, err)
+
+	auditor := &capturingTalosAuditor{}
+
+	backend := router.NewTalosBackend(
+		"test-backend",
+		"test-cluster",
+		&testNodeResolver{},
+		conn,
+		false,
+		func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+			return handler(context.WithValue(ctx, auditVerifierKey{}, "verified"), req)
+		},
+		st.Default(),
+		auditor,
+	)
+
+	ctx := metadata.NewIncomingContext(t.Context(), metadata.Pairs("node", "some-node", "cluster", "test-cluster"))
+
+	_, _, err = backend.GetConnection(ctx, machine.MachineService_Hostname_FullMethodName)
+	require.NoError(t, err)
+
+	require.Equal(t, "verified", auditor.verifierMarker)
+	require.Equal(t, "machine.MachineService/Hostname", auditor.fullMethod)
+	require.Equal(t, "test-cluster", auditor.clusterID)
+	require.Equal(t, "some-node", auditor.nodeID)
+}
+
 func makeGRPCProxy(ctx context.Context, endpoint, serverEndpoint string, st state.State) (func() error, error) {
 	grpcProxyServer := router.NewServer(&testDirector{serverEndpoint: serverEndpoint, omniState: st})
 
@@ -176,6 +213,24 @@ type testDirector struct {
 	serverEndpoint string
 }
 
+type auditVerifierKey struct{}
+
+type capturingTalosAuditor struct {
+	verifierMarker any
+	fullMethod     string
+	clusterID      string
+	nodeID         string
+}
+
+func (c *capturingTalosAuditor) AuditTalosAccess(ctx context.Context, fullMethodName, clusterID, nodeID string) error {
+	c.verifierMarker = ctx.Value(auditVerifierKey{})
+	c.fullMethod = fullMethodName
+	c.clusterID = clusterID
+	c.nodeID = nodeID
+
+	return nil
+}
+
 func (t *testDirector) Director(context.Context, string) (proxy.Mode, []proxy.Backend, error) {
 	conn, err := dial(t.serverEndpoint)
 	if err != nil {
@@ -192,6 +247,7 @@ func (t *testDirector) Director(context.Context, string) (proxy.Mode, []proxy.Ba
 			return handler(ctx, req)
 		},
 		t.omniState,
+		nil,
 	)
 
 	return proxy.One2One, []proxy.Backend{backend}, nil

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -30,7 +30,7 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
-// CreateSchematic implements ManagementServer.
+// CreateSchematic implements managementServer.
 func (s *managementServer) CreateSchematic(ctx context.Context, request *management.CreateSchematicRequest) (*management.CreateSchematicResponse, error) {
 	// creating a schematic is equivalent to creating a machine
 	if _, err := auth.CheckGRPC(ctx, auth.WithRole(role.Operator)); err != nil {

--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -33,7 +33,6 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/client/pkg/panichandler"
-	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	slink "github.com/siderolabs/omni/internal/pkg/siderolink"
@@ -42,11 +41,12 @@ import (
 func (s *managementServer) GetSupportBundle(req *management.GetSupportBundleRequest, serv grpc.ServerStreamingServer[management.GetSupportBundleResponse]) error {
 	ctx := serv.Context()
 
-	if _, err := auth.CheckGRPC(ctx, auth.WithRole(role.Operator)); err != nil {
+	authCtx, _, err := s.checkClusterAuthorization(ctx, req.Cluster, role.Operator)
+	if err != nil {
 		return err
 	}
 
-	resources, err := s.collectClusterResources(ctx, req.Cluster)
+	resources, err := s.collectClusterResources(authCtx, req.Cluster)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,11 @@ func (s *managementServer) GetSupportBundle(req *management.GetSupportBundleRequ
 		cols = collectors.WithSource(cols, "omni")
 	}
 
-	ctx = actor.MarkContextAsInternalActor(ctx)
+	if err = s.auditTalosAccessForNodes(authCtx, management.ManagementService_GetSupportBundle_FullMethodName, req.Cluster, machineIDs); err != nil {
+		return err
+	}
+
+	ctx = actor.MarkContextAsInternalActor(authCtx)
 
 	kubernetesClient, err := s.getKubernetesClient(ctx, req.Cluster)
 	if err != nil {

--- a/internal/backend/powerstage/watcher.go
+++ b/internal/backend/powerstage/watcher.go
@@ -79,15 +79,15 @@ func (watcher *Watcher) Run(ctx context.Context) error {
 func (watcher *Watcher) handleEvent(ctx context.Context, event state.Event) error {
 	defer watcher.notify(ctx, event)
 
+	if event.Error != nil {
+		return fmt.Errorf("power status watcher failed: %w", event.Error)
+	}
+
 	var (
 		clusterMachineExists bool
 		infraMachineStatus   *infra.MachineStatus
 		err                  error
 	)
-
-	if event.Error != nil {
-		return fmt.Errorf("power status watcher failed: %w", event.Error)
-	}
 
 	switch res := event.Resource.(type) {
 	case *omni.ClusterMachine:
@@ -117,6 +117,8 @@ func (watcher *Watcher) handleEvent(ctx context.Context, event state.Event) erro
 		}
 
 		clusterMachineExists = err == nil
+	default:
+		return nil
 	}
 
 	if infraMachineStatus.TypedSpec().Value.PowerState != specs.InfraMachineStatusSpec_POWER_STATE_OFF {
@@ -125,9 +127,14 @@ func (watcher *Watcher) handleEvent(ctx context.Context, event state.Event) erro
 
 	snapshot := omni.NewMachineStatusSnapshot(infraMachineStatus.Metadata().ID())
 
-	if clusterMachineExists { // the machine is assigned to a cluster, mark it as "powering on"
+	switch {
+	case infraMachineStatus.TypedSpec().Value.LastPowerOffId != "":
+		// The infra provider is actively honoring a power-off request, so the machine is intentionally off.
+		snapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF
+	case clusterMachineExists:
+		// Allocated machine is off with no honored power-off, so it is expected to be powered back on.
 		snapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERING_ON
-	} else { // the machine is not assigned to a cluster, mark it as "powered off"
+	default:
 		snapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF
 	}
 

--- a/internal/backend/powerstage/watcher_test.go
+++ b/internal/backend/powerstage/watcher_test.go
@@ -73,6 +73,29 @@ func TestWatcher(t *testing.T) {
 
 	expectNotification(ctx, t, notifyCh)
 
+	// Setting LastPowerOffId on the InfraMachineStatus should flip the stage back to POWERED_OFF,
+	// even though the machine is allocated to a cluster.
+	_, err = safe.StateUpdateWithConflicts(ctx, st, status.Metadata(), func(res *infra.MachineStatus) error {
+		res.TypedSpec().Value.LastPowerOffId = "request-id-1"
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	expectSnapshot(ctx, t, snapshotCh, status.Metadata().ID(), specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF)
+	expectNotification(ctx, t, notifyCh)
+
+	// Clearing LastPowerOffId should flip the stage back to POWERING_ON.
+	_, err = safe.StateUpdateWithConflicts(ctx, st, status.Metadata(), func(res *infra.MachineStatus) error {
+		res.TypedSpec().Value.LastPowerOffId = ""
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	expectSnapshot(ctx, t, snapshotCh, status.Metadata().ID(), specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERING_ON)
+	expectNotification(ctx, t, notifyCh)
+
 	require.NoError(t, st.Destroy(ctx, status.Metadata()))
 
 	expectNotification(ctx, t, notifyCh)

--- a/internal/backend/runtime/omni/controllers/omni/infra_machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/infra_machine.go
@@ -298,6 +298,8 @@ func (helper *infraMachineControllerHelper) modify(ctx context.Context, infraMac
 	clusterMachine, err := safe.ReaderGetByID[*omni.ClusterMachine](ctx, helper.runtime, helper.link.Metadata().ID())
 	if err != nil {
 		if state.IsNotFoundError(err) {
+			infraMachine.TypedSpec().Value.PowerOffRequestId = "" // the machine is not allocated, clear power off request to not block the provider from powering it on
+
 			return nil
 		}
 
@@ -307,6 +309,8 @@ func (helper *infraMachineControllerHelper) modify(ctx context.Context, infraMac
 	helpers.CopyLabels(clusterMachine, infraMachine, omni.LabelCluster, omni.LabelMachineSet, omni.LabelControlPlaneRole, omni.LabelWorkerRole)
 
 	if clusterMachine.Metadata().Phase() == resource.PhaseTearingDown {
+		infraMachine.TypedSpec().Value.PowerOffRequestId = "" // the machine is being deallocated, clear power off request to not block the provider from powering it on
+
 		if clusterMachine.Metadata().Finalizers().Has(ClusterMachineConfigControllerName) {
 			return nil // the cluster machine is not reset yet
 		}
@@ -441,6 +445,7 @@ func (helper *infraMachineControllerHelper) applyInfraMachineConfig(infraMachine
 	// reset the user-override fields except the "Accepted" field
 	infraMachine.TypedSpec().Value.PreferredPowerState = defaultPreferredPowerState
 	infraMachine.TypedSpec().Value.ExtraKernelArgs = ""
+	infraMachine.TypedSpec().Value.PowerOffRequestId = ""
 
 	pendingAccept := config == nil
 
@@ -463,6 +468,7 @@ func (helper *infraMachineControllerHelper) applyInfraMachineConfig(infraMachine
 		}
 
 		infraMachine.TypedSpec().Value.ExtraKernelArgs = config.TypedSpec().Value.ExtraKernelArgs
+		infraMachine.TypedSpec().Value.PowerOffRequestId = config.TypedSpec().Value.PowerOffRequestId
 	}
 
 	if pendingAccept {

--- a/internal/backend/runtime/omni/controllers/omni/machine/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine/status.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package machine
+
+import (
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+// UpdateConnectionStatus updates the connection-related labels and the Connected spec field on machineStatus
+// based on the machine's current connectivity, power state, and infra provider information.
+func UpdateConnectionStatus(machineStatus *omni.MachineStatus, machine *omni.Machine, machineStatusSnapshot *omni.MachineStatusSnapshot, infraMachineStatus *infra.MachineStatus) {
+	connected := machine.TypedSpec().Value.Connected
+	_, isManagedByStaticInfraProvider := machine.Metadata().Labels().Get(omni.LabelIsManagedByStaticInfraProvider)
+	isPoweredOff := machineStatusSnapshot != nil && machineStatusSnapshot.TypedSpec().Value.GetPowerStage() == specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF
+	canBePoweredOn := isManagedByStaticInfraProvider && infraMachineStatus != nil && infraMachineStatus.TypedSpec().Value.PowerState != specs.InfraMachineStatusSpec_POWER_STATE_UNKNOWN
+	isUnallocated := machineStatus.TypedSpec().Value.Cluster == ""
+	infraMachineIsReadyToUse := canBePoweredOn && infraMachineStatus.TypedSpec().Value.ReadyToUse
+
+	machineStatus.TypedSpec().Value.Connected = connected
+
+	if connected {
+		machineStatus.Metadata().Labels().Set(omni.MachineStatusLabelConnected, "")
+		machineStatus.Metadata().Labels().Delete(omni.MachineStatusLabelDisconnected)
+		machineStatus.Metadata().Labels().Set(omni.MachineStatusLabelReadyToUse, "")
+
+		return
+	}
+
+	// The logic for the disconnected machines
+
+	machineStatus.Metadata().Labels().Delete(omni.MachineStatusLabelConnected)
+
+	// If the machine is known to be powered off OR if we can power it on
+	// (e.g., it is managed by the bare-metal infra provider,
+	// and the provider has the BMC credentials of the machine),
+	// we do not mark it as disconnected anymore, as the machine being not connected is expected.
+	if isPoweredOff || canBePoweredOn {
+		machineStatus.Metadata().Labels().Delete(omni.MachineStatusLabelDisconnected)
+	} else {
+		machineStatus.Metadata().Labels().Set(omni.MachineStatusLabelDisconnected, "")
+	}
+
+	// We mark the machine as "ready to use" from Omni's perspective, despite it being not connected, when all the conditions below are satisfied:
+	// - The machine is unallocated, i.e., not yet part of a cluster
+	// - It is managed by a static (e.g., bare-metal) provider
+	// - The provider marked the machine as "ready to use" from its own perspective (no pending wipes etc.)
+	// - The provider can actually power it on (e.g., using BMC) when needed (e.g., when it is added to a cluster)
+	if isUnallocated && infraMachineIsReadyToUse {
+		machineStatus.Metadata().Labels().Set(omni.MachineStatusLabelReadyToUse, "")
+	} else {
+		machineStatus.Metadata().Labels().Delete(omni.MachineStatusLabelReadyToUse)
+	}
+}
+
+// UpdatePowerState updates the PowerState spec field on machineStatus.
+// For machines managed by a static infra provider, the state comes from the infra provider.
+// For other machines, it is derived from the snapshot power stage and connection state.
+func UpdatePowerState(machineStatus *omni.MachineStatus, machine *omni.Machine, machineStatusSnapshot *omni.MachineStatusSnapshot, infraMachineStatus *infra.MachineStatus) {
+	_, isManagedByStaticInfraProvider := machine.Metadata().Labels().Get(omni.LabelIsManagedByStaticInfraProvider)
+
+	if isManagedByStaticInfraProvider {
+		if infraMachineStatus == nil {
+			machineStatus.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_UNKNOWN
+
+			return
+		}
+
+		switch infraMachineStatus.TypedSpec().Value.PowerState {
+		case specs.InfraMachineStatusSpec_POWER_STATE_UNKNOWN:
+			machineStatus.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_UNKNOWN
+		case specs.InfraMachineStatusSpec_POWER_STATE_ON:
+			machineStatus.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_ON
+		case specs.InfraMachineStatusSpec_POWER_STATE_OFF:
+			machineStatus.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_OFF
+		}
+
+		return
+	}
+
+	isPoweredOff := machineStatusSnapshot != nil && machineStatusSnapshot.TypedSpec().Value.GetPowerStage() == specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF
+	if isPoweredOff {
+		machineStatus.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_OFF
+
+		return
+	}
+
+	if machine.TypedSpec().Value.Connected {
+		machineStatus.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_ON
+
+		return
+	}
+
+	machineStatus.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_UNSUPPORTED
+}

--- a/internal/backend/runtime/omni/controllers/omni/machine/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine/status_test.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package machine_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/machine"
+)
+
+func TestUpdateConnectionStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		cluster                string
+		name                   string
+		infraPowerState        specs.InfraMachineStatusSpec_MachinePowerState
+		powerStage             specs.MachineStatusSnapshotSpec_PowerStage
+		isManagedByStaticInfra bool
+		hasSnapshot            bool
+		connected              bool
+		infraReadyToUse        bool
+		hasInfraMachineStatus  bool
+		wantConnected          bool
+		wantDisconnected       bool
+		wantReadyToUse         bool
+		wantConnectedVal       bool
+	}{
+		{
+			name:             "connected machine",
+			connected:        true,
+			wantConnected:    true,
+			wantDisconnected: false,
+			wantReadyToUse:   true,
+			wantConnectedVal: true,
+		},
+		{
+			name:             "disconnected plain machine",
+			connected:        false,
+			wantConnected:    false,
+			wantDisconnected: true,
+			wantReadyToUse:   false,
+			wantConnectedVal: false,
+		},
+		{
+			name:             "powered-off machine",
+			connected:        false,
+			hasSnapshot:      true,
+			powerStage:       specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF,
+			wantConnected:    false,
+			wantDisconnected: false,
+			wantReadyToUse:   false,
+			wantConnectedVal: false,
+		},
+		{
+			name:                   "BM machine with BMC control, unallocated, ready to use",
+			connected:              false,
+			isManagedByStaticInfra: true,
+			hasInfraMachineStatus:  true,
+			infraPowerState:        specs.InfraMachineStatusSpec_POWER_STATE_OFF,
+			infraReadyToUse:        true,
+			wantConnected:          false,
+			wantDisconnected:       false,
+			wantReadyToUse:         true,
+			wantConnectedVal:       false,
+		},
+		{
+			name:                   "BM machine with BMC control, allocated, ready to use",
+			connected:              false,
+			isManagedByStaticInfra: true,
+			cluster:                "some-cluster",
+			hasInfraMachineStatus:  true,
+			infraPowerState:        specs.InfraMachineStatusSpec_POWER_STATE_OFF,
+			infraReadyToUse:        true,
+			wantConnected:          false,
+			wantDisconnected:       false,
+			wantReadyToUse:         false,
+			wantConnectedVal:       false,
+		},
+		{
+			name:                   "BM machine with BMC control, not ready to use",
+			connected:              false,
+			isManagedByStaticInfra: true,
+			hasInfraMachineStatus:  true,
+			infraPowerState:        specs.InfraMachineStatusSpec_POWER_STATE_OFF,
+			infraReadyToUse:        false,
+			wantConnected:          false,
+			wantDisconnected:       false,
+			wantReadyToUse:         false,
+			wantConnectedVal:       false,
+		},
+		{
+			name:                   "BM machine, power state unknown (no BMC control)",
+			connected:              false,
+			isManagedByStaticInfra: true,
+			hasInfraMachineStatus:  true,
+			infraPowerState:        specs.InfraMachineStatusSpec_POWER_STATE_UNKNOWN,
+			infraReadyToUse:        true,
+			wantConnected:          false,
+			wantDisconnected:       true,
+			wantReadyToUse:         false,
+			wantConnectedVal:       false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const id = "test-machine"
+
+			machineRes := omni.NewMachine(id)
+			machineRes.TypedSpec().Value.Connected = tt.connected
+
+			if tt.isManagedByStaticInfra {
+				machineRes.Metadata().Labels().Set(omni.LabelIsManagedByStaticInfraProvider, "")
+			}
+
+			machineStatus := omni.NewMachineStatus(id)
+			machineStatus.TypedSpec().Value.Cluster = tt.cluster
+
+			var snapshot *omni.MachineStatusSnapshot
+
+			if tt.hasSnapshot {
+				snapshot = omni.NewMachineStatusSnapshot(id)
+				snapshot.TypedSpec().Value.PowerStage = tt.powerStage
+			}
+
+			var infraMachineStatus *infra.MachineStatus
+
+			if tt.hasInfraMachineStatus {
+				infraMachineStatus = infra.NewMachineStatus(id)
+				infraMachineStatus.TypedSpec().Value.PowerState = tt.infraPowerState
+				infraMachineStatus.TypedSpec().Value.ReadyToUse = tt.infraReadyToUse
+			}
+
+			machine.UpdateConnectionStatus(machineStatus, machineRes, snapshot, infraMachineStatus)
+
+			_, hasConnected := machineStatus.Metadata().Labels().Get(omni.MachineStatusLabelConnected)
+			_, hasDisconnected := machineStatus.Metadata().Labels().Get(omni.MachineStatusLabelDisconnected)
+			_, hasReadyToUse := machineStatus.Metadata().Labels().Get(omni.MachineStatusLabelReadyToUse)
+
+			assert.Equal(t, tt.wantConnected, hasConnected, "Connected label")
+			assert.Equal(t, tt.wantDisconnected, hasDisconnected, "Disconnected label")
+			assert.Equal(t, tt.wantReadyToUse, hasReadyToUse, "ReadyToUse label")
+			assert.Equal(t, tt.wantConnectedVal, machineStatus.TypedSpec().Value.Connected, "Connected spec field")
+		})
+	}
+}
+
+func TestUpdatePowerState(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name                   string
+		powerStage             specs.MachineStatusSnapshotSpec_PowerStage
+		infraPowerState        specs.InfraMachineStatusSpec_MachinePowerState
+		wantPowerState         specs.MachineStatusSpec_PowerState
+		connected              bool
+		isManagedByStaticInfra bool
+		hasSnapshot            bool
+		hasInfraMachineStatus  bool
+	}{
+		{
+			name:           "connected non-BM machine",
+			connected:      true,
+			wantPowerState: specs.MachineStatusSpec_POWER_STATE_ON,
+		},
+		{
+			name:           "disconnected non-BM machine",
+			connected:      false,
+			wantPowerState: specs.MachineStatusSpec_POWER_STATE_UNSUPPORTED,
+		},
+		{
+			name:           "powered-off non-BM machine (snapshot)",
+			connected:      false,
+			hasSnapshot:    true,
+			powerStage:     specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF,
+			wantPowerState: specs.MachineStatusSpec_POWER_STATE_OFF,
+		},
+		{
+			name:                   "BM machine, power on",
+			isManagedByStaticInfra: true,
+			hasInfraMachineStatus:  true,
+			infraPowerState:        specs.InfraMachineStatusSpec_POWER_STATE_ON,
+			wantPowerState:         specs.MachineStatusSpec_POWER_STATE_ON,
+		},
+		{
+			name:                   "BM machine, power off",
+			isManagedByStaticInfra: true,
+			hasInfraMachineStatus:  true,
+			infraPowerState:        specs.InfraMachineStatusSpec_POWER_STATE_OFF,
+			wantPowerState:         specs.MachineStatusSpec_POWER_STATE_OFF,
+		},
+		{
+			name:                   "BM machine, power state unknown",
+			isManagedByStaticInfra: true,
+			hasInfraMachineStatus:  true,
+			infraPowerState:        specs.InfraMachineStatusSpec_POWER_STATE_UNKNOWN,
+			wantPowerState:         specs.MachineStatusSpec_POWER_STATE_UNKNOWN,
+		},
+		{
+			name:                   "BM machine, no infra status",
+			isManagedByStaticInfra: true,
+			hasInfraMachineStatus:  false,
+			wantPowerState:         specs.MachineStatusSpec_POWER_STATE_UNKNOWN,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const id = "test-machine"
+
+			machineRes := omni.NewMachine(id)
+			machineRes.TypedSpec().Value.Connected = tt.connected
+
+			if tt.isManagedByStaticInfra {
+				machineRes.Metadata().Labels().Set(omni.LabelIsManagedByStaticInfraProvider, "")
+			}
+
+			machineStatus := omni.NewMachineStatus(id)
+
+			var snapshot *omni.MachineStatusSnapshot
+
+			if tt.hasSnapshot {
+				snapshot = omni.NewMachineStatusSnapshot(id)
+				snapshot.TypedSpec().Value.PowerStage = tt.powerStage
+			}
+
+			var infraMachineStatus *infra.MachineStatus
+
+			if tt.hasInfraMachineStatus {
+				infraMachineStatus = infra.NewMachineStatus(id)
+				infraMachineStatus.TypedSpec().Value.PowerState = tt.infraPowerState
+			}
+
+			machine.UpdatePowerState(machineStatus, machineRes, snapshot, infraMachineStatus)
+
+			assert.Equal(t, tt.wantPowerState, machineStatus.TypedSpec().Value.PowerState, "PowerState")
+		})
+	}
+}

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -31,6 +31,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	machinetask "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/task/machine"
+	machinectrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/machine"
 )
 
 type KernelArgsInitializer interface {
@@ -275,8 +276,8 @@ func (ctrl *MachineStatusController) reconcileRunning(ctx context.Context, r con
 			return err
 		}
 
-		ctrl.updateMachineConnectionStatus(machine, inputs, m)
-		ctrl.updateMachinePowerState(machine, inputs, m)
+		machinectrl.UpdateConnectionStatus(m, machine, inputs.machineStatusSnapshot, inputs.infraMachineStatus)
+		machinectrl.UpdatePowerState(m, machine, inputs.machineStatusSnapshot, inputs.infraMachineStatus)
 
 		return ctrl.copyInfraProviderLabels(m, inputs.infraMachineStatus)
 	})
@@ -310,63 +311,6 @@ func (ctrl *MachineStatusController) copyInfraProviderLabels(machineStatus *omni
 	}
 
 	return nil
-}
-
-func (ctrl *MachineStatusController) updateMachinePowerState(machine *omni.Machine, inputs inputs, m *omni.MachineStatus) {
-	_, isManagedByStaticInfraProvider := machine.Metadata().Labels().Get(omni.LabelIsManagedByStaticInfraProvider)
-
-	if isManagedByStaticInfraProvider {
-		if inputs.infraMachineStatus == nil {
-			m.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_UNKNOWN
-
-			return
-		}
-
-		switch inputs.infraMachineStatus.TypedSpec().Value.PowerState {
-		case specs.InfraMachineStatusSpec_POWER_STATE_UNKNOWN:
-			m.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_UNKNOWN
-		case specs.InfraMachineStatusSpec_POWER_STATE_ON:
-			m.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_ON
-		case specs.InfraMachineStatusSpec_POWER_STATE_OFF:
-			m.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_OFF
-		}
-
-		return
-	}
-
-	m.TypedSpec().Value.PowerState = specs.MachineStatusSpec_POWER_STATE_UNSUPPORTED
-}
-
-func (ctrl *MachineStatusController) updateMachineConnectionStatus(machine *omni.Machine, inputs inputs, m *omni.MachineStatus) {
-	connected := machine.TypedSpec().Value.Connected
-
-	m.TypedSpec().Value.Connected = connected
-
-	if connected {
-		m.Metadata().Labels().Set(omni.MachineStatusLabelConnected, "")
-		m.Metadata().Labels().Delete(omni.MachineStatusLabelDisconnected)
-
-		m.Metadata().Labels().Set(omni.MachineStatusLabelReadyToUse, "")
-
-		return
-	}
-
-	m.Metadata().Labels().Delete(omni.MachineStatusLabelConnected)
-
-	infraMachineIsReadyToUse := inputs.infraMachineStatus != nil &&
-		inputs.infraMachineStatus.TypedSpec().Value.PowerState != specs.InfraMachineStatusSpec_POWER_STATE_UNKNOWN &&
-		inputs.infraMachineStatus.TypedSpec().Value.ReadyToUse
-
-	_, isManagedByStaticInfraProvider := machine.Metadata().Labels().Get(omni.LabelIsManagedByStaticInfraProvider)
-	if isManagedByStaticInfraProvider && infraMachineIsReadyToUse && m.TypedSpec().Value.Cluster == "" {
-		m.Metadata().Labels().Set(omni.MachineStatusLabelReadyToUse, "")
-		m.Metadata().Labels().Delete(omni.MachineStatusLabelDisconnected)
-
-		return
-	}
-
-	m.Metadata().Labels().Delete(omni.MachineStatusLabelReadyToUse)
-	m.Metadata().Labels().Set(omni.MachineStatusLabelDisconnected, "")
 }
 
 func (ctrl *MachineStatusController) reconcileTearingDown(ctx context.Context, r controller.QRuntime, logger *zap.Logger, machine *omni.Machine) error {

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot.go
@@ -16,8 +16,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/task"
 	"github.com/siderolabs/gen/optional"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
@@ -177,6 +179,12 @@ func (ctrl *MachineStatusSnapshotController) reconcileRunning(ctx context.Contex
 
 	if !machine.TypedSpec().Value.Connected {
 		ctrl.runner.StopTask(logger, machine.Metadata().ID())
+
+		// machine is disconnected, check if its last known phase was "shutting down",
+		// and if it was, mark it as powered off.
+		if err = ctrl.handleDisconnectedMachinePowerOff(ctx, r, machine.Metadata().ID()); err != nil {
+			return err
+		}
 	}
 
 	if machine.TypedSpec().Value.Connected {
@@ -188,6 +196,35 @@ func (ctrl *MachineStatusSnapshotController) reconcileRunning(ctx context.Contex
 	}
 
 	return nil
+}
+
+// handleDisconnectedMachinePowerOff checks if the machine was in shutting down stage before it got disconnected, and if it was,
+// it creates a snapshot with "powered off" stage, since we won't receive any more updates about this machine's status.
+func (ctrl *MachineStatusSnapshotController) handleDisconnectedMachinePowerOff(ctx context.Context, r controller.QRuntime, machineID resource.ID) error {
+	snapshot, err := safe.ReaderGetByID[*omni.MachineStatusSnapshot](ctx, r, machineID)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if snapshot.TypedSpec().Value.PowerStage == specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF { // already in powered off stage
+		return nil
+	}
+
+	wasShuttingDown := snapshot.TypedSpec().Value.GetMachineStatus().GetStage() == machineapi.MachineStatusEvent_SHUTTING_DOWN
+	if !wasShuttingDown {
+		return nil
+	}
+
+	// create a synthetic snapshot with only power stage information to keep
+	// Talos machine status as-is, but mark the machine power stage as powered off.
+	poweredOffSnapshot := omni.NewMachineStatusSnapshot(machineID)
+	poweredOffSnapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF
+
+	return ctrl.reconcileSnapshot(ctx, r, poweredOffSnapshot)
 }
 
 func (ctrl *MachineStatusSnapshotController) reconcileTearingDown(ctx context.Context, r controller.QRuntime, logger *zap.Logger, machine *omni.Machine) error {


### PR DESCRIPTION
Machines that were shutting down and then disconnect are now shown as "Powered Off" in the UI instead of being stuck in "Shutting Down" with a greyed-out unreachable state.

For machines managed by a static infra provider, shutting down a machine now prevents the provider from automatically powering it back on due to cluster allocation. The provider honors the shutdown request until the machine goes through a deallocation cycle, at which point the request is considered stale.

Intentionally powered-off machines are also excluded from the "disconnected machines" list on the frontend when destroying a cluster, to avoid them being force-destroyed.

The shutdown modal in the frontend now calls a new management API endpoint instead of the Talos API directly. The CLI gains \`omnictl machine shutdown\` and \`omnictl machine power-on\` commands.

Closes siderolabs/omni#1634.
Part of siderolabs/omni-infra-provider-bare-metal#103.