### PR TITLE
fix: getting versions from registry with auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 
 require (
 	cel.dev/expr v0.25.1 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	filippo.io/hpke v0.4.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+N
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 filippo.io/age v1.3.1 h1:hbzdQOJkuaMEpRCLSN1/C5DX74RPcNCk6oqhKMXmZi0=

--- a/internal/pkg/registry/registry.go
+++ b/internal/pkg/registry/registry.go
@@ -8,21 +8,35 @@ package registry
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/authn/github"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-// UpgradeCandidates fetches release tags from the Github.
+// UpgradeCandidates fetches all tags from the given container registry source and returns them as a list of strings.
 func UpgradeCandidates(ctx context.Context, source string) ([]string, error) {
 	repo, err := name.NewRepository(source)
 	if err != nil {
 		return nil, err
 	}
 
-	tags, err := remote.List(repo, remote.WithContext(ctx))
+	tags, err := remote.List(
+		repo,
+		remote.WithContext(ctx),
+		remote.WithAuthFromKeychain(
+			authn.NewMultiKeychain(
+				authn.DefaultKeychain,
+				github.Keychain,
+				google.Keychain,
+			),
+		),
+	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fetching tags from registry %s: %w", repo.String(), err)
 	}
 
 	return tags, nil


### PR DESCRIPTION
Supports docker config, github token and google auth.

Fixes: #2882