### PR TITLE
feat: support raw bytes in the inline fields for manifests/patches

### DIFF
--- a/client/pkg/template/internal/models/inline.go
+++ b/client/pkg/template/internal/models/inline.go
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package models
+
+import (
+	"bytes"
+	"fmt"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// InlineContent represents inline YAML content embedded into a template.
+//
+// It accepts three input forms:
+//   - a single YAML mapping,
+//   - a sequence of YAML mappings (multi-document),
+//   - a raw YAML literal block scalar (bytes).
+//
+//nolint:recvcheck
+type InlineContent struct {
+	raw  []byte
+	docs []map[string]any
+}
+
+// NewInlineContent builds InlineContent from one or more YAML mappings.
+func NewInlineContent(docs ...map[string]any) *InlineContent {
+	return &InlineContent{docs: docs}
+}
+
+// NewInlineContentBytes builds InlineContent from raw YAML bytes.
+func NewInlineContentBytes(raw []byte) *InlineContent {
+	return &InlineContent{raw: raw}
+}
+
+// IsZero reports whether the InlineContent is empty.
+func (i InlineContent) IsZero() bool {
+	return i.raw == nil && len(i.docs) == 0
+}
+
+// Bytes returns the YAML-encoded inline content.
+//
+// Multi-document content is encoded with the standard YAML multi-document framing.
+func (i InlineContent) Bytes() ([]byte, error) {
+	if i.raw != nil {
+		return i.raw, nil
+	}
+
+	if len(i.docs) == 0 {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+
+	encoder := yaml.NewEncoder(&buf)
+
+	for _, doc := range i.docs {
+		if err := encoder.Encode(doc); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (i *InlineContent) UnmarshalYAML(node *yaml.Node) error {
+	//nolint:exhaustive
+	switch node.Kind {
+	case yaml.ScalarNode:
+		// Only allow explicit strings
+		if node.Tag != "!!str" {
+			return fmt.Errorf("expected string, but got %s", node.Tag)
+		}
+
+		i.raw = []byte(node.Value)
+
+		return nil
+	case yaml.MappingNode:
+		var m map[string]any
+
+		if err := node.Decode(&m); err != nil {
+			return err
+		}
+
+		i.docs = []map[string]any{m}
+
+		return nil
+	case yaml.SequenceNode:
+		var s []map[string]any
+
+		if err := node.Decode(&s); err != nil {
+			return err
+		}
+
+		i.docs = s
+
+		return nil
+	default:
+		return fmt.Errorf("unsupported inline node kind %d", node.Kind)
+	}
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (i InlineContent) MarshalYAML() (any, error) {
+	switch {
+	case i.raw != nil:
+		return &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Style: yaml.LiteralStyle,
+			Value: string(i.raw),
+		}, nil
+	case len(i.docs) == 1:
+		return i.docs[0], nil
+	case len(i.docs) > 1:
+		return i.docs, nil
+	default:
+		return nil, nil //nolint:nilnil
+	}
+}

--- a/client/pkg/template/internal/models/inline_test.go
+++ b/client/pkg/template/internal/models/inline_test.go
@@ -1,0 +1,273 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package models_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+
+	"github.com/siderolabs/omni/client/pkg/template/internal/models"
+)
+
+type config struct {
+	Inline models.InlineContent `yaml:"inline"`
+}
+
+func TestInlineContent_UnmarshalSingleMap(t *testing.T) {
+	t.Parallel()
+
+	src := `
+inline:
+  machine:
+    network:
+      kubespan:
+        enabled: true
+`
+
+	var got config
+
+	require.NoError(t, yaml.Unmarshal([]byte(src), &got))
+
+	raw, err := got.Inline.Bytes()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(raw), "kubespan:")
+	assert.Contains(t, string(raw), "enabled: true")
+}
+
+func TestInlineContent_UnmarshalSliceOfMaps(t *testing.T) {
+	t.Parallel()
+
+	src := `
+inline:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: a
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: b
+`
+
+	var got config
+
+	require.NoError(t, yaml.Unmarshal([]byte(src), &got))
+
+	raw, err := got.Inline.Bytes()
+	require.NoError(t, err)
+
+	docs := splitYAMLDocs(t, raw)
+
+	assert.Len(t, docs, 2)
+	assert.Contains(t, docs[0], "name: a")
+	assert.Contains(t, docs[1], "name: b")
+}
+
+func TestInlineContent_UnmarshalRawBytes(t *testing.T) {
+	t.Parallel()
+
+	src := `
+inline: |
+  machine:
+    network:
+      kubespan:
+        enabled: true
+`
+
+	var got config
+
+	require.NoError(t, yaml.Unmarshal([]byte(src), &got))
+
+	raw, err := got.Inline.Bytes()
+	require.NoError(t, err)
+
+	expected := `machine:
+  network:
+    kubespan:
+      enabled: true
+`
+
+	assert.Equal(t, expected, string(raw))
+}
+
+func TestInlineContent_UnmarshalRawBytesMultiDoc(t *testing.T) {
+	t.Parallel()
+
+	src := `inline: |
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: a
+  ---
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: b
+`
+
+	var got config
+
+	require.NoError(t, yaml.Unmarshal([]byte(src), &got))
+
+	raw, err := got.Inline.Bytes()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(raw), "name: a")
+	assert.Contains(t, string(raw), "name: b")
+	assert.Contains(t, string(raw), "---")
+}
+
+func TestInlineContent_RoundtripSingleMap(t *testing.T) {
+	t.Parallel()
+
+	src := `inline:
+  machine:
+    network:
+      kubespan:
+        enabled: true
+`
+
+	var got config
+
+	require.NoError(t, yaml.Unmarshal([]byte(src), &got))
+
+	out, err := yaml.Marshal(got)
+	require.NoError(t, err)
+
+	// re-parse and compare structurally
+	var roundtrip config
+
+	require.NoError(t, yaml.Unmarshal(out, &roundtrip))
+
+	rawIn, err := got.Inline.Bytes()
+	require.NoError(t, err)
+
+	rawOut, err := roundtrip.Inline.Bytes()
+	require.NoError(t, err)
+
+	assert.Equal(t, string(rawIn), string(rawOut))
+}
+
+func TestInlineContent_RoundtripSliceOfMaps(t *testing.T) {
+	t.Parallel()
+
+	src := `inline:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: a
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: b
+`
+
+	var got config
+
+	require.NoError(t, yaml.Unmarshal([]byte(src), &got))
+
+	out, err := yaml.Marshal(&got)
+	require.NoError(t, err)
+
+	var roundtrip config
+
+	require.NoError(t, yaml.Unmarshal(out, &roundtrip))
+
+	rawIn, err := got.Inline.Bytes()
+	require.NoError(t, err)
+
+	rawOut, err := roundtrip.Inline.Bytes()
+	require.NoError(t, err)
+
+	assert.Equal(t, string(rawIn), string(rawOut))
+}
+
+func TestInlineContent_RoundtripRawBytes(t *testing.T) {
+	t.Parallel()
+
+	src := `inline: |
+  machine:
+    network:
+      kubespan:
+        enabled: true
+`
+
+	var got config
+
+	require.NoError(t, yaml.Unmarshal([]byte(src), &got))
+
+	out, err := yaml.Marshal(&got)
+	require.NoError(t, err)
+
+	// raw bytes are re-emitted as a literal block scalar
+	assert.True(t, strings.HasPrefix(string(out), "inline: |"))
+	assert.Contains(t, string(out), "kubespan:")
+}
+
+func TestInlineContent_OmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	type wrapper struct {
+		Name   string               `yaml:"name"`
+		Inline models.InlineContent `yaml:"inline,omitempty"`
+	}
+
+	out, err := yaml.Marshal(wrapper{Name: "alpha"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "name: alpha\n", string(out))
+}
+
+func TestInlineContent_Constructors(t *testing.T) {
+	t.Parallel()
+
+	mapInline := models.NewInlineContent(map[string]any{"a": 1})
+
+	mapBytes, err := mapInline.Bytes()
+	require.NoError(t, err)
+	assert.Contains(t, string(mapBytes), "a: 1")
+
+	listInline := models.NewInlineContent(map[string]any{"a": 1}, map[string]any{"b": 2})
+
+	listBytes, err := listInline.Bytes()
+	require.NoError(t, err)
+	assert.Contains(t, string(listBytes), "a: 1")
+	assert.Contains(t, string(listBytes), "b: 2")
+
+	rawInline := models.NewInlineContentBytes([]byte("a: 1\n"))
+
+	rawBytes, err := rawInline.Bytes()
+	require.NoError(t, err)
+	assert.Equal(t, "a: 1\n", string(rawBytes))
+}
+
+func splitYAMLDocs(t *testing.T, raw []byte) []string {
+	t.Helper()
+
+	dec := yaml.NewDecoder(strings.NewReader(string(raw)))
+
+	var docs []string
+
+	for {
+		var node yaml.Node
+
+		err := dec.Decode(&node)
+		if err != nil {
+			break
+		}
+
+		out, marshalErr := yaml.Marshal(&node)
+		require.NoError(t, marshalErr)
+
+		docs = append(docs, string(out))
+	}
+
+	return docs
+}

--- a/client/pkg/template/internal/models/kubernetes_manifest.go
+++ b/client/pkg/template/internal/models/kubernetes_manifest.go
@@ -5,7 +5,6 @@
 package models
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource/kvutils"
 	"github.com/siderolabs/gen/pair"
 	"github.com/siderolabs/gen/xslices"
-	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -56,11 +54,23 @@ func (c KubernetesManifestMode) MarshalYAML() (any, error) {
 // KubernetesManifest represents the kubernetes manifest to be applied in the cluster.
 // The manifests are applied on the server side.
 type KubernetesManifest struct {
+	Inline      *InlineContent         `yaml:"inline,omitempty"`
 	Descriptors Descriptors            `yaml:",inline"`
 	Name        string                 `yaml:"name"`
 	File        string                 `yaml:"file,omitempty"`
-	Inline      []map[string]any       `yaml:"inline,omitempty"`
 	Mode        KubernetesManifestMode `yaml:"mode"`
+}
+
+// GetManifests returns the inline manifest content as YAML bytes.
+//
+// The result may contain a single document or multiple documents
+// separated by `---`, depending on the input form.
+func (km *KubernetesManifest) GetManifests() ([]byte, error) {
+	if km.Inline == nil {
+		return nil, nil
+	}
+
+	return km.Inline.Bytes()
 }
 
 // Validate a kubernetes manifest.
@@ -99,7 +109,7 @@ func (km *KubernetesManifest) Validate(opts ValidateOptions) error {
 			errs = errors.Join(errs, fmt.Errorf("failed to access %q: %w", km.File, err))
 		}
 	case km.Inline != nil:
-		_, err := yaml.Marshal(km.Inline)
+		_, err := km.GetManifests()
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("failed to marshal inline manifest %q: %w", name, err))
 		}
@@ -126,18 +136,7 @@ func (km *KubernetesManifest) Translate(ctx TranslateContext, prefix string, wei
 	case km.File != "":
 		raw, err = ReadFile(ctx.Root, km.File)
 	case km.Inline != nil:
-		var buf bytes.Buffer
-
-		encoder := yaml.NewEncoder(&buf)
-		for _, document := range km.Inline {
-			if err = encoder.Encode(document); err != nil {
-				break
-			}
-		}
-
-		defer encoder.Close() //nolint:errcheck
-
-		raw = buf.Bytes()
+		raw, err = km.GetManifests()
 	default:
 		return nil, fmt.Errorf("missing manifests contents")
 	}

--- a/client/pkg/template/internal/models/machine.go
+++ b/client/pkg/template/internal/models/machine.go
@@ -107,13 +107,13 @@ func (machine *Machine) Translate(ctx TranslateContext) ([]resource.Resource, er
 	if machine.Install.Disk != "" {
 		patch := Patch{
 			Name: "install-disk",
-			Inline: map[string]any{
+			Inline: NewInlineContent(map[string]any{
 				"machine": map[string]any{
 					"install": map[string]any{
 						"disk": machine.Install.Disk,
 					},
 				},
-			},
+			}),
 		}
 
 		patchResource, err := patch.Translate(

--- a/client/pkg/template/internal/models/patch.go
+++ b/client/pkg/template/internal/models/patch.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/gen/pair"
-	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
@@ -37,7 +36,19 @@ type Patch struct { //nolint:govet
 	File string `yaml:"file,omitempty"`
 
 	// Inline patch content.
-	Inline map[string]any `yaml:"inline,omitempty"`
+	Inline *InlineContent `yaml:"inline,omitempty"`
+}
+
+// GetPatches returns the inline patch content as YAML bytes.
+//
+// The result may contain a single document or multiple documents
+// separated by `---`, depending on the input form.
+func (patch *Patch) GetPatches() ([]byte, error) {
+	if patch.Inline == nil {
+		return nil, nil
+	}
+
+	return patch.Inline.Bytes()
 }
 
 // Validate the model.
@@ -103,7 +114,7 @@ func (patch *Patch) Validate(opts ValidateOptions) error {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("either name or idOverride is required for inline patches"))
 		}
 
-		raw, err := yaml.Marshal(patch.Inline)
+		raw, err := patch.GetPatches()
 		if err != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("failed to marshal inline patch %q: %w", name, err))
 		} else {
@@ -141,7 +152,7 @@ func (patch *Patch) Translate(ctx TranslateContext, prefix string, weight int, l
 	case patch.File != "":
 		raw, err = ReadFile(ctx.Root, patch.File)
 	case patch.Inline != nil:
-		raw, err = yaml.Marshal(patch.Inline)
+		raw, err = patch.GetPatches()
 	default:
 		panic("missing patch contents?")
 	}

--- a/client/pkg/template/operations/export.go
+++ b/client/pkg/template/operations/export.go
@@ -5,7 +5,6 @@
 package operations
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -157,8 +156,6 @@ func writeYAML(writer io.Writer, modelList models.List) (err error) {
 }
 
 func transformConfigPatchToModel(configPatch *omni.ConfigPatch) (models.Patch, error) {
-	var data map[string]any
-
 	buffer, err := configPatch.TypedSpec().Value.GetUncompressedData()
 	if err != nil {
 		return models.Patch{}, fmt.Errorf("failed to get patch data for patch %q: %w", configPatch.Metadata().ID(), err)
@@ -166,16 +163,12 @@ func transformConfigPatchToModel(configPatch *omni.ConfigPatch) (models.Patch, e
 
 	defer buffer.Free()
 
-	patchData := buffer.Data()
-
-	if err = yaml.Unmarshal(patchData, &data); err != nil {
-		return models.Patch{}, fmt.Errorf("failed to unmarshal patch %q: %w", configPatch.Metadata().ID(), err)
-	}
+	raw := slices.Clone(buffer.Data())
 
 	return models.Patch{
 		Descriptors: getUserDescriptors(configPatch),
 		IDOverride:  configPatch.Metadata().ID(),
-		Inline:      data,
+		Inline:      models.NewInlineContentBytes(raw),
 	}, nil
 }
 
@@ -563,23 +556,7 @@ func transformManifestToModel(manifest *omni.KubernetesManifestGroup) (models.Ku
 
 	defer buffer.Free()
 
-	var inline []map[string]any
-
-	dec := yaml.NewDecoder(bytes.NewReader(buffer.Data()))
-
-	for {
-		var doc map[string]any
-
-		if err := dec.Decode(&doc); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-
-			return models.KubernetesManifest{}, fmt.Errorf("error decoding manifest %q: %w", manifest.Metadata().ID(), err)
-		}
-
-		inline = append(inline, doc)
-	}
+	raw := append([]byte(nil), buffer.Data()...)
 
 	name, ok := manifest.Metadata().Annotations().Get(omni.KubernetesManifestName)
 	if !ok {
@@ -595,7 +572,7 @@ func transformManifestToModel(manifest *omni.KubernetesManifestGroup) (models.Ku
 	return models.KubernetesManifest{
 		Name:        name,
 		Mode:        models.KubernetesManifestMode(manifest.TypedSpec().Value.Mode),
-		Inline:      inline,
+		Inline:      models.NewInlineContentBytes(raw),
 		Descriptors: descriptors,
 	}, nil
 }

--- a/client/pkg/template/operations/testdata/export/cluster-template-with-kernel-args.yaml
+++ b/client/pkg/template/operations/testdata/export/cluster-template-with-kernel-args.yaml
@@ -8,34 +8,32 @@ labels:
 kubernetes:
   version: v1.28.2
   manifests:
-    - name: monitoring-config
-      inline:
-        - apiVersion: v1
-          data:
-            prometheus.yaml: |
-              global:
-                scrape_interval: 15s
-          kind: ConfigMap
-          metadata:
-            name: monitoring-config
-            namespace: monitoring
+    - inline: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: monitoring-config
+          namespace: monitoring
+        data:
+          prometheus.yaml: |
+            global:
+              scrape_interval: 15s
+      name: monitoring-config
       mode: full
-    - name: bootstrap-job
-      inline:
-        - apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: bootstrap
-          spec:
-            template:
-              spec:
-                containers:
-                  - command:
-                      - echo
-                      - done
-                    image: busybox
-                    name: bootstrap
-                restartPolicy: Never
+    - inline: |
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: bootstrap
+        spec:
+          template:
+            spec:
+              containers:
+                - name: bootstrap
+                  image: busybox
+                  command: ["echo", "done"]
+              restartPolicy: Never
+      name: bootstrap-job
       mode: one-time
 talos:
   version: v1.5.5
@@ -49,31 +47,31 @@ patches:
   - idOverride: 499-2e4b9030-aade-47cf-8f7f-3031b7ae49bb
     annotations:
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
+          network:
+              kubespan:
+                  enabled: false
   - idOverride: 500-ae981813-420d-464f-a246-fd7e861402f1
     annotations:
       description: Cluster Patch Description
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1410
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1410
   - idOverride: 600-3fb9b4d2-b13c-48a7-9929-3632e68ff5da
     annotations:
       description: Cluster Patch Description 2
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1234
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1234
 ---
 kind: ControlPlane
 systemExtensions:
@@ -92,12 +90,12 @@ patches:
     annotations:
       description: Some Test Description 123
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1111
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1111
 ---
 kind: Workers
 systemExtensions:
@@ -120,12 +118,12 @@ patches:
     annotations:
       description: Some Test Description ABC
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1447
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1447
 ---
 kind: Workers
 name: w07c5e8
@@ -137,12 +135,12 @@ patches:
     annotations:
       description: Some Test Description 987
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1217
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1217
 ---
 kind: Workers
 name: w3c03cf
@@ -154,12 +152,12 @@ patches:
     annotations:
       description: Some Test Description ZXC
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1298
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1298
 ---
 kind: Machine
 name: 024780fe-b0d6-43e0-a868-b142ba0a67a6
@@ -169,12 +167,12 @@ patches:
     annotations:
       description: Some Test Description ASD
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1166
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1166
 kernelArgs:
   - arg-1
   - arg-2

--- a/client/pkg/template/operations/testdata/export/cluster-template.yaml
+++ b/client/pkg/template/operations/testdata/export/cluster-template.yaml
@@ -8,34 +8,32 @@ labels:
 kubernetes:
   version: v1.28.2
   manifests:
-    - name: monitoring-config
-      inline:
-        - apiVersion: v1
-          data:
-            prometheus.yaml: |
-              global:
-                scrape_interval: 15s
-          kind: ConfigMap
-          metadata:
-            name: monitoring-config
-            namespace: monitoring
+    - inline: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: monitoring-config
+          namespace: monitoring
+        data:
+          prometheus.yaml: |
+            global:
+              scrape_interval: 15s
+      name: monitoring-config
       mode: full
-    - name: bootstrap-job
-      inline:
-        - apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: bootstrap
-          spec:
-            template:
-              spec:
-                containers:
-                  - command:
-                      - echo
-                      - done
-                    image: busybox
-                    name: bootstrap
-                restartPolicy: Never
+    - inline: |
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: bootstrap
+        spec:
+          template:
+            spec:
+              containers:
+                - name: bootstrap
+                  image: busybox
+                  command: ["echo", "done"]
+              restartPolicy: Never
+      name: bootstrap-job
       mode: one-time
 talos:
   version: v1.5.5
@@ -49,31 +47,31 @@ patches:
   - idOverride: 499-2e4b9030-aade-47cf-8f7f-3031b7ae49bb
     annotations:
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
+          network:
+              kubespan:
+                  enabled: false
   - idOverride: 500-ae981813-420d-464f-a246-fd7e861402f1
     annotations:
       description: Cluster Patch Description
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1410
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1410
   - idOverride: 600-3fb9b4d2-b13c-48a7-9929-3632e68ff5da
     annotations:
       description: Cluster Patch Description 2
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1234
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1234
 ---
 kind: ControlPlane
 systemExtensions:
@@ -92,12 +90,12 @@ patches:
     annotations:
       description: Some Test Description 123
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1111
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1111
 ---
 kind: Workers
 systemExtensions:
@@ -120,12 +118,12 @@ patches:
     annotations:
       description: Some Test Description ABC
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1447
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1447
 ---
 kind: Workers
 name: w07c5e8
@@ -137,12 +135,12 @@ patches:
     annotations:
       description: Some Test Description 987
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1217
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1217
 ---
 kind: Workers
 name: w3c03cf
@@ -154,12 +152,12 @@ patches:
     annotations:
       description: Some Test Description ZXC
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1298
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1298
 ---
 kind: Machine
 name: 024780fe-b0d6-43e0-a868-b142ba0a67a6
@@ -169,12 +167,12 @@ patches:
     annotations:
       description: Some Test Description ASD
       name: User defined patch
-    inline:
+    inline: |
       machine:
-        network:
-          kubespan:
-            enabled: false
-            mtu: 1166
+          network:
+              kubespan:
+                  enabled: false
+                  mtu: 1166
 ---
 kind: Machine
 systemExtensions:

--- a/client/pkg/template/template_test.go
+++ b/client/pkg/template/template_test.go
@@ -46,6 +46,9 @@ var clusterWithKernelArgs []byte
 //go:embed testdata/cluster-with-manifests.yaml
 var clusterWithManifests []byte
 
+//go:embed testdata/cluster-inline-bytes.yaml
+var clusterInlineBytes []byte
+
 //go:embed testdata/cluster-invalid-manifests1.yaml
 var clusterInvalidManifests1 []byte
 
@@ -139,6 +142,10 @@ func TestLoad(t *testing.T) {
 			data: clusterWithManifests,
 		},
 		{
+			name: "clusterInlineBytes",
+			data: clusterInlineBytes,
+		},
+		{
 			name:          "clusterBadYAML1",
 			data:          clusterBadYAML1,
 			expectedError: "error decoding document at line 1:1: yaml: construct errors:\n  line 7: field containerd not found in type models.Cluster",
@@ -197,6 +204,10 @@ func TestValidate(t *testing.T) {
 		{
 			name: "clusterWithManifests",
 			data: clusterWithManifests,
+		},
+		{
+			name: "clusterInlineBytes",
+			data: clusterInlineBytes,
 		},
 		{
 			name: "clusterInvalidManifests1",
@@ -449,6 +460,70 @@ func TestTranslate(t *testing.T) {
 			require.Equal(t, string(tt.expected), actual.String())
 		})
 	}
+}
+
+func TestTranslate_InlineBytes(t *testing.T) {
+	// DO NOT ADD t.Parallel() HERE, as this test modifies global compression config.
+	originalCompressionConfig := specs.GetCompressionConfig()
+
+	compressionConfig, err := compression.BuildConfig(false, false, false)
+	require.NoError(t, err)
+
+	specs.SetCompressionConfig(compressionConfig)
+	defer specs.SetCompressionConfig(originalCompressionConfig)
+
+	t.Chdir("testdata")
+
+	root := openTestRoot(t)
+
+	templ, err := template.Load(bytes.NewReader(clusterInlineBytes), template.WithRoot(root))
+	require.NoError(t, err)
+
+	require.NoError(t, templ.Validate())
+
+	resources, err := templ.Translate()
+	require.NoError(t, err)
+
+	var (
+		patchData    []byte
+		manifestData []byte
+	)
+
+	for _, r := range resources {
+		switch r.Metadata().Type() {
+		case omni.ConfigPatchType:
+			cp, ok := r.(*omni.ConfigPatch)
+			require.True(t, ok)
+
+			if cp.Metadata().ID() != "200-cluster-inline-bytes-cluster-kubespan-enabled-bytes" {
+				continue
+			}
+
+			buf, getErr := cp.TypedSpec().Value.GetUncompressedData()
+			require.NoError(t, getErr)
+
+			patchData = append([]byte(nil), buf.Data()...)
+
+			buf.Free()
+		case omni.KubernetesManifestGroupType:
+			mg, ok := r.(*omni.KubernetesManifestGroup)
+			require.True(t, ok)
+
+			buf, getErr := mg.TypedSpec().Value.GetUncompressedData()
+			require.NoError(t, getErr)
+
+			manifestData = append([]byte(nil), buf.Data()...)
+
+			buf.Free()
+		}
+	}
+
+	expectedPatch := "machine:\n  network:\n    kubespan:\n      enabled: true\n"
+	require.Equal(t, expectedPatch, string(patchData))
+
+	require.Contains(t, string(manifestData), "name: my-config")
+	require.Contains(t, string(manifestData), "name: other-config")
+	require.Contains(t, string(manifestData), "---")
 }
 
 func TestSync(t *testing.T) {

--- a/client/pkg/template/testdata/cluster-inline-bytes.yaml
+++ b/client/pkg/template/testdata/cluster-inline-bytes.yaml
@@ -1,0 +1,40 @@
+kind: Cluster
+name: inline-bytes-cluster
+kubernetes:
+  version: v1.30.0
+  manifests:
+    - name: raw-bytes-manifest
+      mode: full
+      inline: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: my-config
+          namespace: kube-system
+        data:
+          key: value
+        ---
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: other-config
+          namespace: kube-system
+        data:
+          key: other-value
+talos:
+  version: v1.7.0
+patches:
+  - name: kubespan-enabled-bytes
+    inline: |
+      machine:
+        network:
+          kubespan:
+            enabled: true
+---
+kind: ControlPlane
+machines:
+  - aaaaaaaa-1111-2222-3333-444444444444
+---
+kind: Workers
+machines:
+  - bbbbbbbb-1111-2222-3333-444444444444


### PR DESCRIPTION
Now inline supports all three variants:
- a single inline map (backward compatibility for config patches).
- a list of inline maps
- raw bytes, that can also contain multiple documents.

`omnictl cluster template export` command was updated to export config patches/manifests as raw bytes to ensure that multiple values are properly supported.

Fixes: https://github.com/siderolabs/omni/issues/2683