### PR TITLE
fix: prevent deadlock between machine upgrade and config update

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -214,12 +214,20 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileRunning(
 				zap.String("machine", machineConfig.Metadata().ID()),
 			)
 
-			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("'%s' the machine talos version is out of sync: %w", machineConfig.Metadata().ID(), err)
+			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine talos version is out of sync: %s", machineConfig.Metadata().ID())
 		}
-	} else {
-		if err = ctrl.releaseUpgradeLock(ctx, r, rc.clusterMachine); err != nil {
-			return fmt.Errorf("failed to release upgrade lock: %w", err)
-		}
+	}
+
+	// At this point the machine is in sync: it either needed no upgrade, or the upgrade just
+	// completed. Release the upgrade lock here, before entering the config-apply phase, so the
+	// upgrade and config-update locks are never held simultaneously by the same machine.
+	//
+	// Holding the upgrade lock into the config-apply phase allows a lock-ordering inversion to
+	// deadlock the whole machine set: one machine holds the config-update lock and waits for the
+	// upgrade lock, while another holds the upgrade lock and waits for the config-update lock.
+	// Neither lock is ever released and the machine set is stuck until Omni is restarted.
+	if err = ctrl.releaseUpgradeLock(ctx, r, rc.clusterMachine); err != nil {
+		return fmt.Errorf("failed to release upgrade lock: %w", err)
 	}
 
 	stage := rc.machineStatusSnapshot.TypedSpec().Value.GetMachineStatus().GetStage()
@@ -984,7 +992,7 @@ func (ctrl *ClusterMachineConfigStatusController) acquireConfigUpdateLock(ctx co
 }
 
 func (ctrl *ClusterMachineConfigStatusController) releaseConfigUpdateLock(ctx context.Context, r controller.ReaderWriter, clusterMachine *omni.ClusterMachine) error {
-	if !clusterMachine.Metadata().Finalizers().Has(ConfigUpdateFinalizer) {
+	if clusterMachine == nil || !clusterMachine.Metadata().Finalizers().Has(ConfigUpdateFinalizer) {
 		return nil
 	}
 
@@ -992,7 +1000,7 @@ func (ctrl *ClusterMachineConfigStatusController) releaseConfigUpdateLock(ctx co
 }
 
 func (ctrl *ClusterMachineConfigStatusController) releaseUpgradeLock(ctx context.Context, r controller.ReaderWriter, clusterMachine *omni.ClusterMachine) error {
-	if !clusterMachine.Metadata().Finalizers().Has(UpgradeFinalizer) {
+	if clusterMachine == nil || !clusterMachine.Metadata().Finalizers().Has(UpgradeFinalizer) {
 		return nil
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -1107,3 +1107,75 @@ func createCluster(
 
 	return cluster, machines
 }
+
+// TestUpgradeLockReleasedBeforeConfigApply is a regression test for siderolabs/omni#2805.
+//
+// Once a machine is in sync, it must release the upgrade lock before entering the
+// config-apply phase, so it never holds both the upgrade and the config-update lock at the
+// same time. If it held both, two machines could deadlock, each holding one lock while
+// waiting for the other, stalling the whole machine set.
+func TestUpgradeLockReleasedBeforeConfigApply(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer")))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			st := tc.State
+
+			machineServices := testutils.NewMachineServices(t, st)
+
+			_, machines := createCluster(ctx, t, st, machineServices, "deadlock-regression", 1, 0)
+			id := machines[0].Metadata().ID()
+
+			// Wait for the initial config to be applied: the config-update lock is only taken
+			// once the machine already has an applied config.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+
+			// The machine completes upgrades on request, but its config apply never succeeds, so
+			// it stays in the config-apply phase holding the config-update lock.
+			machineServices.Get(id).OnUpdate = func(ctx context.Context, req *machine.UpgradeRequest, st state.State, machineID string) (*machine.UpgradeResponse, error) {
+				_, tag, _ := strings.Cut(req.Image, ":")
+
+				return &machine.UpgradeResponse{}, safe.StateModify(ctx, st, omni.NewMachineStatus(machineID), func(res *omni.MachineStatus) error {
+					res.TypedSpec().Value.TalosVersion = strings.TrimLeft(tag, "v")
+
+					return nil
+				})
+			}
+			machineServices.Get(id).OnApplyConfig = func(context.Context, *machine.ApplyConfigurationRequest, state.State, string) (*machine.ApplyConfigurationResponse, error) {
+				return nil, errors.New("config apply blocked")
+			}
+
+			// Trigger a config change and an upgrade at the same time.
+			rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), options.Modify(func(r *omni.ClusterMachineConfig) error {
+				return r.TypedSpec().Value.SetUncompressedData([]byte("machine:\n  network:\n    kubespan:\n      enabled: true"))
+			}))
+			rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+				res.TypedSpec().Value.InstallImage.TalosVersion = "1.12.7"
+
+				return nil
+			}))
+
+			// The upgrade completes on the machine.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.MachineStatus, a *assert.Assertions) {
+				a.Equal("1.12.7", res.TypedSpec().Value.TalosVersion)
+			})
+
+			// The machine is now stuck applying config, holding the config-update lock. It must
+			// not also hold the upgrade lock: the upgrade lock has to be released before the
+			// config-apply phase, so a machine never holds both at once.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachine, a *assert.Assertions) {
+				a.True(res.Metadata().Finalizers().Has(machineconfig.ConfigUpdateFinalizer), "should hold the config-update lock")
+				a.False(res.Metadata().Finalizers().Has(machineconfig.UpgradeFinalizer), "must not hold the upgrade lock during config apply")
+			})
+		},
+	)
+}


### PR DESCRIPTION
A control plane could get permanently stuck when a machine needed both a Talos upgrade and a config change at the same time. Config updates and upgrades are each rolled out to a limited number of machines at a time, counted independently. A machine that had already started a config update but then also needed an upgrade would keep its config update slot while waiting for a free upgrade slot. If at the same time another machine held the only upgrade slot while waiting for a free config update slot, the two would wait on each other forever, and no machine in the set could be updated until Omni was restarted. This was most likely on control planes, where both rollouts are limited to one machine at a time.

The machine now gives up its upgrade slot as soon as it is back in sync, before it starts applying the config, so a single machine never occupies both an upgrade and a config update slot at once and the two rollouts can no longer block each other.

Closes siderolabs/omni#2805.