### PR TITLE
fix(frontend): select default join token in installation media wizard

### DIFF
--- a/frontend/src/methods/machineset.ts
+++ b/frontend/src/methods/machineset.ts
@@ -33,8 +33,7 @@ export const sortMachineSetIds = (clusterId: string | undefined, ids: string[]):
     return ids
   }
 
-  const idsCopy = ids.concat()
-  return idsCopy.sort((a, b) => {
+  return ids.toSorted((a, b) => {
     const nameA = machineSetName(clusterId, a)
     const nameB = machineSetName(clusterId, b)
 

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/talos-version.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/talos-version.vue
@@ -56,10 +56,17 @@ const talosVersions = computed(() =>
 )
 
 const joinTokens = computed(() =>
-  joinTokenList.value.map((t) => ({
-    label: t.spec.name || t.metadata.id || '',
-    value: t.metadata.id || '',
-  })),
+  joinTokenList.value
+    .toSorted((a, b) => {
+      if (a.spec.is_default) return -1
+      if (b.spec.is_default) return 1
+
+      return 0
+    })
+    .map((t) => ({
+      label: t.spec.name || t.metadata.id || '',
+      value: t.metadata.id || '',
+    })),
 )
 
 // Form defaults

--- a/frontend/src/views/Modals/UpdateKubernetes.vue
+++ b/frontend/src/views/Modals/UpdateKubernetes.vue
@@ -143,9 +143,9 @@ const groupedK8sVersions = computed(() => {
 })
 
 const allTalosVersions = computed(() =>
-  allTalosVersionsUnsorted.value
-    .slice()
-    .sort((a, b) => semver.compare(a.spec.version!, b.spec.version!)),
+  allTalosVersionsUnsorted.value.toSorted((a, b) =>
+    semver.compare(a.spec.version!, b.spec.version!),
+  ),
 )
 
 function isVersionUpgradeable(version: string) {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -3,6 +3,8 @@
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "typed-router.d.ts"],
   "exclude": ["src/**/*.spec.*", "src/**/*.stories.*"],
   "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "moduleResolution": "Bundler",
     "rootDir": ".",

--- a/frontend/tsconfig.vitest.json
+++ b/frontend/tsconfig.vitest.json
@@ -12,7 +12,7 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
 
-    "lib": ["ES2022"],
+    "lib": ["ES2023"],
     "types": ["node", "jsdom", "@testing-library/jest-dom"],
 
     "paths": {


### PR DESCRIPTION
Select the default join token in the installation media wizard. Also bump tsconfig to `ES2023` (which is baseline widely available) to get access to `.toSorted()`.