### PR TITLE
feat(frontend): add some feedback when omni is loading

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,11 @@
         to continue.
       </strong>
     </noscript>
-    <div id="app"></div>
+    <div id="app">
+      <div class="flex h-screen flex-col items-center justify-center">
+        <span class="animate-pulse delay-3000" style="opacity: 0">Loading Omni ...</span>
+      </div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/frontend/src/AppUnavailable.vue
+++ b/frontend/src/AppUnavailable.vue
@@ -4,15 +4,23 @@ Copyright (c) 2026 Sidero Labs, Inc.
 Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
+<script lang="ts">
+import { ref } from 'vue'
+
+export const appUnavailableError = ref<Error>()
+</script>
+
 <script setup lang="ts">
 import TIcon from '@/components/Icon/TIcon.vue'
+import TAlert from '@/components/TAlert.vue'
 import THeader from '@/components/THeader/THeader.vue'
 </script>
 
 <template>
   <div class="flex min-h-screen flex-col">
     <THeader />
-    <div class="flex flex-1 flex-col items-center justify-center">
+
+    <div class="flex flex-1 flex-col items-center justify-center gap-4">
       <div class="flex gap-4 rounded-lg bg-naturals-n6 px-6 py-4 drop-shadow-md">
         <TIcon icon="warning" class="h-12 w-12 fill-current text-naturals-n14" />
         <div class="flex flex-col text-naturals-n13">
@@ -24,6 +32,10 @@ import THeader from '@/components/THeader/THeader.vue'
           </div>
         </div>
       </div>
+
+      <TAlert v-if="appUnavailableError" type="error" title="Error">
+        {{ appUnavailableError.message }}
+      </TAlert>
     </div>
   </div>
 </template>

--- a/frontend/src/api/options.ts
+++ b/frontend/src/api/options.ts
@@ -2,6 +2,8 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
+import { formatDuration, intervalToDuration } from 'date-fns'
+
 import type { OmniRequestOptions } from '@/methods/interceptor'
 
 import { Runtime } from './common/omni.pb'
@@ -72,8 +74,13 @@ export const withTimeout = (timeout: number) => {
       req.controller = controller
     }
 
-    window.setTimeout(() => {
-      req.controller?.abort()
+    req.timeoutID = window.setTimeout(() => {
+      const duration =
+        timeout >= 1_000
+          ? formatDuration(intervalToDuration({ start: 0, end: timeout }))
+          : `${timeout}ms`
+
+      req.controller?.abort(new Error(`Request timed out after ${duration}`))
     }, timeout)
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,7 +8,6 @@ import '@/index.css'
 import { createAuth0 } from '@auth0/auth0-vue'
 import { milliseconds, millisecondsToSeconds } from 'date-fns'
 import { createApp } from 'vue'
-import { handleHotUpdate } from 'vue-router/auto-routes'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { RequestError } from '@/api/fetch.pb'
@@ -24,39 +23,13 @@ import {
   EulaAcceptanceType,
 } from '@/api/resources'
 import App from '@/App.vue'
-import AppUnavailable from '@/AppUnavailable.vue'
+import AppUnavailable, { appUnavailableError } from '@/AppUnavailable.vue'
 import { AuthType, authType, eulaAccepted, suspended } from '@/methods'
 import router from '@/router'
 
-import { withRuntime } from './api/options'
+import { withRuntime, withTimeout } from './api/options'
 
-// This will update routes at runtime without reloading the page
-if (import.meta.hot) {
-  handleHotUpdate(router)
-}
-
-const setupApp = async () => {
-  let authConfigSpec: AuthConfigSpec | undefined = undefined
-
-  try {
-    const authConfig: Resource<AuthConfigSpec> = await ResourceService.Get(
-      {
-        namespace: DefaultNamespace,
-        type: AuthConfigType,
-        id: AuthConfigID,
-      },
-      withRuntime(Runtime.Omni),
-    )
-
-    authConfigSpec = authConfig?.spec as AuthConfigSpec | undefined
-  } catch (e) {
-    console.error('failed to get auth parameters', e)
-    createApp(AppUnavailable).mount('#app')
-    return
-  }
-
-  suspended.value = authConfigSpec?.suspended ?? false
-
+async function getEulaAccepted(): Promise<boolean> {
   try {
     await ResourceService.Get<Resource<EulaAcceptanceSpec>>(
       {
@@ -65,40 +38,61 @@ const setupApp = async () => {
         id: EulaAcceptanceID,
       },
       withRuntime(Runtime.Omni),
+      withTimeout(10_000),
     )
-    eulaAccepted.value = true
+    return true
   } catch (e) {
-    if ((e as RequestError)?.code !== Code.NOT_FOUND) {
-      console.error('failed to get eula state', e)
-      createApp(AppUnavailable).mount('#app')
-      return
-    }
+    if ((e as RequestError)?.code === Code.NOT_FOUND) return false
+    throw e
+  }
+}
 
-    eulaAccepted.value = false
+async function setupApp() {
+  let authConfig: Resource<AuthConfigSpec>
+
+  try {
+    ;[authConfig, eulaAccepted.value] = await Promise.all([
+      ResourceService.Get<Resource<AuthConfigSpec>>(
+        {
+          namespace: DefaultNamespace,
+          type: AuthConfigType,
+          id: AuthConfigID,
+        },
+        withRuntime(Runtime.Omni),
+        withTimeout(10_000),
+      ),
+      getEulaAccepted(),
+    ])
+  } catch (e) {
+    appUnavailableError.value = new Error(
+      `Failed to load Omni configuration: ${e instanceof Error ? e.message : String(e)}`,
+    )
+    createApp(AppUnavailable).mount('#app')
+    return
   }
 
-  if (authConfigSpec?.saml?.enabled) {
-    authType.value = AuthType.SAML
-  } else if (authConfigSpec?.oidc?.enabled) {
-    authType.value = AuthType.OIDC
-  } else if (authConfigSpec?.auth0?.enabled) {
+  suspended.value = !!authConfig.spec.suspended
+
+  const app = createApp(App).use(router)
+
+  if (authConfig.spec.auth0?.enabled) {
     authType.value = AuthType.Auth0
-  }
 
-  let app = createApp(App).use(router)
-
-  if (authType.value === AuthType.Auth0) {
-    app = app.use(
+    app.use(
       createAuth0({
-        domain: authConfigSpec!.auth0!.domain!,
-        clientId: authConfigSpec!.auth0!.client_id!,
+        domain: authConfig.spec.auth0.domain!,
+        clientId: authConfig.spec.auth0.client_id!,
         authorizationParams: {
           redirect_uri: window.location.origin,
           max_age: millisecondsToSeconds(milliseconds({ minutes: 2 })),
         },
-        useFormData: !!authConfigSpec!.auth0?.useFormData,
+        useFormData: !!authConfig.spec.auth0.useFormData,
       }),
     )
+  } else if (authConfig.spec.saml?.enabled) {
+    authType.value = AuthType.SAML
+  } else if (authConfig.spec.oidc?.enabled) {
+    authType.value = AuthType.OIDC
   }
 
   app.mount('#app')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -7,6 +7,7 @@ import { authGuard } from '@auth0/auth0-vue'
 import { Userpilot } from 'userpilot'
 import { createRouter, createWebHistory, type RouteRecordRedirect } from 'vue-router'
 import { routes } from 'vue-router/auto-routes'
+import { handleHotUpdate } from 'vue-router/auto-routes'
 
 import { AuthFlowQueryParam, FrontendAuthFlow, RedirectQueryParam } from '@/api/resources'
 import { AuthType, authType, eulaAccepted } from '@/methods'
@@ -81,5 +82,10 @@ router.beforeEach(async (to) => {
     }
   }
 })
+
+// This will update routes at runtime without reloading the page
+if (import.meta.hot) {
+  handleHotUpdate(router)
+}
 
 export default router


### PR DESCRIPTION
When Omni is loading, if things take a bit longer than expected, show a loading message. If it takes too long, timeout with an error. Whatever the reason, if an error occurs resulting in AppUnavailable to be shown, show the error on screen to the user.

Loading (only shown if 3s in this state):
<img width="1591" height="1044" alt="image" src="https://github.com/user-attachments/assets/7afb29bc-02fb-40b6-a5ae-bbb2d686d550" />

Error (in this case, timed out after 10s which is a newly added timeout):
<img width="1615" height="1029" alt="image" src="https://github.com/user-attachments/assets/897cca86-dc12-4f19-9459-d5114c930ed2" />
