### PR TITLE
fix: consume SAML sessions once

### DIFF
--- a/internal/pkg/auth/interceptor/saml.go
+++ b/internal/pkg/auth/interceptor/saml.go
@@ -27,7 +27,10 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 
-var errGRPCInvalidSAML = status.Error(codes.Unauthenticated, "invalid session")
+var (
+	errGRPCInvalidSAML        = status.Error(codes.Unauthenticated, "invalid session")
+	errSAMLSessionAlreadyUsed = errors.New("session was already used")
+)
 
 // SAML is a GRPC interceptor that verifies SAML session.
 type SAML struct {
@@ -109,17 +112,17 @@ func (i *SAML) getSession(ctx context.Context, sessionID string) (*authres.SAMLA
 		return nil, errGRPCInvalidSAML
 	}
 
+	if acs.TypedSpec().Value.Used {
+		i.logger.Info("invalid session", zap.Error(errSAMLSessionAlreadyUsed))
+
+		return nil, errGRPCInvalidSAML
+	}
+
 	var assertion saml.Assertion
 
 	err = json.Unmarshal(acs.TypedSpec().Value.Data, &assertion)
 	if err != nil {
 		return nil, err
-	}
-
-	if acs.TypedSpec().Value.Used {
-		i.logger.Info("invalid session", zap.Error(errors.New("session was already used")))
-
-		return nil, errGRPCInvalidSAML
 	}
 
 	if assertion.IssueInstant.Add(saml.MaxIssueDelay).Before(time.Now().UTC()) {
@@ -128,11 +131,24 @@ func (i *SAML) getSession(ctx context.Context, sessionID string) (*authres.SAMLA
 		return nil, errGRPCInvalidSAML
 	}
 
-	_, err = safe.StateUpdateWithConflicts(ctx, i.state, acs.Metadata(), func(r *authres.SAMLAssertion) error {
+	acs, err = safe.StateUpdateWithConflicts(ctx, i.state, acs.Metadata(), func(r *authres.SAMLAssertion) error {
+		if r.TypedSpec().Value.Used {
+			return errSAMLSessionAlreadyUsed
+		}
+
 		r.TypedSpec().Value.Used = true
 
 		return nil
 	})
+	if err != nil {
+		if errors.Is(err, errSAMLSessionAlreadyUsed) {
+			i.logger.Info("invalid session", zap.Error(err))
 
-	return acs, err
+			return nil, errGRPCInvalidSAML
+		}
+
+		return nil, err
+	}
+
+	return acs, nil
 }

--- a/internal/pkg/auth/interceptor/saml_test.go
+++ b/internal/pkg/auth/interceptor/saml_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package interceptor_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/crewjam/saml"
+	"github.com/siderolabs/go-api-signature/pkg/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
+	"github.com/siderolabs/omni/internal/pkg/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/actor"
+	"github.com/siderolabs/omni/internal/pkg/auth/interceptor"
+	"github.com/siderolabs/omni/internal/pkg/ctxstore"
+)
+
+func TestSAMLSessionCanOnlyBeUsedOnceConcurrently(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sessionID    = "test-session"
+		requestCount = 32
+		email        = "user@example.com"
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	assertionData, err := json.Marshal(saml.Assertion{IssueInstant: time.Now().UTC()})
+	require.NoError(t, err)
+
+	assertionResource := authres.NewSAMLAssertion(sessionID)
+	assertionResource.TypedSpec().Value.Data = assertionData
+	assertionResource.TypedSpec().Value.Email = email
+
+	require.NoError(t, st.Create(actor.MarkContextAsInternalActor(ctx), assertionResource))
+
+	samlInterceptor := interceptor.NewSAML(st, zap.NewNop())
+
+	var successCount, unauthenticatedCount atomic.Int32
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	for range requestCount {
+		eg.Go(func() error {
+			_, callErr := samlInterceptor.Unary()(samlRequestContext(ctx, sessionID), nil, nil, noopHandler)
+
+			switch {
+			case callErr == nil:
+				successCount.Add(1)
+			case status.Code(callErr) == codes.Unauthenticated:
+				unauthenticatedCount.Add(1)
+			default:
+				return callErr
+			}
+
+			return nil
+		})
+	}
+
+	require.NoError(t, eg.Wait())
+	assert.Equal(t, int32(1), successCount.Load())
+	assert.Equal(t, int32(requestCount-1), unauthenticatedCount.Load())
+
+	usedAssertion, err := safe.StateGetByID[*authres.SAMLAssertion](ctx, st, sessionID)
+	require.NoError(t, err)
+	assert.True(t, usedAssertion.TypedSpec().Value.Used)
+}
+
+func samlRequestContext(ctx context.Context, sessionID string) context.Context {
+	md := metadata.Pairs(auth.SamlSessionHeaderKey, sessionID)
+
+	ctx = metadata.NewIncomingContext(ctx, md)
+	ctx = ctxstore.WithValue(ctx, auth.GRPCMessageContextKey{Message: message.NewGRPC(md, "/omni.test/SAML")})
+	ctx = ctxstore.WithValue(ctx, &auditlog.Data{})
+
+	return ctx
+}


### PR DESCRIPTION
Ensure a SAML session is accepted by only one concurrent request and later attempts are rejected as invalid.

Add coverage for concurrent requests using the same session token so the single-use behavior stays enforced.