### PR TITLE
fix(frontend): fix apexcharts broken tooltips and initial state

### DIFF
--- a/frontend/src/api/watch.ts
+++ b/frontend/src/api/watch.ts
@@ -16,16 +16,16 @@ import type { GRPCMetadata } from '@/api/options'
 import { withContext, withMetadata, withRuntime } from '@/api/options'
 import type { Metadata } from '@/api/v1alpha1/resource.pb'
 
-export interface Callback {
-  (message: WatchResponse, spec: WatchEventSpec): void
+export interface Callback<T extends Resource> {
+  (message: WatchResponse, spec: WatchEventSpec<T>): void
 }
 
-export type WatchEventSpec = {
-  res?: Resource
-  old?: Resource
+export interface WatchEventSpec<T extends Resource> {
+  res?: T
+  old?: T
 }
 
-class WatchFunc {
+class WatchFunc<T extends Resource> {
   protected runtime: Runtime = Runtime.Kubernetes
   protected callback: (resp: WatchResponse) => void
   protected stream?: Stream<WatchRequest, WatchResponse>
@@ -34,9 +34,9 @@ class WatchFunc {
   public readonly err: Ref<string | null> = ref(null)
   public readonly errCode: Ref<Code | null> = ref(null)
 
-  constructor(callback: Callback) {
+  constructor(callback: Callback<T>) {
     this.callback = (message: WatchResponse) => {
-      const spec: WatchEventSpec = {}
+      const spec: WatchEventSpec<T> = {}
 
       if (message.event?.resource) {
         spec.res = JSON.parse(message.event?.resource)
@@ -199,7 +199,7 @@ export type WatchOptionsMulti = WatchOptionsBase & {
   resource: Omit<Metadata, 'id'>
 }
 
-export default class Watch<T extends Resource> extends WatchFunc {
+export default class Watch<T extends Resource> extends WatchFunc<T> {
   public readonly items?: Ref<T[]>
   public readonly item?: Ref<T | undefined>
   public readonly total = ref(0)
@@ -207,8 +207,8 @@ export default class Watch<T extends Resource> extends WatchFunc {
   private watchItems?: WatchItems<T>
   private lastTotal = 0
 
-  constructor(target: Ref<T[]> | Ref<T | undefined>, callback?: Callback) {
-    let handler: Callback | undefined
+  constructor(target: Ref<T[]> | Ref<T | undefined>, callback?: Callback<T>) {
+    let handler: Callback<T> | undefined
 
     super((event, spec) => {
       callback?.(event, spec)
@@ -282,7 +282,7 @@ export default class Watch<T extends Resource> extends WatchFunc {
     super.onStart()
   }
 
-  private singleItemHandler(message: WatchResponse, spec: WatchEventSpec) {
+  private singleItemHandler(message: WatchResponse, spec: WatchEventSpec<T>) {
     if (message.event?.event_type === EventType.BOOTSTRAPPED) {
       this.loading.value = false
 
@@ -308,7 +308,7 @@ export default class Watch<T extends Resource> extends WatchFunc {
     }
   }
 
-  private listHandler(message: WatchResponse, spec: WatchEventSpec) {
+  private listHandler(message: WatchResponse, spec: WatchEventSpec<T>) {
     if (!this.items || !this.watchItems) return
 
     if (message.event?.event_type === EventType.BOOTSTRAPPED) {
@@ -501,7 +501,7 @@ class WatchItems<T> {
 export type WatchJoinOptions = WatchOptions & { idFunc?: <T>(res: Resource<T>) => string }
 
 export class WatchJoin<T extends Resource> {
-  private watches: WatchFunc[] = []
+  private watches: WatchFunc<T>[] = []
   private items: Ref<T[]>
   private watchItems?: WatchItems<T>
   private itemMap: Record<string, Record<string, Record<string, ResourceSort<T>>>> = {}
@@ -579,7 +579,7 @@ export class WatchJoin<T extends Resource> {
     this.primaryResourceType = primary.resource.type
 
     const handler = (resourceType: string, opts: WatchJoinOptions) => {
-      return (resp: WatchResponse, spec: WatchEventSpec) => {
+      return (resp: WatchResponse, spec: WatchEventSpec<T>) => {
         if (!this.itemMap[resourceType]) {
           this.itemMap[resourceType] = {}
         }

--- a/frontend/src/methods/useResourceWatch.ts
+++ b/frontend/src/methods/useResourceWatch.ts
@@ -37,12 +37,12 @@ interface WatchMultiJoin<TSpec, TStatus> extends WatchBase {
 
 export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsSingle>,
-  callback?: Callback,
+  callback?: Callback<Resource<TSpec, TStatus>>,
 ): WatchSingle<TSpec, TStatus>
 
 export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsMulti>,
-  callback?: Callback,
+  callback?: Callback<Resource<TSpec, TStatus>>,
 ): WatchMulti<TSpec, TStatus>
 
 export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
@@ -51,12 +51,12 @@ export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
 
 export function useResourceWatch<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptions | WatchJoinOptions[]>,
-  callback?: Callback,
+  callback?: Callback<Resource<TSpec, TStatus>>,
 ): WatchSingle<TSpec, TStatus> | WatchMulti<TSpec, TStatus> | WatchMultiJoin<TSpec, TStatus>
 
 export function useResourceWatch<TSpec, TStatus>(
   opts: MaybeRefOrGetter<WatchOptions | WatchJoinOptions[]>,
-  callback?: Callback,
+  callback?: Callback<Resource<TSpec, TStatus>>,
 ) {
   if (isWatchJoinOptions(opts)) return useWatchJoin<TSpec, TStatus>(opts)
 
@@ -68,7 +68,7 @@ export function useResourceWatch<TSpec, TStatus>(
 
 function useWatchSingle<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsSingle>,
-  callback?: Callback,
+  callback?: Callback<Resource<TSpec, TStatus>>,
 ): WatchSingle<TSpec, TStatus> {
   const data = ref<Resource<TSpec, TStatus>>()
 
@@ -85,7 +85,7 @@ function useWatchSingle<TSpec = unknown, TStatus = unknown>(
 
 function useWatchMulti<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<WatchOptionsMulti>,
-  callback?: Callback,
+  callback?: Callback<Resource<TSpec, TStatus>>,
 ): WatchMulti<TSpec, TStatus> {
   const data: Ref<Resource<TSpec, TStatus>[], Resource<TSpec, TStatus>[]> = ref([])
 

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.vue
@@ -26,34 +26,6 @@ import NodesMonitorChart from '@/views/Nodes/components/NodesMonitorChart.vue'
 
 definePage({ name: 'NodeMonitor' })
 
-interface Diffable {
-  [key: string]: number | Diffable | Diffable[]
-}
-
-function diff<T extends Diffable>(a: T, b: T): T {
-  const result: Diffable = {}
-
-  for (const key in a) {
-    const left = a[key]
-    const right = b[key]
-
-    if (typeof left === 'number' && typeof right === 'number') {
-      result[key] = left - right
-    } else if (Array.isArray(left) && Array.isArray(right)) {
-      result[key] = left.map((val, i) => diff(val, right[i]))
-    } else if (
-      !Array.isArray(left) &&
-      !Array.isArray(right) &&
-      typeof left === 'object' &&
-      typeof right === 'object'
-    ) {
-      result[key] = diff(left, right)
-    }
-  }
-
-  return result as T
-}
-
 const route = useRoute()
 
 const processes = ref<Proc[]>([])
@@ -75,20 +47,17 @@ const sortReverse = ref(true)
 
 const memTotal = ref(0)
 
-const sum = (obj: Record<string, number>, ...args: string[]) => {
-  let res = 0
-  for (const k of args) {
-    res += obj[k] || 0
-  }
-
-  return res
-}
-
-const getCPUTotal = (stat: Record<string, number>) => {
-  const idle = sum(stat, 'idle', 'iowait')
-  const nonIdle = sum(stat, 'user', 'nice', 'system', 'irq', 'steal', 'softIrq')
-
-  return idle + nonIdle
+const getCPUTotal = (stat: TalosCPUSpec['cpuTotal']) => {
+  return [
+    stat.idle,
+    stat.iowait,
+    stat.user,
+    stat.nice,
+    stat.system,
+    stat.irq,
+    stat.steal,
+    stat.softIrq,
+  ].reduce<number>((prev, curr) => prev + (curr || 0), 0)
 }
 
 const prevProcs: Record<number, ProcessInfo> = {}
@@ -152,58 +121,85 @@ watchEffect((onCleanup) => {
   })
 })
 
-const handleCPU = (oldObj: Diffable, newObj: Diffable) => {
-  const delta = diff(oldObj, newObj)
-  const stat = delta.cpuTotal as Record<string, number>
-  const total = getCPUTotal(stat)
+interface TalosCPUSpec {
+  contextSwitches?: number
+  cpu?: []
+  cpuTotal: {
+    guest?: number
+    guestNice?: number
+    idle?: number
+    iowait?: number
+    irq?: number
+    nice?: number
+    softIrq?: number
+    steal?: number
+    system?: number
+    user?: number
+  }
+  irqTotal?: number
+  processBlocked?: number
+  processCreated?: number
+  processRunning?: number
+  softIrqTotal?: number
+}
+
+const handleCPU = (oldObj: TalosCPUSpec, newObj: TalosCPUSpec) => {
+  const keys = Object.keys(oldObj.cpuTotal) as (keyof TalosCPUSpec['cpuTotal'])[]
+
+  const cpuTotal = keys.reduce<TalosCPUSpec['cpuTotal']>(
+    (prev, key) => ({
+      ...prev,
+      [key]: (oldObj.cpuTotal[key] || 0) - (newObj.cpuTotal[key] || 0),
+    }),
+    {},
+  )
+
+  const total = getCPUTotal(cpuTotal)
 
   return {
-    system: (stat.system / total) * 100,
-    user: (stat.user / total) * 100,
+    system: ((cpuTotal.system || 0) / total) * 100,
+    user: ((cpuTotal.user || 0) / total) * 100,
   }
 }
 
-const handleTotalCPU = (oldObj: Diffable, newObj: Diffable) => {
+const handleTotalCPU = (oldObj: TalosCPUSpec, newObj: TalosCPUSpec) => {
   const point = handleCPU(oldObj, newObj)
 
   return `${(point.user + point.system).toFixed(1)} %`
 }
 
-const handleMem = (
-  _: unknown,
-  m: { used: number; cached: number; buffers: number; total: number },
-) => {
-  memTotal.value = m.total
+interface TalosMemorySpec {
+  total?: number
+  used?: number
+  cached?: number
+  buffers?: number
+}
+
+const handleMem = (_: TalosMemorySpec, m: TalosMemorySpec) => {
+  memTotal.value = m.total || 0
 
   return {
-    used: m.used - m.cached - m.buffers,
-    cached: m.cached,
-    buffers: m.buffers,
+    used: (m.used || 0) - (m.cached || 0) - (m.buffers || 0),
+    cached: m.cached || 0,
+    buffers: m.buffers || 0,
   }
 }
 
-const handleTotalMem = (
-  _: unknown,
-  m: { used: number; cached: number; buffers: number; total: number },
-) => {
-  const used = m.used - m.cached - m.buffers
+const handleTotalMem = (_: TalosMemorySpec, m: TalosMemorySpec) => {
+  const used = (m.used || 0) - (m.cached || 0) - (m.buffers || 0)
 
-  return `${formatBytes(used * 1024)} / ${formatBytes(m.total * 1024)}`
+  return `${formatBytes(used * 1024)} / ${formatBytes((m.total || 0) * 1024)}`
 }
 
-const handleMaxMem = (_: unknown, m: { total: number }): number => {
-  return m.total
+const handleMaxMem = (_: TalosMemorySpec, m: TalosMemorySpec) => {
+  return m.total || 0
 }
 
-const handleProcs = (oldObj: Diffable, newObj: Diffable) => {
-  const { processCreated } = diff(oldObj, newObj)
-
+const handleProcs = (oldObj: TalosCPUSpec, newObj: TalosCPUSpec) => {
   return {
-    // The diff algorithm should never return only numbers Record<string, number> for this case
-    // But due to how its typed, adding a fallback just incase
-    created: typeof processCreated === 'number' ? processCreated : Number(processCreated),
-    running: newObj.processRunning as number,
-    blocked: newObj.processBlocked as number,
+    created: (oldObj.processCreated || 0) - (newObj.processCreated || 0),
+    running: newObj.processRunning || 0,
+    blocked: newObj.processBlocked || 0,
   }
 }
 
@@ -379,7 +375,6 @@ const sortBy = (id: keyof Proc) => {
 }
 .monitor-chart {
   @apply flex-1 rounded bg-naturals-n2 p-3 pt-4;
-  min-height: 220px;
 }
 .monitor-chart:nth-child(1) {
   @apply mr-3;

--- a/frontend/src/views/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/Nodes/components/NodesMonitorChart.vue
@@ -11,7 +11,7 @@ import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
 import { refDebounced } from '@vueuse/core'
 import type { ApexOptions } from 'apexcharts'
 import { DateTime } from 'luxon'
-import { computed, ref } from 'vue'
+import { computed, ref, useTemplateRef, watchEffect } from 'vue'
 import VueApexCharts from 'vue3-apexcharts/core'
 
 import { Code } from '@/api/google/rpc/code.pb'
@@ -243,6 +243,24 @@ const options = computed(() => {
  */
 const chartProps = computed(() => ({ options: options.value, series: series.value }))
 const chartPropsDebounced = refDebounced(chartProps, 50)
+
+/**
+ * The below workaround only required until upstream PR is released
+ * See: https://github.com/apexcharts/vue3-apexcharts/issues/150
+ */
+const chartRef = useTemplateRef('chartRef')
+// eslint-disable-next-line vue/no-ref-object-reactivity-loss
+const initOptions = options.value
+
+watchEffect(() => {
+  // Wait for internal chart to be created
+  if (!chartRef.value?.chart) return
+
+  chartRef.value.updateOptions({
+    ...chartPropsDebounced.value.options,
+    series: chartPropsDebounced.value.series,
+  })
+})
 </script>
 
 <template>
@@ -271,10 +289,12 @@ const chartPropsDebounced = refDebounced(chartProps, 50)
       </div>
       <VueApexCharts
         v-show="!err && !loading"
+        ref="chartRef"
         width="100%"
         :height="180"
         type="area"
-        v-bind="chartPropsDebounced"
+        :options="initOptions"
+        :series="[]"
       />
     </div>
   </div>

--- a/frontend/src/views/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/Nodes/components/NodesMonitorChart.vue
@@ -8,21 +8,21 @@ included in the LICENSE file.
 import 'apexcharts/area'
 
 import { ExclamationCircleIcon } from '@heroicons/vue/24/outline'
+import { refDebounced } from '@vueuse/core'
 import type { ApexOptions } from 'apexcharts'
 import { DateTime } from 'luxon'
-import type { Ref } from 'vue'
 import { computed, ref } from 'vue'
 import VueApexCharts from 'vue3-apexcharts/core'
 
 import { Code } from '@/api/google/rpc/code.pb'
-import type { WatchResponse } from '@/api/omni/resources/resources.pb'
-import { EventType } from '@/api/omni/resources/resources.pb'
+import type { Resource } from '@/api/grpc'
+import { EventType, type WatchResponse } from '@/api/omni/resources/resources.pb'
 import type { WatchEventSpec, WatchOptions } from '@/api/watch'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
 import { getNonce } from '@/methods'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
-type Props<T> = {
+type Props = {
   watchOpts: WatchOptions
   name: string
   title: string
@@ -53,48 +53,37 @@ const {
   maxFn,
   stacked,
   formatter,
-} = defineProps<Props<T>>()
+} = defineProps<Props>()
 
 type Point = number | number[]
 const series = ref<{ name: string; data: Point[] }[]>([])
 const seriesMap: Record<string, { index: number; version: number }> = {}
 const points: Record<number, Point[]> = {}
-const flush: Record<number, number> = {}
 const total = ref<string>()
 
-const min: Ref<number | undefined> = ref(undefined)
-const max: Ref<number | undefined> = ref(undefined)
+const min = ref<number>()
+const max = ref<number>()
 
 const tailEvents = computed(() => watchOpts.tailEvents ?? 25)
 
-const handlePoint = (message: WatchResponse, spec: WatchEventSpec) => {
+const handlePoint = (message: WatchResponse, spec: WatchEventSpec<Resource<T>>) => {
   if (message.event?.event_type !== EventType.UPDATED) {
     return
   }
 
-  const resource = spec.res
-  const old = spec.old
+  const { res: resource, old } = spec
 
-  const data = pointFn(resource?.spec, old?.spec)
+  if (!resource || !old) return
 
-  if (totalFn) {
-    total.value = totalFn(resource?.spec, old?.spec)
-  }
+  const data = pointFn(resource.spec, old.spec)
 
-  if (minFn) {
-    min.value = minFn(resource?.spec, old?.spec)
-  }
-
-  if (maxFn) {
-    max.value = maxFn(resource?.spec, old?.spec)
-  }
+  total.value = totalFn?.(resource.spec, old.spec)
+  min.value = minFn?.(resource.spec, old.spec)
+  max.value = maxFn?.(resource.spec, old.spec)
 
   for (const key in data) {
     if (!(key in seriesMap)) {
-      series.value.push({
-        name: key,
-        data: [],
-      })
+      series.value = [...series.value, { name: key, data: [] }]
 
       seriesMap[key] = {
         index: series.value.length - 1,
@@ -102,41 +91,39 @@ const handlePoint = (message: WatchResponse, spec: WatchEventSpec) => {
       }
     }
 
-    const version = Number(resource?.metadata?.version ?? '')
+    const version = Number(resource.metadata.version ?? '')
     const meta = seriesMap[key]
     if (version <= meta.version) {
       continue
     }
 
     let point: Point = data[key]
-    const updated = resource?.metadata?.updated
+    const updated = resource.metadata.updated
     if (updated) {
       point = [DateTime.fromISO(updated.toString()).toMillis(), point]
     }
-
-    clearTimeout(flush[meta.index])
 
     if (!points[meta.index]) points[meta.index] = []
 
     points[meta.index].push(point)
     meta.version = version
 
-    flush[meta.index] = window.setTimeout(() => {
-      let dst = series.value[meta.index].data
+    series.value = series.value.map((s, i) => {
+      if (i !== meta.index) return s
 
-      dst = dst.concat(points[meta.index])
+      let dst = s.data.concat(points[i])
 
       if (dst.length >= tailEvents.value) {
-        dst.splice(0, dst.length - tailEvents.value + 1)
+        dst = dst.slice(dst.length - tailEvents.value + 1)
       }
 
-      series.value[meta.index].data = dst
-      points[meta.index] = []
-    }, 50)
+      points[i] = []
+      return { ...s, data: dst }
+    })
   }
 }
 
-const { err, errCode, loading } = useResourceWatch(
+const { err, errCode, loading } = useResourceWatch<T>(
   () => ({
     ...watchOpts,
     tailEvents: tailEvents.value,
@@ -244,6 +231,18 @@ const options = computed(() => {
     },
   } satisfies ApexOptions
 })
+
+/**
+ * Workaround for https://github.com/siderolabs/omni/issues/2756
+ *
+ * To prevent flushing and to ensure options & series get updated together,
+ * we debounce combined series & options as props, at the same rate as we
+ * previously were flushing updates.
+ *
+ * This ensures there are no race conditions between options/series updates.
+ */
+const chartProps = computed(() => ({ options: options.value, series: series.value }))
+const chartPropsDebounced = refDebounced(chartProps, 50)
 </script>
 
 <template>
@@ -273,10 +272,9 @@ const options = computed(() => {
       <VueApexCharts
         v-show="!err && !loading"
         width="100%"
-        height="100%"
+        :height="180"
         type="area"
-        :options="options"
-        :series="series ?? []"
+        v-bind="chartPropsDebounced"
       />
     </div>
   </div>
@@ -285,16 +283,16 @@ const options = computed(() => {
 <style scoped>
 @reference "../../../index.css";
 
-#chartContainer .apexcharts-tooltip {
+#chartContainer :deep(.apexcharts-tooltip) {
   @apply bg-naturals-n3 px-3 py-2.5 text-naturals-n14;
 }
-#chartContainer .apexcharts-tooltip-title {
+#chartContainer :deep(.apexcharts-tooltip-title) {
   @apply bg-naturals-n3 text-naturals-n14;
 }
-#chartContainer .apexcharts-xaxistooltip-bottom {
+#chartContainer :deep(.apexcharts-xaxistooltip-bottom) {
   @apply hidden;
 }
-#chartContainer .apexcharts-tooltip .apexcharts-tooltip-series-group.active {
+#chartContainer :deep(.apexcharts-tooltip .apexcharts-tooltip-series-group.active) {
   @apply bg-naturals-n3;
 }
 </style>


### PR DESCRIPTION
On load, apexcharts was sometimes loading without x-axis information and without tooltips working. When data updates came in later, tooltips were sometimes in a broken state. This fixes that by addressing the underlying race conditions with series/options updates and non-reactive changes being made to the series array. Also improved typing for watch callback, fixed apexcharts tooltip styles not being applied, simplified the diffing code, and added a temporary workaround fix for formatters.

Fixes #2756 