### PR TITLE
feat: register destroy controllers for user-managed resource types

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
@@ -23,7 +23,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/client/pkg/cosi/helpers"
 	"github.com/siderolabs/omni/client/pkg/cosi/labels"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
@@ -106,7 +105,7 @@ func (ctrl *MachineSetNodeController) Settings() controller.QSettings {
 			{
 				Namespace: resources.DefaultNamespace,
 				Type:      omni.MachineSetNodeType,
-				Kind:      controller.InputQMappedDestroyReady,
+				Kind:      controller.InputQMapped,
 			},
 			{
 				Namespace: resources.InfraProviderNamespace,
@@ -290,6 +289,18 @@ func (ctrl *MachineSetNodeController) reconcileRunning(ctx context.Context, logg
 		return err
 	}
 
+	// make sure every managed node carries our finalizer so that it cannot be destroyed out
+	// from under us before we have observed its teardown and finished accounting for it
+	if err = ctrl.ensureNodeFinalizers(ctx, r, machineSetNodes); err != nil {
+		return err
+	}
+
+	// release our finalizer from tearing down nodes once every other finalizer is gone, handing
+	// the actual destruction off to the destroy controller
+	if err = ctrl.releaseDestroyReadyNodes(ctx, r, machineSetNodes); err != nil {
+		return err
+	}
+
 	nodeDiff, allocation, err := ctrl.shouldScale(ctx, r, machineSet, machineSetNodes)
 	if err != nil {
 		return err
@@ -320,7 +331,7 @@ func (ctrl *MachineSetNodeController) reconcileRunning(ctx context.Context, logg
 }
 
 func (ctrl *MachineSetNodeController) reconcileTearingDown(ctx context.Context, r controller.QRuntime, machineSet *omni.MachineSet) error {
-	machineSetNodes, err := safe.ReaderListAll[*omni.MachineSetNode](
+	machineSetNodes, err := ctrl.getAllMachineSetNodes(
 		ctx, r,
 		state.WithLabelQuery(resource.LabelEqual(omni.LabelMachineSet, machineSet.Metadata().ID())),
 	)
@@ -328,22 +339,106 @@ func (ctrl *MachineSetNodeController) reconcileTearingDown(ctx context.Context, 
 		return err
 	}
 
-	ready, err := helpers.TeardownAndDestroyAll(ctx, r, machineSetNodes.Pointers(), controller.WithOwner(""))
-	if err != nil {
-		return err
+	// tear every node down. Once the controller finalizer is the only one left on a node, release it
+	// so the destroy controller can destroy the node. The machine set finalizer is removed only after
+	// every node is destroy-ready, which keeps at least one finalized node around to re-trigger the
+	// controller while teardown is still in progress.
+	allDestroyReady := true
+
+	for machineSetNode := range machineSetNodes.All() {
+		md := machineSetNode.Metadata()
+
+		if _, err = r.Teardown(ctx, md, controller.WithOwner("")); err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
+			return err
+		}
+
+		switch fins := md.Finalizers(); {
+		case fins.Empty():
+			// no finalizers left, destroy controller will pick it up
+		case ctrl.onlyControllerFinalizer(fins):
+			if err = r.RemoveFinalizer(ctx, md, ctrl.Name()); err != nil {
+				return err
+			}
+		case !fins.Has(ctrl.Name()):
+			// the node has other finalizers but not the controller finalizer: add it, so that when
+			// the others drain the node is not destroyed until the controller releases the finalizer
+			if err = r.AddFinalizer(ctx, md, ctrl.Name()); err != nil && !state.IsNotFoundError(err) {
+				return err
+			}
+
+			allDestroyReady = false
+		default:
+			// other controllers still hold finalizers, teardown not finished yet
+			allDestroyReady = false
+		}
 	}
 
-	if !ready {
+	if !allDestroyReady {
 		return nil
 	}
 
 	if machineSet.Metadata().Finalizers().Has(ctrl.Name()) {
-		if err := r.RemoveFinalizer(ctx, machineSet.Metadata(), ctrl.Name()); err != nil {
+		if err = r.RemoveFinalizer(ctx, machineSet.Metadata(), ctrl.Name()); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// ensureNodeFinalizers adds the controller finalizer to every running node it manages, so the
+// node cannot be destroyed before the controller has observed and accounted for its teardown.
+func (ctrl *MachineSetNodeController) ensureNodeFinalizers(ctx context.Context, r controller.QRuntime, machineSetNodes safe.List[*omni.MachineSetNode]) error {
+	for machineSetNode := range machineSetNodes.All() {
+		md := machineSetNode.Metadata()
+
+		if md.Phase() != resource.PhaseRunning {
+			continue
+		}
+
+		if md.Finalizers().Has(ctrl.Name()) {
+			continue
+		}
+
+		if err := r.AddFinalizer(ctx, md, ctrl.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// releaseDestroyReadyNodes removes the controller finalizer from tearing down nodes once it is the
+// only finalizer left, meaning every other controller has finished tearing the node down. This lets
+// the destroy controller destroy them.
+func (ctrl *MachineSetNodeController) releaseDestroyReadyNodes(ctx context.Context, r controller.QRuntime, machineSetNodes safe.List[*omni.MachineSetNode]) error {
+	for machineSetNode := range machineSetNodes.All() {
+		md := machineSetNode.Metadata()
+
+		if md.Phase() != resource.PhaseTearingDown {
+			continue
+		}
+
+		if !ctrl.onlyControllerFinalizer(md.Finalizers()) {
+			continue
+		}
+
+		if err := r.RemoveFinalizer(ctx, md, ctrl.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// onlyControllerFinalizer reports whether the controller finalizer is the only finalizer left,
+// meaning every other controller has finished and the node is ready to be destroyed.
+func (ctrl *MachineSetNodeController) onlyControllerFinalizer(fins *resource.Finalizers) bool {
+	return len(*fins) == 1 && fins.Has(ctrl.Name())
 }
 
 func (ctrl *MachineSetNodeController) destroyOrphaned(
@@ -380,9 +475,15 @@ func (ctrl *MachineSetNodeController) destroyOrphaned(
 		}
 	}
 
-	_, err := helpers.TeardownAndDestroyAll(ctx, r, slices.Values(toDestroy), controller.WithOwner(""))
+	// tear the orphaned nodes down. Our finalizer is released by releaseDestroyReadyNodes once every
+	// other controller has finished, and the destroy controller does the actual destruction.
+	for _, ptr := range toDestroy {
+		if _, err := r.Teardown(ctx, ptr, controller.WithOwner("")); err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+	}
 
-	return err
+	return nil
 }
 
 type allocationConfig struct {
@@ -505,7 +606,7 @@ func (ctrl *MachineSetNodeController) shouldScale(
 	return nodeDiff, allocation, nil
 }
 
-//nolint:gocognit
+//nolint:gocognit,gocyclo,cyclop
 func (ctrl *MachineSetNodeController) createNodes(
 	ctx context.Context,
 	r controller.QRuntime,
@@ -585,6 +686,12 @@ func (ctrl *MachineSetNodeController) createNodes(
 
 			msn.Metadata().Labels().Set(omni.LabelManagedByMachineSetNodeController, "")
 
+			// the node carries the controller finalizer so it cannot be destroyed before the
+			// controller has accounted for its teardown, while staying owner-less so users can still
+			// delete it directly. The finalizer is set before creation so it is persisted atomically,
+			// leaving no window in which the node exists without it.
+			msn.Metadata().Finalizers().Add(ctrl.Name())
+
 			if err = r.Create(ctx, msn, controller.WithCreateNoOwner()); err != nil {
 				if state.IsConflictError(err) {
 					continue
@@ -622,34 +729,19 @@ func (ctrl *MachineSetNodeController) deleteNodes(
 
 	slices.SortStableFunc(usedMachineSetNodes, getSortFunction(machineStatuses))
 
-	// destroy all machines which are currently in tearing down phase and have no finalizers
-	if err := machineSetNodes.ForEachErr(func(machineSetNode *omni.MachineSetNode) error {
-		if machineSetNode.Metadata().Phase() == resource.PhaseRunning {
-			return nil
+	// nodes that are already tearing down count towards the target: they are on their way out and
+	// releaseDestroyReadyNodes hands them off to the destroy controller once every other finalizer is gone
+	machineSetNodes.ForEach(func(machineSetNode *omni.MachineSetNode) {
+		if machineSetNode.Metadata().Phase() != resource.PhaseRunning {
+			machinesToDestroyCount--
 		}
-
-		machinesToDestroyCount--
-
-		if machineSetNode.Metadata().Finalizers().Empty() {
-			return r.Destroy(ctx, machineSetNode.Metadata(), controller.WithOwner(""))
-		}
-
-		return nil
-	}); err != nil {
-		return err
-	}
+	})
 
 	iterations := min(machinesToDestroyCount, len(usedMachineSetNodes))
 
 	for i := range iterations {
-		var (
-			ready bool
-			err   error
-		)
-		if ready, err = helpers.TeardownAndDestroy(
-			ctx, r, usedMachineSetNodes[i].Metadata(),
-			controller.WithOwner(""),
-		); err != nil {
+		ready, err := r.Teardown(ctx, usedMachineSetNodes[i].Metadata(), controller.WithOwner(""))
+		if err != nil {
 			if state.IsNotFoundError(err) {
 				return nil
 			}
@@ -657,11 +749,13 @@ func (ctrl *MachineSetNodeController) deleteNodes(
 			return err
 		}
 
+		logger.Info("removing machine set node", zap.String("machine", usedMachineSetNodes[i].Metadata().ID()))
+
+		// the node still has our finalizer (and likely downstream ones), so teardown is not yet
+		// ready; tear nodes down one at a time and let each teardown re-trigger us for the next
 		if !ready {
 			return nil
 		}
-
-		logger.Info("removed machine set node", zap.String("machine", usedMachineSetNodes[i].Metadata().ID()))
 	}
 
 	return nil

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node_destroy_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node_destroy_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller/generic/destroy"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/gen/optional"
+	"github.com/siderolabs/gen/xslices"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+)
+
+const msnHolderFinalizer = "test-msn-finalizer-holder"
+
+// msnFinalizerHolder mimics the downstream finalizer that MachineSetStatusController holds on
+// every MachineSetNode: it is added while the node is running, and released once the node starts
+// tearing down (standing in for the downstream cleanup that gates destruction).
+type msnFinalizerHolder struct{}
+
+func (msnFinalizerHolder) Name() string { return "MSNFinalizerHolderController" }
+
+func (msnFinalizerHolder) Settings() controller.QSettings {
+	return controller.QSettings{
+		Inputs: []controller.Input{
+			{
+				Namespace: resources.DefaultNamespace,
+				Type:      omni.MachineSetNodeType,
+				Kind:      controller.InputQPrimary,
+			},
+		},
+		Concurrency: optional.Some(uint(4)),
+	}
+}
+
+func (msnFinalizerHolder) MapInput(
+	context.Context, *zap.Logger, controller.QRuntime, controller.ReducedResourceMetadata,
+) ([]resource.Pointer, error) {
+	return nil, nil
+}
+
+func (msnFinalizerHolder) Reconcile(ctx context.Context, _ *zap.Logger, r controller.QRuntime, ptr resource.Pointer) error {
+	msn, err := safe.ReaderGet[*omni.MachineSetNode](ctx, r, ptr)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if msn.Metadata().Phase() == resource.PhaseRunning {
+		if !msn.Metadata().Finalizers().Has(msnHolderFinalizer) {
+			return r.AddFinalizer(ctx, msn.Metadata(), msnHolderFinalizer)
+		}
+
+		return nil
+	}
+
+	// tearing down: simulate downstream cleanup completing and release the finalizer
+	if msn.Metadata().Finalizers().Has(msnHolderFinalizer) {
+		return r.RemoveFinalizer(ctx, msn.Metadata(), msnHolderFinalizer)
+	}
+
+	return nil
+}
+
+// cascadeTestSetup registers the controllers (including the generic destroy controller for
+// MachineSetNode, as in production) and creates a static machine set with `count` matching
+// machines, each node carrying a downstream finalizer. It returns the machine set and node ids.
+func (suite *MachineSetNodeSuite) cascadeTestSetup(ctx context.Context, clusterName, machineSetName string, count int) (*omni.MachineSet, []string) {
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineSetNodeController()))
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewLabelsExtractorController[*omni.MachineStatus]()))
+	suite.Require().NoError(suite.runtime.RegisterQController(msnFinalizerHolder{}))
+	suite.Require().NoError(suite.runtime.RegisterQController(destroy.NewController[*omni.MachineSetNode](optional.Some[uint](4))))
+	// as in production, every user-managed type gets a destroy controller
+	suite.Require().NoError(suite.runtime.RegisterQController(destroy.NewController[*omni.MachineSet](optional.Some[uint](4))))
+
+	labelSets := make([]map[string]string, count)
+	for i := range labelSets {
+		labelSets[i] = map[string]string{
+			omni.MachineStatusLabelArch:            "amd64",
+			omni.MachineStatusLabelAvailable:       "",
+			omni.MachineStatusLabelConnected:       "",
+			omni.MachineStatusLabelReadyToUse:      "",
+			omni.MachineStatusLabelReportingEvents: "",
+		}
+	}
+
+	machines := suite.createMachines(labelSets...)
+
+	cluster := omni.NewCluster(clusterName)
+	cluster.TypedSpec().Value.TalosVersion = "1.6.0"
+	suite.Require().NoError(suite.state.Create(ctx, cluster))
+
+	machineClass := newMachineClass(fmt.Sprintf("%s==amd64", omni.MachineStatusLabelArch))
+	suite.Require().NoError(suite.state.Create(ctx, machineClass))
+
+	machineSet := omni.NewMachineSet(machineSetName)
+	machineSet.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
+	machineSet.Metadata().Labels().Set(omni.LabelWorkerRole, "")
+	machineSet.TypedSpec().Value.MachineAllocation = &specs.MachineSetSpec_MachineAllocation{
+		Name:         machineClass.Metadata().ID(),
+		MachineCount: uint32(count), //nolint:gosec
+	}
+	suite.Require().NoError(suite.state.Create(ctx, machineSet))
+
+	ids := xslices.Map(machines, func(m *omni.MachineStatus) string { return m.Metadata().ID() })
+
+	// all MSNs created and carrying the downstream finalizer
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, ids, func(n *omni.MachineSetNode, assert *assert.Assertions) {
+		assert.True(n.Metadata().Finalizers().Has(msnHolderFinalizer))
+	})
+
+	return machineSet, ids
+}
+
+// TestScaleDownReleasesAllNodes verifies that scaling a machine set down tears down and destroys
+// every node, with the destroy controller doing the destruction. Before the finalizer handoff fix
+// the cascade stalled after the first node, because its destroy-ready wake-up was lost when the
+// destroy controller destroyed it before the controller could map it back to its machine set.
+func (suite *MachineSetNodeSuite) TestScaleDownReleasesAllNodes() {
+	suite.startRuntime()
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*10)
+	defer cancel()
+
+	machineSet, ids := suite.cascadeTestSetup(ctx, "cluster-scaledown", "set-scaledown", 5)
+
+	_, err := safe.StateUpdateWithConflicts(ctx, suite.state, machineSet.Metadata(), func(ms *omni.MachineSet) error {
+		ms.TypedSpec().Value.MachineAllocation.MachineCount = 0
+
+		return nil
+	})
+	suite.Require().NoError(err)
+
+	for _, id := range ids {
+		rtestutils.AssertNoResource[*omni.MachineSetNode](ctx, suite.T(), suite.state, id)
+	}
+}
+
+// TestMachineSetTeardownReleasesAllNodes verifies that tearing the whole machine set down tears
+// down and destroys every node and then releases the machine set itself.
+func (suite *MachineSetNodeSuite) TestMachineSetTeardownReleasesAllNodes() {
+	suite.startRuntime()
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*10)
+	defer cancel()
+
+	machineSet, ids := suite.cascadeTestSetup(ctx, "cluster-teardown", "set-teardown", 5)
+
+	_, err := suite.state.Teardown(ctx, machineSet.Metadata())
+	suite.Require().NoError(err)
+
+	for _, id := range ids {
+		rtestutils.AssertNoResource[*omni.MachineSetNode](ctx, suite.T(), suite.state, id)
+	}
+
+	rtestutils.AssertNoResource[*omni.MachineSet](ctx, suite.T(), suite.state, machineSet.Metadata().ID())
+}
+
+// TestTeardownAdoptsPreexistingNodes covers the upgrade case where a machine set is torn down with
+// nodes that were created before this controller started holding its finalizer. The controller must
+// adopt them so the destroy controller cannot delete them before they are handed off, otherwise the
+// machine set finalizer would never be released.
+func (suite *MachineSetNodeSuite) TestTeardownAdoptsPreexistingNodes() {
+	suite.startRuntime()
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*10)
+	defer cancel()
+
+	const staleFinalizer = "stale-downstream"
+
+	// destroy controllers are registered first; the machine set node controller is registered only
+	// after the stuck pre-upgrade state is in place, so it never gets a chance to finalize the nodes
+	suite.Require().NoError(suite.runtime.RegisterQController(destroy.NewController[*omni.MachineSetNode](optional.Some[uint](4))))
+	suite.Require().NoError(suite.runtime.RegisterQController(destroy.NewController[*omni.MachineSet](optional.Some[uint](4))))
+
+	machineSet := omni.NewMachineSet("set-adopt")
+	machineSet.Metadata().Labels().Set(omni.LabelCluster, "cluster-adopt")
+	machineSet.Metadata().Labels().Set(omni.LabelWorkerRole, "")
+	machineSet.TypedSpec().Value.MachineAllocation = &specs.MachineSetSpec_MachineAllocation{
+		Name:         "some-machine-class",
+		MachineCount: 2,
+	}
+	suite.Require().NoError(suite.state.Create(ctx, machineSet))
+	suite.Require().NoError(suite.state.AddFinalizer(ctx, machineSet.Metadata(), omnictrl.MachineSetNodeControllerName))
+	_, err := suite.state.Teardown(ctx, machineSet.Metadata())
+	suite.Require().NoError(err)
+
+	ids := []string{"adopt-machine-0", "adopt-machine-1"}
+
+	for _, id := range ids {
+		msn := omni.NewMachineSetNode(id, machineSet)
+		msn.Metadata().Labels().Set(omni.LabelManagedByMachineSetNodeController, "")
+
+		suite.Require().NoError(suite.state.Create(ctx, msn))
+		suite.Require().NoError(suite.state.AddFinalizer(ctx, msn.Metadata(), staleFinalizer))
+
+		_, err = suite.state.Teardown(ctx, msn.Metadata())
+		suite.Require().NoError(err)
+	}
+
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineSetNodeController()))
+
+	// the controller adopts the pre-existing nodes, so they stay around (now also carrying our
+	// finalizer) until their downstream cleanup finishes
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, ids, func(n *omni.MachineSetNode, assert *assert.Assertions) {
+		assert.True(n.Metadata().Finalizers().Has(omnictrl.MachineSetNodeControllerName))
+	})
+
+	// finish the downstream cleanup; the nodes and then the machine set must be destroyed
+	for _, id := range ids {
+		suite.Require().NoError(suite.state.RemoveFinalizer(ctx, omni.NewMachineSetNode(id, machineSet).Metadata(), staleFinalizer))
+	}
+
+	for _, id := range ids {
+		rtestutils.AssertNoResource[*omni.MachineSetNode](ctx, suite.T(), suite.state, id)
+	}
+
+	rtestutils.AssertNoResource[*omni.MachineSet](ctx, suite.T(), suite.state, machineSet.Metadata().ID())
+}

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
@@ -13,11 +13,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/controller/generic/destroy"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/kvutils"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/google/uuid"
+	"github.com/siderolabs/gen/optional"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -86,9 +88,10 @@ func (suite *MachineSetNodeSuite) TestReconcile() {
 	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
 	defer cancel()
 
-	suite.Require().NoError(suite.runtime.RegisterQController(&omnictrl.MachineSetNodeController{}))
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineSetNodeController()))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineSetStatusController()))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewLabelsExtractorController[*omni.MachineStatus]()))
+	suite.Require().NoError(suite.runtime.RegisterQController(destroy.NewController[*omni.MachineSetNode](optional.Some[uint](4))))
 
 	machines := suite.createMachines(
 		map[string]string{
@@ -271,9 +274,10 @@ func (suite *MachineSetNodeSuite) TestNoRaceBetweenCleanupAndMachineSetNodeContr
 	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*10)
 	defer cancel()
 
-	suite.Require().NoError(suite.runtime.RegisterQController(&omnictrl.MachineSetNodeController{}))
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineSetNodeController()))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewLabelsExtractorController[*omni.MachineStatus]()))
 	suite.Require().NoError(suite.runtime.RegisterController(omnictrl.NewMachineRequestStatusCleanupController()))
+	suite.Require().NoError(suite.runtime.RegisterQController(destroy.NewController[*omni.MachineSetNode](optional.Some[uint](4))))
 
 	cluster := omni.NewCluster("cluster-race")
 	cluster.TypedSpec().Value.TalosVersion = "1.6.4"

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -34,6 +34,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	resourceregistry "github.com/siderolabs/omni/client/pkg/omni/resources/registry"
 	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	virtualres "github.com/siderolabs/omni/client/pkg/omni/resources/virtual"
@@ -202,9 +203,8 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 	}
 
 	qcontrollers := []controller.QController{
+		// destroy controller for Link, which is not part of the user-managed resource set
 		destroy.NewController[*siderolinkres.Link](optional.Some[uint](4)),
-		destroy.NewController[*omni.Cluster](optional.Some[uint](4)),
-		destroy.NewController[*omni.MachineSet](optional.Some[uint](4)),
 
 		omnictrl.NewBackupDataController(),
 		omnictrl.NewClusterBootstrapStatusController(etcdBackupStoreFactory),
@@ -286,6 +286,16 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		machine.NewStatusLinkController(linkCounterDeltaCh),
 		kubernetes.NewClusterManifestsStatusController(kubernetesRuntime),
 		clusterWorkloadProxyController,
+	}
+
+	// register a destroy controller for each user-managed resource type
+	for _, resource := range resourceregistry.Resources {
+		rd := resource.ResourceDefinition()
+		if _, ok := userManagedResourceTypeSet[rd.Type]; !ok { // not user-managed, continue
+			continue
+		}
+
+		qcontrollers = append(qcontrollers, destroy.NewControllerForResource(rd, optional.Some[uint](4)))
 	}
 
 	if cfg.Auth.Saml.GetEnabled() {


### PR DESCRIPTION
Previously only Cluster and MachineSet had destroy controllers wired up among the user-managed types. Other user-managed resources got stuck in tearing-down state when any controller still held a finalizer at the moment of destroy.

Register a destroy controller for every type in the user-managed set. The Link resource keeps its explicit destroy controller because it is only partially user-managed and is not part of the set.

Bump cosi-runtime to pick up the value-based destroy controller constructor used by the new loop.