### PR TITLE
refactor(frontend): refactor all but the last tlist use of watch.setup

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -141,11 +141,6 @@
       "count": 1
     }
   },
-  "src/views/MachineClasses/MachineTemplate.vue": {
-    "vue/define-props-destructuring": {
-      "count": 1
-    }
-  },
   "src/views/MachineClasses/ProviderConfig.vue": {
     "vue/define-props-destructuring": {
       "count": 1

--- a/frontend/src/pages/(authenticated)/clusters/create.vue
+++ b/frontend/src/pages/(authenticated)/clusters/create.vue
@@ -29,7 +29,7 @@ import {
   PatchBaseWeightMachineSet,
   TalosVersionType,
 } from '@/api/resources'
-import WatchResource, { itemID } from '@/api/watch'
+import { itemID } from '@/api/watch'
 import TButton from '@/components/Button/TButton.vue'
 import TCheckbox from '@/components/Checkbox/TCheckbox.vue'
 import TList from '@/components/List/TList.vue'
@@ -43,6 +43,7 @@ import { setupBackupStatus } from '@/methods'
 import { usePermissions } from '@/methods/auth'
 import { ClusterCommandError, clusterSync, nextAvailableClusterName } from '@/methods/cluster'
 import { useFeatures } from '@/methods/features'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showModal } from '@/modal'
 import { showError, showSuccess } from '@/notification'
 import { initState, PatchID } from '@/states/cluster-management'
@@ -90,8 +91,14 @@ const router = useRouter()
 
 const kubernetesVersionSelector = useTemplateRef('kubernetesVersionSelector')
 
-const talosVersionsList: Ref<Resource<TalosVersionSpec>[]> = ref([])
-const talosVersionsWatch = new WatchResource(talosVersionsList)
+const { data: talosVersionsList } = useResourceWatch<TalosVersionSpec>({
+  runtime: Runtime.Omni,
+  resource: {
+    type: TalosVersionType,
+    namespace: DefaultNamespace,
+  },
+})
+
 const reset = ref(0)
 
 const kubernetesVersions: Ref<string[]> = computed(() => {
@@ -129,14 +136,6 @@ watch(kubernetesVersions, (k8sVersions) => {
     // select the latest supported Kubernetes version by the chosen Talos version (k8sVersions are sorted on backend)
     kubernetesVersionSelector?.value?.selectItem(k8sVersions[k8sVersions.length - 1])
   }
-})
-
-talosVersionsWatch.setup({
-  runtime: Runtime.Omni,
-  resource: {
-    type: TalosVersionType,
-    namespace: DefaultNamespace,
-  },
 })
 
 const { data: features } = useFeatures()

--- a/frontend/src/views/MachineClasses/MachineTemplate.vue
+++ b/frontend/src/views/MachineClasses/MachineTemplate.vue
@@ -5,18 +5,15 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, ref, toRefs } from 'vue'
-
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
 import type { InfraProviderStatusSpec } from '@/api/omni/specs/infra.pb'
 import { GrpcTunnelMode } from '@/api/omni/specs/omni.pb'
 import { InfraProviderNamespace, InfraProviderStatusType } from '@/api/resources'
-import WatchResource from '@/api/watch'
 import JsonForm from '@/components/Form/JsonForm.vue'
 import Labels, { type LabelSelectItem } from '@/components/Labels/Labels.vue'
 import TSelectList from '@/components/SelectList/TSelectList.vue'
 import TInput from '@/components/TInput/TInput.vue'
+import { useResourceWatch } from '@/methods/useResourceWatch'
 
 enum GRPCTunnelMode {
   Default = 'Account Default',
@@ -24,7 +21,7 @@ enum GRPCTunnelMode {
   Disabled = 'Disabled',
 }
 
-const props = defineProps<{
+const { infraProvider, initialLabels, kernelArguments, providerConfig, grpcTunnel } = defineProps<{
   infraProvider: string
   initialLabels: Record<string, LabelSelectItem>
   kernelArguments: string
@@ -33,7 +30,7 @@ const props = defineProps<{
 }>()
 
 const defaultTunnelMode = (() => {
-  switch (props.grpcTunnel) {
+  switch (grpcTunnel) {
     default:
     case GrpcTunnelMode.UNSET:
       return GRPCTunnelMode.Default
@@ -51,27 +48,15 @@ const emit = defineEmits<{
   'update:grpc-tunnel': [GrpcTunnelMode]
 }>()
 
-const { infraProvider, initialLabels, kernelArguments, providerConfig } = toRefs(props)
-
-const infraProviderStatus = ref<Resource<InfraProviderStatusSpec>>()
-const infraProviderStatusWatch = new WatchResource(infraProviderStatus)
-
-infraProviderStatusWatch.setup(
-  computed(() => {
-    if (!infraProvider.value) {
-      return
-    }
-
-    return {
-      resource: {
-        type: InfraProviderStatusType,
-        namespace: InfraProviderNamespace,
-        id: infraProvider.value,
-      },
-      runtime: Runtime.Omni,
-    }
-  }),
-)
+const { data: infraProviderStatus } = useResourceWatch<InfraProviderStatusSpec>(() => ({
+  skip: !infraProvider,
+  resource: {
+    type: InfraProviderStatusType,
+    namespace: InfraProviderNamespace,
+    id: infraProvider,
+  },
+  runtime: Runtime.Omni,
+}))
 
 const updateGRPCTunnelMode = (value: GRPCTunnelMode) => {
   switch (value) {
@@ -92,26 +77,24 @@ const updateGRPCTunnelMode = (value: GRPCTunnelMode) => {
   <div class="text-naturals-n13">Machine Template</div>
   <div class="rounded bg-naturals-n2">
     <div class="px-4 pt-4 pb-2 text-sm text-naturals-n13">Talos Config</div>
-    <div
-      class="machine-template flex flex-col divide-y divide-naturals-n4 border-t-8 border-naturals-n4 text-xs"
-    >
-      <div>
-        <span>Kernel Arguments</span>
+    <div class="flex flex-col divide-y divide-naturals-n4 border-t-8 border-naturals-n4 text-xs">
+      <div class="flex items-center justify-between gap-2 px-4 py-2">
+        <span class="whitespace-nowrap">Kernel Arguments</span>
         <TInput
           class="h-7 w-56"
           :model-value="kernelArguments"
           @update:model-value="(value) => $emit('update:kernel-arguments', value)"
         />
       </div>
-      <div>
-        <span>Initial Labels</span>
+      <div class="flex items-center justify-between gap-2 px-4 py-2">
+        <span class="whitespace-nowrap">Initial Labels</span>
         <Labels
           :model-value="initialLabels"
           @update:model-value="(value) => $emit('update:initial-labels', value)"
         />
       </div>
-      <div>
-        <span>Use gRPC Tunnel</span>
+      <div class="flex items-center justify-between gap-2 px-4 py-2">
+        <span class="whitespace-nowrap">Use gRPC Tunnel</span>
         <TSelectList
           class="h-6"
           :values="[GRPCTunnelMode.Default, GRPCTunnelMode.Enabled, GRPCTunnelMode.Disabled]"
@@ -134,27 +117,3 @@ const updateGRPCTunnelMode = (value: GRPCTunnelMode) => {
     </div>
   </div>
 </template>
-
-<style scoped>
-@reference "../../index.css";
-
-.condition {
-  @apply rounded-md border border-transparent transition-colors;
-}
-
-.condition:focus-within {
-  @apply border-naturals-n8;
-}
-
-code {
-  @apply rounded bg-naturals-n6 px-1 py-0.5 font-mono text-naturals-n13;
-}
-
-.machine-template > * {
-  @apply flex items-center justify-between gap-2 px-4 py-2;
-}
-
-.machine-template > * > *:first-child {
-  @apply whitespace-nowrap;
-}
-</style>

--- a/frontend/src/views/Machines/MachineExtensions.vue
+++ b/frontend/src/views/Machines/MachineExtensions.vue
@@ -9,7 +9,6 @@ import { computed, ref } from 'vue'
 import WordHighlighter from 'vue-word-highlighter'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
 import type {
   ExtensionsConfigurationSpec,
   MachineExtensionsSpec,
@@ -28,8 +27,6 @@ import {
   MachineExtensionsType,
   MachineStatusType,
 } from '@/api/resources'
-import type { WatchOptions } from '@/api/watch'
-import Watch from '@/api/watch'
 import TButton from '@/components/Button/TButton.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
 import TListItem from '@/components/List/TListItem.vue'
@@ -47,12 +44,18 @@ const { clusterId, machineId, readOnly } = defineProps<{
   readOnly?: boolean
 }>()
 
-const machineExtensionsStatus = ref<Resource<MachineExtensionsStatusSpec>>()
-const machineExtensionsStatusWatch = new Watch(machineExtensionsStatus)
+const { data: machineExtensionsStatus, loading: machineExtensionsStatusWatchLoading } =
+  useResourceWatch<MachineExtensionsStatusSpec>(() => ({
+    resource: {
+      namespace: DefaultNamespace,
+      type: MachineExtensionsStatusType,
+      id: machineId,
+    },
+    runtime: Runtime.Omni,
+  }))
+
 const updateExtensionsModalOpen = ref(false)
 const searchString = ref('')
-
-const machineExtensionsStatusWatchLoading = machineExtensionsStatusWatch.loading
 
 const ready = computed(() => {
   return !machineExtensionsStatusWatchLoading.value
@@ -71,61 +74,33 @@ const { data: machineStatus } = useResourceWatch<MachineStatusSpec>(() => ({
 
 const invalidSchematic = computed(() => machineStatus.value?.spec.schematic?.invalid === true)
 
-machineExtensionsStatusWatch.setup(
-  computed((): WatchOptions | undefined => {
-    return {
-      resource: {
-        namespace: DefaultNamespace,
-        type: MachineExtensionsStatusType,
-        id: machineId,
-      },
-      runtime: Runtime.Omni,
-    }
-  }),
-)
+const { data: machineExtensions } = useResourceWatch<MachineExtensionsSpec>(() => {
+  const id = machineExtensionsStatus.value?.metadata.id
 
-const machineExtensions = ref<Resource<MachineExtensionsSpec>>()
+  return {
+    skip: !id,
+    resource: {
+      id: id!,
+      namespace: DefaultNamespace,
+      type: MachineExtensionsType,
+    },
+    runtime: Runtime.Omni,
+  }
+})
 
-const machineExtensionsWatch = new Watch(machineExtensions)
+const { data: extensionsConfiguration } = useResourceWatch<ExtensionsConfigurationSpec>(() => {
+  const id = machineExtensions.value?.metadata.labels?.[ExtensionsConfigurationLabel]
 
-machineExtensionsWatch.setup(
-  computed(() => {
-    if (!machineExtensionsStatus.value) {
-      return
-    }
-
-    return {
-      resource: {
-        id: machineExtensionsStatus.value.metadata.id!,
-        namespace: DefaultNamespace,
-        type: MachineExtensionsType,
-      },
-      runtime: Runtime.Omni,
-    }
-  }),
-)
-
-const extensionsConfiguration = ref<Resource<ExtensionsConfigurationSpec>>()
-
-const configurationsWatch = new Watch(extensionsConfiguration)
-
-configurationsWatch.setup(
-  computed((): WatchOptions | undefined => {
-    const id = machineExtensions.value?.metadata.labels?.[ExtensionsConfigurationLabel]
-    if (!id) {
-      return
-    }
-
-    return {
-      resource: {
-        namespace: DefaultNamespace,
-        type: ExtensionsConfigurationType,
-        id: id,
-      },
-      runtime: Runtime.Omni,
-    }
-  }),
-)
+  return {
+    skip: !id,
+    resource: {
+      namespace: DefaultNamespace,
+      type: ExtensionsConfigurationType,
+      id: id!,
+    },
+    runtime: Runtime.Omni,
+  }
+})
 
 const extensionsState = computed(() => {
   if (!machineExtensionsStatus.value?.spec.extensions) {


### PR DESCRIPTION
Refactor the final use cases of `watch.setup` (excluding `TList`) to be `useResourceWatch`.
`TList` must be tackled on its own in #1534

Related #1471 