### PR TITLE
fix(frontend): keep machine details open when switching

### DIFF
--- a/frontend/src/components/List/TList.vue
+++ b/frontend/src/components/List/TList.vue
@@ -381,8 +381,8 @@ const openPage = (page: number | string) => {
               :side-panel-selected-item-id
               :open-panel="
                 (id: string) => {
-                  sidePanelOpen = !sidePanelOpen
-                  sidePanelSelectedItemId = sidePanelOpen ? id : undefined
+                  sidePanelOpen = !sidePanelOpen || sidePanelSelectedItemId !== id
+                  sidePanelSelectedItemId = id
                 }
               "
             />


### PR DESCRIPTION
When switching from details of one machine to another the panel should remain open. Accidentally broke this in #2666, new logic is slightly wrong.