### PR TITLE
refactor(frontend): remove last cases of any in codebase

### DIFF
--- a/frontend/src/api/grpc.ts
+++ b/frontend/src/api/grpc.ts
@@ -175,8 +175,7 @@ export class Stream<R, T> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Resource<T = any, S = any> = {
+export type Resource<T = unknown, S = unknown> = {
   metadata: Metadata & { name?: string }
   spec: T
   status?: S

--- a/frontend/src/api/watch.ts
+++ b/frontend/src/api/watch.ts
@@ -300,7 +300,7 @@ export default class Watch<T extends Resource> extends WatchFunc<T> {
     switch (message.event?.event_type) {
       case EventType.UPDATED:
       case EventType.CREATED:
-        this.item.value = spec.res as T
+        this.item.value = spec.res
         break
       case EventType.DESTROYED:
         this.item.value = undefined
@@ -340,7 +340,7 @@ export default class Watch<T extends Resource> extends WatchFunc<T> {
   }
 }
 
-const compareFn = <T>(
+const compareFn = <T extends Resource>(
   left: ResourceSort<T>,
   right: ResourceSort<T>,
   sortDescending?: boolean,
@@ -367,8 +367,8 @@ const compareFn = <T>(
   return 0
 }
 
-function getInsertionIndex<T>(
-  arr: Resource<T>[],
+function getInsertionIndex<T extends Resource>(
+  arr: T[],
   item: ResourceSort<T>,
   sortDescending?: boolean,
 ): number {
@@ -417,17 +417,17 @@ export const itemID = (item: {
   return `${item.metadata.namespace || 'default'}.${item.metadata.name ?? item.metadata.id}`
 }
 
-type ResourceSort<T> = Resource<T> & { sortFieldData?: string }
+type ResourceSort<T> = T & { sortFieldData?: string }
 
 // WatchItems wraps items list and handles sort order, insertions and removals.
-class WatchItems<T> {
+class WatchItems<T extends Resource> {
   private items: ResourceSort<T>[]
   private bootstrapList: ResourceSort<T>[] = []
 
   public bootstrapped: boolean = false
   private sortDescending: boolean = false
 
-  constructor(items: Resource<T>[]) {
+  constructor(items: T[]) {
     this.items = items
   }
 
@@ -442,7 +442,7 @@ class WatchItems<T> {
     })
   }
 
-  public createOrUpdate(item: ResourceSort<T>, old?: Resource<T>) {
+  public createOrUpdate(item: ResourceSort<T>, old?: T) {
     const items = this.bootstrapped ? this.items : this.bootstrapList
 
     let foundIndex = this.findIndex(itemID(old ?? item), items)
@@ -491,8 +491,8 @@ class WatchItems<T> {
     this.bootstrapList = []
   }
 
-  private findIndex(id: string, items: Resource<T>[]): number {
-    return items.findIndex((element: Resource<T>) => {
+  private findIndex(id: string, items: T[]): number {
+    return items.findIndex((element: T) => {
       return itemID(element) === id
     })
   }

--- a/frontend/src/components/Form/DateControlRenderer.vue
+++ b/frontend/src/components/Form/DateControlRenderer.vue
@@ -32,7 +32,7 @@ const dataTime = computed(() => (control.value.data ?? '').substr(0, 16))
       type="date"
       :value="dataTime"
       :disabled="!control.enabled"
-      @change="(event) => p.handleChange(control.path, (event.target as any)?.value)"
+      @change="(event) => p.handleChange(control.path, (event.target as HTMLInputElement)?.value)"
     />
     <div
       v-if="isChrome()"

--- a/frontend/src/components/Form/DateTimeControlRenderer.vue
+++ b/frontend/src/components/Form/DateTimeControlRenderer.vue
@@ -36,7 +36,10 @@ const toISOString = (inputDateTime: string) => {
       type="datetime-local"
       :value="dataTime"
       :disabled="!control.enabled"
-      @change="(event) => p.handleChange(control.path, toISOString((event.target as any)?.value))"
+      @change="
+        (event) =>
+          p.handleChange(control.path, toISOString((event.target as HTMLInputElement)?.value))
+      "
     />
     <div
       v-if="isChrome()"

--- a/frontend/src/components/Form/TimeControlRenderer.vue
+++ b/frontend/src/components/Form/TimeControlRenderer.vue
@@ -32,7 +32,7 @@ const dataTime = computed(() => (control.value.data ?? '').substr(0, 16))
       type="time"
       :value="dataTime"
       :disabled="!control.enabled"
-      @change="(event) => p.handleChange(control.path, (event.target as any)?.value)"
+      @change="(event) => p.handleChange(control.path, (event.target as HTMLInputElement)?.value)"
     />
     <div
       v-if="isChrome()"

--- a/frontend/src/methods/cluster.ts
+++ b/frontend/src/methods/cluster.ts
@@ -260,7 +260,7 @@ export const destroyNodes = async (
   let controlPlanes = 0
 
   try {
-    const resp: Resource[] = await ResourceService.List(
+    const resp = await ResourceService.List<Resource<MachineSetNodeSpec>>(
       {
         namespace: DefaultNamespace,
         type: MachineSetNodeType,

--- a/frontend/src/methods/machineset.ts
+++ b/frontend/src/methods/machineset.ts
@@ -4,8 +4,8 @@
 // included in the LICENSE file.
 
 import { Runtime } from '@/api/common/omni.pb'
-import { ResourceService } from '@/api/grpc'
-import { MachineSetSpecMachineAllocationType } from '@/api/omni/specs/omni.pb'
+import { type Resource, ResourceService } from '@/api/grpc'
+import { type MachineSetSpec, MachineSetSpecMachineAllocationType } from '@/api/omni/specs/omni.pb'
 import { withRuntime } from '@/api/options'
 import {
   ControlPlanesIDSuffix,
@@ -97,7 +97,7 @@ export const scaleMachineSet = async (
     throw new Error('machine set count can not be negative')
   }
 
-  const ms = await ResourceService.Get(
+  const ms = await ResourceService.Get<Resource<MachineSetSpec>>(
     {
       id: id,
       type: MachineSetType,

--- a/frontend/src/pages/(authenticated)/settings/backups.vue
+++ b/frontend/src/pages/(authenticated)/settings/backups.vue
@@ -50,7 +50,7 @@ const s3ConfigMetadata = {
 }
 
 onMounted(async () => {
-  const status: Resource<EtcdBackupOverallStatusSpec> = await ResourceService.Get(
+  const status = await ResourceService.Get<Resource<EtcdBackupOverallStatusSpec>>(
     {
       id: EtcdBackupOverallStatusID,
       type: EtcdBackupOverallStatusType,
@@ -68,7 +68,10 @@ onMounted(async () => {
   }
 
   try {
-    const config = await ResourceService.Get(s3ConfigMetadata, withRuntime(Runtime.Omni))
+    const config = await ResourceService.Get<Resource<EtcdBackupS3ConfSpec>>(
+      s3ConfigMetadata,
+      withRuntime(Runtime.Omni),
+    )
 
     s3Spec.value = config?.spec
   } catch (e) {
@@ -120,7 +123,10 @@ const updateConfig = async () => {
   let exists: boolean = false
 
   try {
-    config = await ResourceService.Get(s3ConfigMetadata, withRuntime(Runtime.Omni))
+    config = await ResourceService.Get<Resource<EtcdBackupS3ConfSpec>>(
+      s3ConfigMetadata,
+      withRuntime(Runtime.Omni),
+    )
 
     exists = true
   } catch (e) {
@@ -137,9 +143,16 @@ const updateConfig = async () => {
 
   try {
     if (exists) {
-      await ResourceService.Update(config, config.metadata.version || 0, withRuntime(Runtime.Omni))
+      await ResourceService.Update<Resource<EtcdBackupS3ConfSpec>>(
+        config,
+        config.metadata.version || 0,
+        withRuntime(Runtime.Omni),
+      )
     } else {
-      await ResourceService.Create(config, withRuntime(Runtime.Omni))
+      await ResourceService.Create<Resource<EtcdBackupS3ConfSpec>>(
+        config,
+        withRuntime(Runtime.Omni),
+      )
     }
   } catch (e) {
     showError('Failed to Update Storage Config', e.message)

--- a/frontend/src/states/cluster-management.ts
+++ b/frontend/src/states/cluster-management.ts
@@ -507,7 +507,7 @@ export class State {
       )
     }
 
-    resources = resources.sort((a: Resource, b: Resource) => {
+    resources = resources.sort((a, b) => {
       type TypeKey = keyof typeof typesOrder
 
       if (typesOrder[a.metadata.type! as TypeKey] > typesOrder[b.metadata.type! as TypeKey]) {
@@ -528,8 +528,7 @@ export class State {
     const baseResources: Record<string, Record<string, Resource>> = {}
 
     for (const r of this.baseResources) {
-      baseResources[r.metadata.type!] = baseResources[r.metadata.type!] || {}
-
+      baseResources[r.metadata.type!] ||= {}
       baseResources[r.metadata.type!][r.metadata.id!] = r
     }
 
@@ -543,8 +542,8 @@ export class State {
           ...res.metadata,
         },
         spec: {
-          ...base.spec,
-          ...res.spec,
+          ...(base.spec ?? {}),
+          ...(res.spec ?? {}),
         },
       }
     })
@@ -652,7 +651,7 @@ export const populateExisting = async (clusterName: string) => {
   const resources: Resource[] = []
 
   // list all cluster config patches
-  const patches: Resource<ConfigPatch>[] = await ResourceService.List(
+  const patches = await ResourceService.List<Resource<ConfigPatch>>(
     {
       type: ConfigPatchType,
       namespace: DefaultNamespace,
@@ -667,7 +666,7 @@ export const populateExisting = async (clusterName: string) => {
     patchesByID[patch.metadata.id!] = patch
   }
 
-  const systemExtensions: Resource<ExtensionsConfigurationSpec>[] = await ResourceService.List(
+  const systemExtensions = await ResourceService.List<Resource<ExtensionsConfigurationSpec>>(
     {
       type: ExtensionsConfigurationType,
       namespace: DefaultNamespace,
@@ -831,7 +830,7 @@ export const populateExisting = async (clusterName: string) => {
   }
 
   // get machine set nodes
-  const machineSetNodes: Resource<MachineSetNode>[] = await ResourceService.List(
+  const machineSetNodes = await ResourceService.List<Resource<MachineSetNode>>(
     {
       type: MachineSetNodeType,
       namespace: DefaultNamespace,


### PR DESCRIPTION
Remove the last cases of `any` use in the frontend codebase. Essentially type only changes.