### PR TITLE
feat: allow exposing a Kubernetes service on multiple host ports

### DIFF
--- a/client/pkg/constants/exposedservice.go
+++ b/client/pkg/constants/exposedservice.go
@@ -5,24 +5,36 @@
 package constants
 
 const (
+	// ExposedServiceAnnotationPrefix is the common prefix shared by all annotations that
+	// configure how Kubernetes Services are exposed to Omni.
+	//
+	// The label, icon, and prefix annotations also accept per-host-port suffixed variants
+	// (e.g. "<base>-30080") so that a Service exposing multiple host ports can configure
+	// each one independently. The unsuffixed variant is used as a fallback.
+	ExposedServiceAnnotationPrefix = "omni-kube-service-exposer.sidero.dev/"
+
 	// ExposedServiceLabelAnnotationKey is the annotation to define the human-readable label of Kubernetes Services to expose them to Omni.
 	//
 	// tsgen:ExposedServiceLabelAnnotationKey
-	ExposedServiceLabelAnnotationKey = "omni-kube-service-exposer.sidero.dev/label"
+	ExposedServiceLabelAnnotationKey = ExposedServiceAnnotationPrefix + "label"
 
 	// ExposedServicePortAnnotationKey is the annotation to define the port of Kubernetes Services to expose them to Omni.
 	//
+	// The value is a comma-separated list of entries. Each entry is either a bare host
+	// port or a "host-port:service-port" pair, where the service port can be a number or
+	// a name. Each entry produces its own ExposedService.
+	//
 	// tsgen:ExposedServicePortAnnotationKey
-	ExposedServicePortAnnotationKey = "omni-kube-service-exposer.sidero.dev/port"
+	ExposedServicePortAnnotationKey = ExposedServiceAnnotationPrefix + "port"
 
 	// ExposedServiceIconAnnotationKey is the annotation to define the icon of Kubernetes Services to expose them to Omni.
 	//
 	// tsgen:ExposedServiceIconAnnotationKey
-	ExposedServiceIconAnnotationKey = "omni-kube-service-exposer.sidero.dev/icon"
+	ExposedServiceIconAnnotationKey = ExposedServiceAnnotationPrefix + "icon"
 
 	// ExposedServicePrefixAnnotationKey is the annotation to define the prefix of Kubernetes Services to expose them to Omni.
 	// When it is not defined, a prefix will be generated automatically.
 	//
 	// tsgen:ExposedServicePrefixAnnotationKey
-	ExposedServicePrefixAnnotationKey = "omni-kube-service-exposer.sidero.dev/prefix"
+	ExposedServicePrefixAnnotationKey = ExposedServiceAnnotationPrefix + "prefix"
 )

--- a/internal/backend/runtime/omni/controllers/omni/cluster/data/kube-service-exposer-manifest.tmpl.yaml
+++ b/internal/backend/runtime/omni/controllers/omni/cluster/data/kube-service-exposer-manifest.tmpl.yaml
@@ -47,7 +47,7 @@ spec:
         - operator: Exists
       containers:
         - name: omni-kube-service-exposer
-          image: ghcr.io/siderolabs/kube-service-exposer:v0.2.0
+          image: ghcr.io/siderolabs/kube-service-exposer:v0.3.0
           args:
             - --debug=false
             - --annotation-key={{ .AnnotationKey }}

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/exposedservice.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/exposedservice.go
@@ -8,6 +8,7 @@ package exposedservice
 
 import (
 	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -55,15 +56,28 @@ func IsExposedServiceEvent(k8sObject, oldK8sObject any, logger *zap.Logger) bool
 	oldAnnotations := oldK8sObject.(*corev1.Service).GetObjectMeta().GetAnnotations() //nolint:forcetypeassert,errcheck
 	newAnnotations := k8sObject.(*corev1.Service).GetObjectMeta().GetAnnotations()    //nolint:forcetypeassert,errcheck
 
-	for _, key := range []string{
-		constants.ExposedServiceLabelAnnotationKey, constants.ExposedServicePortAnnotationKey,
-		constants.ExposedServiceIconAnnotationKey, constants.ExposedServicePrefixAnnotationKey,
-	} {
-		if oldAnnotations[key] != newAnnotations[key] {
+	// any change to a key under the exposed-service annotation prefix counts. This
+	// covers the well-known label/port/icon/prefix keys plus their per-host-port
+	// suffixed variants (e.g. "label-30080") without having to enumerate them.
+	for key, oldVal := range oldAnnotations {
+		if !strings.HasPrefix(key, constants.ExposedServiceAnnotationPrefix) {
+			continue
+		}
+
+		if oldVal != newAnnotations[key] {
 			return true
 		}
 	}
 
-	// no change in exposed service related annotations
+	for key, newVal := range newAnnotations {
+		if !strings.HasPrefix(key, constants.ExposedServiceAnnotationPrefix) {
+			continue
+		}
+
+		if newVal != oldAnnotations[key] {
+			return true
+		}
+	}
+
 	return false
 }

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/exposedservice_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/exposedservice_test.go
@@ -102,6 +102,26 @@ func TestIsExposedServiceEvent(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "update service - change in per-host-port suffixed annotation",
+			expectChanged: true,
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.ExposedServicePortAnnotationKey:              "30080,30443",
+						constants.ExposedServicePrefixAnnotationKey + "-30443": "api-v2",
+					},
+				},
+			},
+			oldObj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.ExposedServicePortAnnotationKey:              "30080,30443",
+						constants.ExposedServicePrefixAnnotationKey + "-30443": "api-v1",
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -79,19 +80,47 @@ func (reconciler *Reconciler) ReconcileServices() ([]*omni.ExposedService, error
 	for _, service := range reconciler.services {
 		svcID := service.Name + "." + service.Namespace
 		logger := reconciler.logger.With(zap.String("service", svcID))
-		exposedServiceID := reconciler.cluster + "/" + svcID
 
-		exposedService := reconciler.exposedServices[exposedServiceID]
-		if exposedService == nil {
-			exposedService = omni.NewExposedService(reconciler.cluster + "/" + svcID)
+		hostPorts := parseHostPorts(service.Annotations[constants.ExposedServicePortAnnotationKey], logger)
+
+		// Pre-multi-port releases used a bare "<cluster>/<svc>.<ns>" ID. If such a resource still
+		// exists for this Service, the matching desired host port keeps that ID so the alias label
+		// (and therefore the URL) stays stable across the upgrade. New IDs include the host port.
+		legacyID := reconciler.cluster + "/" + svcID
+
+		// If the annotation value is empty, malformed, or every entry is invalid, preserve
+		// any existing resources for this Service unchanged. A temporary typo on a working
+		// annotation should not tear down the URL — the next valid edit will reconcile it.
+		if len(hostPorts) == 0 {
+			for id, res := range reconciler.exposedServices {
+				if id == legacyID || strings.HasPrefix(id, legacyID+"/") {
+					servicesToKeep = append(servicesToKeep, res)
+				}
+			}
+
+			continue
 		}
 
-		keep, err := reconciler.reconcileService(exposedService, service, logger)
-		if err != nil {
-			return nil, err
-		}
+		multiPort := len(hostPorts) > 1
+		legacyRes := reconciler.exposedServices[legacyID]
 
-		if keep {
+		for _, port := range hostPorts {
+			exposedServiceID := fmt.Sprintf("%s/%d", legacyID, port)
+			if legacyRes != nil && int(legacyRes.TypedSpec().Value.Port) == port {
+				exposedServiceID = legacyID
+			}
+
+			portLogger := logger.With(zap.Int("host_port", port))
+
+			exposedService := reconciler.exposedServices[exposedServiceID]
+			if exposedService == nil {
+				exposedService = omni.NewExposedService(exposedServiceID)
+			}
+
+			if err := reconciler.reconcileService(exposedService, service, port, multiPort, portLogger); err != nil {
+				return nil, err
+			}
+
 			servicesToKeep = append(servicesToKeep, exposedService)
 		}
 	}
@@ -99,38 +128,120 @@ func (reconciler *Reconciler) ReconcileServices() ([]*omni.ExposedService, error
 	return servicesToKeep, nil
 }
 
-func (reconciler *Reconciler) reconcileService(exposedService *omni.ExposedService, service *corev1.Service, logger *zap.Logger) (keep bool, err error) {
-	port, err := strconv.Atoi(service.Annotations[constants.ExposedServicePortAnnotationKey])
-	if err != nil || port < 1 || port > 65535 {
-		logger.Warn("invalid port on Service", zap.String("port", service.Annotations[constants.ExposedServicePortAnnotationKey]))
+// parseHostPorts extracts the list of host ports from the annotation value.
+//
+// The annotation accepts a comma-separated list of entries, where each entry is a bare
+// host port or a "host-port:service-port" pair. Only the host port is relevant to Omni
+// (the service port part is consumed by kube-service-exposer on the cluster). Bad
+// entries are skipped with a warning so that one typo does not invalidate the whole
+// annotation. Duplicates are collapsed. The result is sorted ascending so that
+// alias-collision tie-breaking ("first port wins") is deterministic.
+func parseHostPorts(annotationVal string, logger *zap.Logger) []int {
+	seen := make(map[int]struct{})
 
-		return true, nil //nolint:nilerr
+	var ports []int
+
+	for entry := range strings.SplitSeq(annotationVal, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		hostPortStr, _, _ := strings.Cut(entry, ":")
+
+		port, err := strconv.Atoi(hostPortStr)
+		if err != nil || port < 1 || port > 65535 {
+			logger.Warn("invalid host port in annotation entry", zap.String("entry", entry))
+
+			continue
+		}
+
+		if _, ok := seen[port]; ok {
+			continue
+		}
+
+		seen[port] = struct{}{}
+
+		ports = append(ports, port)
 	}
 
-	label, labelOk := service.Annotations[constants.ExposedServiceLabelAnnotationKey]
+	slices.Sort(ports)
+
+	return ports
+}
+
+// annotationValue returns the value of an annotation, preferring a per-host-port
+// suffixed variant ("<baseKey>-<port>") over the unsuffixed one.
+func annotationValue(svc *corev1.Service, baseKey string, port int) (string, bool) {
+	if v, ok := svc.Annotations[fmt.Sprintf("%s-%d", baseKey, port)]; ok {
+		return v, true
+	}
+
+	v, ok := svc.Annotations[baseKey]
+
+	return v, ok
+}
+
+func (reconciler *Reconciler) reconcileService(exposedService *omni.ExposedService, service *corev1.Service, port int, multiPort bool, logger *zap.Logger) error {
+	label, labelOk := annotationValue(service, constants.ExposedServiceLabelAnnotationKey, port)
 	if !labelOk {
 		label = service.Name + "." + service.Namespace
+		if multiPort {
+			label = fmt.Sprintf("%s:%d", label, port)
+		}
 	}
 
-	icon, err := reconciler.parseIcon(service.Annotations[constants.ExposedServiceIconAnnotationKey])
+	iconStr, _ := annotationValue(service, constants.ExposedServiceIconAnnotationKey, port)
+
+	icon, err := reconciler.parseIcon(iconStr)
 	if err != nil {
 		logger.Debug("invalid icon on Service", zap.Error(err))
 	}
 
-	explicitAliasOpt := optional.None[string]()
-	if explicitAlias, ok := service.Annotations[constants.ExposedServicePrefixAnnotationKey]; ok {
-		explicitAliasOpt = optional.Some(explicitAlias)
-	}
+	explicitAliasOpt := reconciler.resolveExplicitAlias(service, port, multiPort, exposedService.Metadata().ID())
 
 	if err = reconciler.updateExposedService(exposedService, explicitAliasOpt, port, label, icon, logger); err != nil {
-		return false, fmt.Errorf("error updating exposed service: %w", err)
+		return fmt.Errorf("error updating exposed service: %w", err)
 	}
 
 	alias, _ := exposedService.Metadata().Labels().Get(omni.LabelExposedServiceAlias)
 	reconciler.usedAliases[alias] = exposedService.Metadata().ID()
 	reconciler.exposedServices[exposedService.Metadata().ID()] = exposedService
 
-	return true, nil
+	return nil
+}
+
+// resolveExplicitAlias picks the explicit alias for a (service, host port) pair.
+//
+// A per-host-port "prefix-<port>" annotation always wins for that port. The unsuffixed
+// "prefix" annotation is used as a fallback only when the alias is still free for the
+// current resource. In single-port mode that's always the case. In multi-port mode the
+// alias is held by whichever resource owns it first: a legacy bare-ID resource being
+// reused on upgrade keeps its alias, and otherwise the first port to claim the alias
+// wins (which, since iteration is sorted ascending, is the lowest-numbered port). The
+// rest fall back to auto-generated aliases. This avoids a noisy "alias already used"
+// error in the common case where the user only set one prefix annotation but exposes
+// multiple ports.
+func (reconciler *Reconciler) resolveExplicitAlias(service *corev1.Service, port int, multiPort bool, exposedServiceID resource.ID) optional.Optional[string] {
+	if perPort, ok := service.Annotations[fmt.Sprintf("%s-%d", constants.ExposedServicePrefixAnnotationKey, port)]; ok {
+		return optional.Some(perPort)
+	}
+
+	base, ok := service.Annotations[constants.ExposedServicePrefixAnnotationKey]
+	if !ok {
+		return optional.None[string]()
+	}
+
+	if !multiPort {
+		return optional.Some(base)
+	}
+
+	owner, taken := reconciler.usedAliases[strings.ToLower(base)]
+	if !taken || owner == exposedServiceID {
+		return optional.Some(base)
+	}
+
+	return optional.None[string]()
 }
 
 func (reconciler *Reconciler) updateExposedService(res *omni.ExposedService, explicitAliasOpt optional.Optional[string], port int, label, icon string, logger *zap.Logger) error {

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
@@ -6,6 +6,7 @@
 package exposedservice_test
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -34,8 +35,8 @@ func TestReconcilerAddRemove(t *testing.T) {
 	var exposedServices []*omni.ExposedService
 
 	kubernetesServices := makeKubernetesServices(
-		kubernetesService{"default", "test-service-1", "11111", "", ""},
-		kubernetesService{"default", "test-service-2", "22222", "", ""},
+		kubernetesService{ns: "default", name: "test-service-1", port: "11111"},
+		kubernetesService{ns: "default", name: "test-service-2", port: "22222"},
 	)
 
 	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, false, exposedServices, kubernetesServices, logger)
@@ -58,10 +59,12 @@ func TestReconcilerAddRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, exposedServices, 1, "expected one ExposedService to remain after removal")
-	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
+	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], 11111, true)
 
 	// add a new service
-	kubernetesServices = append(kubernetesServices, makeKubernetesServices(kubernetesService{"default", "test-service-3", "33333", "foobar", "Some Label"})...)
+	kubernetesServices = append(kubernetesServices, makeKubernetesServices(
+		kubernetesService{ns: "default", name: "test-service-3", port: "33333", prefix: "foobar", label: "Some Label"},
+	)...)
 
 	reconciler, err = exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, false, exposedServices, kubernetesServices, logger)
 	require.NoError(t, err)
@@ -71,8 +74,8 @@ func TestReconcilerAddRemove(t *testing.T) {
 
 	require.Len(t, exposedServices, 2, "expected two ExposedServices after adding a new one")
 
-	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
-	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], true)
+	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], 11111, true)
+	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], 33333, true)
 }
 
 func TestReconcilerConflictResolution(t *testing.T) {
@@ -84,8 +87,8 @@ func TestReconcilerConflictResolution(t *testing.T) {
 	var exposedServices []*omni.ExposedService
 
 	kubernetesServices := makeKubernetesServices(
-		kubernetesService{"default", "test-service-1", "11111", "testprefix", ""},
-		kubernetesService{"default", "test-service-2", "11111", "testprefix", ""},
+		kubernetesService{ns: "default", name: "test-service-1", port: "11111", prefix: "testprefix"},
+		kubernetesService{ns: "default", name: "test-service-2", port: "11111", prefix: "testprefix"},
 	)
 
 	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, false, exposedServices, kubernetesServices, logger)
@@ -95,8 +98,8 @@ func TestReconcilerConflictResolution(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, exposedServices, 2, "expected two ExposedServices to be created")
-	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
-	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], false)
+	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], 11111, true)
+	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], 11111, false)
 	assert.Contains(t, exposedServices[1].TypedSpec().Value.Error, "used by another service")
 
 	// resolve the conflict
@@ -109,8 +112,8 @@ func TestReconcilerConflictResolution(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, exposedServices, 2, "expected two ExposedServices to be created after conflict resolution")
-	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], true)
-	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], true)
+	assertReconcile(t, cluster, exposedServices[0], kubernetesServices[0], 11111, true)
+	assertReconcile(t, cluster, exposedServices[1], kubernetesServices[1], 11111, true)
 }
 
 func TestReconcilerUseOmniSubdomain(t *testing.T) {
@@ -122,8 +125,8 @@ func TestReconcilerUseOmniSubdomain(t *testing.T) {
 	var exposedServices []*omni.ExposedService
 
 	kubernetesServices := makeKubernetesServices(
-		kubernetesService{"default", "test-service-1", "11111", "my-grafana", "Grafana"},
-		kubernetesService{"default", "test-service-2", "22222", "", ""},
+		kubernetesService{ns: "default", name: "test-service-1", port: "11111", prefix: "my-grafana", label: "Grafana"},
+		kubernetesService{ns: "default", name: "test-service-2", port: "22222"},
 	)
 
 	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, true, exposedServices, kubernetesServices, logger)
@@ -154,7 +157,7 @@ func TestReconcilerUseOmniSubdomainWithPort(t *testing.T) {
 	var exposedServices []*omni.ExposedService
 
 	kubernetesServices := makeKubernetesServices(
-		kubernetesService{"default", "test-service-1", "11111", "grafana", "Grafana"},
+		kubernetesService{ns: "default", name: "test-service-1", port: "11111", prefix: "grafana", label: "Grafana"},
 	)
 
 	reconciler, err := exposedservice.NewReconciler(cluster, workloadProxySubdomain, advertisedAPIURL, true, exposedServices, kubernetesServices, logger)
@@ -174,8 +177,8 @@ func TestReconcilerUseOmniSubdomainEmptySubdomain(t *testing.T) {
 	var exposedServices []*omni.ExposedService
 
 	kubernetesServices := makeKubernetesServices(
-		kubernetesService{"default", "test-service-1", "11111", "grafana", "Grafana"},
-		kubernetesService{"default", "test-service-2", "22222", "my-dashboard", "Dashboard"},
+		kubernetesService{ns: "default", name: "test-service-1", port: "11111", prefix: "grafana", label: "Grafana"},
+		kubernetesService{ns: "default", name: "test-service-2", port: "22222", prefix: "my-dashboard", label: "Dashboard"},
 	)
 
 	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, exposedServices, kubernetesServices, logger)
@@ -198,7 +201,7 @@ func TestReconcilerUseOmniSubdomainEmptySubdomainWithPort(t *testing.T) {
 	var exposedServices []*omni.ExposedService
 
 	kubernetesServices := makeKubernetesServices(
-		kubernetesService{"default", "test-service-1", "11111", "grafana", "Grafana"},
+		kubernetesService{ns: "default", name: "test-service-1", port: "11111", prefix: "grafana", label: "Grafana"},
 	)
 
 	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com:8099", true, exposedServices, kubernetesServices, logger)
@@ -235,7 +238,7 @@ func TestReconcilerInvalidAliases(t *testing.T) {
 			var exposedServices []*omni.ExposedService
 
 			kubernetesServices := makeKubernetesServices(
-				kubernetesService{"default", "test-service-1", "11111", tc.prefix, ""},
+				kubernetesService{ns: "default", name: "test-service-1", port: "11111", prefix: tc.prefix},
 			)
 
 			reconciler, err := exposedservice.NewReconciler(testClusterName, testProxySubdomain, "https://omni.example.com", tc.useOmniSubdomain, exposedServices, kubernetesServices, logger)
@@ -250,11 +253,294 @@ func TestReconcilerInvalidAliases(t *testing.T) {
 	}
 }
 
+func TestReconcilerMultiPort(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "grafana", port: "30080,30443:8080,30444:https"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, nil, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 3, "expected one ExposedService per host port")
+
+	// Resources are returned in ascending host-port order; IDs include the host port; auto-generated label disambiguates by port.
+	expectedPorts := []uint32{30080, 30443, 30444}
+	for i, es := range exposedServices {
+		assert.Equal(t, expectedPorts[i], es.TypedSpec().Value.Port)
+		assert.Equal(t, fmt.Sprintf("%s/grafana.default/%d", testClusterName, expectedPorts[i]), es.Metadata().ID())
+		assert.Equal(t, fmt.Sprintf("grafana.default:%d", expectedPorts[i]), es.TypedSpec().Value.Label)
+		assert.Empty(t, es.TypedSpec().Value.Error)
+		assert.False(t, es.TypedSpec().Value.HasExplicitAlias)
+	}
+}
+
+func TestReconcilerMultiPortPerPortAnnotations(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	svc := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "app", port: "30080,30443"},
+	)[0]
+	svc.Annotations[constants.ExposedServicePrefixAnnotationKey+"-30080"] = "ui"
+	svc.Annotations[constants.ExposedServicePrefixAnnotationKey+"-30443"] = "api"
+	svc.Annotations[constants.ExposedServiceLabelAnnotationKey+"-30080"] = "App UI"
+	svc.Annotations[constants.ExposedServiceLabelAnnotationKey+"-30443"] = "App API"
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, nil, []*corev1.Service{svc}, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2)
+
+	assert.Equal(t, "App UI", exposedServices[0].TypedSpec().Value.Label)
+	assert.Equal(t, "https://ui.omni.example.com", exposedServices[0].TypedSpec().Value.Url)
+	assert.True(t, exposedServices[0].TypedSpec().Value.HasExplicitAlias)
+
+	assert.Equal(t, "App API", exposedServices[1].TypedSpec().Value.Label)
+	assert.Equal(t, "https://api.omni.example.com", exposedServices[1].TypedSpec().Value.Url)
+	assert.True(t, exposedServices[1].TypedSpec().Value.HasExplicitAlias)
+}
+
+func TestReconcilerMultiPortPerPortFallsBackToBase(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	svc := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "app", port: "30080,30443", label: "Shared Label"},
+	)[0]
+	svc.Annotations[constants.ExposedServiceLabelAnnotationKey+"-30443"] = "Override For 30443"
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, nil, []*corev1.Service{svc}, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2)
+	assert.Equal(t, "Shared Label", exposedServices[0].TypedSpec().Value.Label, "30080 should fall back to base label")
+	assert.Equal(t, "Override For 30443", exposedServices[1].TypedSpec().Value.Label)
+}
+
+func TestReconcilerMultiPortLenientPrefixCollision(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	svc := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "app", port: "30080,30443", prefix: "shared"},
+	)[0]
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, nil, []*corev1.Service{svc}, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2)
+
+	// Lowest-numbered port wins the base prefix; the rest auto-generate, no error.
+	assert.Empty(t, exposedServices[0].TypedSpec().Value.Error)
+	assert.Equal(t, "https://shared.omni.example.com", exposedServices[0].TypedSpec().Value.Url)
+	assert.True(t, exposedServices[0].TypedSpec().Value.HasExplicitAlias)
+
+	assert.Empty(t, exposedServices[1].TypedSpec().Value.Error)
+	assert.NotEqual(t, "https://shared.omni.example.com", exposedServices[1].TypedSpec().Value.Url)
+	assert.False(t, exposedServices[1].TypedSpec().Value.HasExplicitAlias)
+}
+
+func TestReconcilerMultiPortBadEntriesSkipped(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "app", port: "30080,not-a-port,30443:8080,99999"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, nil, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2, "only valid host ports should produce ExposedServices")
+	assert.Equal(t, uint32(30080), exposedServices[0].TypedSpec().Value.Port)
+	assert.Equal(t, uint32(30443), exposedServices[1].TypedSpec().Value.Port)
+}
+
+func TestReconcilerMultiPortServicePortPartIgnored(t *testing.T) {
+	// Omni only cares about the host port; the right-hand side of ":" is consumed by
+	// kube-service-exposer on the cluster and must not affect Omni's view.
+	logger := zaptest.NewLogger(t)
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "app", port: "30080:http,30443:8080"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, nil, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2)
+	assert.Equal(t, uint32(30080), exposedServices[0].TypedSpec().Value.Port)
+	assert.Equal(t, uint32(30443), exposedServices[1].TypedSpec().Value.Port)
+}
+
+func TestReconcilerLegacyBareIDPreservedSinglePort(t *testing.T) {
+	// A pre-existing single-port ExposedService uses the legacy "<cluster>/<svc>.<ns>" ID
+	// (no host port suffix). After upgrade, a single-port reconcile must reuse that ID so
+	// the existing alias and URL stay stable.
+	logger := zaptest.NewLogger(t)
+
+	legacy := omni.NewExposedService(testClusterName + "/grafana.default")
+	legacy.Metadata().Labels().Set(omni.LabelCluster, testClusterName)
+	legacy.Metadata().Labels().Set(omni.LabelExposedServiceAlias, "g1ar4n")
+	legacy.TypedSpec().Value.Port = 30080
+	legacy.TypedSpec().Value.HasExplicitAlias = false
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "grafana", port: "30080"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true,
+		[]*omni.ExposedService{legacy}, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 1)
+	assert.Equal(t, testClusterName+"/grafana.default", exposedServices[0].Metadata().ID(), "legacy ID must be reused, not migrated to a suffixed one")
+
+	alias, _ := exposedServices[0].Metadata().Labels().Get(omni.LabelExposedServiceAlias)
+	assert.Equal(t, "g1ar4n", alias, "alias must be preserved across upgrade")
+	assert.Equal(t, "https://g1ar4n.omni.example.com", exposedServices[0].TypedSpec().Value.Url)
+}
+
+func TestReconcilerLegacyBareIDPreservedSingleToMulti(t *testing.T) {
+	// An existing single-port service goes multi-port. The legacy port keeps the bare ID
+	// (and its URL); the new port gets a suffixed ID.
+	logger := zaptest.NewLogger(t)
+
+	legacy := omni.NewExposedService(testClusterName + "/api.default")
+	legacy.Metadata().Labels().Set(omni.LabelCluster, testClusterName)
+	legacy.Metadata().Labels().Set(omni.LabelExposedServiceAlias, "ap1xyz")
+	legacy.TypedSpec().Value.Port = 30080
+	legacy.TypedSpec().Value.HasExplicitAlias = false
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "api", port: "30080,30443"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true,
+		[]*omni.ExposedService{legacy}, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2)
+
+	// 30080 keeps the legacy bare ID and its alias
+	assert.Equal(t, testClusterName+"/api.default", exposedServices[0].Metadata().ID())
+	assert.Equal(t, uint32(30080), exposedServices[0].TypedSpec().Value.Port)
+	alias0, _ := exposedServices[0].Metadata().Labels().Get(omni.LabelExposedServiceAlias)
+	assert.Equal(t, "ap1xyz", alias0, "legacy port must keep its alias")
+
+	// 30443 gets a suffixed ID and a fresh alias
+	assert.Equal(t, testClusterName+"/api.default/30443", exposedServices[1].Metadata().ID())
+	assert.Equal(t, uint32(30443), exposedServices[1].TypedSpec().Value.Port)
+	alias1, _ := exposedServices[1].Metadata().Labels().Get(omni.LabelExposedServiceAlias)
+	assert.NotEqual(t, "ap1xyz", alias1, "new port must get its own alias")
+}
+
+func TestReconcilerLegacyBareIDDroppedWhenPortDoesNotMatch(t *testing.T) {
+	// If none of the desired ports match the legacy resource's spec.port, the legacy
+	// resource is not in servicesToKeep and the tracker (in the caller) will destroy it.
+	// Each desired port gets a fresh suffixed ID.
+	logger := zaptest.NewLogger(t)
+
+	legacy := omni.NewExposedService(testClusterName + "/api.default")
+	legacy.Metadata().Labels().Set(omni.LabelCluster, testClusterName)
+	legacy.Metadata().Labels().Set(omni.LabelExposedServiceAlias, "ap1xyz")
+	legacy.TypedSpec().Value.Port = 30080
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "api", port: "30443,30444"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true,
+		[]*omni.ExposedService{legacy}, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 2)
+
+	for _, es := range exposedServices {
+		assert.NotEqual(t, testClusterName+"/api.default", es.Metadata().ID(), "legacy ID must not be reused when no port matches")
+	}
+}
+
+func TestReconcilerInvalidAnnotationPreservesExistingResources(t *testing.T) {
+	// A malformed annotation value (typo, empty, or all-invalid entries) must not tear
+	// down a previously working ExposedService. The reconciler should pass the existing
+	// resource through unchanged so the next valid edit reconciles it back into shape.
+	logger := zaptest.NewLogger(t)
+
+	existing := omni.NewExposedService(testClusterName + "/grafana.default")
+	existing.Metadata().Labels().Set(omni.LabelCluster, testClusterName)
+	existing.Metadata().Labels().Set(omni.LabelExposedServiceAlias, "g1ar4n")
+	existing.TypedSpec().Value.Port = 30080
+	existing.TypedSpec().Value.Url = "https://g1ar4n.omni.example.com"
+
+	svc := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "grafana", port: "not-a-port"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true,
+		[]*omni.ExposedService{existing}, svc, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 1, "existing resource must be preserved when annotation is unparseable")
+	assert.Equal(t, testClusterName+"/grafana.default", exposedServices[0].Metadata().ID())
+	alias, _ := exposedServices[0].Metadata().Labels().Get(omni.LabelExposedServiceAlias)
+	assert.Equal(t, "g1ar4n", alias)
+	assert.Equal(t, uint32(30080), exposedServices[0].TypedSpec().Value.Port)
+	assert.Equal(t, "https://g1ar4n.omni.example.com", exposedServices[0].TypedSpec().Value.Url)
+}
+
+func TestReconcilerSinglePortUnchangedDefaultLabel(t *testing.T) {
+	// A single-port service keeps the historical default label of "<name>.<ns>" without
+	// the port suffix, so existing UIs stay readable.
+	logger := zaptest.NewLogger(t)
+
+	kubernetesServices := makeKubernetesServices(
+		kubernetesService{ns: "default", name: "grafana", port: "30080"},
+	)
+
+	reconciler, err := exposedservice.NewReconciler(testClusterName, "", "https://omni.example.com", true, nil, kubernetesServices, logger)
+	require.NoError(t, err)
+
+	exposedServices, err := reconciler.ReconcileServices()
+	require.NoError(t, err)
+
+	require.Len(t, exposedServices, 1)
+	assert.Equal(t, "grafana.default", exposedServices[0].TypedSpec().Value.Label)
+}
+
 //nolint:unparam
-func assertReconcile(t *testing.T, cluster string, svc *omni.ExposedService, kubernetesSvc *corev1.Service, success bool) {
+func assertReconcile(t *testing.T, cluster string, svc *omni.ExposedService, kubernetesSvc *corev1.Service, hostPort int, success bool) {
 	t.Helper()
 
-	expectedID := cluster + "/" + kubernetesSvc.Name + "." + kubernetesSvc.Namespace
+	expectedID := fmt.Sprintf("%s/%s.%s/%d", cluster, kubernetesSvc.Name, kubernetesSvc.Namespace, hostPort)
 
 	assert.Equal(t, expectedID, svc.Metadata().ID())
 
@@ -265,16 +551,13 @@ func assertReconcile(t *testing.T, cluster string, svc *omni.ExposedService, kub
 	}
 
 	assert.Empty(t, svc.TypedSpec().Value.Error)
-	assert.Equal(t, kubernetesSvc.Annotations[constants.ExposedServicePortAnnotationKey], strconv.Itoa(int(svc.TypedSpec().Value.Port)))
+	assert.Equal(t, strconv.Itoa(hostPort), strconv.Itoa(int(svc.TypedSpec().Value.Port)))
 
 	prefix, ok := kubernetesSvc.Annotations[constants.ExposedServicePrefixAnnotationKey]
 	assert.Equal(t, ok, svc.TypedSpec().Value.HasExplicitAlias)
 
 	if ok {
 		assert.Contains(t, svc.TypedSpec().Value.Url, prefix)
-	}
-
-	if ok {
 		assert.True(t, svc.TypedSpec().Value.HasExplicitAlias)
 	} else {
 		assert.False(t, svc.TypedSpec().Value.HasExplicitAlias)

--- a/internal/integration/workloadproxy/workloadproxy.go
+++ b/internal/integration/workloadproxy/workloadproxy.go
@@ -269,36 +269,52 @@ func prepareServices(ctx context.Context, t *testing.T, logger *zap.Logger, omni
 		deployment.deployment, services = createKubernetesResources(ctx, t, logger, kubeClient, firstPort, numReplicasPerWorkload, numServicePerWorkload, identifier, iconBase64)
 
 		for _, service := range services {
-			expectedID := clusterID + "/" + service.Name + "." + service.Namespace
-
-			expectedPort, err := strconv.Atoi(service.Annotations[constants.ExposedServicePortAnnotationKey])
-			require.NoError(t, err)
+			legacyID := clusterID + "/" + service.Name + "." + service.Namespace
+			portStrs := strings.Split(service.Annotations[constants.ExposedServicePortAnnotationKey], ",")
+			isMultiPort := len(portStrs) > 1
 
 			expectedLabel := service.Annotations[constants.ExposedServiceLabelAnnotationKey]
 			explicitAlias, hasExplicitAlias := service.Annotations[constants.ExposedServicePrefixAnnotationKey]
 
-			var res *omni.ExposedService
+			// Multi-port lenient rule: only the lowest port can hold an explicit alias;
+			// the rest fall back to auto-generated. In this test setup the multi-port
+			// service has no explicit prefix annotation, so the effective expectation
+			// is "no explicit alias" for both of its ports — but spelling it out keeps
+			// the assertion correct if that ever changes.
+			expectExplicitAlias := hasExplicitAlias && !isMultiPort
 
-			rtestutils.AssertResource[*omni.ExposedService](ctx, t, omniState, expectedID, func(r *omni.ExposedService, assertion *assert.Assertions) {
-				assertion.Equal(expectedPort, int(r.TypedSpec().Value.Port))
-				assertion.Equal(expectedLabel, r.TypedSpec().Value.Label)
-				assertion.Equal(expectedIconBase64, r.TypedSpec().Value.IconBase64)
-				assertion.NotEmpty(r.TypedSpec().Value.Url)
-				assertion.Empty(r.TypedSpec().Value.Error)
-				assertion.Equal(hasExplicitAlias, r.TypedSpec().Value.HasExplicitAlias)
+			for _, portStr := range portStrs {
+				expectedPort, err := strconv.Atoi(portStr)
+				require.NoError(t, err)
 
-				if hasExplicitAlias {
-					assertion.Contains(r.TypedSpec().Value.Url, explicitAlias)
-				}
+				// Fresh services in this test never have a pre-existing legacy bare-ID
+				// resource, so all expected IDs are in the new suffixed format. The
+				// legacy bare-ID reuse path is covered by reconciler unit tests.
+				expectedID := fmt.Sprintf("%s/%d", legacyID, expectedPort)
 
-				res = r
-			})
+				var res *omni.ExposedService
 
-			deployment.services = append(deployment.services, serviceContext{
-				res:        res,
-				svc:        service,
-				deployment: &deployment,
-			})
+				rtestutils.AssertResource[*omni.ExposedService](ctx, t, omniState, expectedID, func(r *omni.ExposedService, assertion *assert.Assertions) {
+					assertion.Equal(expectedPort, int(r.TypedSpec().Value.Port))
+					assertion.Equal(expectedLabel, r.TypedSpec().Value.Label)
+					assertion.Equal(expectedIconBase64, r.TypedSpec().Value.IconBase64)
+					assertion.NotEmpty(r.TypedSpec().Value.Url)
+					assertion.Empty(r.TypedSpec().Value.Error)
+					assertion.Equal(expectExplicitAlias, r.TypedSpec().Value.HasExplicitAlias)
+
+					if expectExplicitAlias {
+						assertion.Contains(r.TypedSpec().Value.Url, explicitAlias)
+					}
+
+					res = r
+				})
+
+				deployment.services = append(deployment.services, serviceContext{
+					res:        res,
+					svc:        service,
+					deployment: &deployment,
+				})
+			}
 		}
 
 		cluster.deployments = append(cluster.deployments, deployment)
@@ -603,12 +619,21 @@ func createKubernetesResources(ctx context.Context, t *testing.T, logger *zap.Lo
 		svcIdentifier := fmt.Sprintf("%s-s%02d", identifier, i)
 		port := firstPort + i
 
+		// Make the last service of each workload multi-port so the multi-port code path
+		// is tested: a single Service annotated with N host ports must produce N
+		// ExposedServices. The extra port is offset by +10000 to avoid collisions with
+		// other workloads' allocations.
+		portAnnotation := strconv.Itoa(port)
+		if i == numServices-1 {
+			portAnnotation = fmt.Sprintf("%d,%d", port, port+10000)
+		}
+
 		service := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      svcIdentifier,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					constants.ExposedServicePortAnnotationKey:  strconv.Itoa(port),
+					constants.ExposedServicePortAnnotationKey:  portAnnotation,
 					constants.ExposedServiceLabelAnnotationKey: svcIdentifier,
 					constants.ExposedServiceIconAnnotationKey:  icon,
 				},


### PR DESCRIPTION
The annotation now accepts a comma-separated list of entries. Each entry is either a bare host port or a "host-port:service-port" pair, where the service port can be a number or a name. Each entry produces its own ExposedService with its own URL.

Before:

    omni-kube-service-exposer.sidero.dev/port: "30080"

After:

    omni-kube-service-exposer.sidero.dev/port: "30080,30443:8080,30444:https"

The label, icon, and prefix annotations gain per-host-port suffixed variants like "label-30080" or "prefix-30443". The suffixed variant wins for that port, otherwise the unsuffixed one is used as a fallback. For multi-port services the unsuffixed prefix is claimed by the lowest port, and other ports auto-generate aliases instead of failing with a duplicate-alias error.

Existing single-port exposed services keep their URLs across the upgrade.

Also bump the kube-service-exposer image to the version that supports the new annotation format.

Closes #2594.