### PR TITLE
feat: add per-class etcd write-bytes rate limiting

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -319,6 +319,18 @@ func defineStorageFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *confi
 	b.DurationVar("storage.sqlite.metrics.refreshInterval", &flagConfig.Storage.Sqlite.Metrics.RefreshInterval)
 	b.DurationVar("storage.sqlite.metrics.refreshTimeout", &flagConfig.Storage.Sqlite.Metrics.RefreshTimeout)
 	b.StringVar("storage.vault.k8sAuthMountPath", &flagConfig.Storage.Vault.K8SAuthMountPath)
+
+	b.DurationVar("storage.rateLimits.etcd.maxWait", &flagConfig.Storage.RateLimits.Etcd.MaxWait)
+	defineEtcdClassWriteRateLimitFlags(b, "user", &flagConfig.Storage.RateLimits.Etcd.User)
+	defineEtcdClassWriteRateLimitFlags(b, "infraProvider", &flagConfig.Storage.RateLimits.Etcd.InfraProvider)
+	defineEtcdClassWriteRateLimitFlags(b, "internal", &flagConfig.Storage.RateLimits.Etcd.Internal)
+}
+
+func defineEtcdClassWriteRateLimitFlags(b *FlagBinder, class string, cls *config.EtcdClassWriteRateLimit) {
+	prefix := "storage.rateLimits.etcd." + class + "."
+
+	b.Uint64Var(prefix+"writeBytesPerSecond", &cls.WriteBytesPerSecond)
+	b.Uint64Var(prefix+"writeBytesBurst", &cls.WriteBytesBurst)
 }
 
 func defineRegistriesFlags(b *FlagBinder, flagConfig *config.Params) {

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -475,6 +475,47 @@ config:
         #refreshInterval: 2m0s
         # RefreshTimeout is the timeout for refreshing SQLite metrics.
         #refreshTimeout: 1m0s
+    # @ignored
+    # RateLimits contains rate-limit settings for state writes. Today the only gate is etcd-specific (bytes/sec,
+    # throttling — see the `etcd` sub-block).
+    rateLimits:
+      # Etcd contains write rate-limit settings that only apply when the default storage backend is etcd. The
+      # bytes/sec gate throttles mutations (Create/Update/Destroy) by marshaled-payload size to protect etcd from
+      # revision/storage blowup. Throttling is bounded by the caller's context deadline and by `maxWait`, whichever is
+      # shorter.
+      etcd:
+        # MaxWait is the maximum time a single mutation will block waiting for tokens before failing with
+        # DeadlineExceeded. The effective wait is min(ctx.Deadline-now, maxWait). Load-bearing for callers that pass
+        # context.Background() — without this cap, a buggy controller could wait indefinitely. 0 means "no internal
+        # cap, rely on ctx deadline alone" (not recommended).
+        #maxWait: 30s
+        # User contains write-bytes throttle settings for operations performed by end users (authenticated humans and
+        # user-owned service accounts).
+        user:
+          # WriteBytesPerSecond is the sustained marshaled-payload byte rate allowed for etcd mutations. 0 disables the
+          # throttle for this class.
+          #writeBytesPerSecond: 0
+          # WriteBytesBurst is the maximum byte burst allowed above WriteBytesPerSecond. Must be at least the size of the
+          # single largest mutation, otherwise that mutation will never admit. 0 disables the throttle for this class.
+          #writeBytesBurst: 0
+        # InfraProvider contains write-bytes throttle settings for operations performed by infrastructure providers.
+        infraProvider:
+          # WriteBytesPerSecond is the sustained marshaled-payload byte rate allowed for etcd mutations. 0 disables the
+          # throttle for this class.
+          #writeBytesPerSecond: 0
+          # WriteBytesBurst is the maximum byte burst allowed above WriteBytesPerSecond. Must be at least the size of the
+          # single largest mutation, otherwise that mutation will never admit. 0 disables the throttle for this class.
+          #writeBytesBurst: 0
+        # Internal contains write-bytes throttle settings for operations performed by Omni's in-process controllers.
+        # Throttling internal callers naturally caps controller-driven write storms at the configured budget — see
+        # CLAUDE.md for the design rationale.
+        internal:
+          # WriteBytesPerSecond is the sustained marshaled-payload byte rate allowed for etcd mutations. 0 disables the
+          # throttle for this class.
+          #writeBytesPerSecond: 0
+          # WriteBytesBurst is the maximum byte burst allowed above WriteBytesPerSecond. Must be at least the size of the
+          # single largest mutation, otherwise that mutation will never admit. 0 disables the throttle for this class.
+          #writeBytesBurst: 0
   # EtcdBackup contains etcd backup configuration for the clusters on Omni.
   etcdBackup:
     # -- LocalPath is the local path where etcd backups are stored.

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/cosi-project/runtime v1.16.0
-	github.com/cosi-project/state-etcd v0.6.0
+	github.com/cosi-project/state-etcd v0.7.0
 	github.com/cosi-project/state-sqlite v0.4.0
 	github.com/crewjam/saml v0.5.1
 	github.com/dustin/go-humanize v1.0.1
@@ -59,6 +59,7 @@ require (
 	github.com/jxskiss/base62 v1.1.0
 	github.com/mattn/go-shellwords v1.0.13
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/siderolabs/crypto v0.6.5
@@ -238,7 +239,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/cors v1.11.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj
 github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cosi-project/runtime v1.16.0 h1:9/chgP4ySF7VcfZVjEjiC73AgIbsNohM7oK1lIAnM7U=
 github.com/cosi-project/runtime v1.16.0/go.mod h1:+GrSnmJjMfWMe6NubevwwXQf/v7afddDLeCbLonvvps=
-github.com/cosi-project/state-etcd v0.6.0 h1:18e4L9bU7gk/d4Q5+bccQqu/wUhZ/4cjqIkb2nkILSM=
-github.com/cosi-project/state-etcd v0.6.0/go.mod h1:hplOOGHR1Rt/T8fiuFcP16thoQDvprqP/aateuCv36o=
+github.com/cosi-project/state-etcd v0.7.0 h1:7EYGKbGClLA0h910oMWxtw4NZh9qt6GebaGxqGm7zts=
+github.com/cosi-project/state-etcd v0.7.0/go.mod h1:hplOOGHR1Rt/T8fiuFcP16thoQDvprqP/aateuCv36o=
 github.com/cosi-project/state-sqlite v0.4.0 h1:SwL5/LlAwnMomRjMM72igPA1F6W/88zbae4cFxqz5vw=
 github.com/cosi-project/state-sqlite v0.4.0/go.mod h1:V20oy2Sfxla0zZ+SJSgjV20feg2xGARlvVPL4Z4KfRo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/hack/compose/grafana/dashboards/omni-details.json
+++ b/hack/compose/grafana/dashboards/omni-details.json
@@ -3020,6 +3020,300 @@
           ],
           "title": "Etcd Writes per second by Operation",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "description": "p95 wait time spent in the etcd write-bytes throttle per caller class. The throttle blocks mutations until enough byte-budget is available, bounded by min(ctx.Deadline-now, storage.rateLimits.etcd.maxWait). Sustained non-zero values mean traffic is exceeding the configured writeBytesPerSecond budget; tune storage.rateLimits.etcd.<class>.writeBytesPerSecond / writeBytesBurst.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 25,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s",
+              "unitScale": true
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 131
+          },
+          "id": 305,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by (class, le) (rate(omni_etcd_write_throttle_wait_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "{{class}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Etcd Write Throttle — p95 Wait Time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "description": "Etcd write throttle timeouts per second, split by caller class (internal / infraprovider / user). A timeout means a mutation's wait expired (caller's ctx deadline or maxWait fired) before enough byte-budget became available. The mutation did NOT reach etcd. Pair with the Failed Bytes/sec panel: high event rate with low byte rate = many small rejections; low event rate with high byte rate = a few large payloads being blocked.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 25,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "ops",
+              "unitScale": true
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 131
+          },
+          "id": 307,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (class) (rate(omni_etcd_write_throttle_failed_total{reason=\"timeout\"}[$__rate_interval]))",
+              "legendFormat": "{{class}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Etcd Write Throttle — Timeouts/sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "description": "Marshaled bytes/sec of etcd writes that failed to admit (throttle timeouts), split by caller class. Comparable to omni_etcd_resource_bytes_total — this is the fraction that did NOT reach etcd. Sustained non-zero values mean traffic is exceeding the configured writeBytesPerSecond — large payloads (e.g. fat ConfigPatches) or persistent over-budget traffic from one class.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 25,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "Bps",
+              "unitScale": true
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 131
+          },
+          "id": 306,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (class) (rate(omni_etcd_write_throttle_failed_bytes_total{reason=\"timeout\"}[$__rate_interval]))",
+              "legendFormat": "{{class}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Etcd Write Throttle — Failed Bytes/sec",
+          "type": "timeseries"
         }
       ],
       "title": "Etcd Writes",

--- a/internal/backend/ratelimit/classify.go
+++ b/internal/backend/ratelimit/classify.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package ratelimit throttles COSI mutations (Create/Update/Destroy) against the
+// etcd backend by marshaled-payload size, per caller class.
+//
+// Throttler is wired as the state-etcd WithLimiter hook: each mutation blocks
+// until enough bytes-budget is available for the marshaled payload, bounded by
+// min(ctx.Deadline-now, maxWait). On timeout it returns codes.DeadlineExceeded.
+// Service accounts and unknown callers share the `user` bucket.
+package ratelimit
+
+import (
+	"github.com/siderolabs/omni/internal/pkg/auth/actor"
+)
+
+const (
+	bucketInternal      = 0
+	bucketInfraProvider = 1
+	bucketUser          = 2
+	bucketCount         = 3
+)
+
+// bucketLabels are the Prometheus `class` label values, mirroring actor.Type names.
+var bucketLabels = [bucketCount]string{
+	bucketInternal:      string(actor.TypeInternal),
+	bucketInfraProvider: string(actor.TypeInfraProvider),
+	bucketUser:          string(actor.TypeUser),
+}
+
+func bucketFor(t actor.Type) int {
+	switch t { //nolint:exhaustive
+	case actor.TypeInternal:
+		return bucketInternal
+	case actor.TypeInfraProvider:
+		return bucketInfraProvider
+	}
+
+	return bucketUser
+}

--- a/internal/backend/ratelimit/throttler.go
+++ b/internal/backend/ratelimit/throttler.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package ratelimit
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/internal/pkg/auth/actor"
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+const (
+	reasonTimeout  = "timeout"
+	reasonOversize = "oversize"
+)
+
+// Throttler gates etcd mutations by marshaled-payload bytes/sec, per caller class.
+//
+// A nil *Throttler is a valid passthrough: Gate returns nil and LimiterFunc returns nil (making state-etcd's WithLimiter option a no-op).
+type Throttler struct {
+	buckets             [bucketCount]*rate.Limiter
+	waitSeconds         [bucketCount]prometheus.Observer
+	admitted            [bucketCount]prometheus.Counter
+	failedTimeout       [bucketCount]prometheus.Counter
+	failedOversize      [bucketCount]prometheus.Counter
+	failedTimeoutBytes  [bucketCount]prometheus.Counter
+	failedOversizeBytes [bucketCount]prometheus.Counter
+	maxWait             time.Duration
+}
+
+// New constructs a Throttler from storage.rateLimits.etcd. Each class's bucket is independent; setting writeBytesPerSecond=0 or writeBytesBurst=0 disables the throttle for that class.
+//
+// Returns nil when every class is disabled, so state-etcd's WithLimiter becomes a true no-op (no metric registration, no per-mutation overhead).
+func New(cfg config.EtcdWriteRateLimits, registry prometheus.Registerer) *Throttler {
+	var buckets [bucketCount]*rate.Limiter
+
+	classCfg := [bucketCount]config.EtcdClassWriteRateLimit{
+		bucketInternal:      cfg.Internal,
+		bucketInfraProvider: cfg.InfraProvider,
+		bucketUser:          cfg.User,
+	}
+
+	anyEnabled := false
+
+	for i, c := range classCfg {
+		buckets[i] = buildLimiter(c.GetWriteBytesPerSecond(), c.GetWriteBytesBurst())
+		if buckets[i] != nil {
+			anyEnabled = true
+		}
+	}
+
+	if !anyEnabled {
+		return nil
+	}
+
+	waitVec := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "omni",
+		Subsystem: "etcd_write_throttle",
+		Name:      "wait_seconds",
+		Help: "Distribution of wait time spent in the etcd write-bytes throttle, per caller class. " +
+			"Successful admissions and timed-out failures are both observed (failures observe their wait-until-timeout duration).",
+		Buckets: []float64{0, 0.001, 0.01, 0.1, 0.5, 1, 2.5, 5, 10, 30},
+	}, []string{"class"})
+	admittedVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "omni",
+		Subsystem: "etcd_write_throttle",
+		Name:      "admitted_total",
+		Help:      "Number of etcd writes admitted by the throttle (after waiting if needed), per caller class.",
+	}, []string{"class"})
+	failedVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "omni",
+		Subsystem: "etcd_write_throttle",
+		Name:      "failed_total",
+		Help: "Number of etcd writes the throttle rejected, per caller class and reason. " +
+			"reason=timeout: the wait exceeded ctx deadline or maxWait. reason=oversize: payload exceeded the configured burst. " +
+			"These mutations did NOT reach etcd.",
+	}, []string{"class", "reason"})
+	failedBytesVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "omni",
+		Subsystem: "etcd_write_throttle",
+		Name:      "failed_bytes_total",
+		Help: "Total marshaled bytes of etcd writes the throttle rejected, per caller class and reason. " +
+			"Comparable to omni_etcd_resource_bytes_total — this is the fraction that did NOT reach etcd.",
+	}, []string{"class", "reason"})
+
+	t := &Throttler{
+		buckets: buckets,
+		maxWait: cfg.GetMaxWait(),
+	}
+
+	for i := range bucketCount {
+		label := bucketLabels[i]
+		t.waitSeconds[i] = waitVec.WithLabelValues(label)
+		t.admitted[i] = admittedVec.WithLabelValues(label)
+		t.failedTimeout[i] = failedVec.WithLabelValues(label, reasonTimeout)
+		t.failedOversize[i] = failedVec.WithLabelValues(label, reasonOversize)
+		t.failedTimeoutBytes[i] = failedBytesVec.WithLabelValues(label, reasonTimeout)
+		t.failedOversizeBytes[i] = failedBytesVec.WithLabelValues(label, reasonOversize)
+	}
+
+	if registry != nil {
+		registry.MustRegister(waitVec, admittedVec, failedVec, failedBytesVec)
+	}
+
+	return t
+}
+
+// Gate blocks until n bytes of budget are available for the caller's class, ctx is canceled, or maxWait elapses — whichever comes first.
+//
+// Returns nil on admission, codes.DeadlineExceeded on timeout, codes.ResourceExhausted when n exceeds the configured burst (no amount of waiting would let it through).
+// n <= 0 is treated as 1 (etcd still produces a revision for empty-payload deletes).
+func (t *Throttler) Gate(ctx context.Context, n int, resType resource.Type) error {
+	if t == nil {
+		return nil
+	}
+
+	bucket := bucketFor(actor.Classify(ctx).Type)
+
+	limiter := t.buckets[bucket]
+	if limiter == nil {
+		return nil
+	}
+
+	if n <= 0 {
+		n = 1
+	}
+
+	// Payloads larger than the burst never admit. Surface that as a separate code so operators can distinguish "configure higher burst" from "loaded too much".
+	if n > limiter.Burst() {
+		t.failedOversize[bucket].Inc()
+		t.failedOversizeBytes[bucket].Add(float64(n))
+
+		return status.Errorf(codes.ResourceExhausted,
+			"etcd write payload (%d bytes) exceeds the configured burst (%d) for class=%s, type=%s",
+			n, limiter.Burst(), bucketLabels[bucket], resType)
+	}
+
+	if limiter.AllowN(time.Now(), n) {
+		t.admitted[bucket].Inc()
+		t.waitSeconds[bucket].Observe(0)
+
+		return nil
+	}
+
+	waitCtx := ctx
+
+	if t.maxWait > 0 {
+		var cancel context.CancelFunc
+
+		waitCtx, cancel = context.WithTimeout(ctx, t.maxWait)
+		defer cancel()
+	}
+
+	start := time.Now()
+
+	err := limiter.WaitN(waitCtx, n)
+
+	elapsed := time.Since(start).Seconds()
+	t.waitSeconds[bucket].Observe(elapsed)
+
+	if err == nil {
+		t.admitted[bucket].Inc()
+
+		return nil
+	}
+
+	t.failedTimeout[bucket].Inc()
+	t.failedTimeoutBytes[bucket].Add(float64(n))
+
+	return status.Errorf(codes.DeadlineExceeded,
+		"etcd write throttled out after %.3fs (class=%s, type=%s, bytes=%d): %v",
+		elapsed, bucketLabels[bucket], resType, n, err)
+}
+
+// LimiterFunc returns a function shaped like state-etcd's etcd.LimiterFunc, suitable for wiring via etcd.WithLimiter.
+func (t *Throttler) LimiterFunc() func(ctx context.Context, eventType state.EventType, resourceType resource.Type, phase, previousPhase resource.Phase, marshaledBytes int) error {
+	if t == nil {
+		return nil
+	}
+
+	return func(ctx context.Context, _ state.EventType, resourceType resource.Type, _, _ resource.Phase, marshaledBytes int) error {
+		return t.Gate(ctx, marshaledBytes, resourceType)
+	}
+}
+
+func buildLimiter(perSecond, burst uint64) *rate.Limiter {
+	if perSecond == 0 || burst == 0 {
+		return nil
+	}
+
+	if burst > math.MaxInt {
+		burst = math.MaxInt
+	}
+
+	return rate.NewLimiter(rate.Limit(perSecond), int(burst))
+}

--- a/internal/backend/ratelimit/throttler_test.go
+++ b/internal/backend/ratelimit/throttler_test.go
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package ratelimit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/internal/backend/ratelimit"
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+func throttleConfig(perSec, burst uint64, maxWait time.Duration) config.EtcdWriteRateLimits {
+	cls := config.EtcdClassWriteRateLimit{}
+	cls.SetWriteBytesPerSecond(perSec)
+	cls.SetWriteBytesBurst(burst)
+
+	cfg := config.EtcdWriteRateLimits{
+		User:          cls,
+		InfraProvider: cls,
+		Internal:      cls,
+	}
+	cfg.SetMaxWait(maxWait)
+
+	return cfg
+}
+
+func TestThrottlerNilIsPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var thr *ratelimit.Throttler
+
+	assert.NoError(t, thr.Gate(t.Context(), 1024, "T"))
+	assert.Nil(t, thr.LimiterFunc())
+}
+
+func TestThrottlerZeroConfigShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	thr := ratelimit.New(config.EtcdWriteRateLimits{}, nil)
+	assert.Nil(t, thr)
+	assert.Nil(t, thr.LimiterFunc())
+
+	for range 10_000 {
+		require.NoError(t, thr.Gate(t.Context(), 1024, "T"))
+	}
+}
+
+func TestThrottlerAdmitsUnderBudget(t *testing.T) {
+	t.Parallel()
+
+	thr := ratelimit.New(throttleConfig(1<<20, 1<<20, time.Second), nil)
+
+	require.NoError(t, thr.Gate(t.Context(), 1024, "T"))
+}
+
+func TestThrottlerBlocksThenAdmits(t *testing.T) {
+	t.Parallel()
+
+	thr := ratelimit.New(throttleConfig(1024, 1024, 5*time.Second), nil)
+
+	ctx := t.Context()
+
+	require.NoError(t, thr.Gate(ctx, 1024, "T"))
+
+	start := time.Now()
+
+	require.NoError(t, thr.Gate(ctx, 1024, "T"))
+
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 500*time.Millisecond, "second admission must have waited for refill")
+}
+
+func TestThrottlerMaxWaitTimesOut(t *testing.T) {
+	t.Parallel()
+
+	thr := ratelimit.New(throttleConfig(1, 1024, 100*time.Millisecond), nil)
+
+	require.NoError(t, thr.Gate(t.Context(), 1024, "T"))
+
+	start := time.Now()
+	err := thr.Gate(t.Context(), 1024, "T")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	assert.LessOrEqual(t, elapsed, time.Second, "should not block longer than ~maxWait")
+}
+
+func TestThrottlerContextDeadlineTakesPrecedenceOverMaxWait(t *testing.T) {
+	t.Parallel()
+
+	thr := ratelimit.New(throttleConfig(1, 1024, 10*time.Second), nil)
+
+	require.NoError(t, thr.Gate(t.Context(), 1024, "T"))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := thr.Gate(ctx, 1024, "T")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	assert.LessOrEqual(t, elapsed, time.Second, "should not block longer than ~ctx deadline")
+}
+
+func TestThrottlerPayloadLargerThanBurst(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	thr := ratelimit.New(throttleConfig(1024, 1024, 10*time.Second), reg)
+
+	start := time.Now()
+	err := thr.Gate(t.Context(), 2048, "T")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	assert.Less(t, elapsed, 100*time.Millisecond, "must return immediately, no waiting")
+
+	// Oversize rejections must be distinguishable from timeouts in metrics.
+	oversize := readCounter(t, reg, "omni_etcd_write_throttle_failed_total", map[string]string{"class": "user", "reason": "oversize"})
+	assert.InDelta(t, 1.0, oversize, 0.0001)
+
+	timeouts := readCounter(t, reg, "omni_etcd_write_throttle_failed_total", map[string]string{"class": "user", "reason": "timeout"})
+	assert.InDelta(t, 0.0, timeouts, 0.0001, "oversize must NOT show up under reason=timeout")
+}
+
+func TestThrottlerFailedMetricsRecordPayloadSize(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	thr := ratelimit.New(throttleConfig(1, 64, 50*time.Millisecond), reg)
+
+	require.NoError(t, thr.Gate(t.Context(), 64, "T"))
+
+	err := thr.Gate(t.Context(), 64, "T")
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	failedBytes := readCounter(t, reg, "omni_etcd_write_throttle_failed_bytes_total", map[string]string{"class": "user", "reason": "timeout"})
+	assert.InDelta(t, 64.0, failedBytes, 0.0001, "failed_bytes must record payload size, not event count")
+
+	failedEvents := readCounter(t, reg, "omni_etcd_write_throttle_failed_total", map[string]string{"class": "user", "reason": "timeout"})
+	assert.InDelta(t, 1.0, failedEvents, 0.0001)
+
+	admitted := readCounter(t, reg, "omni_etcd_write_throttle_admitted_total", map[string]string{"class": "user"})
+	assert.InDelta(t, 1.0, admitted, 0.0001)
+}
+
+func TestThrottlerHistogramObservesAdmittedWaits(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	thr := ratelimit.New(throttleConfig(1000, 1000, time.Second), reg)
+
+	require.NoError(t, thr.Gate(t.Context(), 1000, "T"))
+
+	start := time.Now()
+
+	require.NoError(t, thr.Gate(t.Context(), 500, "T"))
+
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 400*time.Millisecond, "real wait should have happened")
+
+	hist := readHistogram(t, reg, "omni_etcd_write_throttle_wait_seconds", map[string]string{"class": "user"})
+	assert.Equal(t, uint64(2), hist.GetSampleCount())
+	assert.GreaterOrEqual(t, hist.GetSampleSum(), 0.4, "histogram must include the ~500ms wait of the second admission")
+}
+
+func TestThrottlerAdmittedCounterIncrements(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	thr := ratelimit.New(throttleConfig(10_000, 10_000, time.Second), reg)
+
+	for range 5 {
+		require.NoError(t, thr.Gate(t.Context(), 100, "T"))
+	}
+
+	admitted := readCounter(t, reg, "omni_etcd_write_throttle_admitted_total", map[string]string{"class": "user"})
+	assert.InDelta(t, 5.0, admitted, 0.0001)
+}
+
+func TestThrottlerLimiterFuncDelegatesToGate(t *testing.T) {
+	t.Parallel()
+
+	thr := ratelimit.New(throttleConfig(64, 64, 50*time.Millisecond), nil)
+
+	gate := thr.LimiterFunc()
+	require.NotNil(t, gate)
+
+	// First call within burst admits.
+	require.NoError(t, gate(t.Context(), state.Created, "T", resource.PhaseRunning, resource.PhaseRunning, 50))
+
+	// Second call would need to wait > 50ms; maxWait fires.
+	err := gate(t.Context(), state.Created, "T", resource.PhaseRunning, resource.PhaseRunning, 50)
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+}
+
+func readCounter(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+
+		for _, m := range f.GetMetric() {
+			if labelsMatch(m.GetLabel(), labels) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	t.Fatalf("counter %s with labels %v not found", name, labels)
+
+	return 0
+}
+
+func readHistogram(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) *dto.Histogram {
+	t.Helper()
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+
+		for _, m := range f.GetMetric() {
+			if labelsMatch(m.GetLabel(), labels) {
+				return m.GetHistogram()
+			}
+		}
+	}
+
+	t.Fatalf("histogram %s with labels %v not found", name, labels)
+
+	return nil
+}
+
+func labelsMatch(have []*dto.LabelPair, want map[string]string) bool {
+	if len(have) < len(want) {
+		return false
+	}
+
+	for k, v := range want {
+		found := false
+
+		for _, lp := range have {
+			if lp.GetName() == k && lp.GetValue() == v {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/backend/runtime/omni/export_test.go
+++ b/internal/backend/runtime/omni/export_test.go
@@ -29,7 +29,7 @@ func NewMockState(st state.State) (*State, error) {
 }
 
 func NewEtcdPersistentState(ctx context.Context, params *config.Params, logger *zap.Logger) (*PersistentState, error) {
-	return newEtcdPersistentState(ctx, params, nil, logger)
+	return newEtcdPersistentState(ctx, params, nil, nil, logger)
 }
 
 func GetEmbeddedEtcdClientWithServer(params *config.EtcdParams, logger *zap.Logger) (EtcdState, error) {

--- a/internal/backend/runtime/omni/state.go
+++ b/internal/backend/runtime/omni/state.go
@@ -29,6 +29,7 @@ import (
 	resourceregistry "github.com/siderolabs/omni/client/pkg/omni/resources/registry"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/internal/backend/logging"
+	"github.com/siderolabs/omni/internal/backend/ratelimit"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/hooks"
@@ -165,8 +166,8 @@ func NewState(ctx context.Context, params *config.Params, logger *zap.Logger, me
 	case config.StorageDefaultKindEtcd:
 		etcdMetrics := newEtcdMetrics()
 		metricsRegistry.MustRegister(etcdMetrics)
-
-		defaultPersistentState, err = newEtcdPersistentState(ctx, params, etcdMetrics.Observe, logger)
+		throttler := ratelimit.New(params.Storage.RateLimits.Etcd, metricsRegistry)
+		defaultPersistentState, err = newEtcdPersistentState(ctx, params, etcdMetrics.Observe, throttler, logger)
 	default:
 		return nil, fmt.Errorf("unknown storage kind %q", params.Storage.Default.GetKind())
 	}

--- a/internal/backend/runtime/omni/state_etcd.go
+++ b/internal/backend/runtime/omni/state_etcd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/panichandler"
 	"github.com/siderolabs/omni/internal/backend/logging"
+	"github.com/siderolabs/omni/internal/backend/ratelimit"
 	"github.com/siderolabs/omni/internal/backend/runtime/keyprovider"
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
@@ -39,7 +40,7 @@ import (
 // compressionThresholdBytes is the minimum marshaled size of the data to be considered for compression.
 const compressionThresholdBytes = 2048
 
-func newEtcdPersistentState(ctx context.Context, params *config.Params, observer etcd.ObserverFunc, logger *zap.Logger) (state *PersistentState, err error) {
+func newEtcdPersistentState(ctx context.Context, params *config.Params, observer etcd.ObserverFunc, throttler *ratelimit.Throttler, logger *zap.Logger) (state *PersistentState, err error) {
 	accountID := params.Account.GetId()
 	prefix := fmt.Sprintf("/omni/%s", url.PathEscape(accountID))
 
@@ -98,6 +99,7 @@ func newEtcdPersistentState(ctx context.Context, params *config.Params, observer
 		etcd.WithKeyPrefix(prefix),
 		etcd.WithSalt(salt[:]),
 		etcd.WithObserver(observer),
+		etcd.WithLimiter(throttler.LimiterFunc()),
 	)
 
 	return &PersistentState{

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -358,6 +358,28 @@ func (s *EtcdBackup) SetUploadLimitMbps(v uint64) {
 	s.UploadLimitMbps = &v
 }
 
+func (s *EtcdClassWriteRateLimit) GetWriteBytesBurst() uint64 {
+	if s == nil || s.WriteBytesBurst == nil {
+		return *new(uint64)
+	}
+	return *s.WriteBytesBurst
+}
+
+func (s *EtcdClassWriteRateLimit) SetWriteBytesBurst(v uint64) {
+	s.WriteBytesBurst = &v
+}
+
+func (s *EtcdClassWriteRateLimit) GetWriteBytesPerSecond() uint64 {
+	if s == nil || s.WriteBytesPerSecond == nil {
+		return *new(uint64)
+	}
+	return *s.WriteBytesPerSecond
+}
+
+func (s *EtcdClassWriteRateLimit) SetWriteBytesPerSecond(v uint64) {
+	s.WriteBytesPerSecond = &v
+}
+
 func (s *EtcdParams) GetCaFile() string {
 	if s == nil || s.CaFile == nil {
 		return *new(string)
@@ -466,6 +488,17 @@ func (s *EtcdParams) GetRunElections() bool {
 
 func (s *EtcdParams) SetRunElections(v bool) {
 	s.RunElections = &v
+}
+
+func (s *EtcdWriteRateLimits) GetMaxWait() time.Duration {
+	if s == nil || s.MaxWait == nil {
+		return *new(time.Duration)
+	}
+	return *s.MaxWait
+}
+
+func (s *EtcdWriteRateLimits) SetMaxWait(v time.Duration) {
+	s.MaxWait = &v
 }
 
 func (s *EulaAccept) GetEmail() string {

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -1294,7 +1294,8 @@
       "required": [
         "default",
         "vault",
-        "sqlite"
+        "sqlite",
+        "rateLimits"
       ],
       "properties": {
         "default": {
@@ -1308,6 +1309,93 @@
         "sqlite": {
           "description": "Sqlite contains SQLite storage backend configuration. It is used to store machine logs, audit logs, discovery service state, and as the secondary storage for the frequently updated and less critical data.",
           "$ref": "#/definitions/SQLite"
+        },
+        "rateLimits": {
+          "description": "RateLimits contains rate-limit settings for state writes. Today the only gate is etcd-specific (bytes/sec, throttling — see the `etcd` sub-block).",
+          "$ref": "#/definitions/RateLimits"
+        }
+      }
+    },
+    "RateLimits": {
+      "type": "object",
+      "required": [
+        "etcd"
+      ],
+      "properties": {
+        "etcd": {
+          "description": "Etcd contains write rate-limit settings that only apply when the default storage backend is etcd. The bytes/sec gate throttles mutations (Create/Update/Destroy) by marshaled-payload size to protect etcd from revision/storage blowup. Throttling is bounded by the caller's context deadline and by `maxWait`, whichever is shorter.",
+          "$ref": "#/definitions/EtcdWriteRateLimits"
+        }
+      }
+    },
+    "EtcdWriteRateLimits": {
+      "type": "object",
+      "required": [
+        "user",
+        "infraProvider",
+        "internal"
+      ],
+      "description": "EtcdWriteRateLimits contains per-caller-class etcd write-bytes throttle settings plus a shared maxWait cap. Each class's bucket is independent; setting writeBytesPerSecond=0 or writeBytesBurst=0 disables the gate for that class.",
+      "properties": {
+        "maxWait": {
+          "description": "MaxWait is the maximum time a single mutation will block waiting for tokens before failing with DeadlineExceeded. The effective wait is min(ctx.Deadline-now, maxWait). Load-bearing for callers that pass context.Background() — without this cap, a buggy controller could wait indefinitely. 0 means \"no internal cap, rely on ctx deadline alone\" (not recommended).",
+          "x-cli-flag": "storage-rate-limits-etcd-max-wait",
+          "type": "string",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
+          "default": "30s",
+          "goJSONSchema": {
+            "type": "time.Duration",
+            "pointer": true
+          }
+        },
+        "user": {
+          "description": "User contains write-bytes throttle settings for operations performed by end users (authenticated humans and user-owned service accounts).",
+          "$ref": "#/definitions/EtcdClassWriteRateLimit",
+          "properties": {
+            "writeBytesPerSecond": { "x-cli-flag": "storage-rate-limits-etcd-user-write-bytes-per-second" },
+            "writeBytesBurst":     { "x-cli-flag": "storage-rate-limits-etcd-user-write-bytes-burst" }
+          }
+        },
+        "infraProvider": {
+          "description": "InfraProvider contains write-bytes throttle settings for operations performed by infrastructure providers.",
+          "$ref": "#/definitions/EtcdClassWriteRateLimit",
+          "properties": {
+            "writeBytesPerSecond": { "x-cli-flag": "storage-rate-limits-etcd-infra-provider-write-bytes-per-second" },
+            "writeBytesBurst":     { "x-cli-flag": "storage-rate-limits-etcd-infra-provider-write-bytes-burst" }
+          }
+        },
+        "internal": {
+          "description": "Internal contains write-bytes throttle settings for operations performed by Omni's in-process controllers. Throttling internal callers naturally caps controller-driven write storms at the configured budget — see CLAUDE.md for the design rationale.",
+          "$ref": "#/definitions/EtcdClassWriteRateLimit",
+          "properties": {
+            "writeBytesPerSecond": { "x-cli-flag": "storage-rate-limits-etcd-internal-write-bytes-per-second" },
+            "writeBytesBurst":     { "x-cli-flag": "storage-rate-limits-etcd-internal-write-bytes-burst" }
+          }
+        }
+      }
+    },
+    "EtcdClassWriteRateLimit": {
+      "type": "object",
+      "description": "EtcdClassWriteRateLimit defines etcd write-bytes throttle settings for one caller class. Both knobs must be non-zero for the gate to engage.",
+      "properties": {
+        "writeBytesPerSecond": {
+          "description": "WriteBytesPerSecond is the sustained marshaled-payload byte rate allowed for etcd mutations. 0 disables the throttle for this class.",
+          "type": "integer",
+          "minimum": 0,
+          "goJSONSchema": {
+            "type": "uint64",
+            "pointer": true
+          }
+        },
+        "writeBytesBurst": {
+          "description": "WriteBytesBurst is the maximum byte burst allowed above WriteBytesPerSecond. Must be at least the size of the single largest mutation, otherwise that mutation will never admit. 0 disables the throttle for this class.",
+          "type": "integer",
+          "minimum": 0,
+          "goJSONSchema": {
+            "type": "uint64",
+            "pointer": true
+          }
         }
       }
     },

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -192,6 +192,19 @@ type EtcdBackup struct {
 	UploadLimitMbps *uint64 `json:"uploadLimitMbps,omitempty,omitzero" yaml:"uploadLimitMbps,omitempty"`
 }
 
+// EtcdClassWriteRateLimit defines etcd write-bytes throttle settings for one
+// caller class. Both knobs must be non-zero for the gate to engage.
+type EtcdClassWriteRateLimit struct {
+	// WriteBytesBurst is the maximum byte burst allowed above WriteBytesPerSecond.
+	// Must be at least the size of the single largest mutation, otherwise that
+	// mutation will never admit. 0 disables the throttle for this class.
+	WriteBytesBurst *uint64 `json:"writeBytesBurst,omitempty,omitzero" yaml:"writeBytesBurst,omitempty"`
+
+	// WriteBytesPerSecond is the sustained marshaled-payload byte rate allowed for
+	// etcd mutations. 0 disables the throttle for this class.
+	WriteBytesPerSecond *uint64 `json:"writeBytesPerSecond,omitempty,omitzero" yaml:"writeBytesPerSecond,omitempty"`
+}
+
 type EtcdParams struct {
 	// CaFile is the path to the CA certificate file for etcd client connections.
 	CaFile *string `json:"caFile,omitempty,omitzero" yaml:"caFile,omitempty"`
@@ -233,6 +246,33 @@ type EtcdParams struct {
 	// RunElections controls whether the embedded etcd server should run leader
 	// elections. Should be false for single-node Omni installations.
 	RunElections *bool `json:"runElections,omitempty,omitzero" yaml:"runElections,omitempty"`
+}
+
+// EtcdWriteRateLimits contains per-caller-class etcd write-bytes throttle settings
+// plus a shared maxWait cap. Each class's bucket is independent; setting
+// writeBytesPerSecond=0 or writeBytesBurst=0 disables the gate for that class.
+type EtcdWriteRateLimits struct {
+	// InfraProvider contains write-bytes throttle settings for operations performed
+	// by infrastructure providers.
+	InfraProvider EtcdClassWriteRateLimit `json:"infraProvider" yaml:"infraProvider"`
+
+	// Internal contains write-bytes throttle settings for operations performed by
+	// Omni's in-process controllers. Throttling internal callers naturally caps
+	// controller-driven write storms at the configured budget — see CLAUDE.md for the
+	// design rationale.
+	Internal EtcdClassWriteRateLimit `json:"internal" yaml:"internal"`
+
+	// MaxWait is the maximum time a single mutation will block waiting for tokens
+	// before failing with DeadlineExceeded. The effective wait is
+	// min(ctx.Deadline-now, maxWait). Load-bearing for callers that pass
+	// context.Background() — without this cap, a buggy controller could wait
+	// indefinitely. 0 means "no internal cap, rely on ctx deadline alone" (not
+	// recommended).
+	MaxWait *time.Duration `json:"maxWait,omitempty,omitzero" yaml:"maxWait,omitempty"`
+
+	// User contains write-bytes throttle settings for operations performed by end
+	// users (authenticated humans and user-owned service accounts).
+	User EtcdClassWriteRateLimit `json:"user" yaml:"user"`
 }
 
 type EulaAccept struct {
@@ -544,6 +584,15 @@ type Params struct {
 	Support Support `json:"support" yaml:"support"`
 }
 
+type RateLimits struct {
+	// Etcd contains write rate-limit settings that only apply when the default
+	// storage backend is etcd. The bytes/sec gate throttles mutations
+	// (Create/Update/Destroy) by marshaled-payload size to protect etcd from
+	// revision/storage blowup. Throttling is bounded by the caller's context deadline
+	// and by `maxWait`, whichever is shorter.
+	Etcd EtcdWriteRateLimits `json:"etcd" yaml:"etcd"`
+}
+
 type Registries struct {
 	// ImageFactoryBaseURL is the base URL of the Image Factory service used to build
 	// custom machine images.
@@ -769,6 +818,10 @@ type SiderolinkWireGuard struct {
 type Storage struct {
 	// Default contains the default storage backend configuration.
 	Default StorageDefault `json:"default" yaml:"default"`
+
+	// RateLimits contains rate-limit settings for state writes. Today the only gate
+	// is etcd-specific (bytes/sec, throttling — see the `etcd` sub-block).
+	RateLimits RateLimits `json:"rateLimits" yaml:"rateLimits"`
 
 	// Sqlite contains SQLite storage backend configuration. It is used to store
 	// machine logs, audit logs, discovery service state, and as the secondary storage


### PR DESCRIPTION
Throttle etcd writes by payload size, with independent budgets for end users, infra providers, and internal callers. Off by default, can be enabled via storage.rateLimits.etcd.*.

Exposes four new Prometheus series, all labeled by class:
  - omni_etcd_write_throttle_wait_seconds (histogram): time spent waiting for budget
  - omni_etcd_write_throttle_admitted_total: writes that got through after throttling
  - omni_etcd_write_throttle_failed_total: writes that timed out waiting
  - omni_etcd_write_throttle_failed_bytes_total: bytes of writes that timed out

Resolves: #2734, #2737 and #2736
