### PR TITLE
Per-machine log ingestion has no rate limit / back-pressure; one noisy machine can saturate the log store

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -276,6 +276,8 @@ func defineLogsFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *config.P
 	b.IntVar("logs.machine.storage.maxLinesPerMachine", &flagConfig.Logs.Machine.Storage.MaxLinesPerMachine)
 	b.Uint64Var("logs.machine.storage.maxSize", &flagConfig.Logs.Machine.Storage.MaxSize)
 	b.Float64Var("logs.machine.storage.cleanupProbability", &flagConfig.Logs.Machine.Storage.CleanupProbability)
+	b.Uint64Var("logs.machine.ingestionRateLimitBytesPerSecond", &flagConfig.Logs.Machine.IngestionRateLimitBytesPerSecond)
+	b.Uint64Var("logs.machine.ingestionRateBurstBytes", &flagConfig.Logs.Machine.IngestionRateBurstBytes)
 
 	if err := rootCmd.Flags().MarkHidden(b.mustFlagName("logs.machine.storage.cleanupProbability")); err != nil {
 		return err

--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -123,6 +123,15 @@ func Run(ctx context.Context, state *omni.State, cfg *config.Params, logger *zap
 
 	machineMap := siderolink.NewMachineMap(siderolink.NewStateStorage(state.Default()))
 
+	logIngestionLimiter := siderolink.NewLogIngestionLimiter(
+		cfg.Logs.Machine.GetIngestionRateLimitBytesPerSecond(),
+		cfg.Logs.Machine.GetIngestionRateBurstBytes(),
+		logger,
+	)
+	if logIngestionLimiter != nil {
+		prometheus.MustRegister(logIngestionLimiter)
+	}
+
 	logHandler, err := siderolink.NewLogHandler(
 		state.SecondaryStorageDB(),
 		machineMap,
@@ -130,6 +139,7 @@ func Run(ctx context.Context, state *omni.State, cfg *config.Params, logger *zap
 		&cfg.Logs.Machine,
 		logger.With(logging.Component("siderolink_log_handler")),
 		siderolink.WithLogHandlerCleanupCallback(state.SQLiteMetrics().CleanupCallback(sqlite.SubsystemMachineLogs)),
+		siderolink.WithLogIngestionLimiter(logIngestionLimiter),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to set up log handler: %w", err)

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -378,6 +378,12 @@ config:
         #maxSize: 0
         # CleanupProbability is the probability of triggering the cleanup on each log write for that machine.
         #cleanupProbability: 0.01
+      # IngestionRateLimitBytesPerSecond is the maximum bytes per second of machine logs accepted from a single
+      # machine. Zero (default) disables rate limiting.
+      #ingestionRateLimitBytesPerSecond: 0
+      # IngestionRateBurstBytes is the maximum burst bytes for machine log ingestion from a single machine. Defaults
+      # to one second worth of rate when zero.
+      #ingestionRateBurstBytes: 0
     # Audit contains audit logs configuration.
     audit:
       # Enabled controls whether audit logging is enabled.

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -886,6 +886,28 @@ func (s *LogsAudit) SetSqliteTimeout(v time.Duration) {
 	s.SqliteTimeout = &v
 }
 
+func (s *LogsMachine) GetIngestionRateBurstBytes() uint64 {
+	if s == nil || s.IngestionRateBurstBytes == nil {
+		return *new(uint64)
+	}
+	return *s.IngestionRateBurstBytes
+}
+
+func (s *LogsMachine) SetIngestionRateBurstBytes(v uint64) {
+	s.IngestionRateBurstBytes = &v
+}
+
+func (s *LogsMachine) GetIngestionRateLimitBytesPerSecond() uint64 {
+	if s == nil || s.IngestionRateLimitBytesPerSecond == nil {
+		return *new(uint64)
+	}
+	return *s.IngestionRateLimitBytesPerSecond
+}
+
+func (s *LogsMachine) SetIngestionRateLimitBytesPerSecond(v uint64) {
+	s.IngestionRateLimitBytesPerSecond = &v
+}
+
 func (s *LogsMachineStorage) GetCleanupInterval() time.Duration {
 	if s == nil || s.CleanupInterval == nil {
 		return *new(time.Duration)

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -1132,6 +1132,28 @@
         "storage": {
           "description": "Storage contains configuration for machine logs storage.",
           "$ref": "#/definitions/LogsMachineStorage"
+        },
+        "ingestionRateLimitBytesPerSecond": {
+          "description": "IngestionRateLimitBytesPerSecond is the maximum bytes per second of machine logs accepted from a single machine. Zero (default) disables rate limiting.",
+          "x-cli-flag": "machine-log-ingestion-rate-limit-bps",
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "goJSONSchema": {
+            "type": "uint64",
+            "pointer": true
+          }
+        },
+        "ingestionRateBurstBytes": {
+          "description": "IngestionRateBurstBytes is the maximum burst bytes for machine log ingestion from a single machine. Defaults to one second worth of rate when zero.",
+          "x-cli-flag": "machine-log-ingestion-rate-burst-bytes",
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "goJSONSchema": {
+            "type": "uint64",
+            "pointer": true
+          }
         }
       }
     },

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -460,6 +460,14 @@ const LogsLevelInfo LogsLevel = "info"
 const LogsLevelWarn LogsLevel = "warn"
 
 type LogsMachine struct {
+	// IngestionRateBurstBytes is the maximum burst bytes for machine log ingestion
+	// from a single machine. Defaults to one second worth of rate when zero.
+	IngestionRateBurstBytes *uint64 `json:"ingestionRateBurstBytes,omitempty,omitzero" yaml:"ingestionRateBurstBytes,omitempty"`
+
+	// IngestionRateLimitBytesPerSecond is the maximum bytes per second of machine
+	// logs accepted from a single machine. Zero (default) disables rate limiting.
+	IngestionRateLimitBytesPerSecond *uint64 `json:"ingestionRateLimitBytesPerSecond,omitempty,omitzero" yaml:"ingestionRateLimitBytesPerSecond,omitempty"`
+
 	// Storage contains configuration for machine logs storage.
 	Storage LogsMachineStorage `json:"storage" yaml:"storage"`
 }

--- a/internal/pkg/siderolink/loghandler.go
+++ b/internal/pkg/siderolink/loghandler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
@@ -33,6 +34,14 @@ type LogHandlerOption func(*logHandlerOptions)
 
 type logHandlerOptions struct {
 	onCleanup func(int)
+	limiter   *LogIngestionLimiter
+}
+
+// WithLogIngestionLimiter sets a per-machine log ingestion limiter.
+func WithLogIngestionLimiter(limiter *LogIngestionLimiter) LogHandlerOption {
+	return func(o *logHandlerOptions) {
+		o.limiter = limiter
+	}
 }
 
 // WithLogHandlerCleanupCallback sets a callback that is called after cleanup with the number of deleted rows.
@@ -66,6 +75,7 @@ func NewLogHandler(secondaryStorageDB *sqlitexx.Pool, machineMap *MachineMap, om
 		omniState:  omniState,
 		cache:      cache,
 		logger:     logger,
+		limiter:    options.limiter,
 	}
 
 	return &handler, nil
@@ -77,6 +87,7 @@ type LogHandler struct {
 	machineMap *MachineMap
 	logger     *zap.Logger
 	cache      *MachineCache
+	limiter    *LogIngestionLimiter
 }
 
 // Start starts the LogHandler.
@@ -119,6 +130,10 @@ func (h *LogHandler) Start(ctx context.Context) error {
 					machineID := MachineID(event.Resource.Metadata().ID())
 
 					h.machineMap.RemoveByMachineID(machineID)
+
+					if h.limiter != nil {
+						h.limiter.Forget(machineID)
+					}
 
 					err := h.cache.remove(ctx, machineID)
 					if err != nil {
@@ -178,6 +193,12 @@ func (h *LogHandler) writeMessage(ctx context.Context, ip string, data []byte) e
 	id, err := h.machineMap.GetMachineID(ip)
 	if err != nil {
 		return fmt.Errorf("failed to get machine ID for ip address %q: %w", ip, err)
+	}
+
+	if h.limiter != nil {
+		if !h.limiter.Allow(time.Now(), id, len(data)) {
+			return nil
+		}
 	}
 
 	err = h.cache.WriteMessage(ctx, id, data)

--- a/internal/pkg/siderolink/loglimiter.go
+++ b/internal/pkg/siderolink/loglimiter.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package siderolink
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/siderolabs/gen/containers"
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
+
+	"github.com/siderolabs/omni/internal/backend/logging"
+)
+
+const logLimiterDebounceInterval = time.Minute
+
+// LogIngestionLimiter limits machine log ingestion rates per machine.
+//
+// Per-machine entries are created lazily and only removed via Forget when the omni.Machine resource is destroyed or Omni instance is restarted.
+type LogIngestionLimiter struct {
+	droppedLogs *prometheus.CounterVec
+	logger      *zap.Logger
+	limiters    containers.SyncMap[MachineID, *machineLimiter]
+	rateBytes   uint64
+	burstBytes  int
+}
+
+type machineLimiter struct {
+	limiter     *rate.Limiter
+	lastLogTime atomic.Int64
+}
+
+var _ prometheus.Collector = &LogIngestionLimiter{}
+
+// NewLogIngestionLimiter creates a LogIngestionLimiter with the given rate limit. Returns nil if rateBytes is 0 (unlimited).
+func NewLogIngestionLimiter(rateBytes, burstBytes uint64, logger *zap.Logger) *LogIngestionLimiter {
+	if rateBytes == 0 {
+		return nil
+	}
+
+	burst := clampToInt(burstBytes)
+	if burst == 0 {
+		// Default to one second worth of rate.
+		burst = clampToInt(rateBytes)
+	}
+
+	return &LogIngestionLimiter{
+		rateBytes:  rateBytes,
+		burstBytes: burst,
+		droppedLogs: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "omni_machine_logs_dropped_total",
+			Help: "Total bytes of log messages dropped by log ingestion handling.",
+		}, []string{"reason"}),
+		logger: logger.With(logging.Component("siderolink_log_ingestion_limiter")),
+	}
+}
+
+// Allow checks the rate limit for the given machine ID. If the limit is exceeded, it returns false and the message should be dropped.
+func (l *LogIngestionLimiter) Allow(now time.Time, machineID MachineID, size int) bool {
+	ml := l.getOrCreate(machineID)
+
+	if ml.limiter.AllowN(now, size) {
+		return true
+	}
+
+	reason := "rate_limit"
+	message := "log ingestion rate limit exceeded, dropping log messages"
+
+	if size > l.burstBytes {
+		reason = "oversize"
+		message = "log ingestion message exceeds burst limit, dropping"
+	}
+
+	l.droppedLogs.WithLabelValues(reason).Add(float64(size))
+
+	if lastLog := ml.lastLogTime.Load(); now.UnixNano()-lastLog >= int64(logLimiterDebounceInterval) {
+		if ml.lastLogTime.CompareAndSwap(lastLog, now.UnixNano()) {
+			l.logger.Warn(message, zap.String("machine_id", string(machineID)), zap.Int("size", size))
+		}
+	}
+
+	return false
+}
+
+// Forget removes the limiter entry for the given machine ID.
+func (l *LogIngestionLimiter) Forget(machineID MachineID) {
+	l.limiters.Delete(machineID)
+}
+
+func (l *LogIngestionLimiter) getOrCreate(machineID MachineID) *machineLimiter {
+	if ml, ok := l.limiters.Load(machineID); ok {
+		return ml
+	}
+
+	ml := &machineLimiter{
+		limiter: rate.NewLimiter(rate.Limit(l.rateBytes), l.burstBytes),
+	}
+
+	actual, _ := l.limiters.LoadOrStore(machineID, ml)
+
+	return actual
+}
+
+// Describe implements prometheus.Collector.
+func (l *LogIngestionLimiter) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(l, ch)
+}
+
+// Collect implements prometheus.Collector.
+func (l *LogIngestionLimiter) Collect(ch chan<- prometheus.Metric) {
+	l.droppedLogs.Collect(ch)
+}
+
+// clampToInt safely converts a uint64 to int, clamping at math.MaxInt.
+func clampToInt(v uint64) int {
+	if v > uint64(math.MaxInt) {
+		return math.MaxInt
+	}
+
+	return int(v)
+}

--- a/internal/pkg/siderolink/loglimiter_test.go
+++ b/internal/pkg/siderolink/loglimiter_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package siderolink_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/siderolabs/omni/internal/pkg/siderolink"
+)
+
+// testNow is a fixed reference instant used by the limiter tests.
+var testNow = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func TestNewLogIngestionLimiter_DisabledWhenRateZero(t *testing.T) {
+	require.Nil(t, siderolink.NewLogIngestionLimiter(0, 0, zaptest.NewLogger(t)))
+	require.Nil(t, siderolink.NewLogIngestionLimiter(0, 1000, zaptest.NewLogger(t)))
+}
+
+func TestLogIngestionLimiter_AllowsWithinBurst(t *testing.T) {
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zaptest.NewLogger(t))
+
+	assert.True(t, limiter.Allow(testNow, "m1", 50))
+	assert.True(t, limiter.Allow(testNow, "m1", 50))
+}
+
+func TestLogIngestionLimiter_RejectsAfterBurstExhausted(t *testing.T) {
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zaptest.NewLogger(t))
+
+	require.True(t, limiter.Allow(testNow, "m1", 100))
+	assert.False(t, limiter.Allow(testNow, "m1", 1))
+}
+
+func TestLogIngestionLimiter_RejectsOversizeMessages(t *testing.T) {
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zaptest.NewLogger(t))
+
+	// size > burst can never fit, drop immediately.
+	assert.False(t, limiter.Allow(testNow, "m1", 101))
+	assert.False(t, limiter.Allow(testNow, "m1", 10000))
+}
+
+func TestLogIngestionLimiter_TokensRefillOverTime(t *testing.T) {
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zaptest.NewLogger(t))
+
+	require.True(t, limiter.Allow(testNow, "m1", 100))
+	require.False(t, limiter.Allow(testNow, "m1", 50))
+
+	assert.True(t, limiter.Allow(testNow.Add(100*time.Millisecond), "m1", 50))
+}
+
+func TestLogIngestionLimiter_ForgetResetsBucket(t *testing.T) {
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zaptest.NewLogger(t))
+
+	require.True(t, limiter.Allow(testNow, "m1", 100))
+	require.False(t, limiter.Allow(testNow, "m1", 1))
+
+	limiter.Forget("m1")
+
+	// Next Allow gets a fresh full bucket.
+	assert.True(t, limiter.Allow(testNow, "m1", 100))
+}
+
+func TestLogIngestionLimiter_PerMachineIsolation(t *testing.T) {
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zaptest.NewLogger(t))
+
+	require.True(t, limiter.Allow(testNow, "m1", 100))
+	require.False(t, limiter.Allow(testNow, "m1", 1))
+
+	// m2 has its own bucket.
+	assert.True(t, limiter.Allow(testNow, "m2", 100))
+}
+
+func TestLogIngestionLimiter_WarnIsDebounced(t *testing.T) {
+	core, observed := observer.New(zapcore.WarnLevel)
+
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zap.New(core))
+
+	require.True(t, limiter.Allow(testNow, "m1", 100))
+
+	// 100 rejected calls within a minute should emit exactly one warn.
+	for range 100 {
+		assert.False(t, limiter.Allow(testNow, "m1", 1))
+	}
+
+	assert.Equal(t, 1, observed.FilterMessage("log ingestion rate limit exceeded, dropping log messages").Len())
+}
+
+func TestLogIngestionLimiter_WarnFiresAgainAfterDebounce(t *testing.T) {
+	core, observed := observer.New(zapcore.WarnLevel)
+
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zap.New(core))
+
+	require.True(t, limiter.Allow(testNow, "m1", 100))
+	require.False(t, limiter.Allow(testNow, "m1", 1))
+
+	later := testNow.Add(61 * time.Second)
+	require.True(t, limiter.Allow(later, "m1", 100))
+	require.False(t, limiter.Allow(later, "m1", 1))
+
+	assert.Equal(t, 2, observed.FilterMessage("log ingestion rate limit exceeded, dropping log messages").Len())
+}
+
+func TestLogIngestionLimiter_OversizeUsesDistinctWarnAndLabel(t *testing.T) {
+	core, observed := observer.New(zapcore.WarnLevel)
+
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zap.New(core))
+
+	assert.False(t, limiter.Allow(testNow, "m1", 200))
+
+	assert.Equal(t, 1, observed.FilterMessage("log ingestion message exceeds burst limit, dropping").Len())
+}
+
+func TestLogIngestionLimiter_MetricsByReason(t *testing.T) {
+	registry := prometheus.NewRegistry()
+
+	limiter := siderolink.NewLogIngestionLimiter(1000, 100, zaptest.NewLogger(t))
+	registry.MustRegister(limiter)
+
+	require.True(t, limiter.Allow(testNow, "m1", 100))
+	// Oversize drop: should bump reason="oversize" by 200.
+	require.False(t, limiter.Allow(testNow, "m1", 200))
+	// Rate-limit drop: should bump reason="rate_limit" by 1.
+	require.False(t, limiter.Allow(testNow, "m1", 1))
+
+	counts := gatherDroppedTotals(t, registry)
+	assert.Equal(t, float64(200), counts["oversize"])
+	assert.Equal(t, float64(1), counts["rate_limit"])
+}
+
+func gatherDroppedTotals(t *testing.T, registry *prometheus.Registry) map[string]float64 {
+	t.Helper()
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+
+	out := map[string]float64{}
+
+	for _, mf := range mfs {
+		if mf.GetName() != "omni_machine_logs_dropped_total" {
+			continue
+		}
+
+		for _, m := range mf.GetMetric() {
+			var reason string
+
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "reason" {
+					reason = l.GetValue()
+				}
+			}
+
+			out[reason] = m.GetCounter().GetValue()
+		}
+	}
+
+	return out
+}


### PR DESCRIPTION
## Problem
Currently, per-machine log ingestion has no rate limit or back-pressure; one noisy machine can saturate the log store.

The existing `siderolink/ratelimit` limiter is a global, packet-layer bandwidth bucket. While effective at protecting Omni's total NIC throughput, it has two gaps regarding log ingestion:
1. It does not isolate traffic per-tenant (a single machine exhausting the bucket starves control-plane traffic globally).
2. It sits below the log-write path. 

The physical path for machine logs is `ConnHandler.HandleConn` -> `LogHandler.HandleMessage` -> `cache.WriteMessage`. The loop reads off the socket and dispatches to the per-machine SQLite store as fast as TCP delivers it, without any bounds on store I/O from a single machine.

## Implementation Proposed
This PR targets the narrow, surgical spot: `LogHandler.HandleMessage`. Since it already resolves `srcAddress` to a `machineID`, it's the natural place for a per-machine token bucket.

The implementation mirrors the conventions established by the existing packet limiter:
- A `rate.Limiter` token bucket (constructed per-machine).
- Prometheus drop metrics (`omni_machine_logs_dropped_total{reason="rate_limit"}`).
- Debounced warn-logging (`zap` with `lastLogTime`).
- Nil-limiter-means-unlimited config convention, passed in via functional options (`WithLogIngestionLimiter`).
- Sane defaults via `schema.json` configuration (`MachineLogRateLimitBytes` and `MachineLogRateBurstBytes`).

## Questions for Reviewers
I'd love to collaborate on a couple of design choices to make sure this aligns with Sidero's long-term vision:
1. **Drop vs Back-pressure:** This PR drops log lines (with a metric and warn log) rather than slowing the reader (which would apply back-pressure). This protects Omni but loses observability data from the flooding node. Is a lossy drop with metrics preferred, or should we look at a bounded buffer with back-pressure in `HandleConn` instead?
2. **Per-Machine vs Per-Account:** This PR explicitly limits *per-machine* log volume. Per-account quotas as a follow-up might be necessary for multi-machine/multi-account scenarios. Let me know if you agree with phasing per-machine back-pressure as step one.

Any guidance on these would be appreciated!
