### PR TITLE
fix: persist config status when update lock is contended

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -259,6 +259,12 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileRunning(
 				return nil
 			}
 
+			if errors.Is(err, errAcquireConfigLock) {
+				logger.Info("failed to acquire config apply lock, another operation is ongoing", zap.Error(err))
+
+				return nil
+			}
+
 			return fmt.Errorf("failed to apply config to machine '%s': %w", machineConfig.Metadata().ID(), err)
 		}
 	}
@@ -458,6 +464,8 @@ func (ctrl *ClusterMachineConfigStatusController) stageUpgrade(actualTalosVersio
 	return version.Major == 1 && version.Minor == 9 && version.Patch < 3, nil
 }
 
+var errAcquireConfigLock = errors.New("failed to acquire config update lock")
+
 func (ctrl *ClusterMachineConfigStatusController) applyConfig(inputCtx context.Context,
 	logger *zap.Logger,
 	r controller.ReaderWriter,
@@ -512,8 +520,6 @@ func (ctrl *ClusterMachineConfigStatusController) applyConfig(inputCtx context.C
 	defer data.Free()
 
 	if err = ctrl.acquireConfigUpdateLock(ctx, r, rc); err != nil {
-		logger.Debug("skip applying the config, failed to acquire lock", zap.Error(err))
-
 		return 0, err
 	}
 
@@ -946,7 +952,7 @@ func (ctrl *ClusterMachineConfigStatusController) acquireConfigUpdateLock(ctx co
 	}
 
 	if !rc.configUpdatesAllowed {
-		return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine set blocks the config changes")
+		return fmt.Errorf("%w: machine set blocks the config changes", errAcquireConfigLock)
 	}
 
 	machineSetName, ok := rc.clusterMachine.Metadata().Labels().Get(omni.LabelMachineSet)
@@ -984,7 +990,7 @@ func (ctrl *ClusterMachineConfigStatusController) acquireConfigUpdateLock(ctx co
 		}
 
 		if quota <= 0 {
-			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("quota %d for updates reached, waiting for the locks to be released, pending: %#v", updateParallelism, pendingMachines)
+			return fmt.Errorf("%w: quota %d for updates reached, waiting for the locks to be released, pending: %#v", errAcquireConfigLock, updateParallelism, pendingMachines)
 		}
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -514,6 +514,91 @@ func TestMachineConfigStatusController(t *testing.T) {
 		})
 	})
 
+	t.Run("configUpdatesBlockedStillPersistsStatus", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(ctx, t, testutils.TestOptions{}, addControllers, func(ctx context.Context, testContext testutils.TestContext) {
+			clusterName := "config-updates-blocked"
+			machineServices := testutils.NewMachineServices(t, testContext.State)
+			_, machines := createCluster(ctx, t, testContext.State, machineServices, clusterName, 1, 0)
+			require.Len(t, machines, 1)
+
+			id := machines[0].Metadata().ID()
+
+			awaitAllMachinesConfigured(ctx, t, testContext.State, clusterName)
+
+			var sha256BeforeBlock string
+
+			rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.ClusterMachineConfigStatus, assert *assert.Assertions) {
+				assert.NotEmpty(res.TypedSpec().Value.SchematicId)
+				assert.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+
+				sha256BeforeBlock = res.TypedSpec().Value.ClusterMachineConfigSha256
+			})
+
+			rmock.Mock[*omni.MachineSetConfigStatus](
+				ctx, t, testContext.State,
+				options.WithID(omni.ControlPlanesResourceID(clusterName)),
+				options.Modify(func(res *omni.MachineSetConfigStatus) error {
+					res.TypedSpec().Value.ConfigUpdatesAllowed = false
+
+					return nil
+				}),
+			)
+
+			// Push a config change that produces a new SHA. With updates blocked, acquireConfigUpdateLock
+			// will fail and the new SHA must not land on the status.
+			rmock.Mock[*omni.ClusterMachineConfig](
+				ctx, t, testContext.State,
+				options.WithID(id),
+				options.Modify(func(r *omni.ClusterMachineConfig) error {
+					return r.TypedSpec().Value.SetUncompressedData([]byte(`machine:
+  network:
+    kubespan:
+      enabled: true`))
+				}),
+			)
+
+			rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.MachinePendingUpdates, assert *assert.Assertions) {
+				assert.NotEmpty(res.TypedSpec().Value.ConfigDiff)
+			})
+
+			rmock.Mock[*omni.MachineStatus](
+				ctx, t, testContext.State,
+				options.WithID(id),
+				options.Modify(func(res *omni.MachineStatus) error {
+					res.TypedSpec().Value.Schematic.Invalid = true
+					res.TypedSpec().Value.Schematic.Id = ""
+					res.TypedSpec().Value.Schematic.FullId = ""
+
+					return nil
+				}),
+			)
+
+			rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.ClusterMachineConfigStatus, assert *assert.Assertions) {
+				assert.Empty(res.TypedSpec().Value.SchematicId)
+				assert.Equal(sha256BeforeBlock, res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+
+			rmock.Mock[*omni.MachineSetConfigStatus](
+				ctx, t, testContext.State,
+				options.WithID(omni.ControlPlanesResourceID(clusterName)),
+				options.Modify(func(res *omni.MachineSetConfigStatus) error {
+					res.TypedSpec().Value.ConfigUpdatesAllowed = true
+
+					return nil
+				}),
+			)
+
+			rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.ClusterMachineConfigStatus, assert *assert.Assertions) {
+				assert.NotEqual(sha256BeforeBlock, res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+		})
+	})
+
 	// Creates a cluster with the machine with secure boot mode enabled.
 	// Install image should have `installer-secureboot` path.
 	t.Run("secureBootInstallImage", func(t *testing.T) {


### PR DESCRIPTION
acquireConfigUpdateLock returned a SkipReconcileTag-tagged error when a machine set blocked config changes or the update-parallelism quota was exhausted, which caused the qtransform machinery to drop the ClusterMachineConfigStatus output write for that reconciliation. The status then failed to reflect the machine's actual state until an unrelated input change triggered another reconcile.

Replace the tagged error with an errAcquireConfigLock sentinel, log and swallow it in reconcileRunning, and let the reconciliation return nil so the output is persisted and the status stays current while the lock is held elsewhere.
