### PR TITLE
fix(frontend): fix typo in disk usage bar legend text color class

### DIFF
--- a/frontend/src/views/Nodes/components/DiskUsageBar.vue
+++ b/frontend/src/views/Nodes/components/DiskUsageBar.vue
@@ -89,7 +89,7 @@ const getVolumeClass = (volume: Resource<TalosDiscoveredVolumeSpec>) => {
         class="flex items-center gap-1.5"
       >
         <span class="inline-block size-2.5 rounded-sm" :class="getVolumeClass(volume)" />
-        <span class="text-naturalsn-n12 font-medium">
+        <span class="font-medium text-naturals-n12">
           {{ volume.spec.partition_label || volume.spec.label || volume.spec.dev_path }}
         </span>
         <span class="font-medium text-naturals-n10">
@@ -98,7 +98,7 @@ const getVolumeClass = (volume: Resource<TalosDiscoveredVolumeSpec>) => {
       </div>
       <div v-if="unallocatedPercent > 0" class="flex items-center gap-1.5">
         <span class="inline-block size-2.5 rounded-sm bg-naturals-n5" />
-        <span class="text-naturalsn-n12 font-medium">Unallocated</span>
+        <span class="font-medium text-naturals-n12">Unallocated</span>
         <span class="font-medium text-naturals-n10">
           {{ formatBytes(unallocatedSpace) }}
         </span>


### PR DESCRIPTION
`text-naturalsn-n12` (extra `n`) sneaked in with the disks view improvements. tailwind ignores unknown classes so the disk legend labels inherit `text-naturals-n11` from the parent div instead of `text-naturals-n12`.

ends up with partition names and "Unallocated" being the wrong shade of gray.

to reproduce:
1. open any machine's Disks page
2. check the legend below the disk bar, its a bit off

fixed both spots in the legend section of `DiskUsageBar.vue`