### PR TITLE
refactor: update MinIO env names

### DIFF
--- a/hack/compose/docker-compose.yml
+++ b/hack/compose/docker-compose.yml
@@ -105,8 +105,8 @@ services:
     ports:
       - "127.0.0.1:9000:9000"
     environment:
-      MINIO_ACCESS_KEY: access
-      MINIO_SECRET_KEY: secret123
+      MINIO_ROOT_USER: access
+      MINIO_ROOT_PASSWORD: secret123
     command: server /minio-server/export
 
   prometheus:

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -159,7 +159,7 @@ function prepare_minio() {
   mkdir -p "${TEST_OUTPUTS_DIR}/minio/data"
 
   docker run --rm -d -p 9000:9000 \
-    -v "${TEST_OUTPUTS_DIR}/minio/data:/data" -e MINIO_ACCESS_KEY="$access_key" -e MINIO_SECRET_KEY="$secret_key" \
+    -v "${TEST_OUTPUTS_DIR}/minio/data:/data" -e MINIO_ROOT_USER="$access_key" -e MINIO_ROOT_PASSWORD="$secret_key" \
     --name "${MINIO_CONTAINER_NAME}" "${MINIO_DOCKER_IMAGE}" \
     server /data
 


### PR DESCRIPTION
With the old ones, MinIO warns us about deprecation on startup:

```sh
minio-server-1    | INFO: WARNING: MINIO_ACCESS_KEY and MINIO_SECRET_KEY
are deprecated.
minio-server-1    |          Please use MINIO_ROOT_USER and
MINIO_ROOT_PASSWORD
```