### PR TITLE
test: fix data race in machine service mock

### DIFF
--- a/internal/backend/runtime/omni/controllers/testutils/machine_service.go
+++ b/internal/backend/runtime/omni/controllers/testutils/machine_service.go
@@ -425,8 +425,12 @@ func (ms *MachineServiceMock) Version(ctx context.Context, _ *emptypb.Empty) (*m
 		talosVersion = m.TypedSpec().Value.TalosVersion
 	}
 
-	if ms.versionHandler != nil {
-		return ms.versionHandler(ctx, nil)
+	ms.lock.Lock()
+	versionHandler := ms.versionHandler
+	ms.lock.Unlock()
+
+	if versionHandler != nil {
+		return versionHandler(ctx, nil)
 	}
 
 	return &machine.VersionResponse{


### PR DESCRIPTION
The read of the field was not protected by the lock, unlike all other operations, which caused a data race in CA rotation tests.