### PR TITLE
fix: lower minimum discovered Kubernetes version

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/versions.go
+++ b/internal/backend/runtime/omni/controllers/omni/versions.go
@@ -30,8 +30,8 @@ import (
 )
 
 var (
-	// minK8sVersion sets minimum Kubernetes version for building the list of versions.
-	minK8sVersion = semver.MustParse(consts.MinKubernetesVersion)
+	// minDiscoveredK8sVersion sets minimum Kubernetes version for building the list of versions.
+	minDiscoveredK8sVersion = semver.MustParse(consts.MinDiscoveredKubernetesVersion)
 	// minDiscoveredTalosVersion sets minimum Talos version for building the list of versions.
 	minDiscoveredTalosVersion = semver.MustParse(consts.MinDiscoveredTalosVersion)
 	// minTalosVersion sets minimum Talos version which are not deprecated.
@@ -305,7 +305,7 @@ func (ctrl *VersionsController) reconcileKubernetesVersions(ctx context.Context,
 		return nil, err
 	}
 
-	versions := ctrl.getVersionsAfter(allVersions, minK8sVersion, false)
+	versions := ctrl.getVersionsAfter(allVersions, minDiscoveredK8sVersion, false)
 
 	for _, v := range versions {
 		k8sVersion := omni.NewKubernetesVersion(v)

--- a/internal/pkg/constants/versions.go
+++ b/internal/pkg/constants/versions.go
@@ -33,8 +33,8 @@ const DefaultTalosVersion = constants.DefaultTalosVersion
 // AnotherKubernetesVersion is used in the integration tests for Kubernetes upgrade.
 const AnotherKubernetesVersion = "1.35.4"
 
-// MinKubernetesVersion allowed to be used when creating the cluster.
-const MinKubernetesVersion = "1.27.0"
+// MinDiscoveredKubernetesVersion makes Omni pull the versions from this point.
+const MinDiscoveredKubernetesVersion = "1.23.0"
 
 // DenylistedTalosVersions is a list of versions which should never show up in the version picker.
 var DenylistedTalosVersions = Denylist{


### PR DESCRIPTION
Rename `MinKubernetesVersion` to `MinDiscoveredKubernetesVersion` to clarify its role as the floor for version discovery rather than the floor for cluster creation, and lower it to 1.23.0 so older Kubernetes versions are surfaced in the version list.

Fixes: #2914
