### PR TITLE
feat(frontend): show join tokens in saved presets list

### DIFF
--- a/frontend/src/pages/(authenticated)/machines/installation-media/index.stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/index.stories.ts
@@ -9,7 +9,11 @@ import { http, HttpResponse } from 'msw'
 
 import type { DeleteRequest, DeleteResponse } from '@/api/omni/resources/resources.pb'
 import type { InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
-import { DefaultNamespace, InstallationMediaConfigType } from '@/api/resources'
+import {
+  type JoinTokenStatusSpec,
+  JoinTokenStatusSpecState,
+} from '@/api/omni/specs/siderolink.pb.ts'
+import { DefaultNamespace, InstallationMediaConfigType, JoinTokenStatusType } from '@/api/resources'
 import * as DownloadPresetModalStories from '@/views/InstallationMedia/DownloadPresetModal.stories'
 
 import InstallationMedia from './index.vue'
@@ -17,6 +21,8 @@ import InstallationMedia from './index.vue'
 const meta: Meta<typeof InstallationMedia> = {
   component: InstallationMedia,
 }
+
+const joinTokens = faker.helpers.multiple(() => faker.string.alphanumeric(44), { count: 10 })
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -27,6 +33,31 @@ export const Default: Story = {
       handlers: [
         ...DownloadPresetModalStories.Default.parameters.msw.handlers,
 
+        createWatchStreamHandler<JoinTokenStatusSpec>({
+          expectedOptions: {
+            type: JoinTokenStatusType,
+            namespace: DefaultNamespace,
+          },
+          initialResources: joinTokens.slice(1).map(
+            (t, i) => ({
+              spec: {
+                is_default: i === 0,
+                name: faker.word.noun(),
+                state:
+                  i === 0
+                    ? JoinTokenStatusSpecState.ACTIVE
+                    : faker.helpers.enumValue(JoinTokenStatusSpecState),
+              },
+              metadata: {
+                id: t,
+                type: JoinTokenStatusType,
+                namespace: DefaultNamespace,
+              },
+            }),
+            { count: 50 },
+          ),
+        }).handler,
+
         createWatchStreamHandler<InstallationMediaConfigSpec>({
           expectedOptions: {
             namespace: DefaultNamespace,
@@ -35,10 +66,15 @@ export const Default: Story = {
           initialResources: faker.helpers.multiple(
             () => ({
               spec: {
-                talos_version: faker.system.semver(),
+                talos_version: faker.helpers.maybe(() => faker.system.semver()),
+                join_token: faker.helpers.maybe(() => faker.helpers.arrayElement(joinTokens), {
+                  probability: 0.75,
+                }),
               },
               metadata: {
                 id: faker.helpers.slugify(faker.word.words(3)),
+                namespace: DefaultNamespace,
+                type: InstallationMediaConfigType,
                 created: faker.date.past().toISOString(),
               },
             }),

--- a/frontend/src/pages/(authenticated)/machines/installation-media/index.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/index.vue
@@ -6,17 +6,24 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { formatISO, parseISO } from 'date-fns'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { ResourceService } from '@/api/grpc'
 import type { InstallationMediaConfigSpec } from '@/api/omni/specs/omni.pb'
+import { type JoinTokenStatusSpec, JoinTokenStatusSpecState } from '@/api/omni/specs/siderolink.pb'
 import { withRuntime } from '@/api/options'
-import { DefaultNamespace, DefaultTalosVersion, InstallationMediaConfigType } from '@/api/resources'
+import {
+  DefaultNamespace,
+  DefaultTalosVersion,
+  InstallationMediaConfigType,
+  JoinTokenStatusType,
+} from '@/api/resources'
 import { itemID } from '@/api/watch'
 import IconButton from '@/components/Button/IconButton.vue'
 import TButton from '@/components/Button/TButton.vue'
+import TIcon from '@/components/Icon/TIcon.vue'
 import ConfirmModal from '@/components/Modals/ConfirmModal.vue'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/PageHeader.vue'
@@ -25,6 +32,7 @@ import TableCell from '@/components/Table/TableCell.vue'
 import TableRoot from '@/components/Table/TableRoot.vue'
 import TableRow from '@/components/Table/TableRow.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
+import { TCommonStatuses } from '@/constants'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showSuccess } from '@/notification'
 import DownloadPresetModal from '@/views/InstallationMedia/DownloadPresetModal.vue'
@@ -42,6 +50,29 @@ const { data: presets, loading: presetsLoading } = useResourceWatch<Installation
     namespace: DefaultNamespace,
     type: InstallationMediaConfigType,
   },
+})
+
+const { data: joinTokens, loading: joinTokensLoading } = useResourceWatch<JoinTokenStatusSpec>({
+  runtime: Runtime.Omni,
+  resource: {
+    type: JoinTokenStatusType,
+    namespace: DefaultNamespace,
+  },
+})
+
+const loading = computed(() => presetsLoading.value || joinTokensLoading.value)
+const defaultToken = computed(() => joinTokens.value.find((t) => t.spec.is_default))
+
+const presetList = computed(() => {
+  if (loading.value) return
+
+  return presets.value.map((p) => ({
+    ...p,
+    tokenAutomatic: !p.spec.join_token,
+    token: p.spec.join_token
+      ? joinTokens.value.find((t) => t.metadata.id === p.spec.join_token)
+      : defaultToken.value,
+  }))
 })
 
 watch([presets, presetsLoading], ([presets, presetsLoading]) => {
@@ -90,7 +121,7 @@ function clonePreset(preset: (typeof presets.value)[number]) {
 
 <template>
   <PageContainer class="flex h-full flex-col gap-6">
-    <TSpinner v-if="presetsLoading" class="size-8 self-center" />
+    <TSpinner v-if="loading" class="size-8 self-center" />
 
     <div class="flex items-start justify-between gap-1">
       <PageHeader title="Installation Media" />
@@ -109,13 +140,14 @@ function clonePreset(preset: (typeof presets.value)[number]) {
         <TableRow>
           <TableCell th>Name</TableCell>
           <TableCell th>Talos version</TableCell>
+          <TableCell th>Join token</TableCell>
           <TableCell th>Date created</TableCell>
           <TableCell th>Action</TableCell>
         </TableRow>
       </template>
 
       <template #body>
-        <TableRow v-for="preset in presets" :key="itemID(preset)">
+        <TableRow v-for="{ token, tokenAutomatic, ...preset } in presetList" :key="itemID(preset)">
           <TableCell>
             <RouterLink
               class="list-item-link"
@@ -128,7 +160,42 @@ function clonePreset(preset: (typeof presets.value)[number]) {
             </RouterLink>
           </TableCell>
           <TableCell>
-            {{ preset.spec.talos_version || `Automatic (${DefaultTalosVersion})` }}
+            <div class="flex items-center gap-2">
+              {{ preset.spec.talos_version || DefaultTalosVersion }}
+              <span v-if="!preset.spec.talos_version" class="resource-label label-green">
+                Automatic
+              </span>
+            </div>
+          </TableCell>
+          <TableCell>
+            <div class="flex items-center gap-2">
+              <template v-if="token">
+                {{ token.spec.name }}
+              </template>
+
+              <span v-else class="resource-label label-red flex items-center gap-1">
+                <TIcon icon="warning" />
+                Deleted
+              </span>
+
+              <span
+                v-if="token?.spec.state === JoinTokenStatusSpecState.REVOKED"
+                class="resource-label label-red flex items-center gap-1"
+              >
+                <TIcon icon="warning" />
+                {{ TCommonStatuses.REVOKED }}
+              </span>
+
+              <span
+                v-if="token?.spec.state === JoinTokenStatusSpecState.EXPIRED"
+                class="resource-label label-red flex items-center gap-1"
+              >
+                <TIcon icon="warning" />
+                {{ TCommonStatuses.EXPIRED }}
+              </span>
+
+              <span v-if="tokenAutomatic" class="resource-label label-green">Automatic</span>
+            </div>
           </TableCell>
           <TableCell>
             {{

--- a/frontend/src/pages/(authenticated)/machines/jointokens.vue
+++ b/frontend/src/pages/(authenticated)/machines/jointokens.vue
@@ -148,12 +148,7 @@ const openDeleteToken = (token: string) => {
             <div class="tokens-grid flex-1">
               <div class="flex items-center gap-2">
                 <span class="truncate">{{ item.spec.name ?? 'initial token' }}</span>
-                <div
-                  v-if="item.spec.is_default"
-                  class="rounded bg-primary-p3/10 px-2 py-1 text-primary-p3"
-                >
-                  Default
-                </div>
+                <div v-if="item.spec.is_default" class="resource-label label-orange">Default</div>
               </div>
               <div
                 class="cursor-pointer truncate font-mono"


### PR DESCRIPTION
On the saved presets list for installation media, show the selected join token and any relevant badges about it.

Closes #2716 

<img width="970" height="768" alt="image" src="https://github.com/user-attachments/assets/8cefc8a1-6a2a-4375-881f-0bb5deb79076" />
