### PR TITLE
feat: resolve patches/kubernetes manifests relative to the templates dir

### DIFF
--- a/client/pkg/template/internal/models/kubernetes_manifest.go
+++ b/client/pkg/template/internal/models/kubernetes_manifest.go
@@ -104,7 +104,7 @@ func (km *KubernetesManifest) Validate(opts ValidateOptions) error {
 
 	switch {
 	case km.File != "":
-		_, err := StatFile(opts.Root, km.File)
+		_, err := opts.StatFile(km.File)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("failed to access %q: %w", km.File, err))
 		}
@@ -134,7 +134,7 @@ func (km *KubernetesManifest) Translate(ctx TranslateContext, prefix string, wei
 
 	switch {
 	case km.File != "":
-		raw, err = ReadFile(ctx.Root, km.File)
+		raw, err = ctx.ReadFile(km.File)
 	case km.Inline != nil:
 		raw, err = km.GetManifests()
 	default:

--- a/client/pkg/template/internal/models/list.go
+++ b/client/pkg/template/internal/models/list.go
@@ -6,7 +6,6 @@ package models
 
 import (
 	"fmt"
-	"os"
 	"slices"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -122,12 +121,12 @@ func (l List) Validate(opts ValidateOptions) error {
 // Translate a set of models (template) to a set of Omni resources.
 //
 // Translate assumes that the template is valid.
-func (l List) Translate(root *os.Root) ([]resource.Resource, error) {
+func (l List) Translate(fc FileContext) ([]resource.Resource, error) {
 	context := TranslateContext{
+		FileContext:               fc,
 		LockedMachines:            map[MachineID]struct{}{},
 		MachineDescriptors:        map[MachineID]Descriptors{},
 		MachineSetLevelKernelArgs: map[MachineID]KernelArgs{},
-		Root:                      root,
 	}
 
 	for _, model := range l {

--- a/client/pkg/template/internal/models/models.go
+++ b/client/pkg/template/internal/models/models.go
@@ -24,10 +24,18 @@ type Meta struct {
 	Kind string `yaml:"kind"`
 }
 
+// FileContext describes how to resolve and read files referenced by a template.
+type FileContext struct {
+	// Root restricts file access to a single directory tree. When nil, no restriction is applied.
+	Root *os.Root
+	// Dir is the directory used to resolve relative file paths from the template.
+	// When empty, callers should treat it as "." (for example, for non-file-backed templates).
+	Dir string
+}
+
 // TranslateContext is a context for translation.
 type TranslateContext struct {
-	// Root restricts file access to a single directory tree. When nil, no restriction is applied.
-	Root                      *os.Root
+	FileContext
 	LockedMachines            map[MachineID]struct{}
 	MachineDescriptors        map[MachineID]Descriptors
 	MachineSetLevelKernelArgs map[MachineID]KernelArgs
@@ -103,18 +111,27 @@ func (d *Descriptors) Apply(res resource.Resource) {
 
 // ValidateOptions contains options for model validation.
 type ValidateOptions struct {
-	// Root restricts file access to a single directory tree. When nil, no restriction is applied.
-	Root *os.Root
+	FileContext
 }
 
-// resolveForRoot translates a CWD-relative path into a path relative to the root directory.
-func resolveForRoot(root *os.Root, path string) (string, error) {
-	absPath, err := filepath.Abs(path)
+// resolveForDir resolves path against fc.Dir when path is relative.
+func (fc FileContext) resolveForDir(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+
+	return filepath.Join(fc.Dir, path)
+}
+
+// resolveForRoot translates a path into a path relative to fc.Root,
+// resolving relative paths against fc.Dir.
+func (fc FileContext) resolveForRoot(path string) (string, error) {
+	absPath, err := filepath.Abs(fc.resolveForDir(path))
 	if err != nil {
 		return "", err
 	}
 
-	rootAbs, err := filepath.Abs(root.Name())
+	rootAbs, err := filepath.Abs(fc.Root.Name())
 	if err != nil {
 		return "", err
 	}
@@ -122,32 +139,34 @@ func resolveForRoot(root *os.Root, path string) (string, error) {
 	return filepath.Rel(rootAbs, absPath)
 }
 
-// ReadFile reads a file, using root to restrict access when non-nil.
-func ReadFile(root *os.Root, path string) ([]byte, error) {
-	if root == nil {
-		return os.ReadFile(path)
+// ReadFile reads a file, using fc.Root to restrict access when non-nil.
+// Relative paths are resolved against fc.Dir.
+func (fc FileContext) ReadFile(path string) ([]byte, error) {
+	if fc.Root == nil {
+		return os.ReadFile(fc.resolveForDir(path))
 	}
 
-	rel, err := resolveForRoot(root, path)
+	rel, err := fc.resolveForRoot(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return root.ReadFile(rel)
+	return fc.Root.ReadFile(rel)
 }
 
-// StatFile stats a file, using root to restrict access when non-nil.
-func StatFile(root *os.Root, path string) (os.FileInfo, error) {
-	if root == nil {
-		return os.Stat(path)
+// StatFile stats a file, using fc.Root to restrict access when non-nil.
+// Relative paths are resolved against fc.Dir.
+func (fc FileContext) StatFile(path string) (os.FileInfo, error) {
+	if fc.Root == nil {
+		return os.Stat(fc.resolveForDir(path))
 	}
 
-	rel, err := resolveForRoot(root, path)
+	rel, err := fc.resolveForRoot(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return root.Stat(rel)
+	return fc.Root.Stat(rel)
 }
 
 // Model is a base interface for cluster templates.

--- a/client/pkg/template/internal/models/patch.go
+++ b/client/pkg/template/internal/models/patch.go
@@ -101,7 +101,7 @@ func (patch *Patch) Validate(opts ValidateOptions) error {
 
 	switch {
 	case patch.File != "":
-		raw, err := ReadFile(opts.Root, patch.File)
+		raw, err := opts.ReadFile(patch.File)
 		if err != nil {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("failed to access %q: %w", patch.File, err))
 		} else {
@@ -150,7 +150,7 @@ func (patch *Patch) Translate(ctx TranslateContext, prefix string, weight int, l
 
 	switch {
 	case patch.File != "":
-		raw, err = ReadFile(ctx.Root, patch.File)
+		raw, err = ctx.ReadFile(patch.File)
 	case patch.Inline != nil:
 		raw, err = patch.GetPatches()
 	default:

--- a/client/pkg/template/template.go
+++ b/client/pkg/template/template.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -30,21 +31,51 @@ type Option func(*Template)
 // WithRoot sets the root directory for file access restriction.
 func WithRoot(root *os.Root) Option {
 	return func(t *Template) {
-		t.root = root
+		t.fc.Root = root
 	}
 }
 
 // Template is a cluster template.
 type Template struct {
-	root   *os.Root
+	fc     models.FileContext
 	models models.List
 }
 
+// named is implemented by readers backed by a path-like name (e.g. *os.File).
+type named interface {
+	Name() string
+}
+
+// dirFromReader returns the directory of the file backing the reader,
+// or "." when the reader is not file-backed.
+func dirFromReader(input io.Reader) (string, error) {
+	if n, ok := input.(named); ok {
+		if name := n.Name(); name != "" {
+			dir := filepath.Dir(name)
+
+			return filepath.Abs(dir)
+		}
+	}
+
+	return ".", nil
+}
+
 // Load the template from input.
+//
+// When input is an *os.File, relative file paths in the template are resolved
+// against the directory containing that file. Otherwise, paths are resolved
+// against the current working directory.
 func Load(input io.Reader, opts ...Option) (*Template, error) {
 	dec := yaml.NewDecoder(input)
 
-	var template Template
+	dir, err := dirFromReader(input)
+	if err != nil {
+		return nil, fmt.Errorf("error determining directory from input: %w", err)
+	}
+
+	template := Template{
+		fc: models.FileContext{Dir: dir},
+	}
 
 	for _, opt := range opts {
 		opt(&template)
@@ -143,13 +174,13 @@ func WithCluster(clusterName string) *Template {
 // Validate the template.
 func (t *Template) Validate() error {
 	return t.models.Validate(models.ValidateOptions{
-		Root: t.root,
+		FileContext: t.fc,
 	})
 }
 
 // Translate the template into resources.
 func (t *Template) Translate() ([]resource.Resource, error) {
-	return t.models.Translate(t.root)
+	return t.models.Translate(t.fc)
 }
 
 // ClusterName returns the name of the cluster associated with the template.

--- a/client/pkg/template/template_test.go
+++ b/client/pkg/template/template_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -840,6 +841,33 @@ func openTestRoot(t *testing.T) *os.Root {
 	t.Cleanup(func() { root.Close() }) //nolint:errcheck
 
 	return root
+}
+
+// TestLoad_DirRelativeFiles verifies that relative file paths in the template
+// are resolved against the directory containing the template file, regardless
+// of the current working directory.
+func TestLoad_DirRelativeFiles(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	t.Chdir(t.TempDir())
+
+	templatePath := filepath.Join(cwd, "testdata", "cluster1.yaml")
+
+	f, err := os.Open(templatePath)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { f.Close() }) //nolint:errcheck
+
+	root, err := os.OpenRoot(filepath.Join(cwd, "testdata"))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { root.Close() }) //nolint:errcheck
+
+	templ, err := template.Load(f, template.WithRoot(root))
+	require.NoError(t, err)
+
+	require.NoError(t, templ.Validate())
 }
 
 func removeKernelArgs(t *testing.T, in []byte) []byte {


### PR DESCRIPTION
Previous behavior: resolve all includes relative to where `omnictl` runs.
Current behaviour: resolve all includes relative to where targeted template YAML file is stored.

The new behavior should be more straightforward.