### PR TITLE
feat(omnictl): show node name and locked status in cluster status

### DIFF
--- a/client/pkg/template/operations/internal/statustree/helpers.go
+++ b/client/pkg/template/operations/internal/statustree/helpers.go
@@ -139,6 +139,23 @@ func clusterMachineStageString(phase specs.ClusterMachineStatusSpec_Stage) strin
 	return c(phaseString)
 }
 
+func clusterMachineNodeNameString(clusterMachine *omni.ClusterMachineStatus) string {
+	nodename, _ := clusterMachine.Metadata().Labels().Get(omni.ClusterMachineStatusLabelNodeName)
+	if nodename == "" {
+		return ""
+	}
+
+	return color.CyanString("(%s)", nodename)
+}
+
+func clusterMachineLockedString(clusterMachine *omni.ClusterMachineStatus) string {
+	if _, locked := clusterMachine.Metadata().Annotations().Get(omni.MachineLocked); !locked {
+		return ""
+	}
+
+	return " " + color.BlueString("Locked")
+}
+
 func clusterMachineConnected(clusterMachine *omni.ClusterMachineStatus) string {
 	_, connected := clusterMachine.Metadata().Labels().Get(omni.MachineStatusLabelConnected)
 	if connected {
@@ -158,7 +175,7 @@ func clusterMachineConfigOutdated(outdated bool) string {
 
 func clusterMachineConfigStatus(node *omni.ClusterMachineStatus) string {
 	if _, locked := node.Metadata().Labels().Get(omni.UpdateLocked); locked {
-		return " " + color.BlueString("Pending Config Update (Machine Locked)")
+		return " " + color.BlueString("Pending Config Update")
 	}
 
 	switch node.TypedSpec().Value.ConfigApplyStatus {

--- a/client/pkg/template/operations/internal/statustree/statustree.go
+++ b/client/pkg/template/operations/internal/statustree/statustree.go
@@ -58,12 +58,14 @@ func (t NodeWrapper) String() string {
 		)
 	case *omni.ClusterMachineStatus:
 		return fmt.Sprintf(
-			"%s %q %s%s%s%s%s",
+			"%s %q%s %s%s%s%s%s%s",
 			color.YellowString("Machine"),
 			node.Metadata().ID(),
+			clusterMachineNodeNameString(node),
 			clusterMachineStageString(node.TypedSpec().Value.Stage),
 			clusterMachineReadyString(node),
 			clusterMachineConnected(node),
+			clusterMachineLockedString(node),
 			clusterMachineConfigOutdated(!node.TypedSpec().Value.ConfigUpToDate),
 			clusterMachineConfigStatus(node),
 		)


### PR DESCRIPTION
The `omnictl cluster status` tree listed machines by UUID only, while
the Talos/Kubernetes upgrade status messages referenced the friendly
Kubernetes node name, making it hard to correlate which machine a
status line was about. A locked machine was also only surfaced when it
additionally had a pending config update.

Render the node name (from the ClusterMachineStatusLabelNodeName label
already on the resource) in parentheses after the UUID, and show a
dedicated "Locked" indicator whenever the MachineLocked annotation is
set, e.g. `Machine "0000...edb"(omni-foo-abcdef) Running Ready Locked`.
Machines that have not yet joined Kubernetes show no node name rather
than empty parentheses.

Closes https://github.com/siderolabs/omni/issues/1700

Signed-off-by: Fritz Schaal <fritz.schaal@siderolabs.com>

---

Note that this is AI tooling assisted code.