### PR TITLE
feat: add teardown RPCs and tighten state API access

### DIFF
--- a/client/pkg/clusterimport/clusterimport.go
+++ b/client/pkg/clusterimport/clusterimport.go
@@ -136,6 +136,10 @@ func BuildContext(ctx context.Context, input Input, omniState state.State, image
 	}
 
 	if existingCluster != nil {
+		if _, importing := existingCluster.Metadata().Annotations().Get(omni.ClusterImportIsInProgress); importing {
+			return nil, fmt.Errorf("cluster %q already exists in Omni and is marked as importing, run `omnictl cluster import abort %s` to clean it up before retrying", clusterID, clusterID)
+		}
+
 		return nil, fmt.Errorf("cluster %q already exists in Omni", clusterID)
 	}
 
@@ -855,8 +859,26 @@ func (c *Context) createImportedClusterSecrets(ctx context.Context) error {
 		return nil
 	}
 
-	if err := c.omniState.Modify(ctx, c.importedClusterSecrets, noop); err != nil {
+	err := c.omniState.Create(ctx, c.importedClusterSecrets)
+	if err == nil {
+		return nil
+	}
+
+	if !state.IsConflictError(err) {
 		return fmt.Errorf("failed to create imported cluster secrets: %w", err)
+	}
+
+	// An ImportedClusterSecrets with this ID already exists. Since the preflight in BuildContext
+	// confirmed there is no Cluster for this ID, this is an orphan left over from a previous import
+	// that crashed before its matching Cluster was created. It is safe to replace it.
+	c.input.logf("replacing orphaned imported cluster secrets %q", c.importedClusterSecrets.Metadata().ID())
+
+	if err = c.omniState.TeardownAndDestroy(ctx, c.importedClusterSecrets.Metadata()); err != nil {
+		return fmt.Errorf("failed to remove orphaned imported cluster secrets: %w", err)
+	}
+
+	if err = c.omniState.Create(ctx, c.importedClusterSecrets); err != nil {
+		return fmt.Errorf("failed to create imported cluster secrets after removing orphan: %w", err)
 	}
 
 	return nil

--- a/client/pkg/omni/resources/common/common.go
+++ b/client/pkg/omni/resources/common/common.go
@@ -14,13 +14,16 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 )
 
-// UserManagedResourceTypes is a list of resource types that are managed by the user.
+// UserManagedResourceTypes is a list of resource types that are fully managed by the user,
+// i.e., the user can perform all CRUD operations on them directly via the state API.
+//
+// Resources whose lifecycle is partially driven by the user but constrained by the server
+// (e.g., ImportedClusterSecrets which only supports create and destroy, Identity and User
+// whose mutations must go through ManagementService, or JoinToken whose create must go through
+// ManagementService.CreateJoinToken) do not belong here.
 var UserManagedResourceTypes = []resource.Type{
-	authres.IdentityType,
-	authres.UserType,
 	authres.AccessPolicyType,
 	authres.SAMLLabelRuleType,
-	siderolink.JoinTokenType,
 	siderolink.DefaultJoinTokenType,
 	siderolink.GRPCTunnelConfigType,
 	omni.ClusterType,
@@ -34,7 +37,6 @@ var UserManagedResourceTypes = []resource.Type{
 	omni.ExtensionsConfigurationType,
 	omni.KernelArgsType,
 	omni.MachineRequestSetType,
-	omni.ImportedClusterSecretsType,
 	omni.InfraMachineBMCConfigType,
 	omni.InfraMachineConfigType,
 	omni.InstallationMediaConfigType,

--- a/client/pkg/omnictl/apply.go
+++ b/client/pkg/omnictl/apply.go
@@ -22,6 +22,8 @@ import (
 	"github.com/siderolabs/gen/ensure"
 	"github.com/spf13/cobra"
 	"go.yaml.in/yaml/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/omni/client/pkg/client"
 	"github.com/siderolabs/omni/client/pkg/omnictl/internal/access"
@@ -144,22 +146,35 @@ func applyConfigFromBytes(ctx context.Context, client *client.Client, yamlRaw []
 
 	for _, res := range resources {
 		got, err := st.Get(ctx, res.Metadata())
-		if err != nil && !state.IsNotFoundError(err) {
-			return fmt.Errorf("failed to get resource '%s' '%s': %w", res.Metadata().ID(), res.Metadata().Type(), err)
-		}
+		code := status.Code(err)
 
-		if state.IsNotFoundError(err) {
-			err = createResource(ctx, st, res, applyCmdFlags.options)
-			if err != nil {
+		switch {
+		case err == nil:
+			if err = updateResource(ctx, st, got, res, applyCmdFlags.options); err != nil {
+				return fmt.Errorf("failed to update resource '%s' '%s': %w", res.Metadata().ID(), res.Metadata().Type(), err)
+			}
+		case state.IsNotFoundError(err):
+			if err = createResource(ctx, st, res, applyCmdFlags.options); err != nil {
 				return fmt.Errorf("failed to create resource '%s' '%s': %w", res.Metadata().ID(), res.Metadata().Type(), err)
 			}
+		case code == codes.PermissionDenied || code == codes.Unauthenticated:
+			// The caller does not have read access. Fall back to attempting a
+			// blind create. If the resource already exists, the create will
+			// fail with a conflict, which means it exists but we cannot read
+			// it to update it; surface a helpful error.
+			createErr := createResource(ctx, st, res, applyCmdFlags.options)
+			if createErr == nil {
+				continue
+			}
 
-			continue
-		}
+			if state.IsConflictError(createErr) {
+				return fmt.Errorf("resource '%s' '%s' already exists and cannot be read (%w); destroy it before applying again",
+					res.Metadata().ID(), res.Metadata().Type(), err)
+			}
 
-		err = updateResource(ctx, st, got, res, applyCmdFlags.options)
-		if err != nil {
-			return fmt.Errorf("failed to update resource '%s' '%s': %w", res.Metadata().ID(), res.Metadata().Type(), err)
+			return fmt.Errorf("failed to create resource '%s' '%s': %w", res.Metadata().ID(), res.Metadata().Type(), createErr)
+		default:
+			return fmt.Errorf("failed to get resource '%s' '%s': %w", res.Metadata().ID(), res.Metadata().Type(), err)
 		}
 	}
 

--- a/client/pkg/omnictl/resources/destroy.go
+++ b/client/pkg/omnictl/resources/destroy.go
@@ -15,13 +15,23 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/siderolabs/omni/client/pkg/cosi/labels"
 )
 
+// destroyConcurrency caps how many TeardownAndDestroy calls run in parallel.
+const destroyConcurrency = 8
+
 // Destroy tears down and destroys resources of the specified type.
 //
-//nolint:gocognit,gocyclo,cyclop
+// Each resource is deleted via [state.State.TeardownAndDestroy], which over the
+// gRPC adapter is a single atomic call that handles teardown, the wait for
+// finalizers, and destroy server-side. This means the caller does not need read
+// access to the resource, only destroy access.
+//
+// When --all or --selector is used, the resource type must support List (read
+// access) so the IDs can be enumerated. Per-ID deletion has no such requirement.
 func Destroy(ctx context.Context, st state.State, resNS, resType, selector string, all bool, ids []resource.ID) error {
 	rd, err := ResolveType(ctx, st, resType)
 	if err != nil {
@@ -32,20 +42,11 @@ func Destroy(ctx context.Context, st state.State, resNS, resType, selector strin
 		resNS = rd.TypedSpec().DefaultNamespace
 	}
 
-	listMD := resource.NewMetadata(resNS, rd.TypedSpec().Type, "", resource.VersionUndefined)
-
-	var (
-		resourceIDs   []resource.ID
-		useWatchKind  bool
-		watchKindOpts []state.WatchKindOption
-	)
+	var resourceIDs []resource.ID
 
 	if len(ids) > 0 {
 		resourceIDs = slices.Clone(ids)
-		useWatchKind = len(resourceIDs) > 10
 	} else {
-		useWatchKind = true
-
 		if !all && selector == "" {
 			return fmt.Errorf("either resource ID or one of all or selector must be specified")
 		}
@@ -61,86 +62,37 @@ func Destroy(ctx context.Context, st state.State, resNS, resType, selector strin
 			}
 
 			listOpts = append(listOpts, state.WithLabelQuery(labelQuery))
-			watchKindOpts = append(watchKindOpts, state.WatchWithLabelQuery(labelQuery))
 		}
+
+		listMD := resource.NewMetadata(resNS, rd.TypedSpec().Type, "", resource.VersionUndefined)
 
 		if resourceIDs, err = getResourceIDs(ctx, st, listMD, listOpts...); err != nil {
 			return err
 		}
 	}
 
-	watchCh := make(chan state.Event)
+	eg, gctx := errgroup.WithContext(ctx)
+	eg.SetLimit(destroyConcurrency)
 
-	if useWatchKind {
-		if err = st.WatchKind(ctx, listMD, watchCh, watchKindOpts...); err != nil {
-			return err
-		}
-	} else {
-		for _, resourceID := range resourceIDs {
-			err = st.Watch(ctx, resource.NewMetadata(resNS, rd.TypedSpec().Type, resourceID, resource.VersionUndefined), watchCh)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	resourceIDsLeft := map[resource.ID]struct{}{}
-
-	// teardown all resources
 	for _, resourceID := range resourceIDs {
-		destroyReady, teardownErr := st.Teardown(ctx, resource.NewMetadata(resNS, rd.TypedSpec().Type, resourceID, resource.VersionUndefined))
-		if teardownErr != nil {
-			return teardownErr
-		}
+		eg.Go(func() error {
+			md := resource.NewMetadata(resNS, rd.TypedSpec().Type, resourceID, resource.VersionUndefined)
 
-		fmt.Fprintf(os.Stderr, "torn down %s %s\n", rd.TypedSpec().Type, resourceID)
+			if err := st.TeardownAndDestroy(gctx, md); err != nil {
+				if state.IsNotFoundError(err) {
+					return nil
+				}
 
-		if destroyReady {
-			if err = st.Destroy(ctx, resource.NewMetadata(resNS, rd.TypedSpec().Type, resourceID, resource.VersionUndefined)); err != nil {
 				return err
 			}
 
 			fmt.Fprintf(os.Stderr, "destroyed %s %s\n", rd.TypedSpec().Type, resourceID)
 
-			continue
-		}
-
-		resourceIDsLeft[resourceID] = struct{}{}
+			return nil
+		})
 	}
 
-	// until some resources are not deleted yet...
-	for len(resourceIDsLeft) > 0 {
-		var event state.Event
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case event = <-watchCh:
-		}
-
-		switch event.Type {
-		case state.Destroyed:
-			delete(resourceIDsLeft, event.Resource.Metadata().ID())
-		case state.Created, state.Updated:
-			if _, ours := resourceIDsLeft[event.Resource.Metadata().ID()]; !ours {
-				continue
-			}
-
-			if event.Resource.Metadata().Phase() == resource.PhaseTearingDown && event.Resource.Metadata().Finalizers().Empty() {
-				if err = st.Destroy(ctx, event.Resource.Metadata()); err != nil && !state.IsNotFoundError(err) {
-					return err
-				}
-
-				fmt.Fprintf(os.Stderr, "destroyed %s %s\n", rd.TypedSpec().Type, event.Resource.Metadata().ID())
-			}
-		case state.Bootstrapped, state.Noop:
-			// ignore
-		case state.Errored:
-			return fmt.Errorf("error watching for resource deletion: %w", event.Error)
-		}
-	}
-
-	return nil
+	return eg.Wait()
 }
 
 // ResolveType resolves the resource type to a resource definition.

--- a/internal/backend/runtime/omni/audit/audit.go
+++ b/internal/backend/runtime/omni/audit/audit.go
@@ -135,6 +135,16 @@ func (l *Log) LogDestroy(ptr resource.Pointer) DestroyHook {
 	return l.destroyHooks[ptr.Type()]
 }
 
+// LogTeardown returns the hook used to log a teardown event for this type.
+// Teardowns reuse the update hook chain so per-type handlers can distinguish
+// teardown from regular updates via the resource phase.
+func (l *Log) LogTeardown(ptr resource.Pointer) UpdateHook {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	return l.updateHooks[ptr.Type()]
+}
+
 // LogUpdateWithConflicts logs the resource update with conflicts if there is a hook for this type.
 func (l *Log) LogUpdateWithConflicts(ptr resource.Pointer) UpdateWithConflictsHook {
 	l.mu.RLock()

--- a/internal/backend/runtime/omni/audit/audit_test.go
+++ b/internal/backend/runtime/omni/audit/audit_test.go
@@ -19,6 +19,9 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -33,6 +36,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/hooks"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
+	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
@@ -56,7 +60,7 @@ func TestAudit(t *testing.T) {
 	res.Metadata().Labels().Set(auth.LabelPublicKeyUserID, "002cf196-1767-43fd-8e3d-91241e2ce70c")
 
 	res.TypedSpec().Value.Identity = &specs.Identity{Email: "dmitry.matrenichev@siderolabs.com"}
-	res.TypedSpec().Value.Role = "Admin"
+	res.TypedSpec().Value.Role = string(role.Admin)
 	res.TypedSpec().Value.PublicKey = nil
 	res.TypedSpec().Value.Expiration = timestamppb.New(time.Unix(1325587579, 0))
 
@@ -149,7 +153,7 @@ func TestPhaseChangeIsAudited(t *testing.T) {
 	res.Metadata().Labels().Set(auth.LabelPublicKeyUserID, "002cf196-1767-43fd-8e3d-91241e2ce70c")
 
 	res.TypedSpec().Value.Identity = &specs.Identity{Email: "test@siderolabs.com"}
-	res.TypedSpec().Value.Role = "Admin"
+	res.TypedSpec().Value.Role = string(role.Admin)
 	res.TypedSpec().Value.Expiration = timestamppb.New(time.Unix(1325587579, 0))
 
 	createCtx := func() context.Context {
@@ -201,6 +205,84 @@ func TestPhaseChangeIsAudited(t *testing.T) {
 	require.Len(t, events, 2, "expected create + teardown events")
 	require.Equal(t, "create", events[0]["event_type"])
 	require.Equal(t, "teardown", events[1]["event_type"])
+}
+
+// TestAuditStateTeardown verifies the auditState wrapper emits a "teardown"
+// event when state.Teardown is called for a type with an update hook.
+func TestAuditStateTeardown(t *testing.T) {
+	st, l := newAuditStateWithHooks(t)
+
+	res := newPublicKey(t, "teardown-key")
+	require.NoError(t, st.Create(t.Context(), res))
+
+	_, err := st.Teardown(t.Context(), res.Metadata())
+	require.NoError(t, err)
+
+	events := readAuditEvents(t, l)
+	require.Len(t, events, 2, "expected create + teardown events")
+	require.Equal(t, "create", events[0]["event_type"])
+	require.Equal(t, "teardown", events[1]["event_type"])
+}
+
+// TestAuditStateTeardownAndDestroy verifies the auditState wrapper emits both
+// a "teardown" and a "destroy" event when state.TeardownAndDestroy is called.
+func TestAuditStateTeardownAndDestroy(t *testing.T) {
+	st, l := newAuditStateWithHooks(t)
+
+	res := newPublicKey(t, "teardown-and-destroy-key")
+	require.NoError(t, st.Create(t.Context(), res))
+
+	require.NoError(t, st.TeardownAndDestroy(t.Context(), res.Metadata()))
+
+	events := readAuditEvents(t, l)
+	require.Len(t, events, 3, "expected create + teardown + destroy events")
+	require.Equal(t, "create", events[0]["event_type"])
+	require.Equal(t, "teardown", events[1]["event_type"])
+	require.Equal(t, "destroy", events[2]["event_type"])
+}
+
+// TestAuditStateTeardownNoHook verifies that types without registered hooks
+// produce no audit events on Teardown / TeardownAndDestroy.
+func TestAuditStateTeardownNoHook(t *testing.T) {
+	config := config.LogsAudit{Enabled: new(true)}
+	l := must.Value(audit.NewLog(t.Context(), config, testDB(t), zaptest.NewLogger(t)))(t)
+	// no hooks registered
+
+	st := audit.WrapState(state.WrapCore(namespaced.NewState(inmem.Build)), l)
+
+	res := newPublicKey(t, "no-hook-key")
+	require.NoError(t, st.Create(t.Context(), res))
+
+	_, err := st.Teardown(t.Context(), res.Metadata())
+	require.NoError(t, err)
+
+	require.NoError(t, st.TeardownAndDestroy(t.Context(), res.Metadata()))
+
+	require.Empty(t, readAuditEvents(t, l))
+}
+
+func newAuditStateWithHooks(t *testing.T) (state.State, *audit.Log) {
+	t.Helper()
+
+	config := config.LogsAudit{Enabled: new(true)}
+	l := must.Value(audit.NewLog(t.Context(), config, testDB(t), zaptest.NewLogger(t)))(t)
+
+	hooks.Init(l)
+
+	return audit.WrapState(state.WrapCore(namespaced.NewState(inmem.Build)), l), l
+}
+
+func newPublicKey(t *testing.T, id string) *auth.PublicKey {
+	t.Helper()
+
+	res := auth.NewPublicKey(id)
+
+	res.Metadata().Labels().Set(auth.LabelPublicKeyUserID, "002cf196-1767-43fd-8e3d-91241e2ce70c")
+	res.TypedSpec().Value.Identity = &specs.Identity{Email: "test@siderolabs.com"}
+	res.TypedSpec().Value.Role = string(role.Admin)
+	res.TypedSpec().Value.Expiration = timestamppb.New(time.Unix(1325587579, 0))
+
+	return res
 }
 
 func TestK8SAccessAuditSkipsReadLikeRequests(t *testing.T) {

--- a/internal/backend/runtime/omni/audit/hooks/hooks.go
+++ b/internal/backend/runtime/omni/audit/hooks/hooks.go
@@ -20,6 +20,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/common"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
@@ -88,6 +89,25 @@ func Init(a *audit.Log) {
 	emptyDestroyFunc := func(_ context.Context, _ *auditlog.Data, _ resource.Pointer, _ ...state.DestroyOption) error {
 		return nil
 	}
+
+	// ImportedClusterSecrets is not user-managed (only create and destroy are exposed),
+	// so it is not covered by the user-managed loop below. Register explicit create and
+	// destroy hooks so the rare manual import still appears in the audit log.
+	audit.ShouldLogCreate(a, omni.ImportedClusterSecretsType, emptyCreateFunc, audit.WithInternalAgent())
+	audit.ShouldLogDestroy(a, omni.ImportedClusterSecretsType, emptyDestroyFunc, audit.WithInternalAgent())
+
+	// Link is created by Omni when a machine joins, so it is not user-managed, but users
+	// can destroy it to detach a machine. Register an explicit destroy hook so user-driven
+	// machine removals are audited.
+	audit.ShouldLogDestroy(a, siderolink.LinkType, emptyDestroyFunc, audit.WithInternalAgent())
+
+	// JoinToken create must go through the management.CreateJoinToken API (other verbs run
+	// directly against state). It is not user-managed, so register the full set of hooks
+	// explicitly so all join-token operations are audited.
+	audit.ShouldLogCreate(a, siderolink.JoinTokenType, emptyCreateFunc, audit.WithInternalAgent())
+	audit.ShouldLogUpdate(a, siderolink.JoinTokenType, emptyUpdateFunc, audit.WithInternalAgent())
+	audit.ShouldLogUpdateWithConflicts(a, siderolink.JoinTokenType, emptyUpdateFunc, audit.WithInternalAgent())
+	audit.ShouldLogDestroy(a, siderolink.JoinTokenType, emptyDestroyFunc, audit.WithInternalAgent())
 
 	customLoggedResourceTypes := xslices.ToSet(slices.Concat(a.CreateHooksResourceTypes(), a.UpdateHooksResourceTypes(), a.DestroyHooksResourceTypes()))
 

--- a/internal/backend/runtime/omni/audit/state.go
+++ b/internal/backend/runtime/omni/audit/state.go
@@ -128,11 +128,86 @@ func (a *auditState) WatchFor(ctx context.Context, pointer resource.Pointer, con
 }
 
 func (a *auditState) Teardown(ctx context.Context, pointer resource.Pointer, option ...state.TeardownOption) (bool, error) {
-	return a.state.Teardown(ctx, pointer, option...)
+	fn := a.logger.LogTeardown(pointer)
+	if fn == nil {
+		return a.state.Teardown(ctx, pointer, option...)
+	}
+
+	oldRes, err := a.state.Get(ctx, pointer)
+	if err != nil && !state.IsNotFoundError(err) {
+		return false, err
+	}
+
+	ready, err := a.state.Teardown(ctx, pointer, option...)
+	if err != nil {
+		return ready, err
+	}
+
+	if oldRes == nil {
+		return ready, nil
+	}
+
+	var opts state.TeardownOptions
+
+	for _, o := range option {
+		o(&opts)
+	}
+
+	// The teardown event is emitted through the update hook chain with a
+	// synthesized post-teardown resource. Hooks that only care about teardown
+	// (e.g. when newRes is in PhaseTearingDown) trigger as expected, and the
+	// isEqualResource check naturally suppresses idempotent re-teardowns.
+	newRes := oldRes.DeepCopy()
+	newRes.Metadata().SetPhase(resource.PhaseTearingDown)
+
+	return ready, fn(ctx, oldRes, newRes, state.WithUpdateOwner(opts.Owner))
 }
 
 func (a *auditState) TeardownAndDestroy(ctx context.Context, pointer resource.Pointer, option ...state.TeardownAndDestroyOption) error {
-	return a.state.TeardownAndDestroy(ctx, pointer, option...)
+	updateFn := a.logger.LogTeardown(pointer)
+	destroyFn := a.logger.LogDestroy(pointer)
+
+	if updateFn == nil && destroyFn == nil {
+		return a.state.TeardownAndDestroy(ctx, pointer, option...)
+	}
+
+	var oldRes resource.Resource
+
+	if updateFn != nil {
+		var err error
+
+		oldRes, err = a.state.Get(ctx, pointer)
+		if err != nil && !state.IsNotFoundError(err) {
+			return err
+		}
+	}
+
+	if err := a.state.TeardownAndDestroy(ctx, pointer, option...); err != nil {
+		return err
+	}
+
+	var opts state.TeardownAndDestroyOptions
+
+	for _, o := range option {
+		o(&opts)
+	}
+
+	if updateFn != nil && oldRes != nil {
+		newRes := oldRes.DeepCopy()
+		newRes.Metadata().SetPhase(resource.PhaseTearingDown)
+
+		if err := updateFn(ctx, oldRes, newRes, state.WithUpdateOwner(opts.Owner)); err != nil {
+			return err
+		}
+	}
+
+	if destroyFn != nil {
+		if err := destroyFn(ctx, pointer, state.WithDestroyOwner(opts.Owner)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (a *auditState) AddFinalizer(ctx context.Context, pointer resource.Pointer, finalizer ...resource.Finalizer) error {

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node_test.go
@@ -326,9 +326,13 @@ func (suite *MachineSetNodeSuite) TestNoRaceBetweenCleanupAndMachineSetNodeContr
 
 	// Under the bug, the cleanup handler destroys the MSN and MachineSetNodeController
 	// immediately creates a new one for the same machine (new Created() timestamp).
-	// Either keeping the original MSN or leaving it destroyed is acceptable — recreating is not.
+	// Either keeping the original MSN or leaving it destroyed is acceptable, recreating is not.
+	//
+	// Capture the state into a local so the orphan tick goroutine that testify.Never may leave
+	// running after timeout does not race with the next test's SetupTest overwriting suite.state.
+	st := suite.state
 	suite.Require().Never(func() bool {
-		msn, getErr := safe.StateGetByID[*omni.MachineSetNode](ctx, suite.state, machineID)
+		msn, getErr := safe.StateGetByID[*omni.MachineSetNode](ctx, st, machineID)
 		if getErr != nil {
 			return false
 		}

--- a/internal/backend/runtime/omni/controllers/omni/node_unique_token_cleanup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/node_unique_token_cleanup_test.go
@@ -43,8 +43,12 @@ func (suite *MachineStatusSnapshotControllerSuite) TestNodeUniqueTokenCleanup() 
 
 	link := siderolink.NewLink(token.Metadata().ID(), &specs.SiderolinkSpec{})
 
-	suite.Require().NoError(suite.state.Create(ctx, token))
+	// Create the link first so that by the time the controller sees the recreated token,
+	// the link already exists and the token is not treated as orphaned. If the token is
+	// created first, a CI-loaded test goroutine can be preempted long enough between the
+	// two creates for the controller's orphan-TTL requeue to fire and destroy the token.
 	suite.Require().NoError(suite.state.Create(ctx, link))
+	suite.Require().NoError(suite.state.Create(ctx, token))
 
 	time.Sleep(time.Second)
 

--- a/internal/backend/runtime/omni/controllers/omni/secrets/secrets_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/secrets_test.go
@@ -257,7 +257,7 @@ func TestSecretRotation(t *testing.T) {
 	t.Run("trigger Talos CA rotation", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 
 		t.Cleanup(cancel)
 
@@ -381,7 +381,7 @@ func TestSecretRotation(t *testing.T) {
 	t.Run("trigger Kubernetes CA rotation", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 
 		t.Cleanup(cancel)
 

--- a/internal/backend/runtime/omni/controllers/omni/secrets/talosconfig_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/talosconfig_test.go
@@ -47,7 +47,7 @@ func Test_Talosconfig(t *testing.T) {
 	t.Run("reconcile", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*10)
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(

--- a/internal/backend/runtime/omni/export_test.go
+++ b/internal/backend/runtime/omni/export_test.go
@@ -131,3 +131,8 @@ func KubernetesManifestsValidationOptions() []validated.StateOption {
 func EulaValidationOptions(st state.State) []validated.StateOption {
 	return eulaValidationOptions(st)
 }
+
+// FilterAccessByType exposes filterAccessByType for tests.
+func FilterAccessByType(access state.Access) error {
+	return filterAccessByType(access)
+}

--- a/internal/backend/runtime/omni/state_access.go
+++ b/internal/backend/runtime/omni/state_access.go
@@ -550,6 +550,15 @@ func filterAccessByType(access state.Access) error {
 	}
 
 	switch access.ResourceType {
+	case omni.ImportedClusterSecretsType:
+		// External callers can only create and destroy. Reads and updates are denied so the secret
+		// data is never exposed back to the client. Deletion goes through the Teardown RPC which
+		// authorizes as a destroy.
+		if access.Verb == state.Create || access.Verb == state.Destroy {
+			return nil
+		}
+
+		return status.Error(codes.PermissionDenied, "only create and destroy access is permitted for imported cluster secrets")
 	case authres.EulaAcceptanceType:
 		// Allow read and create access. Update and destroy are forbidden — EULA acceptance is permanent.
 		if access.Verb.Readonly() || access.Verb == state.Create {
@@ -559,13 +568,21 @@ func filterAccessByType(access state.Access) error {
 		return status.Error(codes.PermissionDenied, "only read and create access is permitted for EULA acceptance")
 	case siderolink.PendingMachineType,
 		siderolink.LinkType:
-		// Allow read, update and delete access
-		// Update access is required for siderolink by rtestutils.Destroy[*siderolink.Link] call on integration tests
+		// Allow read and delete access. Teardown goes through the Teardown RPC,
+		// which is authorized as a destroy, so external callers do not need update access.
+		if access.Verb.Readonly() || access.Verb == state.Destroy {
+			return nil
+		}
+
+		return status.Error(codes.PermissionDenied, "only read and delete access is permitted")
+	case siderolink.JoinTokenType:
+		// Allow read, update, and destroy. Create must go through the management.CreateJoinToken
+		// API, also enforced in filterAccess upstream.
 		if access.Verb.Readonly() || access.Verb == state.Update || access.Verb == state.Destroy {
 			return nil
 		}
 
-		return status.Error(codes.PermissionDenied, "only read, update and delete access is permitted")
+		return status.Error(codes.PermissionDenied, "only read, update and destroy access is permitted; create should be done via the management.CreateJoinToken API call")
 	case
 		omni.ClusterBootstrapStatusType,
 		omni.ClusterConfigVersionType,
@@ -633,8 +650,10 @@ func filterAccessByType(access state.Access) error {
 		omni.NotificationType,
 		omni.UpgradeRolloutType,
 		authres.AuthConfigType,
+		authres.IdentityType,
 		authres.IdentityLastActiveType,
 		authres.IdentityStatusType,
+		authres.UserType,
 		authres.PublicKeyLastActiveType,
 		authres.ServiceAccountStatusType,
 		siderolink.JoinTokenStatusType,

--- a/internal/backend/runtime/omni/state_access_test.go
+++ b/internal/backend/runtime/omni/state_access_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package omni_test
+
+import (
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/common"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/registry"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni"
+)
+
+var allVerbs = []state.Verb{
+	state.Get,
+	state.List,
+	state.Watch,
+	state.Create,
+	state.Update,
+	state.Destroy,
+}
+
+// TestUserManagedResourceTypesAllowAllOperations verifies that every type in
+// common.UserManagedResourceTypes is permitted for every CRUD verb by filterAccessByType.
+//
+// This is the structural invariant of the "user-managed" list: a type belongs in there only if
+// users can perform all operations on it via the state API.
+func TestUserManagedResourceTypesAllowAllOperations(t *testing.T) {
+	t.Parallel()
+
+	for _, rt := range common.UserManagedResourceTypes {
+		for _, verb := range allVerbs {
+			err := omni.FilterAccessByType(state.Access{ResourceType: rt, Verb: verb})
+
+			assert.NoError(t, err, "user-managed type %q should allow verb %v", rt, verb)
+		}
+	}
+}
+
+// TestFilterAccessByTypeAllRegisteredResources exercises filterAccessByType against every
+// resource type registered in registry.Resources with every CRUD verb.
+//
+// It guards against panics or unexpected error codes and ensures the access filter has a
+// deterministic answer (allow or PermissionDenied) for every known resource type.
+func TestFilterAccessByTypeAllRegisteredResources(t *testing.T) {
+	t.Parallel()
+
+	for _, rd := range registry.Resources {
+		rds := rd.ResourceDefinition()
+
+		for _, verb := range allVerbs {
+			err := omni.FilterAccessByType(state.Access{
+				ResourceNamespace: rds.DefaultNamespace,
+				ResourceType:      rds.Type,
+				Verb:              verb,
+			})
+			if err == nil {
+				continue
+			}
+
+			assert.Equal(t, codes.PermissionDenied, status.Code(err),
+				"type %q with verb %v returned unexpected error code: %v", rds.Type, verb, err)
+		}
+	}
+}

--- a/internal/backend/runtime/omni/state_validation.go
+++ b/internal/backend/runtime/omni/state_validation.go
@@ -1529,11 +1529,6 @@ func importedClusterSecretValidationOptions(st state.State, clusterImportEnabled
 
 			return validateImportedClusterSecrets(ctx, st, res)
 		})),
-		validated.WithUpdateValidations(validated.NewUpdateValidationForType(
-			func(ctx context.Context, oldRes *omni.ImportedClusterSecrets, newRes *omni.ImportedClusterSecrets, _ ...state.UpdateOption) error {
-				return validateImportedClusterSecrets(ctx, st, newRes)
-			},
-		)),
 	}
 }
 
@@ -1544,7 +1539,7 @@ func validateImportedClusterSecrets(ctx context.Context, st state.State, res *om
 			return err
 		}
 	} else {
-		return fmt.Errorf("cannot create/update an ImportedClusterSecrets, as there is already an existing cluster with name: %q", res.Metadata().ID())
+		return fmt.Errorf("cannot create an ImportedClusterSecrets, as there is already an existing cluster with name: %q", res.Metadata().ID())
 	}
 
 	bundle, err := omni.FromImportedSecretsToSecretsBundle(res)

--- a/internal/backend/runtime/omni/state_validation_test.go
+++ b/internal/backend/runtime/omni/state_validation_test.go
@@ -1871,10 +1871,6 @@ func TestImportedClusterSecretValidation(t *testing.T) {
 
 	res.TypedSpec().Value.Data = validSecrets
 	require.NoError(t, st.Create(ctx, res))
-	require.NoError(t, st.Update(ctx, res))
-
-	res.TypedSpec().Value.Data = brokenSecrets
-	require.True(t, validated.IsValidationError(st.Update(ctx, res)), "expected validation error")
 	require.NoError(t, st.Destroy(ctx, res.Metadata()))
 
 	res.TypedSpec().Value.Data = invalidSecrets
@@ -1893,7 +1889,7 @@ func TestImportedClusterSecretValidation(t *testing.T) {
 	res.TypedSpec().Value.Data = validSecrets
 	err = st.Create(ctx, res)
 	require.True(t, validated.IsValidationError(err), "expected validation error")
-	assert.ErrorContains(t, err, "cannot create/update an ImportedClusterSecrets, as there is already an existing cluster with name")
+	assert.ErrorContains(t, err, "cannot create an ImportedClusterSecrets, as there is already an existing cluster with name")
 }
 
 func TestInfraProviderValidation(t *testing.T) {

--- a/internal/backend/runtime/omni/validated/state.go
+++ b/internal/backend/runtime/omni/validated/state.go
@@ -171,6 +171,98 @@ func (v *State) Destroy(ctx context.Context, pointer resource.Pointer, option ..
 	return v.st.Destroy(ctx, pointer, option...)
 }
 
+// Teardown marks a resource as being destroyed, applying the same authorization
+// validations as Destroy.
+//
+// Implements [state.Teardowner], so [state.WrapCore] over this State routes
+// callers through this method instead of the default Get + Update fallback,
+// keeping the operation authorized as a destroy rather than an update.
+func (v *State) Teardown(ctx context.Context, pointer resource.Pointer, option ...state.TeardownOption) (bool, error) {
+	var opts state.TeardownOptions
+
+	for _, o := range option {
+		o(&opts)
+	}
+
+	existing, err := v.st.Get(ctx, pointer)
+	if err != nil && !state.IsNotFoundError(err) {
+		return false, err
+	}
+
+	// teardown is destructive; apply the destroy validations against the
+	// resource, mapping the teardown owner to a destroy owner.
+
+	destroyOpts := []state.DestroyOption{state.WithDestroyOwner(opts.Owner)}
+
+	var validationErrs error
+
+	for _, validation := range v.destroyValidations {
+		if validationErr := validation(ctx, pointer, existing, destroyOpts...); validationErr != nil {
+			validationErrs = multierror.Append(validationErrs, validationErr)
+		}
+	}
+
+	if validationErrs != nil {
+		return false, ValidationError(validationErrs)
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	// delegate to the underlying state. coreWrapper takes the Teardowner fast
+	// path if v.st implements it, otherwise falls back to Get + Update on v.st
+	// itself, bypassing this State's Update intercept.
+	return state.WrapCore(v.st).Teardown(ctx, pointer, option...)
+}
+
+// TeardownAndDestroy tears down a resource and destroys it once all finalizers
+// are gone, applying the same authorization validations as Destroy.
+//
+// Implements [state.TeardownAndDestroyer], so [state.WrapCore] over this State
+// routes callers through this method instead of the default Teardown + WatchFor
+// + Destroy path, ensuring the operation is authorized as a destroy and the
+// wait for finalizers happens against the underlying state.
+func (v *State) TeardownAndDestroy(ctx context.Context, pointer resource.Pointer, option ...state.TeardownAndDestroyOption) error {
+	var opts state.TeardownAndDestroyOptions
+
+	for _, o := range option {
+		o(&opts)
+	}
+
+	existing, err := v.st.Get(ctx, pointer)
+	if err != nil && !state.IsNotFoundError(err) {
+		return err
+	}
+
+	// teardown-and-destroy is destructive; apply the destroy validations against
+	// the resource, mapping the teardown-and-destroy owner to a destroy owner.
+
+	destroyOpts := []state.DestroyOption{state.WithDestroyOwner(opts.Owner)}
+
+	var validationErrs error
+
+	for _, validation := range v.destroyValidations {
+		if validationErr := validation(ctx, pointer, existing, destroyOpts...); validationErr != nil {
+			validationErrs = multierror.Append(validationErrs, validationErr)
+		}
+	}
+
+	if validationErrs != nil {
+		return ValidationError(validationErrs)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// delegate to the underlying state. coreWrapper takes the TeardownAndDestroyer
+	// fast path if v.st implements it, otherwise falls back to Teardown + WatchFor
+	// + Destroy on v.st itself, bypassing this State's Update intercept on the
+	// internal Teardown step.
+	return state.WrapCore(v.st).TeardownAndDestroy(ctx, pointer, option...)
+}
+
 // Watch watches a resource in the underlying state.
 func (v *State) Watch(ctx context.Context, pointer resource.Pointer, events chan<- state.Event, option ...state.WatchOption) error {
 	var validationErrs error

--- a/internal/backend/runtime/omni/validated/state_test.go
+++ b/internal/backend/runtime/omni/validated/state_test.go
@@ -243,6 +243,42 @@ func TestTeardownDestroyValidations(t *testing.T) {
 
 	const teardownOwner = "foobar-controller"
 
+	// Teardown takes the fast path through validated.State and runs only the
+	// destroy validations, not the Update validations.
 	_, err = st.Teardown(ctx, res.Metadata(), state.WithTeardownOwner(teardownOwner))
-	require.EqualError(t, err, fmt.Sprintf("failed to validate: 2 errors occurred:\n\t* update\n\t* destroy by %s\n\n", teardownOwner))
+	require.EqualError(t, err, fmt.Sprintf("failed to validate: 1 error occurred:\n\t* destroy by %s\n\n", teardownOwner))
+}
+
+func TestTeardownAndDestroyValidations(t *testing.T) {
+	innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+	st := state.WrapCore(
+		validated.NewState(
+			innerSt,
+			validated.WithUpdateValidations(func(context.Context, resource.Resource, resource.Resource, ...state.UpdateOption) error {
+				return errors.New("update")
+			}), validated.WithDestroyValidations(func(_ context.Context, _ resource.Pointer, _ resource.Resource, option ...state.DestroyOption) error {
+				opts := state.DestroyOptions{}
+
+				for _, opt := range option {
+					opt(&opts)
+				}
+
+				return errors.New("destroy by " + opts.Owner)
+			}),
+		),
+	)
+
+	res := omni.NewCluster("something")
+
+	require.NoError(t, st.Create(t.Context(), res))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	t.Cleanup(cancel)
+
+	const owner = "foobar-controller"
+
+	// TeardownAndDestroy takes the fast path through validated.State and runs
+	// only the destroy validations, not the Update validations.
+	err := st.TeardownAndDestroy(ctx, res.Metadata(), state.WithTeardownAndDestroyOwner(owner))
+	require.EqualError(t, err, fmt.Sprintf("failed to validate: 1 error occurred:\n\t* destroy by %s\n\n", owner))
 }

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -945,7 +945,7 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 			},
 			{
 				resource:       importedClusterSecret,
-				allowedVerbSet: allVerbsSet,
+				allowedVerbSet: xslices.ToSet([]state.Verb{state.Create, state.Destroy}),
 				isOperatorOnly: true,
 			},
 			{
@@ -1429,11 +1429,11 @@ func AssertResourceAuthz(rootCtx context.Context, rootCli *client.Client, client
 		testCases = append(testCases, []resourceAuthzTestCase{
 			{
 				resource:       siderolink.NewLink(uuid.New().String(), &specs.SiderolinkSpec{}),
-				allowedVerbSet: xslices.ToSet([]state.Verb{state.Get, state.List, state.Update, state.Destroy}),
+				allowedVerbSet: xslices.ToSet([]state.Verb{state.Get, state.List, state.Destroy}),
 			},
 			{
 				resource:       siderolink.NewPendingMachine(uuid.New().String(), &specs.SiderolinkSpec{}),
-				allowedVerbSet: xslices.ToSet([]state.Verb{state.Get, state.List, state.Update, state.Destroy}),
+				allowedVerbSet: xslices.ToSet([]state.Verb{state.Get, state.List, state.Destroy}),
 			},
 		}...)
 

--- a/internal/integration/cluster_test.go
+++ b/internal/integration/cluster_test.go
@@ -628,7 +628,6 @@ func AssertDestroyCluster(testCtx context.Context, omniState state.State, cluste
 		require.NoError(t, err)
 
 		rtestutils.AssertNoResource[*omni.Cluster](ctx, t, omniState, clusterName)
-		rtestutils.AssertNoResource[*omni.ImportedClusterSecrets](ctx, t, omniState, clusterName)
 
 		for _, id := range patches {
 			rtestutils.AssertNoResource[*omni.ConfigPatch](ctx, t, omniState, id)

--- a/internal/integration/import_test.go
+++ b/internal/integration/import_test.go
@@ -121,8 +121,6 @@ func testImport(t *testing.T, options *TestOptions, clusterID string, clusterNod
 
 	_, err = talosClient.Version(client.WithNode(ctx, clusterNodes[0]))
 	require.NoError(t, err)
-
-	rtestutils.AssertNoResource[*omni.ImportedClusterSecrets](ctx, t, omniState, clusterID)
 }
 
 func testUnlockCluster(t *testing.T, options *TestOptions, clusterID string) {


### PR DESCRIPTION
This is the followup of the groundwork done in:
- https://github.com/cosi-project/specification/pull/15
- https://github.com/cosi-project/specification/pull/16
- https://github.com/cosi-project/runtime/pull/666

## Teardown and delete RPCs

The COSI gRPC adapter performs teardown and delete as single blocking calls. The wait for finalizers happens server-side, so callers no longer need read access to the resource. The Omni state authorizes these as destroys, and the audit log captures teardown and destroy events on the new paths. `omnictl apply` and `omnictl delete` work for resources the caller can create and destroy but cannot read.

Also migrate the insecure API listener off the deprecated unencrypted HTTP/2 handler wrapper.

## Tighter access on partially user-managed resources

Several resources had update access only because the old client-side teardown path needed it. Teardown is now its own request authorized as a destroy, so those updates can be denied.

ImportedClusterSecrets accepts only create and destroy. Reads and updates are denied so the secret bundle never leaks back to the client. When a previous import crashed before its cluster was created, the next retry tears down the orphan secrets and creates a fresh set. When a cluster with the target ID already exists, the error message points at the abort command.

Link and PendingMachine drop external update access. Deletion goes through the Teardown RPC.

Identity, User, and JoinToken leave the user-managed list. Their mutations either go through the management API or are restricted to specific verbs, so they get explicit access rules and audit hooks. The user-managed list now strictly means the user can do everything to a resource via the state API. A test enforces that invariant. A second test runs every verb against every registered resource type so nothing falls through to an unhandled case unnoticed.

## Integration test cleanup

Drop two integration assertions that read ImportedClusterSecrets to verify it was gone. The read itself is now denied, so the assertion can no longer answer the question. The cleanup path is covered by unit tests.

## Flake fixes

Two pre-existing test flakes surfaced under CI parallelism.

The machine set node test used testify.Never, which returns on timeout without waiting for the in-flight condition-check goroutine. That orphan kept reading the test suite's state across test boundaries, racing with the next test's setup. Capture the state into a local before the closure so the orphan reads a stable value.

The node unique token cleanup test created the token before the link. Under enough load, the test goroutine could be preempted long enough for the controller's orphan-TTL requeue to fire and destroy the token before the link existed. Create the link first.

A few short timeouts in the secrets controller tests are bumped to absorb CI parallelism overhead.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>