### PR TITLE
feat: periodically re-check FULL-mode kubernetes manifest groups

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
@@ -315,6 +315,19 @@ func (ctrl *ClusterManifestsStatusController) reconcileRunning(ctx context.Conte
 		return controller.NewRequeueInterval(time.Second * 30)
 	}
 
+	// Drift detection for FULL-mode groups: re-check workload cluster
+	// state every 5 minutes so out-of-band deletions/edits get reverted
+	// without a manual nudge. The reconcile path already calls Get on
+	// every manifest in updateStatus, so the next pass will set
+	// OutOfSync and the 30s requeue above takes over from there.
+	if errs == nil {
+		for _, g := range groups {
+			if g.Mode == specs.KubernetesManifestGroupSpec_FULL {
+				return controller.NewRequeueInterval(5 * time.Minute)
+			}
+		}
+	}
+
 	return errs
 }
 


### PR DESCRIPTION
When a kubernetes manifest group is configured in FULL mode, we now requeue the cluster manifest status reconciler every 5 minutes even when everything looks in sync. This allows out-of-band deletions or edits on the workload cluster to be detected and reverted without a manual nudge, since the next reconcile pass will Get every manifest, mark the group OutOfSync, and let the existing 30s requeue drive it back to the desired state.