### PR TITLE
feat(frontend): add join token/talos version placeholders in installation media

### DIFF
--- a/frontend/src/components/AppToast/AppToast.vue
+++ b/frontend/src/components/AppToast/AppToast.vue
@@ -15,6 +15,11 @@ import TIcon from '@/components/Icon/TIcon.vue'
 <template>
   <Toaster
     close-button
+    :offset="{
+      // Custom offset to show toasts above the lower bars we sometimes have
+      bottom: '4.5rem',
+      right: '1rem',
+    }"
     :toast-options="{
       unstyled: true,
       classes: {

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/arch.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/arch.vue
@@ -20,7 +20,7 @@ import RadioGroup from '@/components/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/Radio/RadioGroupOption.vue'
 import { getDocsLink } from '@/methods'
 import { useResourceGet } from '@/methods/useResourceGet'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import { type FormState, resolveTalosVersion } from '@/views/InstallationMedia/useFormState'
 
 definePage({ name: 'InstallationMediaCreateMachineArch' })
 
@@ -28,7 +28,7 @@ const formState = defineModel<FormState>({ required: true })
 
 const secureBootDocsLink = computed(() =>
   getDocsLink('talos', '/platform-specific-installations/bare-metal-platforms', {
-    talosVersion: formState.value.talosVersion,
+    talosVersion: resolveTalosVersion(formState.value.talosVersion),
   }),
 )
 

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/cloud-provider.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/cloud-provider.vue
@@ -16,7 +16,7 @@ import RadioGroup from '@/components/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/Radio/RadioGroupOption.vue'
 import { getDocsLink } from '@/methods'
 import { useResourceList } from '@/methods/useResourceList'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import { type FormState, resolveTalosVersion } from '@/views/InstallationMedia/useFormState'
 
 definePage({ name: 'InstallationMediaCreateCloudProvider' })
 
@@ -30,13 +30,11 @@ const { data } = useResourceList<PlatformConfigSpec>({
   },
 })
 
+const resolvedVersion = computed(() => resolveTalosVersion(formState.value.talosVersion!))
+
 const platforms = computed(() =>
   data.value
-    ?.filter(
-      (p) =>
-        !p.spec.min_version ||
-        (formState.value.talosVersion && gte(formState.value.talosVersion, p.spec.min_version)),
-    )
+    ?.filter((p) => !p.spec.min_version || gte(resolvedVersion.value, p.spec.min_version))
     .map((p) => ({
       ...p,
       spec: {
@@ -44,7 +42,7 @@ const platforms = computed(() =>
         documentation:
           p.spec.documentation &&
           getDocsLink('talos', p.spec.documentation, {
-            talosVersion: formState.value.talosVersion,
+            talosVersion: resolvedVersion.value,
           }),
       },
     })),

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.stories.ts
@@ -24,7 +24,6 @@ import {
 import {
   CloudPlatformConfigType,
   DefaultNamespace,
-  DefaultTalosVersion,
   FeaturesConfigID,
   FeaturesConfigType,
   LabelsMeta,
@@ -34,6 +33,7 @@ import {
   VirtualNamespace,
 } from '@/api/resources'
 import type { TalosctlDownloadsResponse } from '@/methods/useTalosctlDownloads'
+import { AUTOMATIC_VERSION } from '@/views/InstallationMedia/useFormState'
 
 import Confirmation from './confirmation.vue'
 
@@ -43,7 +43,7 @@ const meta: Meta<typeof Confirmation> = {
     modelValue: {
       hardwareType: 'metal',
       machineArch: PlatformConfigSpecArch.ARM64,
-      talosVersion: DefaultTalosVersion,
+      talosVersion: AUTOMATIC_VERSION,
       machineUserLabels: {
         'my-label': { canRemove: true, value: 'my-value' },
       },

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.stories.ts
@@ -9,7 +9,8 @@ import { http, HttpResponse } from 'msw'
 import type { Resource } from '@/api/grpc'
 import type { GetRequest, GetResponse } from '@/api/omni/resources/resources.pb'
 import type { SBCConfigSpec } from '@/api/omni/specs/virtual.pb'
-import { DefaultTalosVersion, SBCConfigType, VirtualNamespace } from '@/api/resources'
+import { SBCConfigType, VirtualNamespace } from '@/api/resources'
+import { AUTOMATIC_VERSION } from '@/views/InstallationMedia/useFormState'
 
 import ExtraArgs from './extra-args.vue'
 
@@ -31,7 +32,7 @@ const SBC: Resource<SBCConfigSpec> = {
 const meta: Meta<typeof ExtraArgs> = {
   component: ExtraArgs,
   args: {
-    modelValue: { talosVersion: DefaultTalosVersion },
+    modelValue: { talosVersion: AUTOMATIC_VERSION },
   },
 }
 
@@ -83,7 +84,7 @@ export const WithOverlayOptions: Story = {
   ...Default,
   args: {
     modelValue: {
-      talosVersion: DefaultTalosVersion,
+      talosVersion: AUTOMATIC_VERSION,
       hardwareType: 'sbc',
       sbcType: SBC.metadata.id,
     },

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.vue
@@ -18,19 +18,17 @@ import TextArea from '@/components/TextArea/TextArea.vue'
 import TInput from '@/components/TInput/TInput.vue'
 import { getDocsLink } from '@/methods'
 import { useResourceGet } from '@/methods/useResourceGet'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import { type FormState, resolveTalosVersion } from '@/views/InstallationMedia/useFormState'
 
 definePage({ name: 'InstallationMediaCreateExtraArgs' })
 
 const formState = defineModel<FormState>({ required: true })
 
-const supportsCustomisingKernelArgs = computed(
-  () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.10.0'),
-)
+const resolvedVersion = computed(() => resolveTalosVersion(formState.value.talosVersion!))
 
-const supportsBootloaderSelection = computed(
-  () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.12.0-alpha.2'),
-)
+const supportsCustomisingKernelArgs = computed(() => gte(resolvedVersion.value, '1.10.0'))
+
+const supportsBootloaderSelection = computed(() => gte(resolvedVersion.value, '1.12.0-alpha.2'))
 
 const { data: selectedSBC } = useResourceGet<SBCConfigSpec>(() => ({
   skip: formState.value.hardwareType !== 'sbc',
@@ -62,7 +60,7 @@ onBeforeMount(() => (formState.value.bootloader ??= SchematicBootloader.BOOT_AUT
       <a
         target="_blank"
         rel="noopener noreferrer"
-        :href="getDocsLink('talos', '/reference/kernel', { talosVersion: formState.talosVersion })"
+        :href="getDocsLink('talos', '/reference/kernel', { talosVersion: resolvedVersion })"
         class="link-primary"
       >
         kernel command line arguments.

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/sbc-type.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/sbc-type.vue
@@ -16,7 +16,7 @@ import RadioGroup from '@/components/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/Radio/RadioGroupOption.vue'
 import { getDocsLink } from '@/methods'
 import { useResourceList } from '@/methods/useResourceList'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import { type FormState, resolveTalosVersion } from '@/views/InstallationMedia/useFormState'
 
 definePage({ name: 'InstallationMediaCreateSBCType' })
 
@@ -30,13 +30,11 @@ const { data } = useResourceList<SBCConfigSpec>({
   },
 })
 
+const resolvedVersion = computed(() => resolveTalosVersion(formState.value.talosVersion!))
+
 const SBCs = computed(() =>
   data.value
-    ?.filter(
-      (sbc) =>
-        !sbc.spec.min_version ||
-        (formState.value.talosVersion && gte(formState.value.talosVersion, sbc.spec.min_version)),
-    )
+    ?.filter((sbc) => !sbc.spec.min_version || gte(resolvedVersion.value, sbc.spec.min_version))
     .map((sbc) => ({
       ...sbc,
       spec: {
@@ -44,7 +42,7 @@ const SBCs = computed(() =>
         documentation:
           sbc.spec.documentation &&
           getDocsLink('talos', sbc.spec.documentation, {
-            talosVersion: formState.value.talosVersion,
+            talosVersion: resolvedVersion.value,
           }),
       },
     })),

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/system-extensions.stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/system-extensions.stories.ts
@@ -7,14 +7,15 @@ import { createWatchStreamHandler } from '@msw/helpers'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
 import type { TalosExtensionsSpec, TalosExtensionsSpecInfo } from '@/api/omni/specs/omni.pb'
-import { DefaultNamespace, DefaultTalosVersion, TalosExtensionsType } from '@/api/resources'
+import { DefaultNamespace, TalosExtensionsType } from '@/api/resources'
+import { AUTOMATIC_VERSION } from '@/views/InstallationMedia/useFormState'
 
 import SystemExtensions from './system-extensions.vue'
 
 const meta: Meta<typeof SystemExtensions> = {
   component: SystemExtensions,
   args: {
-    modelValue: { talosVersion: DefaultTalosVersion },
+    modelValue: { talosVersion: AUTOMATIC_VERSION },
   },
 }
 

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/system-extensions.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/system-extensions.vue
@@ -13,7 +13,7 @@ import { DefaultNamespace, TalosExtensionsType } from '@/api/resources'
 import TCheckbox from '@/components/Checkbox/TCheckbox.vue'
 import TInput from '@/components/TInput/TInput.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import { type FormState, resolveTalosVersion } from '@/views/InstallationMedia/useFormState'
 
 definePage({ name: 'InstallationMediaCreateSystemExtensions' })
 
@@ -22,7 +22,7 @@ const filterExtensions = ref('')
 
 const { data } = useResourceWatch<TalosExtensionsSpec>(() => ({
   resource: {
-    id: formState.value.talosVersion!,
+    id: resolveTalosVersion(formState.value.talosVersion!),
     type: TalosExtensionsType,
     namespace: DefaultNamespace,
   },

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/talos-version.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/talos-version.vue
@@ -6,7 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { compare } from 'semver'
-import { computed, onBeforeMount, watch } from 'vue'
+import { computed, onBeforeMount } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { TalosVersionSpec } from '@/api/omni/specs/omni.pb'
@@ -23,7 +23,11 @@ import TSelectList from '@/components/SelectList/TSelectList.vue'
 import { getDocsLink } from '@/methods'
 import { useFeatures } from '@/methods/features'
 import { useResourceWatch } from '@/methods/useResourceWatch'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import {
+  AUTOMATIC_VERSION,
+  type FormState,
+  resolveTalosVersion,
+} from '@/views/InstallationMedia/useFormState'
 
 definePage({ name: 'InstallationMediaCreateTalosVersion' })
 
@@ -48,15 +52,17 @@ const { data: joinTokenList, loading: joinTokensLoading } = useResourceWatch<Joi
   },
 })
 
-const talosVersions = computed(() =>
-  talosVersionList.value
+const talosVersions = computed(() => [
+  { label: 'Automatic', value: AUTOMATIC_VERSION },
+  ...talosVersionList.value
     .filter((v) => !v.spec.deprecated)
-    .map((v) => v.spec.version!)
-    .sort(compare),
-)
+    .map((v) => ({ label: v.spec.version!, value: v.spec.version! }))
+    .sort((a, b) => compare(a.value, b.value)),
+])
 
-const joinTokens = computed(() =>
-  joinTokenList.value
+const joinTokens = computed(() => [
+  { label: 'Automatic', value: AUTOMATIC_VERSION },
+  ...joinTokenList.value
     .toSorted((a, b) => {
       if (a.spec.is_default) return -1
       if (b.spec.is_default) return 1
@@ -67,11 +73,15 @@ const joinTokens = computed(() =>
       label: t.spec.name || t.metadata.id || '',
       value: t.metadata.id || '',
     })),
-)
+])
+
+const resolvedTalosVersion = computed(() => resolveTalosVersion(formState.value.talosVersion))
 
 // Form defaults
-onBeforeMount(() => (formState.value.talosVersion ??= DefaultTalosVersion))
-watch(joinTokens, (v) => (formState.value.joinToken ??= v[0]?.value))
+onBeforeMount(() => {
+  formState.value.talosVersion ??= AUTOMATIC_VERSION
+  formState.value.joinToken ??= AUTOMATIC_VERSION
+})
 </script>
 
 <template>
@@ -85,17 +95,23 @@ watch(joinTokens, (v) => (formState.value.joinToken ??= v[0]?.value))
     />
 
     <p class="text-xs">
-      Latest recommended version of Talos Linux ({{ DefaultTalosVersion }}).
+      The latest recommended version of Talos Linux is ({{ DefaultTalosVersion }}).
+
       <template v-if="features?.spec.talos_pre_release_versions_enabled">
         <br />
         Pre-release versions are suitable for testing purposes but are not advised for production
         environments.
       </template>
+
+      <br />
+      Selecting
+      <code class="rounded bg-naturals-n4 px-0.5">Automatic</code>
+      will automatically get the latest version, even if it changes.
     </p>
 
     <div class="space-y-2">
       <h2 id="docs-label-id" class="text-xs font-medium text-naturals-n14 after:content-[':']">
-        Documentation for Talos Linux {{ formState.talosVersion }}
+        Documentation for Talos Linux {{ resolvedTalosVersion }}
       </h2>
       <ul
         class="list-inside list-disc space-y-2 text-xs text-primary-p3"
@@ -105,7 +121,7 @@ watch(joinTokens, (v) => (formState.value.joinToken ??= v[0]?.value))
           <a
             :href="
               getDocsLink('talos', `/getting-started/what's-new-in-talos`, {
-                talosVersion: formState.talosVersion,
+                talosVersion: resolvedTalosVersion,
               })
             "
             rel="noopener noreferrer"
@@ -120,7 +136,7 @@ watch(joinTokens, (v) => (formState.value.joinToken ??= v[0]?.value))
           <a
             :href="
               getDocsLink('talos', '/getting-started/support-matrix', {
-                talosVersion: formState.talosVersion,
+                talosVersion: resolvedTalosVersion,
               })
             "
             rel="noopener noreferrer"
@@ -144,6 +160,12 @@ watch(joinTokens, (v) => (formState.value.joinToken ??= v[0]?.value))
       title="Join Token"
       overhead-title
     />
+
+    <p class="text-xs">
+      Selecting
+      <code class="rounded bg-naturals-n4 px-0.5">Automatic</code>
+      will automatically get the default join token, even if it changes.
+    </p>
 
     <h3 class="text-sm font-medium text-naturals-n14">Machine User Labels</h3>
 

--- a/frontend/src/pages/(authenticated)/machines/installation-media/index.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/index.vue
@@ -13,7 +13,7 @@ import { Runtime } from '@/api/common/omni.pb'
 import { ResourceService } from '@/api/grpc'
 import type { InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
 import { withRuntime } from '@/api/options'
-import { DefaultNamespace, InstallationMediaConfigType } from '@/api/resources'
+import { DefaultNamespace, DefaultTalosVersion, InstallationMediaConfigType } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import IconButton from '@/components/Button/IconButton.vue'
 import TButton from '@/components/Button/TButton.vue'
@@ -127,7 +127,9 @@ function clonePreset(preset: (typeof presets.value)[number]) {
               {{ preset.metadata.id }}
             </RouterLink>
           </TableCell>
-          <TableCell>{{ preset.spec.talos_version }}</TableCell>
+          <TableCell>
+            {{ preset.spec.talos_version || `Automatic (${DefaultTalosVersion})` }}
+          </TableCell>
           <TableCell>
             {{
               preset.metadata.created &&

--- a/frontend/src/views/InstallationMedia/Confirmation.vue
+++ b/frontend/src/views/InstallationMedia/Confirmation.vue
@@ -35,7 +35,7 @@ import { useResourceGet } from '@/methods/useResourceGet'
 import { useTalosctlDownloads } from '@/methods/useTalosctlDownloads'
 import { showError } from '@/notification'
 import { formStateToPreset } from '@/views/InstallationMedia/formStateToPreset'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import { type FormState, resolveTalosVersion } from '@/views/InstallationMedia/useFormState'
 import { usePresetDownloadLinks } from '@/views/InstallationMedia/usePresetDownloadLinks'
 import { usePresetSchematic } from '@/views/InstallationMedia/usePresetSchematic'
 import CloseButton from '@/views/Modals/CloseButton.vue'
@@ -46,12 +46,10 @@ defineProps<{
 
 const formState = defineModel<FormState>({ required: true })
 
-const supportsUnifiedInstaller = computed(
-  () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.10.0'),
-)
-const talosctlAvailable = computed(
-  () => !!formState.value.talosVersion && gte(formState.value.talosVersion, '1.11.0-alpha.3'),
-)
+const resolvedTalosVersion = computed(() => resolveTalosVersion(formState.value.talosVersion!))
+
+const supportsUnifiedInstaller = computed(() => gte(resolvedTalosVersion.value, '1.10.0'))
+const talosctlAvailable = computed(() => gte(resolvedTalosVersion.value, '1.11.0-alpha.3'))
 
 const { data: features } = useFeatures()
 const imageDownloadDialog = useTemplateRef<HTMLDialogElement>('downloadImageDialog')
@@ -77,7 +75,7 @@ useEventListener(imageDownloadDialog, 'close', abortImageDownload)
 const { downloads } = useTalosctlDownloads()
 
 const talosctlPaths = computed(
-  () => downloads.value?.get(`v${formState.value.talosVersion}`)?.map((v) => v.url) ?? [],
+  () => downloads.value?.get(`v${resolvedTalosVersion.value}`)?.map((v) => v.url) ?? [],
 )
 
 const { data: selectedCloudProvider } = useResourceGet<PlatformConfigSpec>(() => ({
@@ -132,17 +130,22 @@ const notOnlyDiskImage = computed(
 
 const preset = computed(() => formStateToPreset(formState.value))
 
-const { schematic, schematicLoading, schematicError } = usePresetSchematic(preset)
+const resolvedPreset = computed(() => ({
+  ...preset.value,
+  talos_version: resolvedTalosVersion.value,
+}))
+
+const { schematic, schematicLoading, schematicError } = usePresetSchematic(resolvedPreset)
 const schematicId = computed(() => schematic.value?.id ?? '')
 
-const { links } = usePresetDownloadLinks(schematicId, preset)
+const { links } = usePresetDownloadLinks(schematicId, resolvedPreset)
 
 const factoryUrl = computed(() => features.value?.spec.image_factory_base_url)
 
 const installerImage = computed(() =>
   supportsUnifiedInstaller.value
-    ? `${factoryUrl.value}/${formState.value.hardwareType}-installer${secureBootSuffix.value}/${schematicId.value}:${formState.value.talosVersion}`
-    : `${factoryUrl.value}/installer/${schematicId.value}:${formState.value.talosVersion}`,
+    ? `${factoryUrl.value}/${formState.value.hardwareType}-installer${secureBootSuffix.value}/${schematicId.value}:${resolvedTalosVersion.value}`
+    : `${factoryUrl.value}/installer/${schematicId.value}:${resolvedTalosVersion.value}`,
 )
 </script>
 
@@ -219,7 +222,7 @@ const installerImage = computed(() =>
       />
     </template>
 
-    <template v-if="formState.talosVersion && gte(formState.talosVersion, '1.12.0-alpha.2')">
+    <template v-if="gte(resolvedTalosVersion, '1.12.0-alpha.2')">
       <h3 class="text-sm text-naturals-n14">Local Test Cluster</h3>
       <p>
         To create a local Talos Linux test cluster from this schematic on macOS (Apple Silicon) or
@@ -227,7 +230,7 @@ const installerImage = computed(() =>
       </p>
       <CodeBlock
         :button-attrs="{ 'aria-label': 'Copy create Talos test cluster command' }"
-        :code="`talosctl cluster create qemu --schematic-id=${schematic.id} --talos-version=v${formState.talosVersion}`"
+        :code="`talosctl cluster create qemu --schematic-id=${schematic.id} --talos-version=v${resolvedTalosVersion}`"
       />
     </template>
 
@@ -246,39 +249,37 @@ const installerImage = computed(() =>
     </p>
     <CodeBlock
       :button-attrs="{ 'aria-label': 'Copy PXE booter docker run command' }"
-      :code="`docker run --rm --network host ghcr.io/siderolabs/booter:v0.3.0 --talos-version=v${formState.talosVersion} --schematic-id=${schematic.id}`"
+      :code="`docker run --rm --network host ghcr.io/siderolabs/booter:v0.3.0 --talos-version=v${resolvedTalosVersion} --schematic-id=${schematic.id}`"
     />
 
     <h3 class="text-sm text-naturals-n14">Documentation</h3>
     <ul class="ml-2 flex list-inside list-disc flex-col gap-2 text-primary-p3">
       <li>
         <a
-          v-if="formState.talosVersion"
           class="link-primary"
           :href="
             getDocsLink('talos', `/getting-started/what's-new-in-talos`, {
-              talosVersion: formState.talosVersion,
+              talosVersion: resolvedTalosVersion,
             })
           "
           target="_blank"
           rel="noopener noreferrer"
         >
-          What's New in Talos {{ majorMinorVersion(formState.talosVersion) }}
+          What's New in Talos {{ majorMinorVersion(resolvedTalosVersion) }}
         </a>
       </li>
       <li>
         <a
-          v-if="formState.talosVersion"
           class="link-primary"
           :href="
             getDocsLink('talos', '/getting-started/support-matrix', {
-              talosVersion: formState.talosVersion,
+              talosVersion: resolvedTalosVersion,
             })
           "
           target="_blank"
           rel="noopener noreferrer"
         >
-          Support Matrix for {{ majorMinorVersion(formState.talosVersion) }}
+          Support Matrix for {{ majorMinorVersion(resolvedTalosVersion) }}
         </a>
       </li>
       <li>
@@ -286,7 +287,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', '/getting-started/getting-started', {
-              talosVersion: formState.talosVersion,
+              talosVersion: resolvedTalosVersion,
             })
           "
           target="_blank"
@@ -303,7 +304,7 @@ const installerImage = computed(() =>
             getDocsLink(
               'talos',
               '/platform-specific-installations/bare-metal-platforms/network-config',
-              { talosVersion: formState.talosVersion },
+              { talosVersion: resolvedTalosVersion },
             )
           "
           target="_blank"
@@ -317,7 +318,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', selectedPlatform.spec.documentation, {
-              talosVersion: formState.talosVersion,
+              talosVersion: resolvedTalosVersion,
             })
           "
           target="_blank"
@@ -331,7 +332,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', selectedSBC.spec.documentation, {
-              talosVersion: formState.talosVersion,
+              talosVersion: resolvedTalosVersion,
             })
           "
           target="_blank"
@@ -348,7 +349,7 @@ const installerImage = computed(() =>
             getDocsLink(
               'talos',
               '/platform-specific-installations/bare-metal-platforms/secureboot',
-              { talosVersion: formState.talosVersion },
+              { talosVersion: resolvedTalosVersion },
             )
           "
           target="_blank"
@@ -363,7 +364,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', '/getting-started/prodnotes', {
-              talosVersion: formState.talosVersion,
+              talosVersion: resolvedTalosVersion,
             })
           "
           target="_blank"
@@ -378,7 +379,7 @@ const installerImage = computed(() =>
           class="link-primary"
           :href="
             getDocsLink('talos', '/troubleshooting/troubleshooting', {
-              talosVersion: formState.talosVersion,
+              talosVersion: resolvedTalosVersion,
             })
           "
           target="_blank"

--- a/frontend/src/views/InstallationMedia/DownloadPresetModal.vue
+++ b/frontend/src/views/InstallationMedia/DownloadPresetModal.vue
@@ -6,13 +6,23 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
-import { computed } from 'vue'
+import { compare } from 'semver'
+import { computed, ref, watchEffect } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
-import { DefaultNamespace, InstallationMediaConfigType } from '@/api/resources'
+import type { InstallationMediaConfigSpec, TalosVersionSpec } from '@/api/omni/specs/omni.pb'
+import type { JoinTokenStatusSpec } from '@/api/omni/specs/siderolink.pb'
+import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
+import {
+  DefaultNamespace,
+  DefaultTalosVersion,
+  InstallationMediaConfigType,
+  JoinTokenStatusType,
+  TalosVersionType,
+} from '@/api/resources'
 import IconButton from '@/components/Button/IconButton.vue'
 import TButton from '@/components/Button/TButton.vue'
+import TSelectList from '@/components/SelectList/TSelectList.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
 import TableCell from '@/components/Table/TableCell.vue'
 import TableRoot from '@/components/Table/TableRoot.vue'
@@ -20,7 +30,9 @@ import TableRow from '@/components/Table/TableRow.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { useDownloadImage } from '@/methods/useDownloadImage'
 import { useResourceGet } from '@/methods/useResourceGet'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError } from '@/notification'
+import { resolveTalosVersion } from '@/views/InstallationMedia/useFormState'
 import { usePresetDownloadLinks } from '@/views/InstallationMedia/usePresetDownloadLinks'
 import { usePresetSchematic } from '@/views/InstallationMedia/usePresetSchematic'
 import CloseButton from '@/views/Modals/CloseButton.vue'
@@ -35,6 +47,7 @@ const emit = defineEmits<{
 }>()
 
 const { data } = useResourceGet<InstallationMediaConfigSpec>(() => ({
+  skip: !open,
   runtime: Runtime.Omni,
   resource: {
     namespace: DefaultNamespace,
@@ -45,11 +58,101 @@ const { data } = useResourceGet<InstallationMediaConfigSpec>(() => ({
 
 const { copy } = useClipboard({ copiedDuring: 1000 })
 
-const preset = computed(() => data.value?.spec ?? {})
+// Fetch available versions and tokens for pickers
+const { data: talosVersionList } = useResourceWatch<TalosVersionSpec>(() => ({
+  skip: !open,
+  runtime: Runtime.Omni,
+  resource: {
+    type: TalosVersionType,
+    namespace: DefaultNamespace,
+  },
+}))
+
+const { data: joinTokenList } = useResourceWatch<JoinTokenStatusSpec>(() => ({
+  skip: !open,
+  runtime: Runtime.Omni,
+  resource: {
+    type: JoinTokenStatusType,
+    namespace: DefaultNamespace,
+  },
+}))
+
+// Picker state
+const selectedVersion = ref<string>()
+const selectedToken = ref<string>()
+const selectedArch = ref<PlatformConfigSpecArch>()
+
+const defaultTokenId = computed(
+  () => joinTokenList.value.find((t) => t.spec.is_default)?.metadata.id,
+)
+
+watchEffect(() => {
+  // Reset modal state on close
+  if (!open) {
+    selectedVersion.value = undefined
+    selectedToken.value = undefined
+    selectedArch.value = undefined
+    return
+  }
+
+  if (data.value) {
+    selectedVersion.value = data.value.spec.talos_version || DefaultTalosVersion
+    selectedToken.value = data.value.spec.join_token || defaultTokenId.value
+    selectedArch.value = data.value.spec.architecture
+  }
+})
+
+// Picker options
+const talosVersionOptions = computed(() =>
+  talosVersionList.value
+    .filter((v) => !v.spec.deprecated)
+    .map((v) => v.spec.version!)
+    .sort(compare),
+)
+
+const joinTokenOptions = computed(() =>
+  joinTokenList.value
+    .toSorted((a, b) => {
+      if (a.spec.is_default) return -1
+      if (b.spec.is_default) return 1
+
+      return 0
+    })
+    .map((t) => ({
+      label: t.spec.name || t.metadata.id || '',
+      value: t.metadata.id || '',
+    })),
+)
+
+const isSBC = computed(() => !!data.value?.spec.sbc)
+
+const archOptions = computed(() => {
+  if (isSBC.value) {
+    return [{ label: 'arm64', value: PlatformConfigSpecArch.ARM64 }]
+  }
+
+  return [
+    { label: 'amd64', value: PlatformConfigSpecArch.AMD64 },
+    { label: 'arm64', value: PlatformConfigSpecArch.ARM64 },
+  ]
+})
+
+// Resolved preset: merges original preset with picker overrides
+const resolvedPreset = computed<InstallationMediaConfigSpec>(() => {
+  const spec = data.value?.spec ?? {}
+
+  return {
+    ...spec,
+    talos_version: selectedVersion.value ?? resolveTalosVersion(spec.talos_version),
+    join_token: selectedToken.value ?? spec.join_token,
+    architecture: selectedArch.value ?? spec.architecture,
+  }
+})
+
 const schematicId = computed(() => schematic.value?.id ?? '')
 
-const { schematic } = usePresetSchematic(preset)
-const { links } = usePresetDownloadLinks(schematicId, preset)
+const { schematic } = usePresetSchematic(resolvedPreset)
+const { links } = usePresetDownloadLinks(schematicId, resolvedPreset)
 
 const {
   isGenerating: imageIsGenerating,
@@ -84,6 +187,29 @@ async function close() {
         </div>
 
         <CloseButton class="shrink-0" @click="close" />
+      </div>
+
+      <div class="flex flex-wrap gap-4">
+        <TSelectList
+          v-model="selectedVersion"
+          :values="talosVersionOptions"
+          title="Talos Version"
+          overhead-title
+        />
+
+        <TSelectList
+          v-model="selectedToken"
+          :values="joinTokenOptions"
+          title="Join Token"
+          overhead-title
+        />
+
+        <TSelectList
+          v-model="selectedArch"
+          :values="archOptions"
+          title="Architecture"
+          overhead-title
+        />
       </div>
 
       <TableRoot class="w-full">

--- a/frontend/src/views/InstallationMedia/formStateToPreset.spec.ts
+++ b/frontend/src/views/InstallationMedia/formStateToPreset.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest'
 import { SchematicBootloader } from '@/api/omni/management/management.pb'
 import { GrpcTunnelMode, type InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
 import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import { AUTOMATIC_VERSION, type FormState } from '@/views/InstallationMedia/useFormState'
 
 import { formStateToPreset, presetToFormState } from './formStateToPreset'
 
@@ -33,6 +33,7 @@ describe('form<->preset conversion', () => {
     ).toEqual({
       hardwareType: 'metal',
       talosVersion: 'v1.12.0',
+      joinToken: AUTOMATIC_VERSION,
       machineArch: PlatformConfigSpecArch.AMD64,
       useGrpcTunnel: false,
     })
@@ -148,5 +149,24 @@ describe('form<->preset conversion', () => {
 
     expect(formStateToPreset(formState)).toEqual(preset)
     expect(presetToFormState(preset)).toEqual(formState)
+  })
+
+  it('should pass through empty talos version and join token (auto placeholders)', () => {
+    const formState: FormState = {
+      hardwareType: 'metal',
+      machineArch: PlatformConfigSpecArch.AMD64,
+      talosVersion: '',
+      joinToken: '',
+    }
+
+    const preset = formStateToPreset(formState)
+
+    expect(preset.talos_version).toBe('')
+    expect(preset.join_token).toBe('')
+
+    const roundTripped = presetToFormState(preset)
+
+    expect(roundTripped.talosVersion).toBe(AUTOMATIC_VERSION)
+    expect(roundTripped.joinToken).toBe(AUTOMATIC_VERSION)
   })
 })

--- a/frontend/src/views/InstallationMedia/formStateToPreset.ts
+++ b/frontend/src/views/InstallationMedia/formStateToPreset.ts
@@ -4,7 +4,7 @@
 // included in the LICENSE file.
 import { GrpcTunnelMode, type InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
 import type { LabelSelectItem } from '@/components/Labels/Labels.vue'
-import type { FormState } from '@/views/InstallationMedia/useFormState'
+import { AUTOMATIC_VERSION, type FormState } from '@/views/InstallationMedia/useFormState'
 
 export function formStateToPreset(formState: FormState): InstallationMediaConfigSpec {
   return {
@@ -24,9 +24,9 @@ export function formStateToPreset(formState: FormState): InstallationMediaConfig
           }
         : undefined,
     grpc_tunnel: formState.useGrpcTunnel ? GrpcTunnelMode.ENABLED : GrpcTunnelMode.DISABLED,
-    talos_version: formState.talosVersion,
+    talos_version: formState.talosVersion === AUTOMATIC_VERSION ? '' : formState.talosVersion,
     install_extensions: formState.systemExtensions,
-    join_token: formState.joinToken,
+    join_token: formState.joinToken === AUTOMATIC_VERSION ? '' : formState.joinToken,
     kernel_args: formState.cmdline,
     machine_labels: formState.machineUserLabels
       ? Object.entries(formState.machineUserLabels).reduce<Record<string, string>>(
@@ -47,9 +47,9 @@ export function presetToFormState(preset: InstallationMediaConfigSpec): FormStat
     sbcType: preset.sbc?.overlay,
     overlayOptions: preset.sbc?.overlay_options,
     useGrpcTunnel: preset.grpc_tunnel === GrpcTunnelMode.ENABLED,
-    talosVersion: preset.talos_version,
+    talosVersion: !preset.talos_version ? AUTOMATIC_VERSION : preset.talos_version,
     systemExtensions: preset.install_extensions,
-    joinToken: preset.join_token,
+    joinToken: !preset.join_token ? AUTOMATIC_VERSION : preset.join_token,
     cmdline: preset.kernel_args,
     machineUserLabels: preset.machine_labels
       ? Object.entries(preset.machine_labels).reduce<Record<string, LabelSelectItem>>(

--- a/frontend/src/views/InstallationMedia/useFormState.ts
+++ b/frontend/src/views/InstallationMedia/useFormState.ts
@@ -7,9 +7,15 @@ import { watch } from 'vue'
 
 import type { SchematicBootloader } from '@/api/omni/management/management.pb'
 import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
+import { DefaultTalosVersion } from '@/api/resources'
 import type { LabelSelectItem } from '@/components/Labels/Labels.vue'
 
 export type HardwareType = 'metal' | 'cloud' | 'sbc'
+export const AUTOMATIC_VERSION = 'auto'
+
+export function resolveTalosVersion<T extends string | undefined>(version: T) {
+  return version === AUTOMATIC_VERSION ? DefaultTalosVersion : version
+}
 
 export interface FormState {
   hardwareType?: HardwareType

--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -1592,16 +1592,8 @@ func installationMediaConfigValidationOptions() []validated.StateOption {
 			return nil
 		}
 
-		if res.TypedSpec().Value.TalosVersion == "" {
-			return errors.New("invalid installation media config: talos version is required")
-		}
-
 		if res.TypedSpec().Value.Architecture == specs.PlatformConfigSpec_UNKNOWN_ARCH {
 			return errors.New("invalid installation media config: architecture is required")
-		}
-
-		if res.TypedSpec().Value.JoinToken == "" {
-			return errors.New("invalid installation media config: join token is required")
 		}
 
 		if res.TypedSpec().Value.Cloud != nil && res.TypedSpec().Value.Sbc != nil {

--- a/internal/backend/runtime/omni/state_validation_test.go
+++ b/internal/backend/runtime/omni/state_validation_test.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -1984,18 +1983,11 @@ func TestInstallationMediaConfigValidation(t *testing.T) {
 
 	installationMediaConfig := omnires.NewInstallationMediaConfig("test")
 
+	// Empty talos_version and join_token are valid (placeholder for stable/default)
 	err := st.Create(ctx, installationMediaConfig)
-	require.Contains(t, err.Error(), "invalid installation media config: talos version is required")
-
-	installationMediaConfig.TypedSpec().Value.TalosVersion = constants.DefaultTalosVersion
-	err = st.Create(ctx, installationMediaConfig)
 	require.Contains(t, err.Error(), "invalid installation media config: architecture is required")
 
 	installationMediaConfig.TypedSpec().Value.Architecture = specs.PlatformConfigSpec_AMD64
-	err = st.Create(ctx, installationMediaConfig)
-	require.Contains(t, err.Error(), "invalid installation media config: join token is required")
-
-	installationMediaConfig.TypedSpec().Value.JoinToken = "test-token"
 	installationMediaConfig.TypedSpec().Value.Cloud = &specs.InstallationMediaConfigSpec_Cloud{}
 	installationMediaConfig.TypedSpec().Value.Sbc = &specs.InstallationMediaConfigSpec_SBC{}
 
@@ -2009,23 +2001,9 @@ func TestInstallationMediaConfigValidation(t *testing.T) {
 	modifiedInstallationMediaConfig, ok := installationMediaConfig.DeepCopy().(*omnires.InstallationMediaConfig)
 	require.True(t, ok)
 
-	modifiedInstallationMediaConfig.TypedSpec().Value.TalosVersion = ""
-	err = st.Update(ctx, modifiedInstallationMediaConfig)
-	require.Contains(t, err.Error(), "invalid installation media config: talos version is required")
-
-	modifiedInstallationMediaConfig, ok = installationMediaConfig.DeepCopy().(*omnires.InstallationMediaConfig)
-	require.True(t, ok)
-
 	modifiedInstallationMediaConfig.TypedSpec().Value.Architecture = specs.PlatformConfigSpec_UNKNOWN_ARCH
 	err = st.Update(ctx, modifiedInstallationMediaConfig)
 	require.Contains(t, err.Error(), "invalid installation media config: architecture is required")
-
-	modifiedInstallationMediaConfig, ok = installationMediaConfig.DeepCopy().(*omnires.InstallationMediaConfig)
-	require.True(t, ok)
-
-	modifiedInstallationMediaConfig.TypedSpec().Value.JoinToken = ""
-	err = st.Update(ctx, modifiedInstallationMediaConfig)
-	require.Contains(t, err.Error(), "invalid installation media config: join token is required")
 
 	modifiedInstallationMediaConfig, ok = installationMediaConfig.DeepCopy().(*omnires.InstallationMediaConfig)
 	require.True(t, ok)


### PR DESCRIPTION
InstallationMediaConfig can now use empty strings for talosVersion and joinToken, which resolve to the current stable version and default token at download time.
    
The create wizard adds "Automatic" options to the version and token dropdowns, and the download modal shows version/token/arch pickers for all presets.

Resolves: #2719

<img width="605" height="602" alt="image" src="https://github.com/user-attachments/assets/c8c5e88d-415e-4225-ae90-ab70b29b2341" />

<img width="536" height="590" alt="image" src="https://github.com/user-attachments/assets/d88bbbc9-217f-40db-9d8f-0ee4475aa2d0" />
