### PR TITLE
refactor: drop unused field in create schematic gRPC request

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -1393,7 +1393,6 @@ type CreateSchematicRequest struct {
 	MetaValues               map[uint32]string                               `protobuf:"bytes,3,rep,name=meta_values,json=metaValues,proto3" json:"meta_values,omitempty" protobuf_key:"varint,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	TalosVersion             string                                          `protobuf:"bytes,4,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
 	MediaId                  string                                          `protobuf:"bytes,5,opt,name=media_id,json=mediaId,proto3" json:"media_id,omitempty"`
-	SecureBoot               bool                                            `protobuf:"varint,6,opt,name=secure_boot,json=secureBoot,proto3" json:"secure_boot,omitempty"`
 	SiderolinkGrpcTunnelMode CreateSchematicRequest_SiderolinkGRPCTunnelMode `protobuf:"varint,7,opt,name=siderolink_grpc_tunnel_mode,json=siderolinkGrpcTunnelMode,proto3,enum=management.CreateSchematicRequest_SiderolinkGRPCTunnelMode" json:"siderolink_grpc_tunnel_mode,omitempty"`
 	JoinToken                string                                          `protobuf:"bytes,8,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
 	Overlay                  *CreateSchematicRequest_Overlay                 `protobuf:"bytes,9,opt,name=overlay,proto3" json:"overlay,omitempty"`
@@ -1465,13 +1464,6 @@ func (x *CreateSchematicRequest) GetMediaId() string {
 		return x.MediaId
 	}
 	return ""
-}
-
-func (x *CreateSchematicRequest) GetSecureBoot() bool {
-	if x != nil {
-		return x.SecureBoot
-	}
-	return false
 }
 
 func (x *CreateSchematicRequest) GetSiderolinkGrpcTunnelMode() CreateSchematicRequest_SiderolinkGRPCTunnelMode {
@@ -3298,7 +3290,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\fResponseType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\f\n" +
 	"\bMANIFEST\x10\x01\x12\v\n" +
-	"\aROLLOUT\x10\x02\"\x8b\x06\n" +
+	"\aROLLOUT\x10\x02\"\xf0\x05\n" +
 	"\x16CreateSchematicRequest\x12\x1e\n" +
 	"\n" +
 	"extensions\x18\x01 \x03(\tR\n" +
@@ -3307,9 +3299,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\vmeta_values\x18\x03 \x03(\v22.management.CreateSchematicRequest.MetaValuesEntryR\n" +
 	"metaValues\x12#\n" +
 	"\rtalos_version\x18\x04 \x01(\tR\ftalosVersion\x12\x19\n" +
-	"\bmedia_id\x18\x05 \x01(\tR\amediaId\x12\x1f\n" +
-	"\vsecure_boot\x18\x06 \x01(\bR\n" +
-	"secureBoot\x12z\n" +
+	"\bmedia_id\x18\x05 \x01(\tR\amediaId\x12z\n" +
 	"\x1bsiderolink_grpc_tunnel_mode\x18\a \x01(\x0e2;.management.CreateSchematicRequest.SiderolinkGRPCTunnelModeR\x18siderolinkGrpcTunnelMode\x12\x1d\n" +
 	"\n" +
 	"join_token\x18\b \x01(\tR\tjoinToken\x12D\n" +
@@ -3328,7 +3318,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x18SiderolinkGRPCTunnelMode\x12\b\n" +
 	"\x04AUTO\x10\x00\x12\f\n" +
 	"\bDISABLED\x10\x01\x12\v\n" +
-	"\aENABLED\x10\x02\"D\n" +
+	"\aENABLED\x10\x02J\x04\b\x06\x10\a\"D\n" +
 	"\x1dCreateSchematicFromRawRequest\x12#\n" +
 	"\rraw_schematic\x18\x01 \x01(\fR\frawSchematic\"\xaa\x01\n" +
 	"\x17CreateSchematicResponse\x12!\n" +

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -168,7 +168,7 @@ message CreateSchematicRequest {
   map<uint32, string> meta_values = 3;
   string talos_version = 4;
   string media_id = 5;
-  bool secure_boot = 6;
+  reserved 6;
   SiderolinkGRPCTunnelMode siderolink_grpc_tunnel_mode = 7;
   string join_token = 8;
   Overlay overlay = 9;

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -452,7 +452,6 @@ func (m *CreateSchematicRequest) CloneVT() *CreateSchematicRequest {
 	r := new(CreateSchematicRequest)
 	r.TalosVersion = m.TalosVersion
 	r.MediaId = m.MediaId
-	r.SecureBoot = m.SecureBoot
 	r.SiderolinkGrpcTunnelMode = m.SiderolinkGrpcTunnelMode
 	r.JoinToken = m.JoinToken
 	r.Overlay = m.Overlay.CloneVT()
@@ -1614,9 +1613,6 @@ func (this *CreateSchematicRequest) EqualVT(that *CreateSchematicRequest) bool {
 		return false
 	}
 	if this.MediaId != that.MediaId {
-		return false
-	}
-	if this.SecureBoot != that.SecureBoot {
 		return false
 	}
 	if this.SiderolinkGrpcTunnelMode != that.SiderolinkGrpcTunnelMode {
@@ -3511,16 +3507,6 @@ func (m *CreateSchematicRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error
 		i--
 		dAtA[i] = 0x38
 	}
-	if m.SecureBoot {
-		i--
-		if m.SecureBoot {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x30
-	}
 	if len(m.MediaId) > 0 {
 		i -= len(m.MediaId)
 		copy(dAtA[i:], m.MediaId)
@@ -5399,9 +5385,6 @@ func (m *CreateSchematicRequest) SizeVT() (n int) {
 	l = len(m.MediaId)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
-	}
-	if m.SecureBoot {
-		n += 2
 	}
 	if m.SiderolinkGrpcTunnelMode != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.SiderolinkGrpcTunnelMode))
@@ -8830,26 +8813,6 @@ func (m *CreateSchematicRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.MediaId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 6:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field SecureBoot", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.SecureBoot = bool(v != 0)
 		case 7:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field SiderolinkGrpcTunnelMode", wireType)

--- a/client/pkg/omnictl/internal/download/download.go
+++ b/client/pkg/omnictl/internal/download/download.go
@@ -529,7 +529,6 @@ func createSchematic(ctx context.Context, client *client.Client, image ImageInfo
 		MetaValues:               metaValues,
 		ExtraKernelArgs:          params.ExtraKernelArgs,
 		Extensions:               extensions,
-		SecureBoot:               params.SecureBoot,
 		TalosVersion:             params.TalosVersion,
 		SiderolinkGrpcTunnelMode: params.GrpcTunnelMode,
 		JoinToken:                params.JoinToken,

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -184,7 +184,6 @@ export type CreateSchematicRequest = {
   meta_values?: {[key: number]: string}
   talos_version?: string
   media_id?: string
-  secure_boot?: boolean
   siderolink_grpc_tunnel_mode?: CreateSchematicRequestSiderolinkGRPCTunnelMode
   join_token?: string
   overlay?: CreateSchematicRequestOverlay

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.stories.ts
@@ -245,13 +245,13 @@ export const Default = {
           async ({ request }) => {
             await delay(2_000)
 
-            const { secure_boot, talos_version, join_token } = await request.clone().json()
+            const { talos_version, join_token } = await request.clone().json()
 
             const schematic_id = faker.string.uuid()
 
             return HttpResponse.json({
               schematic_id,
-              pxe_url: `https://pxe.factory.talos.dev/pxe/${schematic_id}/${talos_version}/metal-arm64-${secure_boot ? '-secureboot' : ''}`,
+              pxe_url: `https://pxe.factory.talos.dev/pxe/${schematic_id}/${talos_version}/metal-arm64`,
               schematic_yml: dump(
                 {
                   customization: {

--- a/frontend/src/schemas/config_1_12.schema.json
+++ b/frontend/src/schemas/config_1_12.schema.json
@@ -1177,9 +1177,9 @@
             "off"
           ],
           "title": "adLACPActive",
-          "description": "Whether to send LACPDU frames periodically.\n",
-          "markdownDescription": "Whether to send LACPDU frames periodically.",
-          "x-intellij-html-description": "\u003cp\u003eWhether to send LACPDU frames periodically.\u003c/p\u003e\n"
+          "description": "Whether to send LACPDU frames periodically, defaults to “on” if mode is 802.3ad.\n",
+          "markdownDescription": "Whether to send LACPDU frames periodically, defaults to \"on\" if mode is 802.3ad.",
+          "x-intellij-html-description": "\u003cp\u003eWhether to send LACPDU frames periodically, defaults to \u0026ldquo;on\u0026rdquo; if mode is 802.3ad.\u003c/p\u003e\n"
         },
         "primaryReselect": {
           "enum": [

--- a/frontend/src/views/InstallationMedia/usePresetSchematic.ts
+++ b/frontend/src/views/InstallationMedia/usePresetSchematic.ts
@@ -58,7 +58,6 @@ export function usePresetSchematic(presetRef: MaybeRefOrGetter<InstallationMedia
             : undefined,
         overlay,
         talos_version: preset.talos_version,
-        secure_boot: preset.secure_boot,
         siderolink_grpc_tunnel_mode:
           preset.grpc_tunnel === GrpcTunnelMode.ENABLED
             ? CreateSchematicRequestSiderolinkGRPCTunnelMode.ENABLED


### PR DESCRIPTION
The field `secure_boot` was unused when creating a schematic. Drop that field.