### PR TITLE
feat(frontend): add improvements to disks view

### DIFF
--- a/frontend/src/views/Machines/MachineDisks.stories.ts
+++ b/frontend/src/views/Machines/MachineDisks.stories.ts
@@ -224,6 +224,224 @@ export const WithEmptyVolume: Story = {
   },
 }
 
+export const WithCdrom: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<TalosDiskSpec>({
+          expectedOptions: {
+            namespace: TalosRuntimeNamespace,
+            type: TalosDiskType,
+          },
+          initialResources: [
+            {
+              metadata: {
+                id: 'sr0',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiskType,
+              },
+              spec: {
+                cdrom: true,
+                dev_path: '/dev/sr0',
+                pretty_size: '750 MB',
+                size: 786432000,
+                readonly: true,
+                transport: 'ata',
+              },
+            },
+            {
+              // Empty CD-ROM: should be hidden from the view
+              metadata: {
+                id: 'sr1',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiskType,
+              },
+              spec: {
+                cdrom: true,
+                dev_path: '/dev/sr1',
+                pretty_size: '0 B',
+                size: 0,
+                readonly: true,
+              },
+            },
+          ],
+        }).handler,
+
+        createWatchStreamHandler<TalosDiscoveredVolumeSpec>({
+          expectedOptions: {
+            namespace: TalosRuntimeNamespace,
+            type: TalosDiscoveredVolumeType,
+          },
+          initialResources: [
+            {
+              // Non-empty CDROM: name is set, so it is shown.
+              metadata: {
+                id: 'sr0',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiscoveredVolumeType,
+              },
+              spec: {
+                dev_path: '/dev/sr0',
+                name: 'iso9660',
+                pretty_size: '750 MB',
+                size: 786432000,
+                type: 'disk',
+              },
+            },
+            {
+              // Empty CDROM: name is "" — Talos always creates the volume entry
+              // but leaves name blank when no media is present. This disk should
+              // be hidden from the view.
+              metadata: {
+                id: 'sr1',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiscoveredVolumeType,
+              },
+              spec: {
+                dev_path: '/dev/sr1',
+                name: '',
+                pretty_size: '0 B',
+                size: 0,
+                type: 'disk',
+              },
+            },
+          ],
+        }).handler,
+
+        createWatchStreamHandler<TalosVolumeStatusSpec>({
+          expectedOptions: {
+            namespace: TalosRuntimeNamespace,
+            type: TalosVolumeStatusType,
+          },
+          initialResources: [],
+        }).handler,
+      ],
+    },
+  },
+}
+
+export const WithLuksEncryption: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<TalosDiskSpec>({
+          expectedOptions: {
+            namespace: TalosRuntimeNamespace,
+            type: TalosDiskType,
+          },
+          initialResources: [
+            {
+              metadata: {
+                id: 'vda',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiskType,
+              },
+              spec: {
+                dev_path: '/dev/vda',
+                pretty_size: '20 GB',
+                size: 21474836480,
+                transport: 'virtio',
+              },
+            },
+            {
+              // Device-mapper device for the open LUKS container — should be
+              // filtered out and NOT rendered as a top-level disk.
+              metadata: {
+                id: 'dm-0',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiskType,
+              },
+              spec: {
+                dev_path: '/dev/dm-0',
+                pretty_size: '104 MB',
+                size: 104857600,
+              },
+            },
+          ],
+        }).handler,
+
+        createWatchStreamHandler<TalosDiscoveredVolumeSpec>({
+          expectedOptions: {
+            namespace: TalosRuntimeNamespace,
+            type: TalosDiscoveredVolumeType,
+          },
+          initialResources: [
+            {
+              metadata: {
+                id: 'vda1',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiscoveredVolumeType,
+              },
+              spec: {
+                dev_path: '/dev/vda1',
+                name: 'vfat',
+                parent: 'vda',
+                partition_index: 1,
+                partition_label: 'EFI',
+                pretty_size: '105 MB',
+                size: 105906176,
+                type: 'partition',
+              },
+            },
+            {
+              // LUKS-encrypted partition: name is 'luks2' in the raw discovered
+              // volume, but VolumeStatus provides the inner filesystem (xfs).
+              metadata: {
+                id: 'vda2',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiscoveredVolumeType,
+              },
+              spec: {
+                dev_path: '/dev/vda2',
+                name: 'luks2',
+                parent: 'vda',
+                partition_index: 2,
+                partition_label: 'EPHEMERAL',
+                pretty_size: '19 GB',
+                size: 20265148416,
+                type: 'partition',
+              },
+            },
+          ],
+        }).handler,
+
+        createWatchStreamHandler<TalosVolumeStatusSpec>({
+          expectedOptions: {
+            namespace: TalosRuntimeNamespace,
+            type: TalosVolumeStatusType,
+          },
+          initialResources: [
+            {
+              metadata: {
+                id: 'EPHEMERAL',
+                namespace: TalosRuntimeNamespace,
+                type: TalosVolumeStatusType,
+              },
+              spec: {
+                configuredEncryptionKeys: ['static'],
+                encryptionProvider: 'luks2',
+                encryptionSlot: 0,
+                filesystem: 'xfs',
+                location: '/dev/vda2',
+                mountLocation: '/dev/dm-0',
+                mountSpec: {
+                  targetPath: '/var',
+                },
+                parentLocation: '/dev/vda',
+                partitionIndex: 2,
+                phase: 'ready',
+                prettySize: '19 GB',
+                size: 20265148416,
+                type: 'partition',
+              },
+            },
+          ],
+        }).handler,
+      ],
+    },
+  },
+}
+
 export const NoData: Story = {
   parameters: {
     msw: {

--- a/frontend/src/views/Machines/MachineDisks.vue
+++ b/frontend/src/views/Machines/MachineDisks.vue
@@ -157,7 +157,14 @@ const errCode = computed(
 
 const organizedDisks = computed(() =>
   disks.value
-    .filter((d) => !d.metadata.id?.startsWith('loop'))
+    .filter(
+      (d) =>
+        !d.metadata.id?.startsWith('loop') &&
+        // Device-mapper devices (dm-N) are synthetic kernel block devices created for
+        // things like LUKS encryption. They are represented through their parent
+        // partition's VolumeStatus and should not appear as top-level disk entries.
+        !d.metadata.id?.startsWith('dm-'),
+    )
     .map((disk) => ({
       disk,
       partitions: volumes.value
@@ -169,7 +176,10 @@ const organizedDisks = computed(() =>
         .sort(
           (a, b) => (a.volume.spec.partition_index || 0) - (b.volume.spec.partition_index || 0),
         ),
-    })),
+    }))
+    // Hide empty CD-ROMs. Talos always creates a DiscoveredVolume for a CDROM
+    // drive but leaves `name` (filesystem type) as "" when no media is present.
+    .filter((d) => !d.disk.spec.cdrom || d.partitions.some((p) => p.volume.spec.name)),
 )
 </script>
 
@@ -209,6 +219,12 @@ const organizedDisks = computed(() =>
               {{ diskInfo.disk.spec.pretty_size }}
             </span>
             <div class="flex items-center gap-2">
+              <span
+                v-if="diskInfo.disk.spec.cdrom"
+                class="rounded bg-naturals-n5 px-2 py-1 text-xs text-naturals-n13"
+              >
+                CD-ROM
+              </span>
               <span
                 v-if="diskInfo.disk.spec.transport"
                 class="rounded bg-naturals-n5 px-2 py-1 text-xs text-naturals-n13"

--- a/frontend/src/views/Nodes/components/DiskPartitionTable.vue
+++ b/frontend/src/views/Nodes/components/DiskPartitionTable.vue
@@ -34,7 +34,19 @@ const getFilesystemIcon = (fsType?: string): IconType => {
   const lower = fsType.toLowerCase()
   if (lower.includes('xfs') || lower.includes('ext')) return 'server'
   if (lower.includes('vfat') || lower.includes('fat')) return 'cpu-chip'
+  if (lower.includes('luks')) return 'locked'
   return 'document'
+}
+
+const getEffectiveFilesystem = (
+  volume: Resource<TalosDiscoveredVolumeSpec>,
+  volumeStatus?: Resource<TalosVolumeStatusSpec>,
+): string => {
+  // When encryption is active, the DV name is luks, but we want to show the actual filesystem
+  if (volumeStatus?.spec.encryptionProvider && volumeStatus.spec.filesystem) {
+    return volumeStatus.spec.filesystem
+  }
+  return volume.spec.name || volumeStatus?.spec.filesystem || 'N/A'
 }
 
 const isEncrypted = (item?: Resource<TalosVolumeStatusSpec>) => {
@@ -91,7 +103,7 @@ const getEncryptionIcon = (item?: Resource<TalosVolumeStatusSpec>): IconType => 
           <TableCell>
             <div class="flex items-center gap-2">
               <TIcon
-                :icon="getFilesystemIcon(volume.spec.name || volumeStatus?.spec.filesystem)"
+                :icon="getFilesystemIcon(getEffectiveFilesystem(volume, volumeStatus))"
                 class="size-4 shrink-0 text-naturals-n14"
               />
 
@@ -111,7 +123,7 @@ const getEncryptionIcon = (item?: Resource<TalosVolumeStatusSpec>): IconType => 
           </TableCell>
 
           <TableCell class="font-medium">
-            {{ volume.spec.name || volumeStatus?.spec.filesystem || 'N/A' }}
+            {{ getEffectiveFilesystem(volume, volumeStatus) }}
           </TableCell>
 
           <TableCell>

--- a/frontend/src/views/Nodes/components/DiskUsageBar.vue
+++ b/frontend/src/views/Nodes/components/DiskUsageBar.vue
@@ -41,6 +41,7 @@ const getVolumeClass = (volume: Resource<TalosDiscoveredVolumeSpec>) => {
   if (label?.includes('boot')) return 'bg-orange-500'
   if (label?.includes('state')) return 'bg-purple-500'
   if (label?.includes('ephemeral')) return 'bg-blue-500'
+  if (fsType?.includes('luks')) return 'bg-indigo-500'
   if (fsType?.includes('xfs') || fsType?.includes('ext')) return 'bg-green-600'
   if (fsType?.includes('vfat') || fsType?.includes('fat')) return 'bg-yellow-600'
   if (fsType?.includes('swap')) return 'bg-red-500'


### PR DESCRIPTION
Filter out empty CD-ROMs from machine disks, hide device mapper entries for encrypted volumes, fix file system display for luks partitions, add a colour for luks partitions, and show a CD-ROM label in the header.
