### PR TITLE
fix(frontend): clear page state when keys are cleared

### DIFF
--- a/frontend/e2e/talemu/auth.spec.ts
+++ b/frontend/e2e/talemu/auth.spec.ts
@@ -20,13 +20,13 @@ test('Key expiration without existing auth session', async ({ page }) => {
 
   await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible()
 
-  // Invalidate keys
-  await page.evaluate(() => {
-    localStorage.setItem('keyExpirationTime', new Date(0).toISOString())
+  await test.step('Invalidate keys', async () => {
+    await page.evaluate(() => localStorage.setItem('keyExpirationTime', new Date(0).toISOString()))
+
+    // Clear auth0 cookies
+    await page.context().clearCookies()
+    await page.goto('/')
   })
-  // Clear auth0 cookies
-  await page.context().clearCookies()
-  await page.goto('/')
 
   await expect(page.getByText('Log in')).toBeVisible()
 })
@@ -36,16 +36,11 @@ test('Key expiration with existing auth session', async ({ page }) => {
 
   await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible()
 
-  // Invalidate keys
-  await page.evaluate(() => {
-    localStorage.setItem('keyExpirationTime', new Date(0).toISOString())
+  await test.step('Invalidate keys', async () => {
+    await page.evaluate(() => localStorage.setItem('keyExpirationTime', new Date(0).toISOString()))
+    await page.goto('/')
   })
-  await page.goto('/')
 
-  // Need this to make sure getByText polling doesn't miss the auth page
-  await page.waitForURL('**/authenticate**')
-
-  await expect(page.getByText('Authenticate UI Access')).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible()
 })
 
@@ -54,15 +49,10 @@ test('Escape invalid key state', async ({ page }) => {
 
   await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible()
 
-  // Purposefully break signatures
-  await page.evaluate(() => {
-    localStorage.setItem('publicKeyID', 'fake!')
+  await test.step('Purposefully break signatures', async () => {
+    await page.evaluate(() => localStorage.setItem('publicKeyID', 'fake!'))
+    await page.goto('/')
   })
-  await page.goto('/')
 
-  // Need this to make sure getByText polling doesn't miss the auth page
-  await page.waitForURL('**/authenticate**')
-
-  await expect(page.getByText('Authenticate UI Access')).toBeVisible()
   await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible()
 })

--- a/frontend/src/methods/key.spec.ts
+++ b/frontend/src/methods/key.spec.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
   vi.mocked(useRoute, { partial: true }).mockReturnValue({})
   vi.mocked(useRouter, { partial: true }).mockReturnValue({
     isReady: vi.fn(),
-    replace: vi.fn(),
+    resolve: vi.fn().mockReturnValue({ href: '' }),
   })
 
   vi.mocked(useRouter().isReady).mockImplementation(async () => {
@@ -133,7 +133,7 @@ describe('useWatchKeyExpiry', () => {
 
     await flushPromises()
 
-    expect(useRouter().replace).not.toHaveBeenCalled()
+    expect(useRouter().resolve).not.toHaveBeenCalled()
   })
 
   test('clears keys if invalidated', async () => {
@@ -145,13 +145,13 @@ describe('useWatchKeyExpiry', () => {
     await flushPromises()
 
     expect(useKeys().keyPair.value).toBeTruthy()
-    expect(useRouter().replace).not.toHaveBeenCalled()
+    expect(useRouter().resolve).not.toHaveBeenCalled()
 
     useKeys().invalidate()
     await flushPromises()
 
     expect(useKeys().keyPair.value).toBeFalsy()
-    expect(useRouter().replace).toHaveBeenCalledExactlyOnceWith({
+    expect(useRouter().resolve).toHaveBeenCalledExactlyOnceWith({
       name: 'Authenticate',
       query: { flow: 'frontend', redirect: 'fullPath' },
     })
@@ -166,7 +166,7 @@ describe('useWatchKeyExpiry', () => {
     await flushPromises()
 
     expect(useKeys().keyPair.value).toBeFalsy()
-    expect(useRouter().replace).toHaveBeenCalledExactlyOnceWith({
+    expect(useRouter().resolve).toHaveBeenCalledExactlyOnceWith({
       name: 'Authenticate',
       query: { flow: 'frontend', redirect: 'fullPath' },
     })
@@ -181,12 +181,12 @@ describe('useWatchKeyExpiry', () => {
     await flushPromises()
 
     expect(useKeys().keyPair.value).toBeDefined()
-    expect(useRouter().replace).not.toHaveBeenCalled()
+    expect(useRouter().resolve).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(milliseconds({ minutes: 2 }))
 
     expect(useKeys().keyPair.value).toBeFalsy()
-    expect(useRouter().replace).toHaveBeenCalledExactlyOnceWith({
+    expect(useRouter().resolve).toHaveBeenCalledExactlyOnceWith({
       name: 'Authenticate',
       query: { flow: 'frontend', redirect: 'fullPath' },
     })
@@ -206,12 +206,12 @@ describe('useWatchKeyExpiry', () => {
     await flushPromises()
 
     expect(useKeys().keyPair.value).toBeDefined()
-    expect(useRouter().replace).not.toHaveBeenCalled()
+    expect(useRouter().resolve).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(milliseconds({ minutes: 2 }))
 
     expect(useKeys().keyPair.value).toBeFalsy()
-    expect(useRouter().replace).not.toHaveBeenCalled()
+    expect(useRouter().resolve).not.toHaveBeenCalled()
   })
 
   test('cleans up on unmount', async () => {
@@ -223,13 +223,13 @@ describe('useWatchKeyExpiry', () => {
     await flushPromises()
 
     expect(useKeys().keyPair.value).toBeDefined()
-    expect(useRouter().replace).not.toHaveBeenCalled()
+    expect(useRouter().resolve).not.toHaveBeenCalled()
 
     wrapper.unmount()
     await vi.advanceTimersByTimeAsync(milliseconds({ minutes: 2 }))
 
     expect(useKeys().keyPair.value).toBeDefined()
-    expect(useRouter().replace).not.toHaveBeenCalled()
+    expect(useRouter().resolve).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/methods/key.ts
+++ b/frontend/src/methods/key.ts
@@ -90,10 +90,13 @@ export function useWatchKeyExpiry() {
        */
       if (route.name === 'Authenticate') return
 
-      router.replace({
-        name: 'Authenticate',
-        query: { [AuthFlowQueryParam]: FrontendAuthFlow, [RedirectQueryParam]: route.fullPath },
-      })
+      // Using location.replace instead of router.replace to do a full reload to clear any invalid states
+      window.location.replace(
+        router.resolve({
+          name: 'Authenticate',
+          query: { [AuthFlowQueryParam]: FrontendAuthFlow, [RedirectQueryParam]: route.fullPath },
+        }).href,
+      )
     }
   })
 }


### PR DESCRIPTION
After clearing keys, use `location.replace` instead of `router.replace` to do a full page reload to clear any invalid key related state. This addresses an issue where user might see a blank screen if something breaks with their keys whilst still having a valid auth session. Usually an invalid auth session triggers a redirect to the auth provider, causing the same state reset. This also fixes a flakey test in `e2e-talemu` suite which was suffering from this.