### PR TITLE
fix: add more input validations to management API

### DIFF
--- a/internal/backend/export_test.go
+++ b/internal/backend/export_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package backend
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni/internal/backend/imagefactory"
+)
+
+func MakeTalosctlHandler(imageFactoryClient *imagefactory.Client, logger *zap.Logger) (http.Handler, error) {
+	return makeTalosctlHandler(imageFactoryClient, logger)
+}

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -722,8 +722,12 @@ func (s *managementServer) CreateJoinToken(ctx context.Context, request *managem
 
 	joinToken := siderolinkres.NewJoinToken(token)
 
-	if request.Name == "" && len(request.Name) > omni.MaxJoinTokenNameLength {
-		return nil, status.Error(codes.InvalidArgument, "token name is invalid")
+	if request.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "token name cannot be empty")
+	}
+
+	if len(request.Name) > omni.MaxJoinTokenNameLength {
+		return nil, status.Errorf(codes.InvalidArgument, "token name cannot be longer than %d symbols", omni.MaxJoinTokenNameLength)
 	}
 
 	joinToken.TypedSpec().Value.Name = request.Name

--- a/internal/backend/grpc/management_validation_test.go
+++ b/internal/backend/grpc/management_validation_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package grpc_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/client/api/omni/management"
+	grpcomni "github.com/siderolabs/omni/internal/backend/grpc"
+	omniruntime "github.com/siderolabs/omni/internal/backend/runtime/omni"
+	"github.com/siderolabs/omni/internal/pkg/auth"
+	"github.com/siderolabs/omni/internal/pkg/auth/role"
+	"github.com/siderolabs/omni/internal/pkg/ctxstore"
+)
+
+func TestCreateJoinTokenValidation(t *testing.T) {
+	server := grpcomni.NewManagementServer(nil, nil, zaptest.NewLogger(t), false, nil, nil)
+	ctx := ctxstore.WithValue(context.Background(), auth.EnabledAuthContextKey{Enabled: true})
+	ctx = ctxstore.WithValue(ctx, auth.RoleContextKey{Role: role.Admin})
+
+	for _, tt := range []struct {
+		request *management.CreateJoinTokenRequest
+		name    string
+	}{
+		{
+			name:    "empty name",
+			request: &management.CreateJoinTokenRequest{},
+		},
+		{
+			name: "name too long",
+			request: &management.CreateJoinTokenRequest{
+				Name: strings.Repeat("x", omniruntime.MaxJoinTokenNameLength+1),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := server.CreateJoinToken(ctx, tt.request)
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+func TestCreateSchematicFromRawAuthorization(t *testing.T) {
+	server := grpcomni.NewManagementServer(nil, nil, zaptest.NewLogger(t), false, nil, nil)
+	request := &management.CreateSchematicFromRawRequest{
+		RawSchematic: []byte(":\n"),
+	}
+
+	for _, tt := range []struct {
+		role    role.Role
+		name    string
+		allowed bool
+	}{
+		{
+			name: "reader denied",
+			role: role.Reader,
+		},
+		{
+			name:    "operator allowed",
+			role:    role.Operator,
+			allowed: true,
+		},
+		{
+			name:    "infra provider allowed",
+			role:    role.InfraProvider,
+			allowed: true,
+		},
+		{
+			name:    "admin allowed",
+			role:    role.Admin,
+			allowed: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := ctxstore.WithValue(context.Background(), auth.EnabledAuthContextKey{Enabled: true})
+			ctx = ctxstore.WithValue(ctx, auth.RoleContextKey{Role: tt.role})
+
+			_, err := server.CreateSchematicFromRaw(ctx, request)
+			require.Error(t, err)
+
+			if !tt.allowed {
+				require.Equal(t, codes.PermissionDenied, status.Code(err))
+
+				return
+			}
+
+			require.ErrorContains(t, err, "failed to unmarshal raw schematic")
+		})
+	}
+}

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/image-factory/pkg/client"
 	"github.com/siderolabs/image-factory/pkg/schematic"
@@ -126,7 +127,7 @@ func (s *managementServer) CreateSchematic(ctx context.Context, request *managem
 
 // CreateSchematicFromRaw implements managementServer.
 func (s *managementServer) CreateSchematicFromRaw(ctx context.Context, request *management.CreateSchematicFromRawRequest) (*management.CreateSchematicResponse, error) {
-	if _, err := auth.CheckGRPC(ctx, auth.WithValidSignature(true)); err != nil {
+	if _, err := auth.CheckGRPC(ctx, auth.WithExactRoles(role.InfraProvider, role.Operator, role.Admin)); err != nil {
 		return nil, err
 	}
 
@@ -149,6 +150,12 @@ func (s *managementServer) CreateSchematicFromRaw(ctx context.Context, request *
 }
 
 func (s *managementServer) getOverlay(ctx context.Context, req *management.CreateSchematicRequest) (schematic.Overlay, error) {
+	if req.TalosVersion != "" {
+		if _, err := semver.ParseTolerant(req.TalosVersion); err != nil {
+			return schematic.Overlay{}, status.Error(codes.InvalidArgument, "invalid Talos version")
+		}
+	}
+
 	if !quirks.New(req.TalosVersion).SupportsOverlay() {
 		return schematic.Overlay{}, nil
 	}

--- a/internal/backend/grpc/schematics_test.go
+++ b/internal/backend/grpc/schematics_test.go
@@ -167,6 +167,11 @@ func (suite *GrpcSuite) TestSchematicCreate() {
 
 	suite.Require().NoError(suite.state.Create(ctx, media))
 
+	overlayMedia := omni.NewInstallationMedia("overlay-test")
+	overlayMedia.TypedSpec().Value.Overlay = "test-overlay"
+
+	suite.Require().NoError(suite.state.Create(ctx, overlayMedia))
+
 	for _, tt := range []struct {
 		request       *management.CreateSchematicRequest
 		expectedError func(*testing.T, error)
@@ -269,10 +274,25 @@ func (suite *GrpcSuite) TestSchematicCreate() {
 				require.Equal(t, codes.InvalidArgument, status.Code(err))
 			},
 		},
+		{
+			name: "invalid Talos version",
+			request: &management.CreateSchematicRequest{
+				TalosVersion: "../../secret",
+				MediaId:      "overlay-test",
+			},
+			expectedError: func(t *testing.T, err error) {
+				require.Equal(t, codes.InvalidArgument, status.Code(err))
+			},
+		},
 	} {
 		req := tt.request
-		req.TalosVersion = "v1.6.5"
-		req.MediaId = "test"
+		if req.TalosVersion == "" {
+			req.TalosVersion = "v1.6.5"
+		}
+
+		if req.MediaId == "" {
+			req.MediaId = "test"
+		}
 
 		suite.T().Run(tt.name, func(t *testing.T) {
 			resp, err := client.CreateSchematic(ctx, req)

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/blang/semver/v4"
 	coidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/cosi-project/runtime/api/v1alpha1"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -1271,6 +1272,12 @@ func makeTalosctlHandler(imageFactoryClient *imagefactory.Client, logger *zap.Lo
 		}
 
 		talosVersion := r.PathValue("version")
+		if _, err := semver.ParseTolerant(talosVersion); err != nil {
+			logger.Info("invalid Talos version", zap.Error(err))
+			writeResult(result{Status: "invalid Talos version"}, http.StatusBadRequest)
+
+			return
+		}
 
 		actual, _ := cacherMap.LoadOrStore(talosVersion, &cache.Value[[]string]{Duration: time.Hour})
 

--- a/internal/backend/server_test.go
+++ b/internal/backend/server_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package backend_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	backend "github.com/siderolabs/omni/internal/backend"
+	"github.com/siderolabs/omni/internal/backend/imagefactory"
+)
+
+func TestTalosctlHandlerRejectsInvalidVersion(t *testing.T) {
+	var upstreamRequests atomic.Int32
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		upstreamRequests.Add(1)
+
+		require.Equal(t, "/talosctl/v1.2.3", req.URL.Path)
+
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte(`["download-url"]`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(upstream.Close)
+
+	imageFactoryClient, err := imagefactory.NewClient(nil, upstream.URL)
+	require.NoError(t, err)
+
+	handler, err := backend.MakeTalosctlHandler(imageFactoryClient, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	validReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/talosctl/downloads/v1.2.3", nil)
+	validReq.SetPathValue("version", "v1.2.3")
+
+	validResp := httptest.NewRecorder()
+	handler.ServeHTTP(validResp, validReq)
+
+	require.Equal(t, http.StatusOK, validResp.Code)
+	require.Equal(t, int32(1), upstreamRequests.Load())
+
+	invalidReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/talosctl/downloads/..%2fsecret", nil)
+	invalidReq.SetPathValue("version", "../secret")
+
+	invalidResp := httptest.NewRecorder()
+	handler.ServeHTTP(invalidResp, invalidReq)
+
+	require.Equal(t, http.StatusBadRequest, invalidResp.Code)
+	require.Equal(t, int32(1), upstreamRequests.Load())
+}


### PR DESCRIPTION
The Talos version inputs in the schematic creation and talosctl download paths are now validated as semver, so invalid version strings are rejected before they reach the image factory client. The role check on raw schematic creation is tightened to operator, admin, and infra provider. The join token name check is fixed to reject both empty names and names exceeding the maximum length, where the previous condition was a no-op.