### PR TITLE
fix: fix the storm of `PendingUpdateStatus` create/destroy

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_test.go
@@ -58,17 +58,17 @@ func (suite *ClusterMachineStatusSuite) TestNoMachineStatusSnapShotClusterStatus
 func (suite *ClusterMachineStatusSuite) TestApplyConfigErrorPropagation() {
 	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true, false)
 
-	md := omni.NewClusterMachineConfigStatus(testID).Metadata()
-	_, err := safe.StateUpdateWithConflicts(suite.ctx, suite.state, md, func(s *omni.ClusterMachineConfigStatus) error {
-		s.TypedSpec().Value.LastConfigError = "TestApplyConfigErrorPropagation error"
+	rmock.Mock[*omni.ClusterMachineConfigStatus](suite.ctx, suite.T(), suite.state, options.WithID(testID),
+		options.Modify(func(s *omni.ClusterMachineConfigStatus) error {
+			s.TypedSpec().Value.LastConfigError = "TestApplyConfigErrorPropagation error"
 
-		return nil
-	})
-	suite.Require().NoError(err)
+			return nil
+		}),
+	)
 
 	clusterMachineStatus := omni.NewClusterMachineStatus(testID)
 
-	err = retry.Constant(5*time.Second, retry.WithUnits(100*time.Millisecond)).RetryWithContext(suite.ctx, func(ctx context.Context) error {
+	err := retry.Constant(5*time.Second, retry.WithUnits(100*time.Millisecond)).RetryWithContext(suite.ctx, func(ctx context.Context) error {
 		res, resErr := safe.StateGet[*omni.ClusterMachineStatus](ctx, suite.state, clusterMachineStatus.Metadata())
 		if resErr != nil {
 			return retry.ExpectedError(resErr)
@@ -94,17 +94,17 @@ func (suite *ClusterMachineStatusSuite) TestApplyConfigErrorPropagation() {
 func (suite *ClusterMachineStatusSuite) TestOutdatedConfig() {
 	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true, false)
 
-	md := omni.NewClusterMachineConfigStatus(testID).Metadata()
-	_, err := safe.StateUpdateWithConflicts(suite.ctx, suite.state, md, func(s *omni.ClusterMachineConfigStatus) error {
-		s.TypedSpec().Value.ClusterMachineConfigVersion = "42"
+	rmock.Mock[*omni.ClusterMachineConfigStatus](suite.ctx, suite.T(), suite.state, options.WithID(testID),
+		options.Modify(func(s *omni.ClusterMachineConfigStatus) error {
+			s.TypedSpec().Value.ClusterMachineConfigVersion = "42"
 
-		return nil
-	})
-	suite.Require().NoError(err)
+			return nil
+		}),
+	)
 
 	clusterMachineStatus := omni.NewClusterMachineStatus(testID)
 
-	err = retry.Constant(5*time.Second, retry.WithUnits(100*time.Millisecond)).RetryWithContext(suite.ctx, func(ctx context.Context) error {
+	err := retry.Constant(5*time.Second, retry.WithUnits(100*time.Millisecond)).RetryWithContext(suite.ctx, func(ctx context.Context) error {
 		res, resErr := safe.StateGet[*omni.ClusterMachineStatus](ctx, suite.state, clusterMachineStatus.Metadata())
 		if resErr != nil {
 			return retry.ExpectedError(resErr)

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -1016,7 +1016,7 @@ func (ctrl *ClusterMachineConfigStatusController) computePendingUpdates(ctx cont
 	)
 
 	if rc.machineConfigStatus != nil && rc.installImage != nil &&
-		rc.machineConfigStatus.TypedSpec().Value.TalosVersion != "" && rc.machineConfigStatus.TypedSpec().Value.SchematicId != "" {
+		rc.machineConfigStatus.TypedSpec().Value.TalosVersion != "" && rc.machineConfigStatus.TypedSpec().Value.SchematicId != "" && rc.shouldUpgrade {
 		currentSchematicID = rc.machineConfigStatus.TypedSpec().Value.SchematicId
 		currentTalosVersion = rc.machineConfigStatus.TypedSpec().Value.TalosVersion
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -346,7 +346,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 			machineServices := testutils.NewMachineServices(t, testContext.State)
 
-			_, machines := createCluster(ctx, t, testContext.State, machineServices, clusterName, 1, 0, options.WithTalosVersion(actualTalosVersion))
+			_, machines := createCluster(ctx, t, testContext.State, machineServices, clusterName, 1, 0, withClusterMockOption(options.WithTalosVersion(actualTalosVersion)))
 
 			machineServices.ForEach(func(m *testutils.MachineServiceMock) {
 				m.OnUpdate = upgradeHandler
@@ -394,7 +394,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 			machineServices := testutils.NewMachineServices(t, testContext.State)
 
-			_, machines := createCluster(ctx, t, testContext.State, machineServices, clusterName, 1, 0, options.WithTalosVersion("1.10.0"))
+			_, machines := createCluster(ctx, t, testContext.State, machineServices, clusterName, 1, 0, withClusterMockOption(options.WithTalosVersion("1.10.0")))
 
 			ids := xslices.Map(machines, func(m *omni.ClusterMachine) string {
 				return m.Metadata().ID()
@@ -515,7 +515,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 			machineServices := testutils.NewMachineServices(t, testContext.State)
 
-			_, machines := createCluster(ctx, t, testContext.State, machineServices, clusterName, 1, 0, options.WithTalosVersion(talosVersion))
+			_, machines := createCluster(ctx, t, testContext.State, machineServices, clusterName, 1, 0, withClusterMockOption(options.WithTalosVersion(talosVersion)))
 
 			ids := xslices.Map(machines, func(m *omni.ClusterMachine) string {
 				return m.Metadata().ID()
@@ -676,6 +676,92 @@ func TestMachineConfigStatusController(t *testing.T) {
 		)
 	})
 
+	t.Run("noPendingUpdatesStorm", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*10)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(ctx, t, testutils.TestOptions{}, addControllers,
+			func(ctx context.Context, testContext testutils.TestContext) {
+				clusterName := "no-system-disk"
+
+				machineServices := testutils.NewMachineServices(t, testContext.State)
+
+				// Drop the system disk from the MachineStatus default before
+				// the ClusterMachineConfig is created so the controller never
+				// observes a system disk on its first reconciliation.
+				cluster, machines := createCluster(ctx, t, testContext.State, machineServices, clusterName, 1, 0,
+					withMachineStatusModifier(func(res *omni.MachineStatus) error {
+						res.TypedSpec().Value.Hardware.Blockdevices = nil
+
+						return nil
+					}),
+				)
+
+				require.Len(t, machines, 1)
+
+				id := machines[0].Metadata().ID()
+
+				updates := make(chan state.Event, 32)
+
+				err := testContext.State.Watch(ctx, omni.NewMachinePendingUpdates(id).Metadata(), updates)
+				require.NoError(t, err)
+
+				rmock.Mock[*omni.ClusterMachineConfigStatus](ctx, t, testContext.State,
+					options.WithID(id),
+					options.Modify(func(res *omni.ClusterMachineConfigStatus) error {
+						res.TypedSpec().Value.ClusterMachineConfigSha256 = "fake-sha256"
+						res.TypedSpec().Value.SchematicId = "abcd"
+						res.TypedSpec().Value.TalosVersion = "1.12.6"
+
+						return nil
+					}),
+				)
+
+				rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, testContext.State,
+					options.WithID(id),
+					options.Modify(func(res *omni.MachineConfigGenOptions) error {
+						res.TypedSpec().Value.InstallImage.TalosVersion = "1.13.0"
+
+						return nil
+					}),
+				)
+
+				awaitAllMachinesConfigured(ctx, t, testContext.State, cluster.Metadata().ID())
+
+				rmock.Mock[*omni.ClusterStatus](ctx, t, testContext.State,
+					options.WithID(cluster.Metadata().ID()),
+					options.Modify(func(res *omni.ClusterStatus) error {
+						res.TypedSpec().Value.Ready = false
+
+						return nil
+					}),
+				)
+
+				time.Sleep(time.Second * 2)
+
+				updateCount := 0
+
+				watchCtx, cancel := context.WithTimeout(ctx, time.Second*2)
+				defer cancel()
+
+				for {
+					select {
+					case e := <-updates:
+						updateCount++
+
+						t.Logf("event %s %s", e.Type, e.Resource.Metadata())
+
+						require.Less(t, updateCount, 30, "too many updates received, possible pending updates storm")
+					case <-watchCtx.Done():
+						return
+					}
+				}
+			},
+		)
+	})
+
 	// Test graceful rollout with max parallelism.
 	t.Run("gracefulConfigRollout", func(t *testing.T) {
 		t.Parallel()
@@ -818,6 +904,30 @@ func TestMachineConfigStatusController(t *testing.T) {
 	})
 }
 
+// createClusterOption customizes the resources spawned by createCluster.
+type createClusterOption func(*createClusterOptions)
+
+type createClusterOptions struct {
+	machineStatusModifier func(*omni.MachineStatus) error
+	clusterOpts           []options.MockOption
+}
+
+// withClusterMockOption forwards an option to the cluster Mock call.
+func withClusterMockOption(opt options.MockOption) createClusterOption {
+	return func(o *createClusterOptions) {
+		o.clusterOpts = append(o.clusterOpts, opt)
+	}
+}
+
+// withMachineStatusModifier applies an additional modifier to every
+// MachineStatus created by createCluster. It runs after the default preset,
+// so it can override defaults like the system disk.
+func withMachineStatusModifier(fn func(*omni.MachineStatus) error) createClusterOption {
+	return func(o *createClusterOptions) {
+		o.machineStatusModifier = fn
+	}
+}
+
 func createCluster(
 	ctx context.Context,
 	t *testing.T,
@@ -825,11 +935,17 @@ func createCluster(
 	machineServices *testutils.MachineServices,
 	clusterName string,
 	controlPlanes, workers int,
-	opts ...options.MockOption,
+	opts ...createClusterOption,
 ) (*omni.Cluster, []*omni.ClusterMachine) {
+	var clusterOpts createClusterOptions
+
+	for _, o := range opts {
+		o(&clusterOpts)
+	}
+
 	clusterOptions := append([]options.MockOption{
 		options.WithID(clusterName),
-	}, opts...)
+	}, clusterOpts.clusterOpts...)
 
 	cluster := rmock.Mock[*omni.Cluster](ctx, t, st,
 		clusterOptions...,
@@ -924,14 +1040,21 @@ func createCluster(
 			}),
 		)
 
-		rmock.Mock[*omni.MachineStatus](ctx, t, st, options.SameID(machine),
+		machineStatusOpts := []options.MockOption{
+			options.SameID(machine),
 			options.Modify(func(res *omni.MachineStatus) error {
 				res.TypedSpec().Value.Maintenance = false
 
 				return nil
 			}),
 			options.WithMachineServices(ctx, machineServices),
-		)
+		}
+
+		if clusterOpts.machineStatusModifier != nil {
+			machineStatusOpts = append(machineStatusOpts, options.Modify(clusterOpts.machineStatusModifier))
+		}
+
+		rmock.Mock[*omni.MachineStatus](ctx, t, st, machineStatusOpts...)
 
 		rmock.Mock[*omni.Machine](ctx, t, st, options.SameID(machine))
 		rmock.Mock[*omni.ClusterMachineStatus](ctx, t, st, options.SameID(machine))

--- a/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
+++ b/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
@@ -30,7 +30,9 @@ import (
 	"github.com/siderolabs/omni/internal/backend/installimage"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+	machineconfigctrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/machineconfig"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/secrets"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/talosupgrade"
 	"github.com/siderolabs/omni/internal/pkg/certs"
 	"github.com/siderolabs/omni/internal/pkg/constants"
 )
@@ -410,6 +412,9 @@ machine:
 	setOwner[*omni.TalosConfig](secrets.NewTalosConfigController(omnictrl.DefaultDebounceDuration).ControllerName)
 	setOwner[*omni.Machine](omnictrl.NewMachineController().ControllerName)
 	setOwner[*omni.MachineSetStatus](omnictrl.NewMachineSetStatusController().ControllerName)
+	setOwner[*omni.UpgradeRollout](talosupgrade.NewStatusController().ControllerName)
+	setOwner[*omni.TalosUpgradeStatus](talosupgrade.NewStatusController().ControllerName)
+	setOwner[*omni.ClusterMachineConfigStatus](machineconfigctrl.NewClusterMachineConfigStatusController("", "").ControllerName)
 }
 
 // GetOwner returns the default owner used by the mock library for the resource.


### PR DESCRIPTION
Use `shouldUpgrade` bool flag when computing the config/upgrade diffs. Otherwise any if `shouldUpgrade` gets out of sync with the condition inside the `ClusterMachineConfigStatus` controller causes it to loop creating and deleting pending changes.


(cherry picked from commit 83bdb57959e4aa02af188c56d8a05885e0cc4336)