### PR TITLE
feat: set infra provider factory endpoint to the one configured in omni

### DIFF
--- a/client/pkg/infra/infra.go
+++ b/client/pkg/infra/infra.go
@@ -27,6 +27,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/infra/internal/resources"
 	"github.com/siderolabs/omni/client/pkg/infra/provision"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
 // ProviderConfig defines the schema, human-readable provider name and description.
@@ -100,15 +101,6 @@ func (provider *Provider[T]) Run(ctx context.Context, logger *zap.Logger, opts .
 		options.concurrency = 1
 	}
 
-	if options.imageFactory == nil {
-		var err error
-
-		options.imageFactory, err = imagefactory.NewClient(imagefactory.ClientOptions{})
-		if err != nil {
-			return err
-		}
-	}
-
 	options.clientOptions = append(options.clientOptions, client.WithOmniClientOptions(
 		omni.WithProviderID(provider.id),
 	))
@@ -132,6 +124,20 @@ func (provider *Provider[T]) Run(ctx context.Context, logger *zap.Logger, opts .
 		st = state.State()
 	default:
 		return fmt.Errorf("invalid infra provider configuration: either WithOmniEndpoint or WithState option should be used")
+	}
+
+	features, err := safe.ReaderGetByID[*omnires.FeaturesConfig](ctx, st, omnires.FeaturesConfigID)
+	if err != nil {
+		return err
+	}
+
+	if options.imageFactory == nil {
+		options.imageFactory, err = imagefactory.NewClient(imagefactory.ClientOptions{
+			FactoryEndpoint: features.TypedSpec().Value.ImageFactoryBaseUrl,
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	runtime, err := runtime.NewRuntime(st, logger)

--- a/client/pkg/infra/infra_test.go
+++ b/client/pkg/infra/infra_test.go
@@ -380,6 +380,9 @@ func setupInfra(ctx context.Context, t *testing.T, p *provisioner, opts ...infra
 
 	logger := zaptest.NewLogger(t)
 
+	features := omni.NewFeaturesConfig(omni.FeaturesConfigID)
+	require.NoError(t, state.Create(ctx, features))
+
 	pc := infra.ProviderConfig{
 		Name:        "Test Provider",
 		Description: "This is the test provider",


### PR DESCRIPTION
Set infra provider factory endpoint to the one configured in Omni features state, which itself is from args/config. Expose the configured factory URL on the provider.