### PR TITLE
feat: collect `ClusterKubernetesManifestStatus` in the support bundles

### DIFF
--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -263,6 +263,10 @@ func (s *managementServer) collectClusterResources(ctx context.Context, cluster 
 			id: cluster,
 		},
 		{
+			rt: omni.ClusterKubernetesManifestsStatusType,
+			id: cluster,
+		},
+		{
 			rt:          omni.MachineSetType,
 			listOptions: clusterQuery,
 		},


### PR DESCRIPTION
It doesn't contain any secrets and is very helpful when analyzing the issues in the cluster.