### PR TITLE
fix: keep exposed services reachable after a health check flap

### DIFF
--- a/internal/backend/workloadproxy/lb/lb.go
+++ b/internal/backend/workloadproxy/lb/lb.go
@@ -9,6 +9,7 @@ package lb
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"time"
 
@@ -18,21 +19,26 @@ import (
 )
 
 // LB is a minimal wrapper around [upstream.List] which provides a simpler interface for picking an upstream address.
+//
+// addresses and fallbackCounter are only accessed from Reconcile and PickAddress, both of which the workload
+// proxy reconciler always calls while holding its own mutex, so they need no synchronization of their own.
 type LB struct {
-	logger    *zap.Logger
-	upstreams *upstream.List[node]
+	logger          *zap.Logger
+	upstreams       *upstream.List[node]
+	addresses       []string
+	fallbackCounter uint
 }
 
 // New creates a new load balancer with the given upstream addresses and logger.
 func New(upstreamAddresses []string, logger *zap.Logger, options ...upstream.ListOption) (*LB, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	nodes := slices.Values(xslices.Map(upstreamAddresses, func(addr string) node {
 		return node{address: addr, logger: logger}
 	}))
 	nodesEqual := func(a, b node) bool { return a.address == b.address }
-
-	if logger == nil {
-		logger = zap.NewNop()
-	}
 
 	upstreams, err := upstream.NewListWithCmp(nodes, nodesEqual, options...)
 	if err != nil {
@@ -42,6 +48,7 @@ func New(upstreamAddresses []string, logger *zap.Logger, options ...upstream.Lis
 	return &LB{
 		logger:    logger,
 		upstreams: upstreams,
+		addresses: slices.Clone(upstreamAddresses),
 	}, nil
 }
 
@@ -52,18 +59,33 @@ func (lb *LB) Reconcile(upstreamAddresses []string) error {
 	}))
 
 	lb.upstreams.Reconcile(nodes)
+	lb.addresses = slices.Clone(upstreamAddresses)
 
 	return nil
 }
 
-// PickAddress picks a healthy upstream address from the load balancer.
+// PickAddress picks a healthy upstream address, falling back to any known upstream when all are benched.
 func (lb *LB) PickAddress() (string, error) {
 	pickedNode, err := lb.upstreams.Pick()
-	if err != nil {
-		return "", err
+	if err == nil {
+		return pickedNode.address, nil
 	}
 
-	return pickedNode.address, nil
+	// Optimistic fallback: when every upstream is benched, Pick reports no upstreams available.
+	// A cold load balancer (freshly created after an Omni restart, all scores starting at zero)
+	// gets benched by a single failed health check, e.g. one that coincided with a brief upstream
+	// blip, and would otherwise keep failing until the next health check restores a score, up to
+	// one health check interval later. Hand out a known upstream anyway, round-robin: if it
+	// actually serves, the caller recovers immediately, and the periodic health check brings the
+	// score back up on its own.
+	if errors.Is(err, upstream.ErrNoUpstreams) && len(lb.addresses) > 0 {
+		addr := lb.addresses[lb.fallbackCounter%uint(len(lb.addresses))]
+		lb.fallbackCounter++
+
+		return addr, nil
+	}
+
+	return "", err
 }
 
 // Notify notifies the load balancer for it to refresh its internal state.

--- a/internal/backend/workloadproxy/lb/lb_test.go
+++ b/internal/backend/workloadproxy/lb/lb_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lb_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/siderolabs/go-loadbalancer/upstream"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/omni/internal/backend/workloadproxy/lb"
+)
+
+// TestPickAddressFallback verifies that when every upstream is benched, PickAddress still
+// hands out a known upstream (round-robin) instead of failing. This is the recovery path
+// for a cold load balancer right after an Omni restart, where a single failed health check
+// benches every node and the proxy would otherwise return 502 until the next health check.
+func TestPickAddressFallback(t *testing.T) {
+	t.Parallel()
+
+	addresses := []string{"127.0.0.1:1", "127.0.0.2:1"} // refused on connect, so every node stays benched
+
+	// A negative initial score starts every upstream benched, and the failing health checks keep
+	// them there, so Pick reports no upstreams available and the fallback is exercised.
+	l, err := lb.New(
+		addresses, zaptest.NewLogger(t),
+		upstream.WithInitialScore(-1),
+		upstream.WithHealthcheckTimeout(time.Second),
+		upstream.WithHealthcheckInterval(time.Hour),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(l.Shutdown)
+
+	first, err := l.PickAddress()
+	require.NoError(t, err)
+	require.Contains(t, addresses, first)
+
+	second, err := l.PickAddress()
+	require.NoError(t, err)
+	require.Contains(t, addresses, second)
+
+	require.NotEqual(t, first, second, "fallback should round-robin across all known upstreams")
+}


### PR DESCRIPTION
After an Omni restart the workload proxy load balancers start fresh and only learn upstream health from periodic checks. A single failed check, for example one coinciding with a brief upstream blip, can mark every upstream of an exposed service as unhealthy, and the proxy then returns errors for that service until the next check even once the upstream is reachable again.

The load balancer now falls back to a known upstream when none are pickable, rotating across them. If it serves the request the caller recovers right away, and the periodic check restores the healthy state on its own. Steady state behavior is unchanged.

This showed up as an intermittent failure of the workload proxy upgrade integration test.