### PR TITLE
feat:  Expose EC2 Tags as Machine Labels

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -8544,7 +8544,9 @@ type MachineStatusSpec_PlatformMetadata struct {
 	// Provider ID (for the Node resource).
 	ProviderId string `protobuf:"bytes,7,opt,name=provider_id,json=providerId,proto3" json:"provider_id,omitempty"`
 	// Spot instance flag.
-	Spot          bool `protobuf:"varint,8,opt,name=spot,proto3" json:"spot,omitempty"`
+	Spot bool `protobuf:"varint,8,opt,name=spot,proto3" json:"spot,omitempty"`
+	// Tags map the instance's tags (cloud).
+	Tags          map[string]string `protobuf:"bytes,9,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -8633,6 +8635,13 @@ func (x *MachineStatusSpec_PlatformMetadata) GetSpot() bool {
 		return x.Spot
 	}
 	return false
+}
+
+func (x *MachineStatusSpec_PlatformMetadata) GetTags() map[string]string {
+	if x != nil {
+		return x.Tags
+	}
+	return nil
 }
 
 type MachineStatusSpec_Schematic struct {
@@ -9210,7 +9219,7 @@ type MachineStatusSpec_Schematic_InitialState struct {
 
 func (x *MachineStatusSpec_Schematic_InitialState) Reset() {
 	*x = MachineStatusSpec_Schematic_InitialState{}
-	mi := &file_omni_specs_omni_proto_msgTypes[115]
+	mi := &file_omni_specs_omni_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9222,7 +9231,7 @@ func (x *MachineStatusSpec_Schematic_InitialState) String() string {
 func (*MachineStatusSpec_Schematic_InitialState) ProtoMessage() {}
 
 func (x *MachineStatusSpec_Schematic_InitialState) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[115]
+	mi := &file_omni_specs_omni_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9259,7 +9268,7 @@ type ClusterSpec_Features struct {
 
 func (x *ClusterSpec_Features) Reset() {
 	*x = ClusterSpec_Features{}
-	mi := &file_omni_specs_omni_proto_msgTypes[116]
+	mi := &file_omni_specs_omni_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9271,7 +9280,7 @@ func (x *ClusterSpec_Features) String() string {
 func (*ClusterSpec_Features) ProtoMessage() {}
 
 func (x *ClusterSpec_Features) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[116]
+	mi := &file_omni_specs_omni_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9318,7 +9327,7 @@ type ClusterMachineStatusSpec_ProvisionStatus struct {
 
 func (x *ClusterMachineStatusSpec_ProvisionStatus) Reset() {
 	*x = ClusterMachineStatusSpec_ProvisionStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[117]
+	mi := &file_omni_specs_omni_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9330,7 +9339,7 @@ func (x *ClusterMachineStatusSpec_ProvisionStatus) String() string {
 func (*ClusterMachineStatusSpec_ProvisionStatus) ProtoMessage() {}
 
 func (x *ClusterMachineStatusSpec_ProvisionStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[117]
+	mi := &file_omni_specs_omni_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9372,7 +9381,7 @@ type MachinePendingUpdatesSpec_Upgrade struct {
 
 func (x *MachinePendingUpdatesSpec_Upgrade) Reset() {
 	*x = MachinePendingUpdatesSpec_Upgrade{}
-	mi := &file_omni_specs_omni_proto_msgTypes[118]
+	mi := &file_omni_specs_omni_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9384,7 +9393,7 @@ func (x *MachinePendingUpdatesSpec_Upgrade) String() string {
 func (*MachinePendingUpdatesSpec_Upgrade) ProtoMessage() {}
 
 func (x *MachinePendingUpdatesSpec_Upgrade) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[118]
+	mi := &file_omni_specs_omni_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9440,7 +9449,7 @@ type ClusterSecretsSpec_Certs struct {
 
 func (x *ClusterSecretsSpec_Certs) Reset() {
 	*x = ClusterSecretsSpec_Certs{}
-	mi := &file_omni_specs_omni_proto_msgTypes[119]
+	mi := &file_omni_specs_omni_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9452,7 +9461,7 @@ func (x *ClusterSecretsSpec_Certs) String() string {
 func (*ClusterSecretsSpec_Certs) ProtoMessage() {}
 
 func (x *ClusterSecretsSpec_Certs) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[119]
+	mi := &file_omni_specs_omni_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9492,7 +9501,7 @@ type ClusterSecretsSpec_Certs_CA struct {
 
 func (x *ClusterSecretsSpec_Certs_CA) Reset() {
 	*x = ClusterSecretsSpec_Certs_CA{}
-	mi := &file_omni_specs_omni_proto_msgTypes[120]
+	mi := &file_omni_specs_omni_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9504,7 +9513,7 @@ func (x *ClusterSecretsSpec_Certs_CA) String() string {
 func (*ClusterSecretsSpec_Certs_CA) ProtoMessage() {}
 
 func (x *ClusterSecretsSpec_Certs_CA) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[120]
+	mi := &file_omni_specs_omni_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9549,7 +9558,7 @@ type MachineSetSpec_MachineClass struct {
 
 func (x *MachineSetSpec_MachineClass) Reset() {
 	*x = MachineSetSpec_MachineClass{}
-	mi := &file_omni_specs_omni_proto_msgTypes[121]
+	mi := &file_omni_specs_omni_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9561,7 +9570,7 @@ func (x *MachineSetSpec_MachineClass) String() string {
 func (*MachineSetSpec_MachineClass) ProtoMessage() {}
 
 func (x *MachineSetSpec_MachineClass) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[121]
+	mi := &file_omni_specs_omni_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9613,7 +9622,7 @@ type MachineSetSpec_MachineAllocation struct {
 
 func (x *MachineSetSpec_MachineAllocation) Reset() {
 	*x = MachineSetSpec_MachineAllocation{}
-	mi := &file_omni_specs_omni_proto_msgTypes[122]
+	mi := &file_omni_specs_omni_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9625,7 +9634,7 @@ func (x *MachineSetSpec_MachineAllocation) String() string {
 func (*MachineSetSpec_MachineAllocation) ProtoMessage() {}
 
 func (x *MachineSetSpec_MachineAllocation) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[122]
+	mi := &file_omni_specs_omni_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9676,7 +9685,7 @@ type MachineSetSpec_BootstrapSpec struct {
 
 func (x *MachineSetSpec_BootstrapSpec) Reset() {
 	*x = MachineSetSpec_BootstrapSpec{}
-	mi := &file_omni_specs_omni_proto_msgTypes[123]
+	mi := &file_omni_specs_omni_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9688,7 +9697,7 @@ func (x *MachineSetSpec_BootstrapSpec) String() string {
 func (*MachineSetSpec_BootstrapSpec) ProtoMessage() {}
 
 func (x *MachineSetSpec_BootstrapSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[123]
+	mi := &file_omni_specs_omni_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9730,7 +9739,7 @@ type MachineSetSpec_RollingUpdateStrategyConfig struct {
 
 func (x *MachineSetSpec_RollingUpdateStrategyConfig) Reset() {
 	*x = MachineSetSpec_RollingUpdateStrategyConfig{}
-	mi := &file_omni_specs_omni_proto_msgTypes[124]
+	mi := &file_omni_specs_omni_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9742,7 +9751,7 @@ func (x *MachineSetSpec_RollingUpdateStrategyConfig) String() string {
 func (*MachineSetSpec_RollingUpdateStrategyConfig) ProtoMessage() {}
 
 func (x *MachineSetSpec_RollingUpdateStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[124]
+	mi := &file_omni_specs_omni_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9777,7 +9786,7 @@ type MachineSetSpec_UpdateStrategyConfig struct {
 
 func (x *MachineSetSpec_UpdateStrategyConfig) Reset() {
 	*x = MachineSetSpec_UpdateStrategyConfig{}
-	mi := &file_omni_specs_omni_proto_msgTypes[125]
+	mi := &file_omni_specs_omni_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9789,7 +9798,7 @@ func (x *MachineSetSpec_UpdateStrategyConfig) String() string {
 func (*MachineSetSpec_UpdateStrategyConfig) ProtoMessage() {}
 
 func (x *MachineSetSpec_UpdateStrategyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[125]
+	mi := &file_omni_specs_omni_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9824,7 +9833,7 @@ type ControlPlaneStatusSpec_Condition struct {
 
 func (x *ControlPlaneStatusSpec_Condition) Reset() {
 	*x = ControlPlaneStatusSpec_Condition{}
-	mi := &file_omni_specs_omni_proto_msgTypes[126]
+	mi := &file_omni_specs_omni_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9836,7 +9845,7 @@ func (x *ControlPlaneStatusSpec_Condition) String() string {
 func (*ControlPlaneStatusSpec_Condition) ProtoMessage() {}
 
 func (x *ControlPlaneStatusSpec_Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[126]
+	mi := &file_omni_specs_omni_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9891,7 +9900,7 @@ type KubernetesStatusSpec_NodeStatus struct {
 
 func (x *KubernetesStatusSpec_NodeStatus) Reset() {
 	*x = KubernetesStatusSpec_NodeStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[127]
+	mi := &file_omni_specs_omni_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9903,7 +9912,7 @@ func (x *KubernetesStatusSpec_NodeStatus) String() string {
 func (*KubernetesStatusSpec_NodeStatus) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_NodeStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[127]
+	mi := &file_omni_specs_omni_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9951,7 +9960,7 @@ type KubernetesStatusSpec_StaticPodStatus struct {
 
 func (x *KubernetesStatusSpec_StaticPodStatus) Reset() {
 	*x = KubernetesStatusSpec_StaticPodStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[128]
+	mi := &file_omni_specs_omni_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9963,7 +9972,7 @@ func (x *KubernetesStatusSpec_StaticPodStatus) String() string {
 func (*KubernetesStatusSpec_StaticPodStatus) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_StaticPodStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[128]
+	mi := &file_omni_specs_omni_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10010,7 +10019,7 @@ type KubernetesStatusSpec_NodeStaticPods struct {
 
 func (x *KubernetesStatusSpec_NodeStaticPods) Reset() {
 	*x = KubernetesStatusSpec_NodeStaticPods{}
-	mi := &file_omni_specs_omni_proto_msgTypes[129]
+	mi := &file_omni_specs_omni_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10022,7 +10031,7 @@ func (x *KubernetesStatusSpec_NodeStaticPods) String() string {
 func (*KubernetesStatusSpec_NodeStaticPods) ProtoMessage() {}
 
 func (x *KubernetesStatusSpec_NodeStaticPods) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[129]
+	mi := &file_omni_specs_omni_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10066,7 +10075,7 @@ type MachineClassSpec_Provision struct {
 
 func (x *MachineClassSpec_Provision) Reset() {
 	*x = MachineClassSpec_Provision{}
-	mi := &file_omni_specs_omni_proto_msgTypes[130]
+	mi := &file_omni_specs_omni_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10078,7 +10087,7 @@ func (x *MachineClassSpec_Provision) String() string {
 func (*MachineClassSpec_Provision) ProtoMessage() {}
 
 func (x *MachineClassSpec_Provision) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[130]
+	mi := &file_omni_specs_omni_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10149,7 +10158,7 @@ type MachineConfigGenOptionsSpec_InstallImage struct {
 
 func (x *MachineConfigGenOptionsSpec_InstallImage) Reset() {
 	*x = MachineConfigGenOptionsSpec_InstallImage{}
-	mi := &file_omni_specs_omni_proto_msgTypes[131]
+	mi := &file_omni_specs_omni_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10161,7 +10170,7 @@ func (x *MachineConfigGenOptionsSpec_InstallImage) String() string {
 func (*MachineConfigGenOptionsSpec_InstallImage) ProtoMessage() {}
 
 func (x *MachineConfigGenOptionsSpec_InstallImage) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[131]
+	mi := &file_omni_specs_omni_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10230,7 +10239,7 @@ type KubernetesUsageSpec_Quantity struct {
 
 func (x *KubernetesUsageSpec_Quantity) Reset() {
 	*x = KubernetesUsageSpec_Quantity{}
-	mi := &file_omni_specs_omni_proto_msgTypes[132]
+	mi := &file_omni_specs_omni_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10242,7 +10251,7 @@ func (x *KubernetesUsageSpec_Quantity) String() string {
 func (*KubernetesUsageSpec_Quantity) ProtoMessage() {}
 
 func (x *KubernetesUsageSpec_Quantity) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[132]
+	mi := &file_omni_specs_omni_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10289,7 +10298,7 @@ type KubernetesUsageSpec_Pod struct {
 
 func (x *KubernetesUsageSpec_Pod) Reset() {
 	*x = KubernetesUsageSpec_Pod{}
-	mi := &file_omni_specs_omni_proto_msgTypes[133]
+	mi := &file_omni_specs_omni_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10301,7 +10310,7 @@ func (x *KubernetesUsageSpec_Pod) String() string {
 func (*KubernetesUsageSpec_Pod) ProtoMessage() {}
 
 func (x *KubernetesUsageSpec_Pod) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[133]
+	mi := &file_omni_specs_omni_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10341,7 +10350,7 @@ type ImagePullRequestSpec_NodeImageList struct {
 
 func (x *ImagePullRequestSpec_NodeImageList) Reset() {
 	*x = ImagePullRequestSpec_NodeImageList{}
-	mi := &file_omni_specs_omni_proto_msgTypes[134]
+	mi := &file_omni_specs_omni_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10353,7 +10362,7 @@ func (x *ImagePullRequestSpec_NodeImageList) String() string {
 func (*ImagePullRequestSpec_NodeImageList) ProtoMessage() {}
 
 func (x *ImagePullRequestSpec_NodeImageList) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[134]
+	mi := &file_omni_specs_omni_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10398,7 +10407,7 @@ type TalosExtensionsSpec_Info struct {
 
 func (x *TalosExtensionsSpec_Info) Reset() {
 	*x = TalosExtensionsSpec_Info{}
-	mi := &file_omni_specs_omni_proto_msgTypes[135]
+	mi := &file_omni_specs_omni_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10410,7 +10419,7 @@ func (x *TalosExtensionsSpec_Info) String() string {
 func (*TalosExtensionsSpec_Info) ProtoMessage() {}
 
 func (x *TalosExtensionsSpec_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[135]
+	mi := &file_omni_specs_omni_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10479,7 +10488,7 @@ type MachineExtensionsStatusSpec_Item struct {
 
 func (x *MachineExtensionsStatusSpec_Item) Reset() {
 	*x = MachineExtensionsStatusSpec_Item{}
-	mi := &file_omni_specs_omni_proto_msgTypes[136]
+	mi := &file_omni_specs_omni_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10491,7 +10500,7 @@ func (x *MachineExtensionsStatusSpec_Item) String() string {
 func (*MachineExtensionsStatusSpec_Item) ProtoMessage() {}
 
 func (x *MachineExtensionsStatusSpec_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[136]
+	mi := &file_omni_specs_omni_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10538,7 +10547,7 @@ type ClusterDiagnosticsSpec_Node struct {
 
 func (x *ClusterDiagnosticsSpec_Node) Reset() {
 	*x = ClusterDiagnosticsSpec_Node{}
-	mi := &file_omni_specs_omni_proto_msgTypes[142]
+	mi := &file_omni_specs_omni_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10550,7 +10559,7 @@ func (x *ClusterDiagnosticsSpec_Node) String() string {
 func (*ClusterDiagnosticsSpec_Node) ProtoMessage() {}
 
 func (x *ClusterDiagnosticsSpec_Node) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[142]
+	mi := &file_omni_specs_omni_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10592,7 +10601,7 @@ type InfraMachineBMCConfigSpec_IPMI struct {
 
 func (x *InfraMachineBMCConfigSpec_IPMI) Reset() {
 	*x = InfraMachineBMCConfigSpec_IPMI{}
-	mi := &file_omni_specs_omni_proto_msgTypes[143]
+	mi := &file_omni_specs_omni_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10604,7 +10613,7 @@ func (x *InfraMachineBMCConfigSpec_IPMI) String() string {
 func (*InfraMachineBMCConfigSpec_IPMI) ProtoMessage() {}
 
 func (x *InfraMachineBMCConfigSpec_IPMI) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[143]
+	mi := &file_omni_specs_omni_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10657,7 +10666,7 @@ type InfraMachineBMCConfigSpec_API struct {
 
 func (x *InfraMachineBMCConfigSpec_API) Reset() {
 	*x = InfraMachineBMCConfigSpec_API{}
-	mi := &file_omni_specs_omni_proto_msgTypes[144]
+	mi := &file_omni_specs_omni_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10669,7 +10678,7 @@ func (x *InfraMachineBMCConfigSpec_API) String() string {
 func (*InfraMachineBMCConfigSpec_API) ProtoMessage() {}
 
 func (x *InfraMachineBMCConfigSpec_API) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[144]
+	mi := &file_omni_specs_omni_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10703,7 +10712,7 @@ type InfraProviderCombinedStatusSpec_Health struct {
 
 func (x *InfraProviderCombinedStatusSpec_Health) Reset() {
 	*x = InfraProviderCombinedStatusSpec_Health{}
-	mi := &file_omni_specs_omni_proto_msgTypes[145]
+	mi := &file_omni_specs_omni_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10715,7 +10724,7 @@ func (x *InfraProviderCombinedStatusSpec_Health) String() string {
 func (*InfraProviderCombinedStatusSpec_Health) ProtoMessage() {}
 
 func (x *InfraProviderCombinedStatusSpec_Health) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[145]
+	mi := &file_omni_specs_omni_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10761,7 +10770,7 @@ type InstallationMediaConfigSpec_Cloud struct {
 
 func (x *InstallationMediaConfigSpec_Cloud) Reset() {
 	*x = InstallationMediaConfigSpec_Cloud{}
-	mi := &file_omni_specs_omni_proto_msgTypes[146]
+	mi := &file_omni_specs_omni_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10773,7 +10782,7 @@ func (x *InstallationMediaConfigSpec_Cloud) String() string {
 func (*InstallationMediaConfigSpec_Cloud) ProtoMessage() {}
 
 func (x *InstallationMediaConfigSpec_Cloud) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[146]
+	mi := &file_omni_specs_omni_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10806,7 +10815,7 @@ type InstallationMediaConfigSpec_SBC struct {
 
 func (x *InstallationMediaConfigSpec_SBC) Reset() {
 	*x = InstallationMediaConfigSpec_SBC{}
-	mi := &file_omni_specs_omni_proto_msgTypes[147]
+	mi := &file_omni_specs_omni_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10818,7 +10827,7 @@ func (x *InstallationMediaConfigSpec_SBC) String() string {
 func (*InstallationMediaConfigSpec_SBC) ProtoMessage() {}
 
 func (x *InstallationMediaConfigSpec_SBC) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[147]
+	mi := &file_omni_specs_omni_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10866,7 +10875,7 @@ type ClusterMachineSecretsSpec_Rotation struct {
 
 func (x *ClusterMachineSecretsSpec_Rotation) Reset() {
 	*x = ClusterMachineSecretsSpec_Rotation{}
-	mi := &file_omni_specs_omni_proto_msgTypes[149]
+	mi := &file_omni_specs_omni_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10878,7 +10887,7 @@ func (x *ClusterMachineSecretsSpec_Rotation) String() string {
 func (*ClusterMachineSecretsSpec_Rotation) ProtoMessage() {}
 
 func (x *ClusterMachineSecretsSpec_Rotation) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[149]
+	mi := &file_omni_specs_omni_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10942,7 +10951,7 @@ type ClusterKubernetesManifestsStatusSpec_ManifestStatus struct {
 
 func (x *ClusterKubernetesManifestsStatusSpec_ManifestStatus) Reset() {
 	*x = ClusterKubernetesManifestsStatusSpec_ManifestStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[151]
+	mi := &file_omni_specs_omni_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10954,7 +10963,7 @@ func (x *ClusterKubernetesManifestsStatusSpec_ManifestStatus) String() string {
 func (*ClusterKubernetesManifestsStatusSpec_ManifestStatus) ProtoMessage() {}
 
 func (x *ClusterKubernetesManifestsStatusSpec_ManifestStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[151]
+	mi := &file_omni_specs_omni_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11016,7 +11025,7 @@ type ClusterKubernetesManifestsStatusSpec_GroupStatus struct {
 
 func (x *ClusterKubernetesManifestsStatusSpec_GroupStatus) Reset() {
 	*x = ClusterKubernetesManifestsStatusSpec_GroupStatus{}
-	mi := &file_omni_specs_omni_proto_msgTypes[152]
+	mi := &file_omni_specs_omni_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11028,7 +11037,7 @@ func (x *ClusterKubernetesManifestsStatusSpec_GroupStatus) String() string {
 func (*ClusterKubernetesManifestsStatusSpec_GroupStatus) ProtoMessage() {}
 
 func (x *ClusterKubernetesManifestsStatusSpec_GroupStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_omni_proto_msgTypes[152]
+	mi := &file_omni_specs_omni_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11083,7 +11092,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x05image\x18\x02 \x01(\tR\x05image\"3\n" +
 	"\tMetaValue\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\rR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"\xdd\x19\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"\xdf\x1a\n" +
 	"\x11MachineStatusSpec\x12#\n" +
 	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12C\n" +
 	"\bhardware\x18\x02 \x01(\v2'.specs.MachineStatusSpec.HardwareStatusR\bhardware\x12@\n" +
@@ -11153,7 +11162,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\n" +
 	"speed_mbps\x18\x03 \x01(\rR\tspeedMbps\x12\x17\n" +
 	"\alink_up\x18\x04 \x01(\bR\x06linkUp\x12 \n" +
-	"\vdescription\x18\x05 \x01(\tR\vdescription\x1a\xf1\x01\n" +
+	"\vdescription\x18\x05 \x01(\tR\vdescription\x1a\xf3\x02\n" +
 	"\x10PlatformMetadata\x12\x1a\n" +
 	"\bplatform\x18\x01 \x01(\tR\bplatform\x12\x1a\n" +
 	"\bhostname\x18\x02 \x01(\tR\bhostname\x12\x16\n" +
@@ -11164,7 +11173,11 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"instanceId\x12\x1f\n" +
 	"\vprovider_id\x18\a \x01(\tR\n" +
 	"providerId\x12\x12\n" +
-	"\x04spot\x18\b \x01(\bR\x04spot\x1a\xdb\x03\n" +
+	"\x04spot\x18\b \x01(\bR\x04spot\x12G\n" +
+	"\x04tags\x18\t \x03(\v23.specs.MachineStatusSpec.PlatformMetadata.TagsEntryR\x04tags\x1a7\n" +
+	"\tTagsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\xdb\x03\n" +
 	"\tSchematic\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\ainvalid\x18\x02 \x01(\bR\ainvalid\x12\x1e\n" +
@@ -11984,7 +11997,7 @@ func file_omni_specs_omni_proto_rawDescGZIP() []byte {
 }
 
 var file_omni_specs_omni_proto_enumTypes = make([]protoimpl.EnumInfo, 29)
-var file_omni_specs_omni_proto_msgTypes = make([]protoimpl.MessageInfo, 155)
+var file_omni_specs_omni_proto_msgTypes = make([]protoimpl.MessageInfo, 156)
 var file_omni_specs_omni_proto_goTypes = []any{
 	(ConfigApplyStatus)(0),                                         // 0: specs.ConfigApplyStatus
 	(MachineSetPhase)(0),                                           // 1: specs.MachineSetPhase
@@ -12130,51 +12143,52 @@ var file_omni_specs_omni_proto_goTypes = []any{
 	(*MachineStatusSpec_HardwareStatus_MemoryModule)(nil),          // 141: specs.MachineStatusSpec.HardwareStatus.MemoryModule
 	(*MachineStatusSpec_HardwareStatus_BlockDevice)(nil),           // 142: specs.MachineStatusSpec.HardwareStatus.BlockDevice
 	(*MachineStatusSpec_NetworkStatus_NetworkLinkStatus)(nil),      // 143: specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
-	(*MachineStatusSpec_Schematic_InitialState)(nil),               // 144: specs.MachineStatusSpec.Schematic.InitialState
-	(*ClusterSpec_Features)(nil),                                   // 145: specs.ClusterSpec.Features
-	(*ClusterMachineStatusSpec_ProvisionStatus)(nil),               // 146: specs.ClusterMachineStatusSpec.ProvisionStatus
-	(*MachinePendingUpdatesSpec_Upgrade)(nil),                      // 147: specs.MachinePendingUpdatesSpec.Upgrade
-	(*ClusterSecretsSpec_Certs)(nil),                               // 148: specs.ClusterSecretsSpec.Certs
-	(*ClusterSecretsSpec_Certs_CA)(nil),                            // 149: specs.ClusterSecretsSpec.Certs.CA
-	(*MachineSetSpec_MachineClass)(nil),                            // 150: specs.MachineSetSpec.MachineClass
-	(*MachineSetSpec_MachineAllocation)(nil),                       // 151: specs.MachineSetSpec.MachineAllocation
-	(*MachineSetSpec_BootstrapSpec)(nil),                           // 152: specs.MachineSetSpec.BootstrapSpec
-	(*MachineSetSpec_RollingUpdateStrategyConfig)(nil),             // 153: specs.MachineSetSpec.RollingUpdateStrategyConfig
-	(*MachineSetSpec_UpdateStrategyConfig)(nil),                    // 154: specs.MachineSetSpec.UpdateStrategyConfig
-	(*ControlPlaneStatusSpec_Condition)(nil),                       // 155: specs.ControlPlaneStatusSpec.Condition
-	(*KubernetesStatusSpec_NodeStatus)(nil),                        // 156: specs.KubernetesStatusSpec.NodeStatus
-	(*KubernetesStatusSpec_StaticPodStatus)(nil),                   // 157: specs.KubernetesStatusSpec.StaticPodStatus
-	(*KubernetesStatusSpec_NodeStaticPods)(nil),                    // 158: specs.KubernetesStatusSpec.NodeStaticPods
-	(*MachineClassSpec_Provision)(nil),                             // 159: specs.MachineClassSpec.Provision
-	(*MachineConfigGenOptionsSpec_InstallImage)(nil),               // 160: specs.MachineConfigGenOptionsSpec.InstallImage
-	(*KubernetesUsageSpec_Quantity)(nil),                           // 161: specs.KubernetesUsageSpec.Quantity
-	(*KubernetesUsageSpec_Pod)(nil),                                // 162: specs.KubernetesUsageSpec.Pod
-	(*ImagePullRequestSpec_NodeImageList)(nil),                     // 163: specs.ImagePullRequestSpec.NodeImageList
-	(*TalosExtensionsSpec_Info)(nil),                               // 164: specs.TalosExtensionsSpec.Info
-	(*MachineExtensionsStatusSpec_Item)(nil),                       // 165: specs.MachineExtensionsStatusSpec.Item
-	nil,                                                            // 166: specs.MachineStatusMetricsSpec.PlatformsEntry
-	nil,                                                            // 167: specs.MachineStatusMetricsSpec.SecureBootStatusEntry
-	nil,                                                            // 168: specs.MachineStatusMetricsSpec.UkiStatusEntry
-	nil,                                                            // 169: specs.ClusterMetricsSpec.FeaturesEntry
-	nil,                                                            // 170: specs.ClusterStatusMetricsSpec.PhasesEntry
-	(*ClusterDiagnosticsSpec_Node)(nil),                            // 171: specs.ClusterDiagnosticsSpec.Node
-	(*InfraMachineBMCConfigSpec_IPMI)(nil),                         // 172: specs.InfraMachineBMCConfigSpec.IPMI
-	(*InfraMachineBMCConfigSpec_API)(nil),                          // 173: specs.InfraMachineBMCConfigSpec.API
-	(*InfraProviderCombinedStatusSpec_Health)(nil),                 // 174: specs.InfraProviderCombinedStatusSpec.Health
-	(*InstallationMediaConfigSpec_Cloud)(nil),                      // 175: specs.InstallationMediaConfigSpec.Cloud
-	(*InstallationMediaConfigSpec_SBC)(nil),                        // 176: specs.InstallationMediaConfigSpec.SBC
-	nil,                                                            // 177: specs.InstallationMediaConfigSpec.MachineLabelsEntry
-	(*ClusterMachineSecretsSpec_Rotation)(nil),                     // 178: specs.ClusterMachineSecretsSpec.Rotation
-	nil, // 179: specs.UpgradeRolloutSpec.MachineSetsUpgradeQuotaEntry
-	(*ClusterKubernetesManifestsStatusSpec_ManifestStatus)(nil), // 180: specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus
-	(*ClusterKubernetesManifestsStatusSpec_GroupStatus)(nil),    // 181: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus
-	nil,                                 // 182: specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry
-	nil,                                 // 183: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry
-	(*durationpb.Duration)(nil),         // 184: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),       // 185: google.protobuf.Timestamp
-	(*machine.MachineStatusEvent)(nil),  // 186: machine.MachineStatusEvent
-	(PlatformConfigSpec_Arch)(0),        // 187: specs.PlatformConfigSpec.Arch
-	(management.SchematicBootloader)(0), // 188: management.SchematicBootloader
+	nil, // 144: specs.MachineStatusSpec.PlatformMetadata.TagsEntry
+	(*MachineStatusSpec_Schematic_InitialState)(nil),   // 145: specs.MachineStatusSpec.Schematic.InitialState
+	(*ClusterSpec_Features)(nil),                       // 146: specs.ClusterSpec.Features
+	(*ClusterMachineStatusSpec_ProvisionStatus)(nil),   // 147: specs.ClusterMachineStatusSpec.ProvisionStatus
+	(*MachinePendingUpdatesSpec_Upgrade)(nil),          // 148: specs.MachinePendingUpdatesSpec.Upgrade
+	(*ClusterSecretsSpec_Certs)(nil),                   // 149: specs.ClusterSecretsSpec.Certs
+	(*ClusterSecretsSpec_Certs_CA)(nil),                // 150: specs.ClusterSecretsSpec.Certs.CA
+	(*MachineSetSpec_MachineClass)(nil),                // 151: specs.MachineSetSpec.MachineClass
+	(*MachineSetSpec_MachineAllocation)(nil),           // 152: specs.MachineSetSpec.MachineAllocation
+	(*MachineSetSpec_BootstrapSpec)(nil),               // 153: specs.MachineSetSpec.BootstrapSpec
+	(*MachineSetSpec_RollingUpdateStrategyConfig)(nil), // 154: specs.MachineSetSpec.RollingUpdateStrategyConfig
+	(*MachineSetSpec_UpdateStrategyConfig)(nil),        // 155: specs.MachineSetSpec.UpdateStrategyConfig
+	(*ControlPlaneStatusSpec_Condition)(nil),           // 156: specs.ControlPlaneStatusSpec.Condition
+	(*KubernetesStatusSpec_NodeStatus)(nil),            // 157: specs.KubernetesStatusSpec.NodeStatus
+	(*KubernetesStatusSpec_StaticPodStatus)(nil),       // 158: specs.KubernetesStatusSpec.StaticPodStatus
+	(*KubernetesStatusSpec_NodeStaticPods)(nil),        // 159: specs.KubernetesStatusSpec.NodeStaticPods
+	(*MachineClassSpec_Provision)(nil),                 // 160: specs.MachineClassSpec.Provision
+	(*MachineConfigGenOptionsSpec_InstallImage)(nil),   // 161: specs.MachineConfigGenOptionsSpec.InstallImage
+	(*KubernetesUsageSpec_Quantity)(nil),               // 162: specs.KubernetesUsageSpec.Quantity
+	(*KubernetesUsageSpec_Pod)(nil),                    // 163: specs.KubernetesUsageSpec.Pod
+	(*ImagePullRequestSpec_NodeImageList)(nil),         // 164: specs.ImagePullRequestSpec.NodeImageList
+	(*TalosExtensionsSpec_Info)(nil),                   // 165: specs.TalosExtensionsSpec.Info
+	(*MachineExtensionsStatusSpec_Item)(nil),           // 166: specs.MachineExtensionsStatusSpec.Item
+	nil,                                                // 167: specs.MachineStatusMetricsSpec.PlatformsEntry
+	nil,                                                // 168: specs.MachineStatusMetricsSpec.SecureBootStatusEntry
+	nil,                                                // 169: specs.MachineStatusMetricsSpec.UkiStatusEntry
+	nil,                                                // 170: specs.ClusterMetricsSpec.FeaturesEntry
+	nil,                                                // 171: specs.ClusterStatusMetricsSpec.PhasesEntry
+	(*ClusterDiagnosticsSpec_Node)(nil),                // 172: specs.ClusterDiagnosticsSpec.Node
+	(*InfraMachineBMCConfigSpec_IPMI)(nil),             // 173: specs.InfraMachineBMCConfigSpec.IPMI
+	(*InfraMachineBMCConfigSpec_API)(nil),              // 174: specs.InfraMachineBMCConfigSpec.API
+	(*InfraProviderCombinedStatusSpec_Health)(nil),     // 175: specs.InfraProviderCombinedStatusSpec.Health
+	(*InstallationMediaConfigSpec_Cloud)(nil),          // 176: specs.InstallationMediaConfigSpec.Cloud
+	(*InstallationMediaConfigSpec_SBC)(nil),            // 177: specs.InstallationMediaConfigSpec.SBC
+	nil,                                                // 178: specs.InstallationMediaConfigSpec.MachineLabelsEntry
+	(*ClusterMachineSecretsSpec_Rotation)(nil),         // 179: specs.ClusterMachineSecretsSpec.Rotation
+	nil, // 180: specs.UpgradeRolloutSpec.MachineSetsUpgradeQuotaEntry
+	(*ClusterKubernetesManifestsStatusSpec_ManifestStatus)(nil), // 181: specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus
+	(*ClusterKubernetesManifestsStatusSpec_GroupStatus)(nil),    // 182: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus
+	nil,                                 // 183: specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry
+	nil,                                 // 184: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry
+	(*durationpb.Duration)(nil),         // 185: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),       // 186: google.protobuf.Timestamp
+	(*machine.MachineStatusEvent)(nil),  // 187: machine.MachineStatusEvent
+	(PlatformConfigSpec_Arch)(0),        // 188: specs.PlatformConfigSpec.Arch
+	(management.SchematicBootloader)(0), // 189: management.SchematicBootloader
 }
 var file_omni_specs_omni_proto_depIdxs = []int32{
 	134, // 0: specs.MachineStatusSpec.hardware:type_name -> specs.MachineStatusSpec.HardwareStatus
@@ -12186,43 +12200,43 @@ var file_omni_specs_omni_proto_depIdxs = []int32{
 	138, // 6: specs.MachineStatusSpec.diagnostics:type_name -> specs.MachineStatusSpec.Diagnostic
 	5,   // 7: specs.MachineStatusSpec.power_state:type_name -> specs.MachineStatusSpec.PowerState
 	30,  // 8: specs.MachineStatusSpec.security_state:type_name -> specs.SecurityState
-	145, // 9: specs.ClusterSpec.features:type_name -> specs.ClusterSpec.Features
+	146, // 9: specs.ClusterSpec.features:type_name -> specs.ClusterSpec.Features
 	37,  // 10: specs.ClusterSpec.backup_configuration:type_name -> specs.EtcdBackupConf
-	184, // 11: specs.EtcdBackupConf.interval:type_name -> google.protobuf.Duration
-	185, // 12: specs.EtcdBackupSpec.created_at:type_name -> google.protobuf.Timestamp
-	184, // 13: specs.BackupDataSpec.interval:type_name -> google.protobuf.Duration
+	185, // 11: specs.EtcdBackupConf.interval:type_name -> google.protobuf.Duration
+	186, // 12: specs.EtcdBackupSpec.created_at:type_name -> google.protobuf.Timestamp
+	185, // 13: specs.BackupDataSpec.interval:type_name -> google.protobuf.Duration
 	6,   // 14: specs.EtcdBackupStatusSpec.status:type_name -> specs.EtcdBackupStatusSpec.Status
-	185, // 15: specs.EtcdBackupStatusSpec.last_backup_time:type_name -> google.protobuf.Timestamp
-	185, // 16: specs.EtcdBackupStatusSpec.last_backup_attempt:type_name -> google.protobuf.Timestamp
-	185, // 17: specs.EtcdManualBackupSpec.backup_at:type_name -> google.protobuf.Timestamp
+	186, // 15: specs.EtcdBackupStatusSpec.last_backup_time:type_name -> google.protobuf.Timestamp
+	186, // 16: specs.EtcdBackupStatusSpec.last_backup_attempt:type_name -> google.protobuf.Timestamp
+	186, // 17: specs.EtcdManualBackupSpec.backup_at:type_name -> google.protobuf.Timestamp
 	43,  // 18: specs.EtcdBackupOverallStatusSpec.last_backup_status:type_name -> specs.EtcdBackupStatusSpec
 	7,   // 19: specs.ClusterMachineStatusSpec.stage:type_name -> specs.ClusterMachineStatusSpec.Stage
 	0,   // 20: specs.ClusterMachineStatusSpec.config_apply_status:type_name -> specs.ConfigApplyStatus
-	146, // 21: specs.ClusterMachineStatusSpec.provision_status:type_name -> specs.ClusterMachineStatusSpec.ProvisionStatus
+	147, // 21: specs.ClusterMachineStatusSpec.provision_status:type_name -> specs.ClusterMachineStatusSpec.ProvisionStatus
 	54,  // 22: specs.ClusterStatusSpec.machines:type_name -> specs.Machines
 	8,   // 23: specs.ClusterStatusSpec.phase:type_name -> specs.ClusterStatusSpec.Phase
-	147, // 24: specs.MachinePendingUpdatesSpec.upgrade:type_name -> specs.MachinePendingUpdatesSpec.Upgrade
-	148, // 25: specs.ClusterSecretsSpec.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
+	148, // 24: specs.MachinePendingUpdatesSpec.upgrade:type_name -> specs.MachinePendingUpdatesSpec.Upgrade
+	149, // 25: specs.ClusterSecretsSpec.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
 	9,   // 26: specs.MachineSetSpec.update_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	151, // 27: specs.MachineSetSpec.machine_class:type_name -> specs.MachineSetSpec.MachineAllocation
-	152, // 28: specs.MachineSetSpec.bootstrap_spec:type_name -> specs.MachineSetSpec.BootstrapSpec
+	152, // 27: specs.MachineSetSpec.machine_class:type_name -> specs.MachineSetSpec.MachineAllocation
+	153, // 28: specs.MachineSetSpec.bootstrap_spec:type_name -> specs.MachineSetSpec.BootstrapSpec
 	9,   // 29: specs.MachineSetSpec.delete_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	154, // 30: specs.MachineSetSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	154, // 31: specs.MachineSetSpec.delete_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	151, // 32: specs.MachineSetSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
+	155, // 30: specs.MachineSetSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	155, // 31: specs.MachineSetSpec.delete_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	152, // 32: specs.MachineSetSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
 	9,   // 33: specs.MachineSetSpec.upgrade_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	154, // 34: specs.MachineSetSpec.upgrade_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	155, // 34: specs.MachineSetSpec.upgrade_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
 	12,  // 35: specs.TalosUpgradeStatusSpec.phase:type_name -> specs.TalosUpgradeStatusSpec.Phase
 	1,   // 36: specs.MachineSetStatusSpec.phase:type_name -> specs.MachineSetPhase
 	54,  // 37: specs.MachineSetStatusSpec.machines:type_name -> specs.Machines
-	151, // 38: specs.MachineSetStatusSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
+	152, // 38: specs.MachineSetStatusSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
 	9,   // 39: specs.MachineSetConfigStatusSpec.update_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	154, // 40: specs.MachineSetConfigStatusSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	186, // 41: specs.MachineStatusSnapshotSpec.machine_status:type_name -> machine.MachineStatusEvent
+	155, // 40: specs.MachineSetConfigStatusSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	187, // 41: specs.MachineStatusSnapshotSpec.machine_status:type_name -> machine.MachineStatusEvent
 	13,  // 42: specs.MachineStatusSnapshotSpec.power_stage:type_name -> specs.MachineStatusSnapshotSpec.PowerStage
-	155, // 43: specs.ControlPlaneStatusSpec.conditions:type_name -> specs.ControlPlaneStatusSpec.Condition
-	156, // 44: specs.KubernetesStatusSpec.nodes:type_name -> specs.KubernetesStatusSpec.NodeStatus
-	158, // 45: specs.KubernetesStatusSpec.static_pods:type_name -> specs.KubernetesStatusSpec.NodeStaticPods
+	156, // 43: specs.ControlPlaneStatusSpec.conditions:type_name -> specs.ControlPlaneStatusSpec.Condition
+	157, // 44: specs.KubernetesStatusSpec.nodes:type_name -> specs.KubernetesStatusSpec.NodeStatus
+	159, // 45: specs.KubernetesStatusSpec.static_pods:type_name -> specs.KubernetesStatusSpec.NodeStaticPods
 	16,  // 46: specs.KubernetesUpgradeStatusSpec.phase:type_name -> specs.KubernetesUpgradeStatusSpec.Phase
 	70,  // 47: specs.OngoingTaskSpec.talos_upgrade:type_name -> specs.TalosUpgradeStatusSpec
 	79,  // 48: specs.OngoingTaskSpec.kubernetes_upgrade:type_name -> specs.KubernetesUpgradeStatusSpec
@@ -12233,88 +12247,89 @@ var file_omni_specs_omni_proto_depIdxs = []int32{
 	87,  // 53: specs.FeaturesConfigSpec.user_pilot_settings:type_name -> specs.UserPilotSettings
 	88,  // 54: specs.FeaturesConfigSpec.stripe_settings:type_name -> specs.StripeSettings
 	89,  // 55: specs.FeaturesConfigSpec.account:type_name -> specs.Account
-	184, // 56: specs.EtcdBackupSettings.tick_interval:type_name -> google.protobuf.Duration
-	184, // 57: specs.EtcdBackupSettings.min_interval:type_name -> google.protobuf.Duration
-	184, // 58: specs.EtcdBackupSettings.max_interval:type_name -> google.protobuf.Duration
-	159, // 59: specs.MachineClassSpec.auto_provision:type_name -> specs.MachineClassSpec.Provision
-	160, // 60: specs.MachineConfigGenOptionsSpec.install_image:type_name -> specs.MachineConfigGenOptionsSpec.InstallImage
-	161, // 61: specs.KubernetesUsageSpec.cpu:type_name -> specs.KubernetesUsageSpec.Quantity
-	161, // 62: specs.KubernetesUsageSpec.mem:type_name -> specs.KubernetesUsageSpec.Quantity
-	161, // 63: specs.KubernetesUsageSpec.storage:type_name -> specs.KubernetesUsageSpec.Quantity
-	162, // 64: specs.KubernetesUsageSpec.pods:type_name -> specs.KubernetesUsageSpec.Pod
-	163, // 65: specs.ImagePullRequestSpec.node_image_list:type_name -> specs.ImagePullRequestSpec.NodeImageList
-	164, // 66: specs.TalosExtensionsSpec.items:type_name -> specs.TalosExtensionsSpec.Info
+	185, // 56: specs.EtcdBackupSettings.tick_interval:type_name -> google.protobuf.Duration
+	185, // 57: specs.EtcdBackupSettings.min_interval:type_name -> google.protobuf.Duration
+	185, // 58: specs.EtcdBackupSettings.max_interval:type_name -> google.protobuf.Duration
+	160, // 59: specs.MachineClassSpec.auto_provision:type_name -> specs.MachineClassSpec.Provision
+	161, // 60: specs.MachineConfigGenOptionsSpec.install_image:type_name -> specs.MachineConfigGenOptionsSpec.InstallImage
+	162, // 61: specs.KubernetesUsageSpec.cpu:type_name -> specs.KubernetesUsageSpec.Quantity
+	162, // 62: specs.KubernetesUsageSpec.mem:type_name -> specs.KubernetesUsageSpec.Quantity
+	162, // 63: specs.KubernetesUsageSpec.storage:type_name -> specs.KubernetesUsageSpec.Quantity
+	163, // 64: specs.KubernetesUsageSpec.pods:type_name -> specs.KubernetesUsageSpec.Pod
+	164, // 65: specs.ImagePullRequestSpec.node_image_list:type_name -> specs.ImagePullRequestSpec.NodeImageList
+	165, // 66: specs.TalosExtensionsSpec.items:type_name -> specs.TalosExtensionsSpec.Info
 	17,  // 67: specs.MachineUpgradeStatusSpec.phase:type_name -> specs.MachineUpgradeStatusSpec.Phase
-	165, // 68: specs.MachineExtensionsStatusSpec.extensions:type_name -> specs.MachineExtensionsStatusSpec.Item
-	166, // 69: specs.MachineStatusMetricsSpec.platforms:type_name -> specs.MachineStatusMetricsSpec.PlatformsEntry
-	167, // 70: specs.MachineStatusMetricsSpec.secure_boot_status:type_name -> specs.MachineStatusMetricsSpec.SecureBootStatusEntry
-	168, // 71: specs.MachineStatusMetricsSpec.uki_status:type_name -> specs.MachineStatusMetricsSpec.UkiStatusEntry
-	169, // 72: specs.ClusterMetricsSpec.features:type_name -> specs.ClusterMetricsSpec.FeaturesEntry
-	170, // 73: specs.ClusterStatusMetricsSpec.phases:type_name -> specs.ClusterStatusMetricsSpec.PhasesEntry
+	166, // 68: specs.MachineExtensionsStatusSpec.extensions:type_name -> specs.MachineExtensionsStatusSpec.Item
+	167, // 69: specs.MachineStatusMetricsSpec.platforms:type_name -> specs.MachineStatusMetricsSpec.PlatformsEntry
+	168, // 70: specs.MachineStatusMetricsSpec.secure_boot_status:type_name -> specs.MachineStatusMetricsSpec.SecureBootStatusEntry
+	169, // 71: specs.MachineStatusMetricsSpec.uki_status:type_name -> specs.MachineStatusMetricsSpec.UkiStatusEntry
+	170, // 72: specs.ClusterMetricsSpec.features:type_name -> specs.ClusterMetricsSpec.FeaturesEntry
+	171, // 73: specs.ClusterStatusMetricsSpec.phases:type_name -> specs.ClusterStatusMetricsSpec.PhasesEntry
 	32,  // 74: specs.MachineRequestSetSpec.meta_values:type_name -> specs.MetaValue
 	3,   // 75: specs.MachineRequestSetSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	171, // 76: specs.ClusterDiagnosticsSpec.nodes:type_name -> specs.ClusterDiagnosticsSpec.Node
+	172, // 76: specs.ClusterDiagnosticsSpec.nodes:type_name -> specs.ClusterDiagnosticsSpec.Node
 	19,  // 77: specs.ClusterMachineRequestStatusSpec.stage:type_name -> specs.ClusterMachineRequestStatusSpec.Stage
 	21,  // 78: specs.InfraMachineConfigSpec.power_state:type_name -> specs.InfraMachineConfigSpec.MachinePowerState
 	20,  // 79: specs.InfraMachineConfigSpec.acceptance_status:type_name -> specs.InfraMachineConfigSpec.AcceptanceStatus
-	172, // 80: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
-	173, // 81: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
-	174, // 82: specs.InfraProviderCombinedStatusSpec.health:type_name -> specs.InfraProviderCombinedStatusSpec.Health
-	187, // 83: specs.InstallationMediaConfigSpec.architecture:type_name -> specs.PlatformConfigSpec.Arch
-	175, // 84: specs.InstallationMediaConfigSpec.cloud:type_name -> specs.InstallationMediaConfigSpec.Cloud
-	176, // 85: specs.InstallationMediaConfigSpec.sbc:type_name -> specs.InstallationMediaConfigSpec.SBC
+	173, // 80: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
+	174, // 81: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
+	175, // 82: specs.InfraProviderCombinedStatusSpec.health:type_name -> specs.InfraProviderCombinedStatusSpec.Health
+	188, // 83: specs.InstallationMediaConfigSpec.architecture:type_name -> specs.PlatformConfigSpec.Arch
+	176, // 84: specs.InstallationMediaConfigSpec.cloud:type_name -> specs.InstallationMediaConfigSpec.Cloud
+	177, // 85: specs.InstallationMediaConfigSpec.sbc:type_name -> specs.InstallationMediaConfigSpec.SBC
 	3,   // 86: specs.InstallationMediaConfigSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	177, // 87: specs.InstallationMediaConfigSpec.machine_labels:type_name -> specs.InstallationMediaConfigSpec.MachineLabelsEntry
-	188, // 88: specs.InstallationMediaConfigSpec.bootloader:type_name -> management.SchematicBootloader
+	178, // 87: specs.InstallationMediaConfigSpec.machine_labels:type_name -> specs.InstallationMediaConfigSpec.MachineLabelsEntry
+	189, // 88: specs.InstallationMediaConfigSpec.bootloader:type_name -> management.SchematicBootloader
 	22,  // 89: specs.SecretRotationSpec.status:type_name -> specs.SecretRotationSpec.Status
 	23,  // 90: specs.SecretRotationSpec.phase:type_name -> specs.SecretRotationSpec.Phase
 	24,  // 91: specs.SecretRotationSpec.component:type_name -> specs.SecretRotationSpec.Component
-	148, // 92: specs.SecretRotationSpec.certs:type_name -> specs.ClusterSecretsSpec.Certs
-	148, // 93: specs.SecretRotationSpec.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
-	149, // 94: specs.SecretRotationSpec.backup_certs_os:type_name -> specs.ClusterSecretsSpec.Certs.CA
-	149, // 95: specs.SecretRotationSpec.backup_certs_k8s:type_name -> specs.ClusterSecretsSpec.Certs.CA
+	149, // 92: specs.SecretRotationSpec.certs:type_name -> specs.ClusterSecretsSpec.Certs
+	149, // 93: specs.SecretRotationSpec.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
+	150, // 94: specs.SecretRotationSpec.backup_certs_os:type_name -> specs.ClusterSecretsSpec.Certs.CA
+	150, // 95: specs.SecretRotationSpec.backup_certs_k8s:type_name -> specs.ClusterSecretsSpec.Certs.CA
 	23,  // 96: specs.ClusterSecretsRotationStatusSpec.phase:type_name -> specs.SecretRotationSpec.Phase
 	24,  // 97: specs.ClusterSecretsRotationStatusSpec.component:type_name -> specs.SecretRotationSpec.Component
-	178, // 98: specs.ClusterMachineSecretsSpec.rotation:type_name -> specs.ClusterMachineSecretsSpec.Rotation
-	179, // 99: specs.UpgradeRolloutSpec.machine_sets_upgrade_quota:type_name -> specs.UpgradeRolloutSpec.MachineSetsUpgradeQuotaEntry
+	179, // 98: specs.ClusterMachineSecretsSpec.rotation:type_name -> specs.ClusterMachineSecretsSpec.Rotation
+	180, // 99: specs.UpgradeRolloutSpec.machine_sets_upgrade_quota:type_name -> specs.UpgradeRolloutSpec.MachineSetsUpgradeQuotaEntry
 	25,  // 100: specs.NotificationSpec.type:type_name -> specs.NotificationSpec.Type
 	26,  // 101: specs.KubernetesManifestGroupSpec.mode:type_name -> specs.KubernetesManifestGroupSpec.Mode
-	182, // 102: specs.ClusterKubernetesManifestsStatusSpec.groups:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry
+	183, // 102: specs.ClusterKubernetesManifestsStatusSpec.groups:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry
 	140, // 103: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
 	141, // 104: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
 	142, // 105: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
 	143, // 106: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
-	31,  // 107: specs.MachineStatusSpec.Schematic.overlay:type_name -> specs.Overlay
-	32,  // 108: specs.MachineStatusSpec.Schematic.meta_values:type_name -> specs.MetaValue
-	144, // 109: specs.MachineStatusSpec.Schematic.initial_state:type_name -> specs.MachineStatusSpec.Schematic.InitialState
-	149, // 110: specs.ClusterSecretsSpec.Certs.os:type_name -> specs.ClusterSecretsSpec.Certs.CA
-	149, // 111: specs.ClusterSecretsSpec.Certs.k8s:type_name -> specs.ClusterSecretsSpec.Certs.CA
-	10,  // 112: specs.MachineSetSpec.MachineClass.allocation_type:type_name -> specs.MachineSetSpec.MachineClass.Type
-	11,  // 113: specs.MachineSetSpec.MachineAllocation.allocation_type:type_name -> specs.MachineSetSpec.MachineAllocation.Type
-	153, // 114: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
-	2,   // 115: specs.ControlPlaneStatusSpec.Condition.type:type_name -> specs.ConditionType
-	14,  // 116: specs.ControlPlaneStatusSpec.Condition.status:type_name -> specs.ControlPlaneStatusSpec.Condition.Status
-	15,  // 117: specs.ControlPlaneStatusSpec.Condition.severity:type_name -> specs.ControlPlaneStatusSpec.Condition.Severity
-	157, // 118: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
-	32,  // 119: specs.MachineClassSpec.Provision.meta_values:type_name -> specs.MetaValue
-	3,   // 120: specs.MachineClassSpec.Provision.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	30,  // 121: specs.MachineConfigGenOptionsSpec.InstallImage.security_state:type_name -> specs.SecurityState
-	18,  // 122: specs.MachineExtensionsStatusSpec.Item.phase:type_name -> specs.MachineExtensionsStatusSpec.Item.Phase
-	22,  // 123: specs.ClusterMachineSecretsSpec.Rotation.status:type_name -> specs.SecretRotationSpec.Status
-	23,  // 124: specs.ClusterMachineSecretsSpec.Rotation.phase:type_name -> specs.SecretRotationSpec.Phase
-	24,  // 125: specs.ClusterMachineSecretsSpec.Rotation.component:type_name -> specs.SecretRotationSpec.Component
-	148, // 126: specs.ClusterMachineSecretsSpec.Rotation.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
-	27,  // 127: specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus.phase:type_name -> specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus.Phase
-	28,  // 128: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.phase:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.Phase
-	26,  // 129: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.mode:type_name -> specs.KubernetesManifestGroupSpec.Mode
-	183, // 130: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.manifests:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry
-	181, // 131: specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry.value:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus
-	180, // 132: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry.value:type_name -> specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus
-	133, // [133:133] is the sub-list for method output_type
-	133, // [133:133] is the sub-list for method input_type
-	133, // [133:133] is the sub-list for extension type_name
-	133, // [133:133] is the sub-list for extension extendee
-	0,   // [0:133] is the sub-list for field type_name
+	144, // 107: specs.MachineStatusSpec.PlatformMetadata.tags:type_name -> specs.MachineStatusSpec.PlatformMetadata.TagsEntry
+	31,  // 108: specs.MachineStatusSpec.Schematic.overlay:type_name -> specs.Overlay
+	32,  // 109: specs.MachineStatusSpec.Schematic.meta_values:type_name -> specs.MetaValue
+	145, // 110: specs.MachineStatusSpec.Schematic.initial_state:type_name -> specs.MachineStatusSpec.Schematic.InitialState
+	150, // 111: specs.ClusterSecretsSpec.Certs.os:type_name -> specs.ClusterSecretsSpec.Certs.CA
+	150, // 112: specs.ClusterSecretsSpec.Certs.k8s:type_name -> specs.ClusterSecretsSpec.Certs.CA
+	10,  // 113: specs.MachineSetSpec.MachineClass.allocation_type:type_name -> specs.MachineSetSpec.MachineClass.Type
+	11,  // 114: specs.MachineSetSpec.MachineAllocation.allocation_type:type_name -> specs.MachineSetSpec.MachineAllocation.Type
+	154, // 115: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
+	2,   // 116: specs.ControlPlaneStatusSpec.Condition.type:type_name -> specs.ConditionType
+	14,  // 117: specs.ControlPlaneStatusSpec.Condition.status:type_name -> specs.ControlPlaneStatusSpec.Condition.Status
+	15,  // 118: specs.ControlPlaneStatusSpec.Condition.severity:type_name -> specs.ControlPlaneStatusSpec.Condition.Severity
+	158, // 119: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
+	32,  // 120: specs.MachineClassSpec.Provision.meta_values:type_name -> specs.MetaValue
+	3,   // 121: specs.MachineClassSpec.Provision.grpc_tunnel:type_name -> specs.GrpcTunnelMode
+	30,  // 122: specs.MachineConfigGenOptionsSpec.InstallImage.security_state:type_name -> specs.SecurityState
+	18,  // 123: specs.MachineExtensionsStatusSpec.Item.phase:type_name -> specs.MachineExtensionsStatusSpec.Item.Phase
+	22,  // 124: specs.ClusterMachineSecretsSpec.Rotation.status:type_name -> specs.SecretRotationSpec.Status
+	23,  // 125: specs.ClusterMachineSecretsSpec.Rotation.phase:type_name -> specs.SecretRotationSpec.Phase
+	24,  // 126: specs.ClusterMachineSecretsSpec.Rotation.component:type_name -> specs.SecretRotationSpec.Component
+	149, // 127: specs.ClusterMachineSecretsSpec.Rotation.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
+	27,  // 128: specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus.phase:type_name -> specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus.Phase
+	28,  // 129: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.phase:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.Phase
+	26,  // 130: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.mode:type_name -> specs.KubernetesManifestGroupSpec.Mode
+	184, // 131: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.manifests:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry
+	182, // 132: specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry.value:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus
+	181, // 133: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry.value:type_name -> specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus
+	134, // [134:134] is the sub-list for method output_type
+	134, // [134:134] is the sub-list for method input_type
+	134, // [134:134] is the sub-list for extension type_name
+	134, // [134:134] is the sub-list for extension extendee
+	0,   // [0:134] is the sub-list for field type_name
 }
 
 func init() { file_omni_specs_omni_proto_init() }
@@ -12336,7 +12351,7 @@ func file_omni_specs_omni_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_omni_specs_omni_proto_rawDesc), len(file_omni_specs_omni_proto_rawDesc)),
 			NumEnums:      29,
-			NumMessages:   155,
+			NumMessages:   156,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -150,6 +150,8 @@ message MachineStatusSpec {
     string provider_id = 7;
     // Spot instance flag.
     bool spot = 8;
+    // Tags map the instance's tags (cloud).
+    map<string, string> tags = 9;
   }
 
   message Schematic {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -276,6 +276,13 @@ func (m *MachineStatusSpec_PlatformMetadata) CloneVT() *MachineStatusSpec_Platfo
 	r.InstanceId = m.InstanceId
 	r.ProviderId = m.ProviderId
 	r.Spot = m.Spot
+	if rhs := m.Tags; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Tags = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -3613,6 +3620,18 @@ func (this *MachineStatusSpec_PlatformMetadata) EqualVT(that *MachineStatusSpec_
 	}
 	if this.Spot != that.Spot {
 		return false
+	}
+	if len(this.Tags) != len(that.Tags) {
+		return false
+	}
+	for i, vx := range this.Tags {
+		vy, ok := that.Tags[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -8340,6 +8359,25 @@ func (m *MachineStatusSpec_PlatformMetadata) MarshalToSizedBufferVT(dAtA []byte)
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Tags) > 0 {
+		for k := range m.Tags {
+			v := m.Tags[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4a
+		}
 	}
 	if m.Spot {
 		i--
@@ -16629,6 +16667,14 @@ func (m *MachineStatusSpec_PlatformMetadata) SizeVT() (n int) {
 	if m.Spot {
 		n += 2
 	}
+	if len(m.Tags) > 0 {
+		for k, v := range m.Tags {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -21712,6 +21758,133 @@ func (m *MachineStatusSpec_PlatformMetadata) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Spot = bool(v != 0)
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Tags", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Tags == nil {
+				m.Tags = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Tags[mapkey] = mapvalue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/omni/resources/omni/annotations.go
+++ b/client/pkg/omni/resources/omni/annotations.go
@@ -57,6 +57,13 @@ const (
 	// tsgen:KernelArgsInitialized
 	KernelArgsInitialized = SystemLabelPrefix + "kernel-args-initialized"
 
+	// PlatformTagLabelsInitialized indicates that user labels have been initialized from PlatformMetadata tags.
+	//
+	// This annotation is set on MachineStatus resource.
+	//
+	// tsgen:PlatformTagLabelsInitialized
+	PlatformTagLabelsInitialized = SystemLabelPrefix + "platform-tag-labels-initialized"
+
 	// TaintedByBreakGlassTimestamp is set on the ClusterStatus when it was tainted by break glass.
 	// The presence of the taint is determined by the label LabelClusterTaintedByBreakGlass on the ClusterStatus resource.
 	TaintedByBreakGlassTimestamp = SystemLabelPrefix + "tainted-by-break-glass-timestamp"

--- a/client/pkg/omni/resources/omni/machine_status.go
+++ b/client/pkg/omni/resources/omni/machine_status.go
@@ -113,10 +113,10 @@ func setLabelOptional(labels *resource.Labels, key string, valueFunc func() opti
 	}
 }
 
-// MachineStatusReconcileLabels builds a set of labels based on hardware/meta information.
+// ReconcileMachineStatusLabels builds a set of labels based on hardware/meta information.
 //
 //nolint:gocognit
-func MachineStatusReconcileLabels(machineStatus *MachineStatus) {
+func ReconcileMachineStatusLabels(machineStatus *MachineStatus) {
 	labels := machineStatus.Metadata().Labels()
 
 	setLabel(labels, MachineStatusLabelCores, func() string {

--- a/client/pkg/omni/resources/omni/machine_status_test.go
+++ b/client/pkg/omni/resources/omni/machine_status_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/runtime"
 )
 
-func TestMachineStatusReconcileLabels(t *testing.T) {
+func TestReconcileMachineStatusLabels(t *testing.T) {
 	t.Parallel()
 
 	for _, test := range []struct { //nolint:govet
@@ -133,7 +133,7 @@ func TestMachineStatusReconcileLabels(t *testing.T) {
 
 			ms.TypedSpec().Value = test.spec
 
-			omni.MachineStatusReconcileLabels(ms)
+			omni.ReconcileMachineStatusLabels(ms)
 
 			assert.Equal(t, test.want, ms.Metadata().Labels().Raw())
 		})

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -84,6 +84,7 @@ export const KubernetesManifestName = "name";
 export const ClusterLocked = "omni.sidero.dev/cluster-locked";
 export const ClusterImportIsInProgress = "omni.sidero.dev/cluster-import-is-in-progress";
 export const KernelArgsInitialized = "omni.sidero.dev/kernel-args-initialized";
+export const PlatformTagLabelsInitialized = "omni.sidero.dev/platform-tag-labels-initialized";
 export const EtcdBackupS3ConfID = "etcd-backup-s3-conf";
 export const EtcdBackupS3ConfType = "EtcdBackupS3Configs.omni.sidero.dev";
 export const BackupDataType = "BackupDatas.omni.sidero.dev";

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
@@ -277,6 +277,7 @@ func pollPlatformMetadata(ctx context.Context, c *client.Client, info *Info) err
 				InstanceId:   r.TypedSpec().InstanceID,
 				ProviderId:   r.TypedSpec().ProviderID,
 				Spot:         r.TypedSpec().Spot,
+				Tags:         r.TypedSpec().Tags,
 			}
 
 			return nil

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -118,6 +118,10 @@ func (ctrl *MachineStatusController) Settings() controller.QSettings {
 				Kind: controller.OutputExclusive,
 				Type: omni.MachineStatusType,
 			},
+			{
+				Kind: controller.OutputShared,
+				Type: omni.MachineLabelsType,
+			},
 		},
 		Concurrency: optional.Some[uint](4),
 		RunHook: func(ctx context.Context, _ *zap.Logger, r controller.QRuntime) error {
@@ -268,7 +272,9 @@ func (ctrl *MachineStatusController) reconcileRunning(ctx context.Context, r con
 
 		helpers.CopyUserLabels(m, ctrl.mergeLabels(m, inputs.machineLabels))
 
-		ctrl.reconcileLabels(m, inputs.infraMachineStatus)
+		if errLabels := ctrl.reconcileLabels(m, inputs.infraMachineStatus); errLabels != nil {
+			return errLabels
+		}
 
 		if err = ctrl.setClusterRelation(inputs, m); err != nil {
 			return err
@@ -330,8 +336,8 @@ func (ctrl *MachineStatusController) reconcileTearingDown(ctx context.Context, r
 
 //nolint:gocyclo,cyclop,gocognit
 func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r controller.QRuntime, event machinetask.Info) error {
-	if err := safe.WriterModify(ctx, r, omni.NewMachineStatus(event.MachineID), func(m *omni.MachineStatus) error {
-		spec := m.TypedSpec().Value
+	if err := safe.WriterModify(ctx, r, omni.NewMachineStatus(event.MachineID), func(machineStatus *omni.MachineStatus) error {
+		spec := machineStatus.TypedSpec().Value
 
 		if event.LastError != nil {
 			spec.LastError = event.LastError.Error()
@@ -406,7 +412,7 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 		if event.ImageLabels != nil {
 			spec.ImageLabels = event.ImageLabels
 
-			m.Metadata().Labels().Do(func(temp kvutils.TempKV) {
+			machineStatus.Metadata().Labels().Do(func(temp kvutils.TempKV) {
 				for key, value := range spec.ImageLabels {
 					temp.Set(key, value)
 				}
@@ -414,9 +420,9 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 		}
 
 		if event.NoAccess {
-			m.Metadata().Labels().Set(omni.MachineStatusLabelInvalidState, "")
+			machineStatus.Metadata().Labels().Set(omni.MachineStatusLabelInvalidState, "")
 		} else {
-			m.Metadata().Labels().Delete(omni.MachineStatusLabelInvalidState)
+			machineStatus.Metadata().Labels().Delete(omni.MachineStatusLabelInvalidState)
 		}
 
 		if event.SecurityState != nil {
@@ -424,14 +430,24 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 		}
 
 		if event.Schematic != nil {
-			if err := ctrl.handleEventSchematic(ctx, m, event); err != nil {
+			if err := ctrl.handleEventSchematic(ctx, machineStatus, event); err != nil {
 				return fmt.Errorf("failed to handle schematic event: %w", err)
 			}
 		}
 
 		spec.Maintenance = event.MaintenanceMode
 
-		ctrl.reconcileLabels(m, event.InfraMachineStatus)
+		if err := ctrl.reconcileLabels(machineStatus, event.InfraMachineStatus); err != nil {
+			return fmt.Errorf("failed to reconcile labels: %w", err)
+		}
+
+		// Intentionally do this separately from the usual labels reconciliation, as these
+		// are based only on PlatformMetadata tags.
+		if machineStatus.TypedSpec().Value.PlatformMetadata != nil {
+			if err := ctrl.reconcilePlatformTagLabels(ctx, r, machineStatus); err != nil {
+				return err
+			}
+		}
 
 		return nil
 	}); err != nil && !state.IsPhaseConflictError(err) {
@@ -453,6 +469,43 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 		if _, err := ctrl.ImageFactoryClient.EnsureSchematic(ctx, machineSchematic); err != nil {
 			return fmt.Errorf("error ensuring schematic: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// reconcilePlatformTagLabels bootstraps a MachineLabels resource from PlatformMetadata tags on the first join
+// and stamps the PlatformTagLabelsInitialized annotation on both machineLabels and machineStatus when done.
+// Subsequent calls are short-circuited by the annotation on machineLabels.
+// We only populate these labels on Omni join; from there on the user can freely modify them.
+func (ctrl *MachineStatusController) reconcilePlatformTagLabels(ctx context.Context, r controller.QRuntime, machineStatus *omni.MachineStatus) error {
+	if err := safe.WriterModify(ctx, r, omni.NewMachineLabels(machineStatus.Metadata().ID()), func(machineLabels *omni.MachineLabels) error {
+		// Skip if annotation is set on either resource, but ensure eventual consistency, in case any of the writes failed before.
+		if _, isAnnotated := machineStatus.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized); isAnnotated {
+			machineLabels.Metadata().Annotations().Set(omni.PlatformTagLabelsInitialized, "")
+
+			return nil
+		}
+
+		if _, isAnnotated := machineLabels.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized); isAnnotated {
+			machineStatus.Metadata().Annotations().Set(omni.PlatformTagLabelsInitialized, "")
+
+			return nil
+		}
+
+		for k, v := range machineStatus.TypedSpec().Value.PlatformMetadata.GetTags() {
+			// Do not overwrite pre-existing user labels.
+			if _, ok := machineLabels.Metadata().Labels().Get(k); !ok {
+				machineLabels.Metadata().Labels().Set(k, v)
+			}
+		}
+
+		machineLabels.Metadata().Annotations().Set(omni.PlatformTagLabelsInitialized, "")
+		machineStatus.Metadata().Annotations().Set(omni.PlatformTagLabelsInitialized, "")
+
+		return nil
+	}, controller.WithModifyNoOwner()); err != nil {
+		return err
 	}
 
 	return nil
@@ -526,14 +579,14 @@ func (ctrl *MachineStatusController) handleEventSchematic(ctx context.Context, m
 	return nil
 }
 
-// reconcileLabels is a wrapper around omni.MachineStatusReconcileLabels, but it overrides the "installed" label
+// reconcileLabels is a wrapper around omni.ReconcileMachineStatusLabels, but it overrides the "installed" label
 // based on a matching infra.MachineStatus for that machine.
 //
 // This is because if there is a matching infra.MachineStatus, it means that the machine is managed by a static infrastructure provider (e.g., the bare-metal provider),
 // and it might be powered off by the provider. In that case, the block disks information on the MachineStatus might be not up to date,
 // and the information on infra.MachineStatus will be more reliable.
-func (ctrl *MachineStatusController) reconcileLabels(machineStatus *omni.MachineStatus, infraMachineStatus *infra.MachineStatus) {
-	omni.MachineStatusReconcileLabels(machineStatus)
+func (ctrl *MachineStatusController) reconcileLabels(machineStatus *omni.MachineStatus, infraMachineStatus *infra.MachineStatus) error {
+	omni.ReconcileMachineStatusLabels(machineStatus)
 
 	if infraMachineStatus != nil {
 		if infraMachineStatus.TypedSpec().Value.Installed {
@@ -542,6 +595,8 @@ func (ctrl *MachineStatusController) reconcileLabels(machineStatus *omni.Machine
 			machineStatus.Metadata().Labels().Delete(omni.MachineStatusLabelInstalled)
 		}
 	}
+
+	return nil
 }
 
 type inputs struct {
@@ -597,11 +652,11 @@ func (ctrl *MachineStatusController) handleInputs(ctx context.Context, r control
 	return in, nil
 }
 
-func (ctrl *MachineStatusController) mergeLabels(m *omni.MachineStatus, machineLabels *omni.MachineLabels) map[string]string {
+func (ctrl *MachineStatusController) mergeLabels(machineStatus *omni.MachineStatus, machineLabels *omni.MachineLabels) map[string]string {
 	labels := map[string]string{}
 
-	if m.TypedSpec().Value.ImageLabels != nil {
-		maps.Copy(labels, m.TypedSpec().Value.ImageLabels)
+	if machineStatus.TypedSpec().Value.ImageLabels != nil {
+		maps.Copy(labels, machineStatus.TypedSpec().Value.ImageLabels)
 	}
 
 	if machineLabels != nil {

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/image-factory/pkg/constants"
 	"github.com/siderolabs/image-factory/pkg/schematic"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
@@ -221,16 +222,16 @@ func (suite *MachineStatusSuite) TestMachineUserLabels() {
 
 	metaKey := runtime.NewMetaKey(runtime.NamespaceName, runtime.MetaKeyTagToID(meta.LabelsMeta))
 
-	labels := meta.ImageLabels{
+	imageLabels := meta.ImageLabels{
 		Labels: map[string]string{
-			"label1": "value1",
+			"imageLabel1": "imageLabelVal1",
 		},
 	}
 
-	d, err := labels.Encode()
+	imageLabelsBytes, err := imageLabels.Encode()
 	suite.Require().NoError(err)
 
-	metaKey.TypedSpec().Value = string(d)
+	metaKey.TypedSpec().Value = string(imageLabelsBytes)
 
 	suite.Require().NoError(suite.machineService.state.Create(suite.ctx, metaKey))
 
@@ -250,82 +251,328 @@ func (suite *MachineStatusSuite) TestMachineUserLabels() {
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
 		assert.NotNilf(status.TypedSpec().Value.ImageLabels, "initial labels not loaded")
 
-		val, ok := status.Metadata().Labels().Get("label1")
-		assert.Truef(ok, "label1 is not set in the initial labels")
-		assert.EqualValues("value1", val)
+		imageLabel1Val, ok := status.Metadata().Labels().Get("imageLabel1")
+		assert.Truef(ok, "imageLabel1 is not set in the initial labels")
+		assert.EqualValues("imageLabelVal1", imageLabel1Val)
 	})
 
 	// now create user labels and see how it merges initial and user labels
 
 	machineLabels := omni.NewMachineLabels(testID)
 	machineLabels.Metadata().Labels().Set("test", "")
+	machineLabels.Metadata().Labels().Set("duplicateInPlatformTagsAndUserLabels", "valueShouldStay")
 
 	suite.Assert().NoError(suite.state.Create(suite.ctx, machineLabels))
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
-		val, ok := status.Metadata().Labels().Get("label1")
-		assert.Truef(ok, "label1 is not set in the initial labels")
-		assert.EqualValues("value1", val)
+		val, ok := status.Metadata().Labels().Get("imageLabel1")
+		assert.Truef(ok, "imageLabel1 is not set")
+		assert.EqualValues("imageLabelVal1", val)
 
 		val, ok = status.Metadata().Labels().Get("test")
-		assert.Truef(ok, "label1 is not set in the initial labels")
+		assert.Truef(ok, "test label is not set")
 		assert.EqualValues("", val)
+
+		val, ok = status.Metadata().Labels().Get("duplicateInPlatformTagsAndUserLabels")
+		assert.Truef(ok, "duplicateInPlatformTagsAndUserLabels label is not set")
+		assert.EqualValues("valueShouldStay", val)
 	})
 
-	// overwrite initial label value
+	// create PlatformMetadata with non-empty Tags and see if they are propagated through MachineLabels
 
-	_, err = safe.StateUpdateWithConflicts[*omni.MachineLabels](ctx, suite.state, machineLabels.Metadata(), func(ml *omni.MachineLabels) error {
-		ml.Metadata().Labels().Set("label1", "gasp")
+	platformMetadata := runtime.NewPlatformMetadataSpec(runtime.NamespaceName, testID)
+	platformMetadata.TypedSpec().Tags = map[string]string{
+		"platformMetadataTag1":                 "platformMetadataValue",
+		"duplicateInPlatformTagsAndUserLabels": "shouldNotOverwriteUserValue",
+	}
+	suite.Assert().NoError(suite.machineService.state.Create(ctx, platformMetadata))
 
-		return nil
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineLabels *omni.MachineLabels, assert *assert.Assertions) {
+		_, initialized := machineLabels.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(initialized, "PlatformTagLabelsInitialized annotation must be set on MachineLabels")
 	})
 
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
+		_, initialized := status.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(initialized, "PlatformTagLabelsInitialized annotation must be set on MachineStatus")
+
+		assert.NotNilf(status.TypedSpec().Value.ImageLabels, "initial labels not loaded")
+
+		imageLabel1Val, ok := status.Metadata().Labels().Get("imageLabel1")
+		assert.Truef(ok, "imageLabel1 is not set")
+		assert.EqualValues("imageLabelVal1", imageLabel1Val)
+
+		platformMetadataVal, ok := status.Metadata().Labels().Get("platformMetadataTag1")
+		assert.Truef(ok, "platformMetadataTag is not set")
+		assert.EqualValues("platformMetadataValue", platformMetadataVal)
+
+		duplicateInPlatformTagsAndUserLabelsVal, ok := status.Metadata().Labels().Get("duplicateInPlatformTagsAndUserLabels")
+		assert.Truef(ok, "duplicateInPlatformTagsAndUserLabels is not set")
+		assert.EqualValues("valueShouldStay", duplicateInPlatformTagsAndUserLabelsVal)
+	})
+
+	// overwrite image label value via MachineLabels
+	_, err = safe.StateUpdateWithConflicts(
+		ctx, suite.state,
+		omni.NewMachineLabels(testID).Metadata(),
+		func(machineLabels *omni.MachineLabels) error {
+			machineLabels.Metadata().Labels().Set("imageLabel1", "userOverride")
+
+			return nil
+		},
+		state.WithUpdateOwner(""),
+	)
 	suite.Require().NoError(err)
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
-		val, ok := status.Metadata().Labels().Get("label1")
-		assert.Truef(ok, "label1 doesn't exist")
-		assert.EqualValues("gasp", val)
+		val, ok := status.Metadata().Labels().Get("imageLabel1")
+		assert.Truef(ok, "imageLabel1 doesn't exist")
+		assert.EqualValues("userOverride", val)
+
+		platformMetadataVal, ok := status.Metadata().Labels().Get("platformMetadataTag1")
+		assert.Truef(ok, "platformMetadataTag doesn't exist")
+		assert.EqualValues("platformMetadataValue", platformMetadataVal)
 	})
 
-	// reverts back to initial when the machine labels resource gets removed
+	// labels created from PlatformMetadata tags should be removable by the user
+	_, err = safe.StateUpdateWithConflicts(ctx, suite.state,
+		omni.NewMachineLabels(testID).Metadata(),
+		func(machineLabels *omni.MachineLabels) error {
+			machineLabels.Metadata().Labels().Delete("platformMetadataTag1")
 
-	rtestutils.Destroy[*omni.MachineLabels](suite.ctx, suite.T(), suite.state, []string{testID})
+			return nil
+		}, state.WithUpdateOwner(""))
+	suite.Require().NoError(err)
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
-		val, ok := status.Metadata().Labels().Get("label1")
-		assert.Truef(ok, "label1 doesn't exist")
-		assert.EqualValues("value1", val)
+		val, ok := status.Metadata().Labels().Get("imageLabel1")
+		assert.Truef(ok, "imageLabel1 doesn't exist")
+		assert.EqualValues("userOverride", val)
+
+		_, ok = status.Metadata().Labels().Get("platformMetadataTag1")
+		assert.Falsef(ok, "platformMetadataTag1 should not be set after it's removed from MachineLabels")
 	})
 
-	machineLabels.Metadata().Labels().Set("label2", "aaa")
+	// Trigger MachineStatusController reconciliation through an Info event.
+	// Ensures platform tag labels are not re-added after being removed.
+	_, err = safe.StateUpdateWithConflicts(ctx, suite.machineService.state, platformMetadata.Metadata(),
+		func(res *runtime.PlatformMetadata) error {
+			return nil
+		})
+	suite.Require().NoError(err)
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
+		val, ok := status.Metadata().Labels().Get("imageLabel1")
+		assert.Truef(ok, "imageLabel1 doesn't exist")
+		assert.EqualValues("userOverride", val)
+
+		_, ok = status.Metadata().Labels().Get("platformMetadataTag1")
+		assert.Falsef(ok, "platformMetadataTag1 should not be set after removal and reconciliation")
+	})
+
+	// MachineLabels value takes precedence over image labels for the same key.
+	// machineLabels was re-created by the controller, so update rather than create.
+	_, err = safe.StateUpdateWithConflicts(
+		ctx, suite.state,
+		omni.NewMachineLabels(testID).Metadata(),
+		func(machineLabels *omni.MachineLabels) error {
+			machineLabels.Metadata().Labels().Set("imageLabel2", "aaa")
+
+			return nil
+		},
+		state.WithUpdateOwner(""),
+	)
+	suite.Require().NoError(err)
+
+	_, err = safe.StateUpdateWithConflicts(ctx, suite.machineService.state, metaKey.Metadata(), func(res *runtime.MetaKey) error {
+		imageLabels.Labels["imageLabel1"] = "updated"
+		imageLabels.Labels["imageLabel2"] = "override"
+
+		encoded, encodeErr := imageLabels.Encode()
+		if encodeErr != nil {
+			return encodeErr
+		}
+
+		res.TypedSpec().Value = string(encoded)
+
+		return nil
+	})
+	suite.Require().NoError(err)
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
+		val, ok := status.Metadata().Labels().Get("imageLabel1")
+		assert.Truef(ok, "imageLabel1 doesn't exist")
+		assert.EqualValues("userOverride", val) // user override in MachineLabels takes precedence over image label update
+
+		val, ok = status.Metadata().Labels().Get("imageLabel2")
+		assert.Truef(ok, "imageLabel2 doesn't exist")
+		assert.EqualValues("aaa", val)
+	})
+}
+
+// TestMachineUserLabelsEmptyPlatformTags verifies that when PlatformMetadata carries no tags,
+// the PlatformTagLabelsInitialized annotation is still stamped on MachineLabels and pre-existing
+// user labels are left untouched across repeated reconciliations. It also verifies that tags
+// subsequently added to PlatformMetadata are not propagated to MachineLabels, because the
+// annotation already marks the one-time bootstrap as done.
+func (suite *MachineStatusSuite) TestMachineUserLabelsEmptyPlatformTags() {
+	suite.setup()
+
+	machine := omni.NewMachine(testID)
+	spec := machine.TypedSpec().Value
+
+	spec.Connected = true
+	spec.ManagementAddress = suite.socketConnectionString
+
+	machineStatusSnapshot := omni.NewMachineStatusSnapshot(testID)
+	machineStatusSnapshot.TypedSpec().Value = &specs.MachineStatusSnapshotSpec{
+		MachineStatus: &machineapi.MachineStatusEvent{},
+	}
+
+	suite.Assert().NoError(suite.state.Create(suite.ctx, machine))
+	suite.Assert().NoError(suite.state.Create(suite.ctx, machineStatusSnapshot))
+
+	machineLabels := omni.NewMachineLabels(testID)
+	machineLabels.Metadata().Labels().Set("userLabel1", "userValue1")
+	machineLabels.Metadata().Labels().Set("userLabel2", "userValue2")
 
 	suite.Assert().NoError(suite.state.Create(suite.ctx, machineLabels))
 
-	_, err = safe.StateUpdateWithConflicts(ctx, suite.machineService.state, metaKey.Metadata(), func(res *runtime.MetaKey) error {
-		labels.Labels["label1"] = "updated"
-		labels.Labels["label2"] = "override"
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
+	defer cancel()
 
-		d, err = labels.Encode()
-		if err != nil {
-			return err
-		}
+	// create PlatformMetadata with empty Tags
+	platformMetadata := runtime.NewPlatformMetadataSpec(runtime.NamespaceName, testID)
+	suite.Assert().NoError(suite.machineService.state.Create(ctx, platformMetadata))
 
-		res.TypedSpec().Value = string(d)
-
-		return nil
+	// the annotation must be set even when Tags is empty, and no extra labels should appear
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineLabels *omni.MachineLabels, assert *assert.Assertions) {
+		_, initialized := machineLabels.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(initialized, "PlatformTagLabelsInitialized annotation must be set on MachineLabels even when platform tags are empty")
 	})
 
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+		_, initialized := machineStatus.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(initialized, "PlatformTagLabelsInitialized annotation must be set on MachineStatus even when platform tags are empty")
+
+		val, ok := machineStatus.Metadata().Labels().Get("userLabel1")
+		assert.Truef(ok, "userLabel1 should still be set")
+		assert.EqualValues("userValue1", val)
+
+		val, ok = machineStatus.Metadata().Labels().Get("userLabel2")
+		assert.Truef(ok, "userLabel2 should still be set")
+		assert.EqualValues("userValue2", val)
+	})
+
+	// update PlatformMetadata to now carry non-empty tags — because the annotation is already set,
+	// these tags must NOT be bootstrapped into MachineLabels
+	_, err := safe.StateUpdateWithConflicts(ctx, suite.machineService.state, platformMetadata.Metadata(),
+		func(res *runtime.PlatformMetadata) error {
+			res.TypedSpec().Tags = map[string]string{
+				"lateTag1": "lateValue1",
+			}
+
+			return nil
+		})
 	suite.Require().NoError(err)
 
-	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
-		val, ok := status.Metadata().Labels().Get("label1")
-		assert.Truef(ok, "label1 doesn't exist")
-		assert.EqualValues("updated", val)
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineLabels *omni.MachineLabels, assert *assert.Assertions) {
+		_, initialized := machineLabels.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(initialized, "PlatformTagLabelsInitialized annotation must remain set on MachineLabels after re-reconciliation")
+	})
 
-		val, ok = status.Metadata().Labels().Get("label2")
-		assert.Truef(ok, "label2 doesn't exist")
-		assert.EqualValues("aaa", val)
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+		_, initialized := machineStatus.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(initialized, "PlatformTagLabelsInitialized annotation must remain set on MachineStatus after re-reconciliation")
+
+		val, ok := machineStatus.Metadata().Labels().Get("userLabel1")
+		assert.Truef(ok, "userLabel1 should still be set after re-reconciliation")
+		assert.EqualValues("userValue1", val)
+
+		val, ok = machineStatus.Metadata().Labels().Get("userLabel2")
+		assert.Truef(ok, "userLabel2 should still be set after re-reconciliation")
+		assert.EqualValues("userValue2", val)
+
+		_, ok = machineStatus.Metadata().Labels().Get("lateTag1")
+		assert.Falsef(ok, "lateTag1 must not be added: bootstrap already ran when tags were empty")
+	})
+}
+
+func (suite *MachineStatusSuite) TestPlatformTagLabelsSetEventuallyConsistent() {
+	suite.setup()
+
+	machine := omni.NewMachine(testID)
+	spec := machine.TypedSpec().Value
+	spec.Connected = true
+	spec.ManagementAddress = suite.socketConnectionString
+
+	machineStatusSnapshot := omni.NewMachineStatusSnapshot(testID)
+	machineStatusSnapshot.TypedSpec().Value = &specs.MachineStatusSnapshotSpec{
+		MachineStatus: &machineapi.MachineStatusEvent{},
+	}
+
+	suite.Assert().NoError(suite.state.Create(suite.ctx, machine))
+	suite.Assert().NoError(suite.state.Create(suite.ctx, machineStatusSnapshot))
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
+	defer cancel()
+
+	platformMetadata := runtime.NewPlatformMetadataSpec(runtime.NamespaceName, testID)
+	platformMetadata.TypedSpec().Tags = map[string]string{"ec2Tag": "ec2Value"}
+	suite.Assert().NoError(suite.machineService.state.Create(ctx, platformMetadata))
+
+	// Wait for the normal bootstrap path: both resources must have the annotation.
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineLabels *omni.MachineLabels, assert *assert.Assertions) {
+		_, ok := machineLabels.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(ok, "MachineLabels must have PlatformTagLabelsInitialized after bootstrap")
+	})
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+		_, ok := machineStatus.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(ok, "MachineStatus must have PlatformTagLabelsInitialized after bootstrap")
+	})
+
+	// Case 1: MachineStatus retains the annotation; MachineLabels loses it.
+	// Simulates a partial failure where the MachineStatus write committed but the subsequent
+	// MachineLabels write did not. Removing the annotation from MachineLabels also triggers
+	// re-reconciliation (it is a mapped input), so no explicit trigger is needed.
+	_, err := safe.StateUpdateWithConflicts(ctx, suite.state,
+		omni.NewMachineLabels(testID).Metadata(),
+		func(ml *omni.MachineLabels) error {
+			ml.Metadata().Annotations().Delete(omni.PlatformTagLabelsInitialized)
+
+			return nil
+		}, state.WithUpdateOwner(""))
+	suite.Require().NoError(err)
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineLabels *omni.MachineLabels, assert *assert.Assertions) {
+		_, ok := machineLabels.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(ok, "PlatformTagLabelsInitialized must be restored on MachineLabels when MachineStatus already has it")
+	})
+
+	// Case 2: MachineLabels retains the annotation; MachineStatus loses it.
+	// Simulates a partial failure where the inner MachineLabels WriterModify committed but the
+	// outer MachineStatus WriterModify failed. MachineStatus is not a regular mapped input, so
+	// a direct annotation removal does not trigger reconciliation on its own; we drive the next
+	// cycle via a no-op MachineLabels update.
+	_, err = safe.StateUpdateWithConflicts(ctx, suite.state,
+		omni.NewMachineStatus(testID).Metadata(),
+		func(status *omni.MachineStatus) error {
+			status.Metadata().Annotations().Delete(omni.PlatformTagLabelsInitialized)
+
+			return nil
+		}, state.WithUpdateOwner(omnictrl.MachineStatusControllerName))
+	suite.Require().NoError(err)
+
+	_, err = safe.StateUpdateWithConflicts(ctx, suite.state,
+		omni.NewMachineLabels(testID).Metadata(),
+		func(ml *omni.MachineLabels) error { return nil },
+		state.WithUpdateOwner(""))
+	suite.Require().NoError(err)
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+		_, ok := machineStatus.Metadata().Annotations().Get(omni.PlatformTagLabelsInitialized)
+		assert.True(ok, "PlatformTagLabelsInitialized must be restored on MachineStatus when MachineLabels already has it")
 	})
 }
 

--- a/internal/integration/blocks_test.go
+++ b/internal/integration/blocks_test.go
@@ -71,7 +71,7 @@ func AssertBlockProxyAPIAccessShouldWork(ctx context.Context, options *TestOptio
 	return []subTest{
 		{
 			"ClusterKubernetesAPIShouldBeAccessibleViaOmni",
-			AssertKubernetesAPIAccessViaOmni(ctx, options.omniClient, clusterName, true, 5*time.Minute),
+			AssertKubernetesAPIAccessViaOmni(ctx, options.omniClient, clusterName, true, 10*time.Minute),
 		},
 		{
 			"ClusterTalosAPIShouldBeAccessibleViaOmni",
@@ -152,7 +152,7 @@ func AssertBlockRestoreEtcdFromLatestBackup(ctx context.Context, testOptions *Te
 	).Append(
 		subTest{
 			"KubernetesAPIShouldBeAccessible",
-			AssertKubernetesAPIAccessViaOmni(ctx, omniClient, clusterName, false, 300*time.Second),
+			AssertKubernetesAPIAccessViaOmni(ctx, omniClient, clusterName, false, 10*time.Minute),
 		},
 		subTest{
 			"ClusterNodesShouldBeInDesiredState",

--- a/internal/integration/cluster_test.go
+++ b/internal/integration/cluster_test.go
@@ -437,7 +437,7 @@ func AssertClusterMachinesStage(testCtx context.Context, st state.State, cluster
 // AssertClusterMachinesReady verifies that cluster machines reach ready state.
 func AssertClusterMachinesReady(testCtx context.Context, st state.State, clusterName string) TestFunc {
 	return func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(testCtx, 4*time.Minute)
+		ctx, cancel := context.WithTimeout(testCtx, 20*time.Minute)
 		defer cancel()
 
 		require := require.New(t)


### PR DESCRIPTION
Exposes Talos `PlatformMetadata` tags as user-editable (removable) machine labels in Omni.
- The labels based on `PlatformMetadata` tags are populated only once, when the machine joins. Once that succeeds, we set the `PlatformTagLabelsInitialized` annotation on the corresponding `MachineStatus` and `MachineLabels` resources, which prevent this reconciliation from repeating ever again.
    - A reboot will not recreate these labels.
    - Changing the `PlatformMetadata` tags (e.g. in EC2) will not be surfaced as labels in Omni if the machine already joined. 
    - The goal of annotating both is to have a failsafe if any of the resource writes fails. For example, if writing the annotation to `MachineStatus` fails, we still have the annotation on `MachineLabels` to catch us, preventing further reconciliation. Mind that it is the `MachineStatus` controller that modifies `MachineStatus` (and `MachineLabels`).
- If there's a label key conflict between custom user labels and labels based on PlatformMetadata tags, the custom user labels take priority. My assumption is that the user has to take intentional action to set the custom user label, and hence override a pre-existing label. This is similar to how `imageLabels` are handled ([src](https://github.com/majabojarska/omni/blob/ddfa70a9cf2af9028aaaeeb82df7fea0e3399ed6/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go#L427-L448)).  

This change is effective not only for EC2 instance tags, but for any platform that exposes `tags` through `PlatformMetadata`.

---

I've developed this under the local Omni compose stack, with a rigged Talos build ([diff](https://github.com/siderolabs/talos/commit/73200bd3736eab82d880e4071d4bef1b53163245)), to return mocked `PlatformMetadata` `tags` on _metal_.

```sh
omnictl get machinestatus -o yaml | yq '.spec.platformmetadata.tags'

[WARN] omnictl version "1.7.3" differs from the backend version "1.8.0-beta.1-16-gb469ce73".
usertag1: value1
usertag2: value2
usertag3emptyval: ""
---
# SNIP
```

The tag propagation logic is already in place for the aws provider ([src](https://github.com/majabojarska/talos/blob/3cc6c121ec37c4a920aadad5e29ec9247f7cd8f8/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go#L260)), for example:
```sh
talosctl -n <publicly-routable-ipv4> get --insecure platformmetadata -oyaml | yq '.spec.tags'
Name: majabojarska-talos-aws
TagNoValue: ""
TagWithVal1: Val1
TagWithVal2: Val2
```