### PR TITLE
backports: for v1.8.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/siderolabs/gen v0.8.6
 	github.com/siderolabs/go-api-signature v0.3.12
 	github.com/siderolabs/go-debug v0.6.2
-	github.com/siderolabs/go-kubernetes v0.2.37
+	github.com/siderolabs/go-kubernetes v0.2.38
 	github.com/siderolabs/go-loadbalancer v0.5.0
 	github.com/siderolabs/go-pointer v1.0.1
 	github.com/siderolabs/go-retry v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,8 @@ github.com/siderolabs/go-debug v0.6.2 h1:zWWMTcrYDVyiNTotSxEVg++hj9mb2ctuTNVnOeC
 github.com/siderolabs/go-debug v0.6.2/go.mod h1:tcHnBjzOfEC/Stfc+cpP8J9Y6y5Pp89XNBN0n3dsWD4=
 github.com/siderolabs/go-kubeconfig v0.1.2 h1:0D0v3lXUKon+A2qRFwOnc9m4qSB+e+5WDmvGjiJPH8Y=
 github.com/siderolabs/go-kubeconfig v0.1.2/go.mod h1:FMl17PHjjAJjdeUTMN+gBzGH0lhsCbj2IX9/HNMpMh0=
-github.com/siderolabs/go-kubernetes v0.2.37 h1:A7/8XZpsdHoJxkXrFL88cJ3t2KpB+tWzBaMGDsakHmY=
-github.com/siderolabs/go-kubernetes v0.2.37/go.mod h1:n9K8JCv6bRfK1P7c8insZglPsHMdUcvWmm/9LGLRNcc=
+github.com/siderolabs/go-kubernetes v0.2.38 h1:HzBHnSE0zA/7eXpqRnfDYS94F5KO9QMW6tOqIQ33O2Y=
+github.com/siderolabs/go-kubernetes v0.2.38/go.mod h1:4DBVXLASGnJIhbDRJNl9DayYohYLu3VhQ1cpY/Gj2nw=
 github.com/siderolabs/go-loadbalancer v0.5.0 h1:0v7E6GrxoONyqwcmHiA+J0vIDPWbkTmevHGCFb4tjdc=
 github.com/siderolabs/go-loadbalancer v0.5.0/go.mod h1:tRVouZ9i2R/TRbNUF9MqyBlV2wsjX0cxkYTjPXcI9P0=
 github.com/siderolabs/go-pointer v1.0.1 h1:f7Yi4IK1jptS8yrT9GEbwhmGcVxvPQgBUG/weH3V3DM=

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -213,12 +213,20 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileRunning(
 				zap.String("machine", machineConfig.Metadata().ID()),
 			)
 
-			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("'%s' the machine talos version is out of sync: %w", machineConfig.Metadata().ID(), err)
+			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine talos version is out of sync: %s", machineConfig.Metadata().ID())
 		}
-	} else {
-		if err = ctrl.releaseUpgradeLock(ctx, r, rc.clusterMachine); err != nil {
-			return fmt.Errorf("failed to release upgrade lock: %w", err)
-		}
+	}
+
+	// At this point the machine is in sync: it either needed no upgrade, or the upgrade just
+	// completed. Release the upgrade lock here, before entering the config-apply phase, so the
+	// upgrade and config-update locks are never held simultaneously by the same machine.
+	//
+	// Holding the upgrade lock into the config-apply phase allows a lock-ordering inversion to
+	// deadlock the whole machine set: one machine holds the config-update lock and waits for the
+	// upgrade lock, while another holds the upgrade lock and waits for the config-update lock.
+	// Neither lock is ever released and the machine set is stuck until Omni is restarted.
+	if err = ctrl.releaseUpgradeLock(ctx, r, rc.clusterMachine); err != nil {
+		return fmt.Errorf("failed to release upgrade lock: %w", err)
 	}
 
 	stage := rc.machineStatusSnapshot.TypedSpec().Value.GetMachineStatus().GetStage()
@@ -977,7 +985,7 @@ func (ctrl *ClusterMachineConfigStatusController) acquireConfigUpdateLock(ctx co
 }
 
 func (ctrl *ClusterMachineConfigStatusController) releaseConfigUpdateLock(ctx context.Context, r controller.ReaderWriter, clusterMachine *omni.ClusterMachine) error {
-	if !clusterMachine.Metadata().Finalizers().Has(ConfigUpdateFinalizer) {
+	if clusterMachine == nil || !clusterMachine.Metadata().Finalizers().Has(ConfigUpdateFinalizer) {
 		return nil
 	}
 
@@ -985,7 +993,7 @@ func (ctrl *ClusterMachineConfigStatusController) releaseConfigUpdateLock(ctx co
 }
 
 func (ctrl *ClusterMachineConfigStatusController) releaseUpgradeLock(ctx context.Context, r controller.ReaderWriter, clusterMachine *omni.ClusterMachine) error {
-	if !clusterMachine.Metadata().Finalizers().Has(UpgradeFinalizer) {
+	if clusterMachine == nil || !clusterMachine.Metadata().Finalizers().Has(UpgradeFinalizer) {
 		return nil
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -1069,3 +1069,75 @@ func createCluster(
 
 	return cluster, machines
 }
+
+// TestUpgradeLockReleasedBeforeConfigApply is a regression test for siderolabs/omni#2805.
+//
+// Once a machine is in sync, it must release the upgrade lock before entering the
+// config-apply phase, so it never holds both the upgrade and the config-update lock at the
+// same time. If it held both, two machines could deadlock, each holding one lock while
+// waiting for the other, stalling the whole machine set.
+func TestUpgradeLockReleasedBeforeConfigApply(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer")))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			st := tc.State
+
+			machineServices := testutils.NewMachineServices(t, st)
+
+			_, machines := createCluster(ctx, t, st, machineServices, "deadlock-regression", 1, 0)
+			id := machines[0].Metadata().ID()
+
+			// Wait for the initial config to be applied: the config-update lock is only taken
+			// once the machine already has an applied config.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+
+			// The machine completes upgrades on request, but its config apply never succeeds, so
+			// it stays in the config-apply phase holding the config-update lock.
+			machineServices.Get(id).OnUpdate = func(ctx context.Context, req *machine.UpgradeRequest, st state.State, machineID string) (*machine.UpgradeResponse, error) {
+				_, tag, _ := strings.Cut(req.Image, ":")
+
+				return &machine.UpgradeResponse{}, safe.StateModify(ctx, st, omni.NewMachineStatus(machineID), func(res *omni.MachineStatus) error {
+					res.TypedSpec().Value.TalosVersion = strings.TrimLeft(tag, "v")
+
+					return nil
+				})
+			}
+			machineServices.Get(id).OnApplyConfig = func(context.Context, *machine.ApplyConfigurationRequest, state.State, string) (*machine.ApplyConfigurationResponse, error) {
+				return nil, errors.New("config apply blocked")
+			}
+
+			// Trigger a config change and an upgrade at the same time.
+			rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), options.Modify(func(r *omni.ClusterMachineConfig) error {
+				return r.TypedSpec().Value.SetUncompressedData([]byte("machine:\n  network:\n    kubespan:\n      enabled: true"))
+			}))
+			rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+				res.TypedSpec().Value.InstallImage.TalosVersion = "1.12.7"
+
+				return nil
+			}))
+
+			// The upgrade completes on the machine.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.MachineStatus, a *assert.Assertions) {
+				a.Equal("1.12.7", res.TypedSpec().Value.TalosVersion)
+			})
+
+			// The machine is now stuck applying config, holding the config-update lock. It must
+			// not also hold the upgrade lock: the upgrade lock has to be released before the
+			// config-apply phase, so a machine never holds both at once.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachine, a *assert.Assertions) {
+				a.True(res.Metadata().Finalizers().Has(machineconfig.ConfigUpdateFinalizer), "should hold the config-update lock")
+				a.False(res.Metadata().Finalizers().Has(machineconfig.UpgradeFinalizer), "must not hold the upgrade lock during config apply")
+			})
+		},
+	)
+}

--- a/internal/backend/runtime/omni/controllers/omni/versions.go
+++ b/internal/backend/runtime/omni/controllers/omni/versions.go
@@ -30,8 +30,8 @@ import (
 )
 
 var (
-	// minK8sVersion sets minimum Kubernetes version for building the list of versions.
-	minK8sVersion = semver.MustParse(consts.MinKubernetesVersion)
+	// minDiscoveredK8sVersion sets minimum Kubernetes version for building the list of versions.
+	minDiscoveredK8sVersion = semver.MustParse(consts.MinDiscoveredKubernetesVersion)
 	// minDiscoveredTalosVersion sets minimum Talos version for building the list of versions.
 	minDiscoveredTalosVersion = semver.MustParse(consts.MinDiscoveredTalosVersion)
 	// minTalosVersion sets minimum Talos version which are not deprecated.
@@ -305,7 +305,7 @@ func (ctrl *VersionsController) reconcileKubernetesVersions(ctx context.Context,
 		return nil, err
 	}
 
-	versions := ctrl.getVersionsAfter(allVersions, minK8sVersion, false)
+	versions := ctrl.getVersionsAfter(allVersions, minDiscoveredK8sVersion, false)
 
 	for _, v := range versions {
 		k8sVersion := omni.NewKubernetesVersion(v)

--- a/internal/backend/saml/session_test.go
+++ b/internal/backend/saml/session_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	csaml "github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
+	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
@@ -62,6 +63,7 @@ func TestUserInfo(t *testing.T) {
 	} {
 		t.Run(tt.file, func(t *testing.T) {
 			fakeTime = tt.time
+			csaml.Clock = dsig.NewFakeClockAt(csaml.TimeNow())
 
 			rootURL, err := url.Parse(tt.rootURL)
 			require.NoError(t, err)

--- a/internal/pkg/constants/versions.go
+++ b/internal/pkg/constants/versions.go
@@ -33,8 +33,8 @@ const DefaultTalosVersion = constants.DefaultTalosVersion
 // AnotherKubernetesVersion is used in the integration tests for Kubernetes upgrade.
 const AnotherKubernetesVersion = "1.35.4"
 
-// MinKubernetesVersion allowed to be used when creating the cluster.
-const MinKubernetesVersion = "1.27.0"
+// MinDiscoveredKubernetesVersion makes Omni pull the versions from this point.
+const MinDiscoveredKubernetesVersion = "1.23.0"
 
 // DenylistedTalosVersions is a list of versions which should never show up in the version picker.
 var DenylistedTalosVersions = Denylist{


### PR DESCRIPTION
PRs backported:
- https://github.com/siderolabs/omni/pull/2916
- https://github.com/siderolabs/omni/pull/2919
- https://github.com/siderolabs/omni/pull/2926
- https://github.com/siderolabs/omni/pull/2934