### PR TITLE
refactor: drop compose `version` (from hack)

### DIFF
--- a/hack/generate-certs/main.go
+++ b/hack/generate-certs/main.go
@@ -251,8 +251,7 @@ func (c *cfg) validate() error {
 	}
 }
 
-const composeTemplate = `version: '3.8'
-services:
+const composeTemplate = `services:
   omni:
     command: >-
       --sqlite-storage-path=/_out/secondary-storage/sqlite.db


### PR DESCRIPTION
It's deprecated

```sh
WARN[0000]
/home/majabojarska/Projects/siderolabs/omni/hack/compose/docker-compose.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```