### PR TITLE
feat(helm): support loadBalancerIP for WireGuard service

### DIFF
--- a/deploy/helm/omni/README.md
+++ b/deploy/helm/omni/README.md
@@ -383,6 +383,7 @@ Here are the configurable parameters of the Omni chart and their default values.
 | service.wireguard.annotations | object | `{}` | Annotations for the WireGuard service. |
 | service.wireguard.clusterIP | string | `""` | ClusterIP for the WireGuard service. |
 | service.wireguard.labels | object | `{}` | Additional labels for the WireGuard service. |
+| service.wireguard.loadBalancerIP | string | `""` | loadBalancerIP for the WireGuard service. |
 | service.wireguard.nodePort | int | `30180` | NodePort for the WireGuard service. |
 | service.wireguard.port | int | `50180` | Port for the WireGuard service. |
 | service.wireguard.type | string | `"NodePort"` | Service type for WireGuard (NodePort or LoadBalancer recommended). |

--- a/deploy/helm/omni/templates/service/service-wireguard.yaml
+++ b/deploy/helm/omni/templates/service/service-wireguard.yaml
@@ -17,6 +17,9 @@ spec:
   {{- with .Values.service.wireguard.clusterIP }}
   clusterIP: {{ . | quote}}
   {{- end }}
+  {{- if and .Values.service.wireguard.loadBalancerIP (eq .Values.service.wireguard.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.wireguard.loadBalancerIP | quote }}
+  {{- end }}
   ports:
     - name: wireguard
       {{- if and .Values.service.wireguard.nodePort (or (eq .Values.service.wireguard.type "NodePort") (eq .Values.service.wireguard.type "LoadBalancer")) }}

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -869,6 +869,8 @@ service:
     port: 50180
     # -- NodePort for the WireGuard service.
     nodePort: 30180
+    # -- loadBalancerIP for the WireGuard service.
+    loadBalancerIP: ""
     # -- ClusterIP for the WireGuard service.
     clusterIP: ""
 # Omni metrics configuration


### PR DESCRIPTION
Adds Helm chart support for configuring a static `loadBalancerIP` on the WireGuard Kubernetes Service.

The new `service.wireguard.loadBalancerIP` value is rendered only when the WireGuard service type is `LoadBalancer`, matching the field’s intended Kubernetes usage.

**Changes:**

- Add `service.wireguard.loadBalancerIP` to `values.yaml`
- Render `spec.loadBalancerIP` for the WireGuard Service when `service.wireguard.type` is `LoadBalancer`
  
**Testing**

- Not run; Helm template-only change

**Note**

On the Kubernetes API side: `.spec.loadBalancerIP` is deprecated since Kubernetes v1.24 because its behavior is provider-specific and it does not support dual-stack well.

This PR intentionally only exposes the existing Kubernetes Service field as an optional Helm value and only renders it for `service.wireguard.type: LoadBalancer`. This keeps the default behavior unchanged while allowing environments whose load balancer implementation still supports this field, for example NSX-NCP or MetalLB, to request a specific WireGuard LoadBalancer IP.

I did not add a provider-specific annotation because the annotation differs by LB implementation, and NSX-NCP uses `spec.loadBalancerIP` for this use case.