### PR TITLE
feat(frontend): allow changing config diff sort order

### DIFF
--- a/frontend/src/components/DiffRenderer/DiffRenderer.vue
+++ b/frontend/src/components/DiffRenderer/DiffRenderer.vue
@@ -92,23 +92,34 @@ function measureElement(el?: Element | ComponentPublicInstance | null) {
 
 <template>
   <div class="flex h-full flex-col gap-4">
-    <div v-if="withSearch" class="flex items-center gap-2">
-      <TInput v-model.trim="search" title="Search" class="grow" @keydown.enter="nextMatch" />
+    <div v-if="withSearch || $slots['extra-controls']" class="flex items-center gap-2">
+      <slot
+        name="extra-controls"
+        :search
+        :matched-lines="matchedLines"
+        :current-match-index="currentMatchIndex"
+        :next-match="nextMatch"
+        :prev-match="prevMatch"
+      />
 
-      <div class="flex gap-1">
-        <IconButton
-          :disabled="!matchedLines.length"
-          icon="arrow-up"
-          aria-label="Previous match"
-          @click="prevMatch"
-        />
-        <IconButton
-          :disabled="!matchedLines.length"
-          icon="arrow-down"
-          aria-label="Next match"
-          @click="nextMatch"
-        />
-      </div>
+      <template v-if="withSearch">
+        <TInput v-model.trim="search" title="Search" class="grow" @keydown.enter="nextMatch" />
+
+        <div class="flex gap-1">
+          <IconButton
+            :disabled="!matchedLines.length"
+            icon="arrow-up"
+            aria-label="Previous match"
+            @click="prevMatch"
+          />
+          <IconButton
+            :disabled="!matchedLines.length"
+            icon="arrow-down"
+            aria-label="Next match"
+            @click="nextMatch"
+          />
+        </div>
+      </template>
     </div>
 
     <div ref="scrollContainerRef" class="min-h-0 flex-1 overflow-y-auto font-mono text-sm/relaxed">

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/config-diffs.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/config-diffs.vue
@@ -5,7 +5,8 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed } from 'vue'
+import { compareAsc, compareDesc, parseISO } from 'date-fns'
+import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -13,6 +14,7 @@ import type { MachineConfigDiffSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, LabelMachine, MachineConfigDiffType } from '@/api/resources'
 import DiffRenderer from '@/components/DiffRenderer/DiffRenderer.vue'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
+import TSelectList from '@/components/SelectList/TSelectList.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import { formatISO } from '@/methods/time'
@@ -35,8 +37,20 @@ const { data: configDiffs, loading: diffsLoading } = useResourceWatch<MachineCon
   }),
 )
 
+const sortOrder = ref<'asc' | 'desc'>('desc')
+
+const sortOptions = [
+  { label: 'Creation Time ⬇', value: 'desc' as const },
+  { label: 'Creation Time ⬆', value: 'asc' as const },
+]
+
 const combinedDiff = computed(() =>
   configDiffs.value
+    .toSorted((a, b) =>
+      sortOrder.value === 'desc'
+        ? compareDesc(parseISO(a.metadata.created!), parseISO(b.metadata.created!))
+        : compareAsc(parseISO(a.metadata.created!), parseISO(b.metadata.created!)),
+    )
     .map((d) => `# Created on ${formatISO(d.metadata.created!)}\n${d.spec.diff}`)
     .join('\n'),
 )
@@ -49,7 +63,11 @@ const combinedDiff = computed(() =>
         No previously applied config diffs found for this machine
       </TAlert>
 
-      <DiffRenderer v-else class="h-full" :diff="combinedDiff" with-search />
+      <DiffRenderer v-else class="h-full" :diff="combinedDiff" with-search>
+        <template #extra-controls>
+          <TSelectList v-model="sortOrder" title="Sort by" :values="sortOptions" />
+        </template>
+      </DiffRenderer>
     </template>
 
     <TSpinner v-else class="mx-auto my-8 size-6" />


### PR DESCRIPTION
Sort config diffs by newest first by default, and include a select dropdown to switch between oldest/newest first

Closes #2895 

<img width="592" height="707" alt="image" src="https://github.com/user-attachments/assets/900282ee-1183-4d2a-901b-5338050d752e" />
