### PR TITLE
feat(frontend): move editing logic for kernel args into a modal

### DIFF
--- a/frontend/src/views/Machines/EditKernelArgsModal.vue
+++ b/frontend/src/views/Machines/EditKernelArgsModal.vue
@@ -1,0 +1,138 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import { Code } from '@/api/google/rpc/code.pb'
+import { type Resource, ResourceService } from '@/api/grpc'
+import type { KernelArgsSpec, KernelArgsStatusSpec } from '@/api/omni/specs/omni.pb'
+import { withRuntime } from '@/api/options'
+import { DefaultNamespace, KernelArgsType } from '@/api/resources'
+import ManagedByTemplatesWarning from '@/components/ManagedByTemplatesWarning.vue'
+import Modal from '@/components/Modals/Modal.vue'
+import TInput from '@/components/TInput/TInput.vue'
+import { showError, showSuccess } from '@/notification'
+
+const { machineId, kernelArgs, kernelArgsStatus } = defineProps<{
+  machineId: string
+  kernelArgs?: Resource<KernelArgsSpec>
+  kernelArgsStatus?: Resource<KernelArgsStatusSpec>
+}>()
+
+const unmetConditions = computed(() => kernelArgsStatus?.spec.unmet_conditions)
+const initialArgs = computed(() => kernelArgs?.spec.args?.map((arg) => arg.trim()).join(' ') ?? '')
+
+const open = defineModel<boolean>('open', { default: false })
+const args = ref('')
+
+watch([open, initialArgs], () => (args.value = initialArgs.value))
+
+async function confirm() {
+  try {
+    await updateKernelArgs()
+  } catch (e) {
+    showError('Failed to Update Kernel Args', e.message)
+    return
+  }
+
+  open.value = false
+  showSuccess('Kernel args are updated')
+}
+
+async function updateKernelArgs() {
+  const argsSplit = args.value
+    .trim()
+    .split(' ')
+    .filter((arg) => arg.trim() !== '')
+
+  const emptyArgs = argsSplit.length === 0
+
+  if (!kernelArgs && emptyArgs) return
+
+  if (emptyArgs) {
+    try {
+      await ResourceService.Delete(
+        {
+          id: machineId,
+          namespace: DefaultNamespace,
+          type: KernelArgsType,
+        },
+        withRuntime(Runtime.Omni),
+      )
+    } catch (e) {
+      if (e.code === Code.NOT_FOUND) return
+
+      throw e
+    }
+
+    return
+  }
+
+  if (!kernelArgs) {
+    await ResourceService.Create(
+      {
+        metadata: {
+          id: machineId,
+          namespace: DefaultNamespace,
+          type: KernelArgsType,
+        },
+        spec: {
+          args: argsSplit,
+        },
+      },
+      withRuntime(Runtime.Omni),
+    )
+
+    return
+  }
+
+  await ResourceService.Update(
+    {
+      ...kernelArgs,
+      spec: {
+        ...kernelArgs.spec,
+        args: argsSplit,
+      },
+    },
+    kernelArgs.metadata.version,
+    withRuntime(Runtime.Omni),
+  )
+}
+</script>
+
+<template>
+  <Modal
+    v-model:open="open"
+    title="Edit Extra Kernel Args"
+    action-label="Save"
+    :action-disabled="args === initialArgs"
+    @confirm="confirm"
+  >
+    <ManagedByTemplatesWarning :resource="kernelArgs" />
+
+    <div class="flex flex-col gap-6">
+      <div v-if="unmetConditions?.length" class="flex flex-col gap-2">
+        <div class="font-bold text-primary-p3">
+          Kernel args won't be updated immediately, there are unmet conditions
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <span
+            v-for="(condition, index) in unmetConditions"
+            :key="index"
+            class="my-0.5 rounded border-l-3 border-l-yellow-y1 bg-naturals-n5 py-1 pl-3 text-xs text-naturals-n13"
+          >
+            {{ condition }}
+          </span>
+        </div>
+      </div>
+
+      <TInput v-model="args" class="h-full flex-1 font-mono" placeholder="none" />
+    </div>
+  </Modal>
+</template>

--- a/frontend/src/views/Machines/MachineKernelArgs.vue
+++ b/frontend/src/views/Machines/MachineKernelArgs.vue
@@ -5,27 +5,22 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import { Code } from '@/api/google/rpc/code.pb'
-import { ResourceService } from '@/api/grpc'
 import { type KernelArgsSpec, type KernelArgsStatusSpec } from '@/api/omni/specs/omni.pb'
-import { withRuntime } from '@/api/options'
 import { DefaultNamespace, KernelArgsStatusType, KernelArgsType } from '@/api/resources'
 import IconButton from '@/components/Button/IconButton.vue'
-import TButton from '@/components/Button/TButton.vue'
-import ManagedByTemplatesWarning from '@/components/ManagedByTemplatesWarning.vue'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
-import TInput from '@/components/TInput/TInput.vue'
+import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
-import { showError, showSuccess } from '@/notification'
+import EditKernelArgsModal from '@/views/Machines/EditKernelArgsModal.vue'
 
 const { machine } = defineProps<{
   machine: string
 }>()
 
-const args = ref('')
+const editKernelArgsModalOpen = ref(false)
 
 const { data: status } = useResourceWatch<KernelArgsStatusSpec>(() => ({
   runtime: Runtime.Omni,
@@ -36,16 +31,6 @@ const { data: status } = useResourceWatch<KernelArgsStatusSpec>(() => ({
   },
 }))
 
-const currentArgs = computed(() => {
-  return status.value?.spec.current_args?.join(' ') || ''
-})
-const currentCmdline = computed(() => {
-  return status.value?.spec.current_cmdline || ''
-})
-const unmetConditions = computed(() => {
-  return status.value?.spec.unmet_conditions || []
-})
-
 const { data: kernelArgs } = useResourceWatch<KernelArgsSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
@@ -55,137 +40,37 @@ const { data: kernelArgs } = useResourceWatch<KernelArgsSpec>(() => ({
   },
 }))
 
-const initialArgs = computed(
-  () => kernelArgs.value?.spec.args?.map((arg) => arg.trim()).join(' ') ?? '',
-)
-
-watch(initialArgs, () => (args.value = initialArgs.value))
-
-const handleUpdateKernelArgs = async () => {
-  try {
-    await updateKernelArgs()
-  } catch (e) {
-    showError(`Failed to Update Kernel Args`, e.message)
-
-    return
-  }
-
-  editArgs.value = false
-  showSuccess(`Kernel args are updated`)
-
-  close()
-}
-
-const updateKernelArgs = async () => {
-  const argsSplit = args.value
-    .trim()
-    .split(' ')
-    .filter((arg) => arg.trim() !== '')
-  const emptyArgs = argsSplit.length === 0
-
-  if (!kernelArgs.value && emptyArgs) {
-    return
-  }
-
-  if (emptyArgs) {
-    try {
-      await ResourceService.Delete(
-        {
-          id: machine,
-          namespace: DefaultNamespace,
-          type: KernelArgsType,
-        },
-        withRuntime(Runtime.Omni),
-      )
-    } catch (e) {
-      if (e.code === Code.NOT_FOUND) {
-        return
-      }
-
-      throw e
-    }
-
-    return
-  }
-
-  if (!kernelArgs.value) {
-    await ResourceService.Create(
-      {
-        metadata: {
-          id: machine,
-          namespace: DefaultNamespace,
-          type: KernelArgsType,
-        },
-        spec: {
-          args: argsSplit,
-        },
-      },
-      withRuntime(Runtime.Omni),
-    )
-
-    return
-  }
-
-  kernelArgs.value.spec.args = argsSplit
-
-  await ResourceService.Update(
-    kernelArgs.value,
-    kernelArgs.value.metadata.version,
-    withRuntime(Runtime.Omni),
-  )
-}
-
-const editArgs = ref(false)
+const currentArgs = computed(() => status.value?.spec.current_args?.join(' ') ?? '')
+const currentCmdline = computed(() => status.value?.spec.current_cmdline ?? '')
 </script>
 
 <template>
   <PageContainer class="flex flex-col gap-2">
-    <h3 class="text-base text-naturals-n14">Update Kernel Args of Machine {{ machine }}</h3>
-
-    <ManagedByTemplatesWarning :resource="kernelArgs" />
-
-    <template v-if="unmetConditions.length > 0">
-      <div class="font-bold text-primary-p3">
-        Kernel args won't be updated immediately, there are unmet conditions
-      </div>
-      <div class="flex flex-col">
-        <span
-          v-for="(condition, index) in unmetConditions"
-          :key="index"
-          class="my-0.5 rounded border-l-3 border-l-yellow-y1 bg-naturals-n5 py-1 pl-3 text-xs text-naturals-n13"
-        >
-          {{ condition }}
-        </span>
-      </div>
-    </template>
-
     <div class="text-sm font-semibold text-naturals-n14">Current Kernel Cmdline</div>
     <code class="rounded bg-naturals-n6 px-2.5 py-2 font-mono text-xs text-naturals-n13">
       {{ currentCmdline || 'none' }}
     </code>
-    <template v-if="!editArgs">
-      <div class="text-sm font-semibold text-naturals-n14">Current Kernel Args</div>
-      <div class="my-0.5 flex items-center gap-2 rounded bg-naturals-n6 pr-2">
-        <code class="flex-1 rounded bg-naturals-n6 px-2.5 py-2 font-mono text-xs text-naturals-n13">
-          {{ currentArgs || 'none' }}
-        </code>
-        <IconButton
-          v-if="currentArgs === initialArgs"
-          icon="edit"
-          @click="() => (editArgs = true)"
-        />
-      </div>
-    </template>
 
-    <template v-if="currentArgs !== initialArgs || editArgs">
-      <div class="text-sm font-semibold text-naturals-n14">New Kernel Args</div>
-      <div class="flex flex-wrap items-center gap-2">
-        <TInput v-model="args" class="h-full flex-1 font-mono" placeholder="none" />
-        <TButton v-if="editArgs" class="h-9 w-32" @click="() => (editArgs = false)">Cancel</TButton>
-        <TButton variant="highlighted" class="h-9 w-32" @click="handleUpdateKernelArgs">
-          Update
-        </TButton>
-      </div>
-    </template>
+    <div class="text-sm font-semibold text-naturals-n14">Extra Kernel Args</div>
+    <div class="my-0.5 flex items-center gap-2 rounded bg-naturals-n6 pr-2">
+      <code class="flex-1 rounded bg-naturals-n6 px-2.5 py-2 font-mono text-xs text-naturals-n13">
+        {{ currentArgs || 'none' }}
+      </code>
+
+      <Tooltip description="Edit Extra Kernel Args">
+        <IconButton
+          aria-label="Edit Extra Kernel Args"
+          icon="edit"
+          @click="editKernelArgsModalOpen = true"
+        />
+      </Tooltip>
+    </div>
+
+    <EditKernelArgsModal
+      v-model:open="editKernelArgsModalOpen"
+      :machine-id="machine"
+      :kernel-args
+      :kernel-args-status="status"
+    />
   </PageContainer>
 </template>


### PR DESCRIPTION
Move editing logic for kernel args into a modal, and rename current args to extra kernel args, which is more clear.