### PR TITLE
feat: destroy imported cluster secrets after bundle is consumed

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/secrets/cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/cleanup.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
+)
+
+// ImportedClusterSecretsCleanupControllerName is the name of the controller.
+const ImportedClusterSecretsCleanupControllerName = "ImportedClusterSecretsCleanupController"
+
+// ImportedClusterSecretsCleanupController destroys ImportedClusterSecrets once the SecretsController
+// has copied the secrets bundle into the matching ClusterSecrets and marked it as imported,
+// so the source secrets do not linger in the state after they have been consumed.
+type ImportedClusterSecretsCleanupController struct{}
+
+// Name implements controller.QController interface.
+func (ctrl *ImportedClusterSecretsCleanupController) Name() string {
+	return ImportedClusterSecretsCleanupControllerName
+}
+
+// Settings implements controller.QController interface.
+func (ctrl *ImportedClusterSecretsCleanupController) Settings() controller.QSettings {
+	return controller.QSettings{
+		Inputs: []controller.Input{
+			{
+				Namespace: resources.DefaultNamespace,
+				Type:      omni.ClusterSecretsType,
+				Kind:      controller.InputQPrimary,
+			},
+		},
+		Outputs: []controller.Output{
+			{
+				Type: omni.ImportedClusterSecretsType,
+				Kind: controller.OutputShared,
+			},
+		},
+	}
+}
+
+// Reconcile implements controller.QController interface.
+func (ctrl *ImportedClusterSecretsCleanupController) Reconcile(ctx context.Context, logger *zap.Logger, r controller.QRuntime, ptr resource.Pointer) error {
+	cs, err := safe.ReaderGetByID[*omni.ClusterSecrets](ctx, r, ptr.ID())
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to get ClusterSecrets %q: %w", ptr.ID(), err)
+	}
+
+	if !cs.TypedSpec().Value.GetImported() {
+		return nil
+	}
+
+	ics, err := safe.ReaderGetByID[*omni.ImportedClusterSecrets](ctx, r, cs.Metadata().ID())
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to get ImportedClusterSecrets %q: %w", cs.Metadata().ID(), err)
+	}
+
+	logger.Info("destroying consumed imported cluster secrets", zap.String("id", ics.Metadata().ID()))
+
+	destroyed, err := helpers.TeardownAndDestroy(ctx, r, ics.Metadata(), controller.WithOwner(""))
+	if err != nil {
+		return fmt.Errorf("failed to teardown and destroy ImportedClusterSecrets %q: %w", ics.Metadata().ID(), err)
+	}
+
+	if !destroyed {
+		return controller.NewRequeueError(fmt.Errorf("waiting for ImportedClusterSecrets %q to be destroyed", ics.Metadata().ID()), 10*time.Second)
+	}
+
+	return nil
+}
+
+// MapInput implements controller.QController interface.
+func (ctrl *ImportedClusterSecretsCleanupController) MapInput(context.Context, *zap.Logger, controller.QRuntime, controller.ReducedResourceMetadata) ([]resource.Pointer, error) {
+	return nil, nil
+}

--- a/internal/backend/runtime/omni/controllers/omni/secrets/cleanup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/cleanup_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package secrets_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/secrets"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
+)
+
+func TestImportedClusterSecretsCleanup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("destroys ICS once ClusterSecrets is marked imported", func(t *testing.T) {
+		t.Parallel()
+
+		testutils.WithRuntime(
+			t.Context(),
+			t,
+			testutils.TestOptions{},
+			func(_ context.Context, testContext testutils.TestContext) {
+				require.NoError(t, testContext.Runtime.RegisterQController(&secrets.ImportedClusterSecretsCleanupController{}))
+			},
+			func(ctx context.Context, testContext testutils.TestContext) {
+				st := testContext.State
+
+				const clusterID = "imported-cluster"
+
+				ics := omni.NewImportedClusterSecrets(clusterID)
+				ics.TypedSpec().Value.Data = "secret-bundle"
+				require.NoError(t, st.Create(ctx, ics))
+
+				cs := omni.NewClusterSecrets(clusterID)
+				cs.TypedSpec().Value.Data = []byte("derived-bundle")
+				cs.TypedSpec().Value.Imported = true
+				require.NoError(t, st.Create(ctx, cs))
+
+				rtestutils.AssertNoResource[*omni.ImportedClusterSecrets](ctx, t, st, clusterID)
+			},
+		)
+	})
+}

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -242,6 +242,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		redactedmachineconfig.NewController(redactedmachineconfig.ControllerOptions{}),
 		omnictrl.NewSchematicConfigurationController(imageFactoryClient),
 		secrets.NewSecretsController(storeFactory),
+		&secrets.ImportedClusterSecretsCleanupController{},
 		secrets.NewTalosConfigController(constants.CertificateValidityTime),
 		omnictrl.NewTalosExtensionsController(imageFactoryClient),
 		omnictrl.NewMachineStatusSnapshotController(siderolinkEventsCh, powerStageEventsCh),

--- a/internal/integration/import_test.go
+++ b/internal/integration/import_test.go
@@ -121,6 +121,8 @@ func testImport(t *testing.T, options *TestOptions, clusterID string, clusterNod
 
 	_, err = talosClient.Version(client.WithNode(ctx, clusterNodes[0]))
 	require.NoError(t, err)
+
+	rtestutils.AssertNoResource[*omni.ImportedClusterSecrets](ctx, t, omniState, clusterID)
 }
 
 func testUnlockCluster(t *testing.T, options *TestOptions, clusterID string) {


### PR DESCRIPTION
ImportedClusterSecrets carries cluster bootstrap material that becomes redundant once the SecretsController copies it into ClusterSecrets and marks the result Imported=true. Add a a new QController ImportedClusterSecretsCleanupController that wakes on ClusterSecrets changes and tears down the matching ImportedClusterSecrets so the source secrets do not linger in the state.
