### PR TITLE
feat: validate resource metadata at the state layer

### DIFF
--- a/internal/backend/runtime/omni/validations/export_test.go
+++ b/internal/backend/runtime/omni/validations/export_test.go
@@ -108,3 +108,7 @@ func KubernetesManifestsValidationOptions() []validated.StateOption {
 func EulaValidationOptions(st state.State) []validated.StateOption {
 	return eulaValidationOptions(st)
 }
+
+func MetadataValidationOptions() []validated.StateOption {
+	return metadataValidationOptions()
+}

--- a/internal/backend/runtime/omni/validations/metadata.go
+++ b/internal/backend/runtime/omni/validations/metadata.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package validations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
+)
+
+const (
+	// MaxResourceIDLength caps the byte length of a resource ID.
+	MaxResourceIDLength = 1024
+
+	// MaxLabelKeyLength caps the byte length of a label key.
+	MaxLabelKeyLength = 1024
+
+	// MaxLabelValueLength caps the byte length of a label value.
+	MaxLabelValueLength = 16 * 1024
+
+	// MaxLabelsCount caps the number of labels on a resource.
+	MaxLabelsCount = 256
+
+	// MaxAnnotationKeyLength caps the byte length of an annotation key.
+	MaxAnnotationKeyLength = MaxLabelKeyLength
+
+	// MaxAnnotationValueLength caps the byte length of an annotation value.
+	MaxAnnotationValueLength = MaxLabelValueLength
+
+	// MaxAnnotationsCount caps the number of annotations on a resource.
+	MaxAnnotationsCount = MaxLabelsCount
+)
+
+// metadataValidationOptions enforces universal metadata rules: resource ID rules at create time
+// (non-empty, no control characters, length cap), and label and annotation rules at both create and
+// update (key non-empty, key/value within length cap, no control characters, count cap). Label and
+// annotation updates validate only entries that are new or changed compared to the existing
+// resource, so existing offending values do not block unrelated updates.
+func metadataValidationOptions() []validated.StateOption {
+	return []validated.StateOption{
+		validated.WithCreateValidations(
+			func(_ context.Context, res resource.Resource, _ ...state.CreateOption) error {
+				return validateResourceID(res.Metadata().ID())
+			},
+			func(_ context.Context, res resource.Resource, _ ...state.CreateOption) error {
+				return validateMetadataMap("label", nil, res.Metadata().Labels().Raw(), MaxLabelsCount, MaxLabelKeyLength, MaxLabelValueLength)
+			},
+			func(_ context.Context, res resource.Resource, _ ...state.CreateOption) error {
+				return validateMetadataMap("annotation", nil, res.Metadata().Annotations().Raw(), MaxAnnotationsCount, MaxAnnotationKeyLength, MaxAnnotationValueLength)
+			},
+		),
+		validated.WithUpdateValidations(
+			func(_ context.Context, oldRes, newRes resource.Resource, _ ...state.UpdateOption) error {
+				return validateMetadataMap("label", existingLabels(oldRes), newRes.Metadata().Labels().Raw(), MaxLabelsCount, MaxLabelKeyLength, MaxLabelValueLength)
+			},
+			func(_ context.Context, oldRes, newRes resource.Resource, _ ...state.UpdateOption) error {
+				return validateMetadataMap("annotation", existingAnnotations(oldRes), newRes.Metadata().Annotations().Raw(), MaxAnnotationsCount, MaxAnnotationKeyLength, MaxAnnotationValueLength)
+			},
+		),
+	}
+}
+
+func validateResourceID(id string) error {
+	if id == "" {
+		return errors.New("resource ID must not be empty")
+	}
+
+	if len(id) > MaxResourceIDLength {
+		return fmt.Errorf("resource ID is too long: %d bytes (max %d)", len(id), MaxResourceIDLength)
+	}
+
+	if strings.ContainsFunc(id, isControlChar) {
+		return errors.New("resource ID must not contain control characters")
+	}
+
+	return nil
+}
+
+// validateMetadataMap applies entry and count rules to a label or annotation map. On update, the
+// caller passes the old map so unchanged entries are skipped and the count cap only fires when the
+// new map both exceeds the cap and grew compared to the old.
+//
+//nolint:unparam
+func validateMetadataMap(kind string, old, current map[string]string, maxCount, maxKey, maxValue int) error {
+	if len(current) > maxCount && len(current) > len(old) {
+		return fmt.Errorf("too many %ss: %d (max %d)", kind, len(current), maxCount)
+	}
+
+	for k, v := range current {
+		if oldV, existed := old[k]; existed && oldV == v {
+			continue
+		}
+
+		if err := validateMetadataEntry(kind, k, v, maxKey, maxValue); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateMetadataEntry(kind, key, value string, maxKey, maxValue int) error {
+	if key == "" {
+		return fmt.Errorf("%s key must not be empty", kind)
+	}
+
+	if len(key) > maxKey {
+		return fmt.Errorf("%s key is too long: %d bytes (max %d)", kind, len(key), maxKey)
+	}
+
+	if strings.ContainsFunc(key, isControlChar) {
+		return fmt.Errorf("%s key %q must not contain control characters", kind, key)
+	}
+
+	if len(value) > maxValue {
+		return fmt.Errorf("%s value for key %q is too long: %d bytes (max %d)", kind, key, len(value), maxValue)
+	}
+
+	if strings.ContainsFunc(value, isControlChar) {
+		return fmt.Errorf("%s value for key %q must not contain control characters", kind, key)
+	}
+
+	return nil
+}
+
+func isControlChar(r rune) bool {
+	return unicode.IsControl(r)
+}
+
+func existingLabels(res resource.Resource) map[string]string {
+	if res == nil {
+		return nil
+	}
+
+	return res.Metadata().Labels().Raw()
+}
+
+func existingAnnotations(res resource.Resource) map[string]string {
+	if res == nil {
+		return nil
+	}
+
+	return res.Metadata().Annotations().Raw()
+}

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -1739,6 +1739,215 @@ func TestInfraMachineConfigValidation(t *testing.T) {
 	require.NoError(t, st.Destroy(ctx, conf.Metadata()))
 }
 
+func TestMetadataIDValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		id          string
+		errContains string
+	}{
+		{name: "valid", id: "regular-id"},
+		{name: "empty", id: "", errContains: "must not be empty"},
+		{name: "newline", id: "foo\nbar", errContains: "control character"},
+		{name: "tab", id: "foo\tbar", errContains: "control character"},
+		{name: "NUL", id: "foo\x00bar", errContains: "control character"},
+		{name: "ANSI escape", id: "\x1b[31mred\x1b[0m", errContains: "control character"},
+		{name: "DEL", id: "foo\x7fbar", errContains: "control character"},
+		{name: "NEL", id: "foo\u0085bar", errContains: "control character"},
+		{
+			name:        "too long",
+			id:          strings.Repeat("x", validations.MaxResourceIDLength+1),
+			errContains: "too long",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+			st := validated.NewState(innerSt, validations.MetadataValidationOptions()...)
+
+			res := omnires.NewKernelArgs(tt.id)
+
+			err := st.Create(ctx, res)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
+func TestMetadataLabelsAnnotationsValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create rejects bad entries", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tt := range []struct {
+			labels      map[string]string
+			annotations map[string]string
+			name        string
+			errContains string
+		}{
+			{name: "valid labels and annotations", labels: map[string]string{"env": "prod"}, annotations: map[string]string{"note": "ok"}},
+			{name: "empty label key", labels: map[string]string{"": "v"}, errContains: "label key must not be empty"},
+			{name: "empty annotation key", annotations: map[string]string{"": "v"}, errContains: "annotation key must not be empty"},
+			{name: "newline in label key", labels: map[string]string{"foo\nbar": "v"}, errContains: "label key"},
+			{name: "newline in label value", labels: map[string]string{"k": "v\nbroken"}, errContains: "label value"},
+			{
+				name:        "label key too long",
+				labels:      map[string]string{strings.Repeat("k", validations.MaxLabelKeyLength+1): "v"},
+				errContains: "label key is too long",
+			},
+			{
+				name:        "label value too long",
+				labels:      map[string]string{"k": strings.Repeat("v", validations.MaxLabelValueLength+1)},
+				errContains: "label value for key",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+				t.Cleanup(cancel)
+
+				innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+				st := validated.NewState(innerSt, validations.MetadataValidationOptions()...)
+
+				res := omnires.NewKernelArgs("test-" + strings.ReplaceAll(tt.name, " ", "-"))
+				for k, v := range tt.labels {
+					res.Metadata().Labels().Set(k, v)
+				}
+
+				for k, v := range tt.annotations {
+					res.Metadata().Annotations().Set(k, v)
+				}
+
+				err := st.Create(ctx, res)
+				if tt.errContains == "" {
+					require.NoError(t, err)
+
+					return
+				}
+
+				assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+				assert.ErrorContains(t, err, tt.errContains)
+			})
+		}
+	})
+
+	t.Run("create rejects count over cap", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+		st := validated.NewState(innerSt, validations.MetadataValidationOptions()...)
+
+		res := omnires.NewKernelArgs("count-test")
+		for i := range validations.MaxLabelsCount + 1 {
+			res.Metadata().Labels().Set(fmt.Sprintf("k%d", i), "v")
+		}
+
+		err := st.Create(ctx, res)
+		assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+		assert.ErrorContains(t, err, "too many labels")
+	})
+
+	t.Run("update with unchanged offending entries passes", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		// Stage an offending resource via the inner state (bypassing validation).
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		res := omnires.NewKernelArgs("update-test-1")
+		res.Metadata().Labels().Set("", "empty-key-still-here")
+		res.Metadata().Labels().Set("foo\nbar", "newline-key-still-here")
+		res.Metadata().Annotations().Set("", "empty-anno-still-here")
+		require.NoError(t, innerSt.Create(ctx, res))
+
+		st := validated.NewState(innerSt, validations.MetadataValidationOptions()...)
+
+		// Update the spec without changing labels or annotations: should succeed.
+		updated, err := safe.StateGetByID[*omnires.KernelArgs](ctx, state.WrapCore(st), "update-test-1")
+		require.NoError(t, err)
+
+		updated.TypedSpec().Value.Args = []string{"console=ttyS0"}
+		require.NoError(t, st.Update(ctx, updated))
+	})
+
+	t.Run("update rejects newly added bad entries", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		res := omnires.NewKernelArgs("update-test-2")
+		res.Metadata().Labels().Set("", "preexisting")
+		require.NoError(t, innerSt.Create(ctx, res))
+
+		st := validated.NewState(innerSt, validations.MetadataValidationOptions()...)
+
+		updated, err := safe.StateGetByID[*omnires.KernelArgs](ctx, state.WrapCore(st), "update-test-2")
+		require.NoError(t, err)
+
+		updated.Metadata().Labels().Set("foo\nbar", "fresh-bad-key")
+
+		err = st.Update(ctx, updated)
+		assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+		assert.ErrorContains(t, err, "label key")
+	})
+
+	t.Run("update count cap permits unchanged over-cap state", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		// Pre-populate with more labels than the cap, bypassing validation.
+		res := omnires.NewKernelArgs("update-test-3")
+		for i := range validations.MaxLabelsCount + 10 {
+			res.Metadata().Labels().Set(fmt.Sprintf("k%d", i), "v")
+		}
+
+		require.NoError(t, innerSt.Create(ctx, res))
+
+		st := validated.NewState(innerSt, validations.MetadataValidationOptions()...)
+
+		// Same-count update (over cap, but did not grow): allowed.
+		updated, err := safe.StateGetByID[*omnires.KernelArgs](ctx, state.WrapCore(st), "update-test-3")
+		require.NoError(t, err)
+
+		updated.TypedSpec().Value.Args = []string{"x"}
+		require.NoError(t, st.Update(ctx, updated))
+
+		// Add one more: count grew past cap from over-cap state → reject.
+		updated, err = safe.StateGetByID[*omnires.KernelArgs](ctx, state.WrapCore(st), "update-test-3")
+		require.NoError(t, err)
+		updated.Metadata().Labels().Set("extra-one", "v")
+
+		err = st.Update(ctx, updated)
+		assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+		assert.ErrorContains(t, err, "too many labels")
+	})
+}
+
 func TestNodeForceDestroyRequestValidation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/runtime/omni/validations/validations.go
+++ b/internal/backend/runtime/omni/validations/validations.go
@@ -22,6 +22,7 @@ import (
 // Options returns the full set of state validation options for all user-facing resource types.
 func Options(st state.State, etcdBackupStoreFactory store.Factory, cfg *config.Params) []validated.StateOption {
 	return slices.Concat(
+		metadataValidationOptions(),
 		clusterValidationOptions(st, cfg.EtcdBackup, cfg.Services.EmbeddedDiscoveryService),
 		relationLabelsValidationOptions(),
 		accessPolicyValidationOptions(),


### PR DESCRIPTION
Resource IDs, labels, and annotations are now validated at the state layer for every resource type.

IDs are checked on create only, since they are immutable. Labels and annotations are checked on create and update with a diff-aware strategy: only entries that changed from the existing resource are re-validated, so previously stored offending values do not block unrelated updates.