### PR TITLE
test: mock clock in saml test

### DIFF
--- a/internal/backend/saml/session_test.go
+++ b/internal/backend/saml/session_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	csaml "github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
+	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
@@ -62,6 +63,7 @@ func TestUserInfo(t *testing.T) {
 	} {
 		t.Run(tt.file, func(t *testing.T) {
 			fakeTime = tt.time
+			csaml.Clock = dsig.NewFakeClockAt(csaml.TimeNow())
 
 			rootURL, err := url.Parse(tt.rootURL)
 			require.NoError(t, err)


### PR DESCRIPTION
Also mock the clock in SAML tests as using real clock is now failing due to cert expiring in the test data