### PR TITLE
test: bump Talos to 1.13.3

### DIFF
--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -22,8 +22,8 @@ echo "127.0.0.1 omni.localhost" | tee -a /etc/hosts
 # Settings.
 LATEST_STABLE_OMNI=$(git tag -l --sort=-version:refname HEAD "v*" | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
 
-export TALOS_VERSION=1.13.2
-export KUBERNETES_VERSION=1.36.0
+export TALOS_VERSION=1.13.3
+export KUBERNETES_VERSION=1.36.1
 # To use in:
 # - Omni upgrade tests, to prevent Talos changes interfering with Omni changes
 # - Talos minor upgrade tests


### PR DESCRIPTION
This should improve e2e-scaling test stability even more.