### PR TITLE
refactor: replace injectable clocks with real time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/hashicorp/vault/api/auth/kubernetes v0.12.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20260208201424-4c385a1f6a73
-	github.com/jonboulle/clockwork v0.5.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/jxskiss/base62 v1.1.0
 	github.com/mattn/go-shellwords v1.0.13
@@ -206,6 +205,7 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/jsimonetti/rtnetlink/v2 v2.2.1-0.20260317095713-310581b9c6ac // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect

--- a/internal/backend/oidc/internal/storage/keys/storage.go
+++ b/internal/backend/oidc/internal/storage/keys/storage.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/go-jose/go-jose/v4"
@@ -37,7 +36,6 @@ import (
 //nolint:govet
 type Storage struct {
 	st     state.State
-	clock  clock.Clock
 	logger *zap.Logger
 
 	mu           sync.Mutex
@@ -46,10 +44,9 @@ type Storage struct {
 }
 
 // NewStorage creates a new Storage.
-func NewStorage(st state.State, clock clock.Clock, logger *zap.Logger) *Storage {
+func NewStorage(st state.State, logger *zap.Logger) *Storage {
 	result := &Storage{
 		st:     st,
-		clock:  clock,
 		logger: logger,
 	}
 
@@ -133,10 +130,14 @@ func (s *Storage) RunRefreshKey(ctx context.Context, opts ...Opts) error {
 		s.logger.Error("key refresher failed", zap.Error(err))
 
 		// wait some time before restarting
+		timer := time.NewTimer(10 * time.Second)
+
 		select {
 		case <-ctx.Done():
+			timer.Stop()
+
 			return nil
-		case <-s.clock.After(10 * time.Second):
+		case <-timer.C:
 		}
 	}
 
@@ -144,7 +145,7 @@ func (s *Storage) RunRefreshKey(ctx context.Context, opts ...Opts) error {
 }
 
 func (s *Storage) runRefreshKey(ctx context.Context, ch chan<- op.SigningKey) error {
-	ticker := s.clock.Ticker(external.KeyRotationInterval)
+	ticker := time.NewTicker(external.KeyRotationInterval)
 	defer ticker.Stop()
 
 	for ctx.Err() == nil {
@@ -204,7 +205,7 @@ func (s *Storage) storeKey(ctx context.Context, keyID string, privateKey *rsa.Pr
 
 	maxTokenFiletime := s.MaxTokenLifetime()
 
-	key.TypedSpec().Value.Expiration = timestamppb.New(s.clock.Now().Add(2*external.KeyRotationInterval + maxTokenFiletime))
+	key.TypedSpec().Value.Expiration = timestamppb.New(time.Now().Add(2*external.KeyRotationInterval + maxTokenFiletime))
 
 	s.logger.Info(
 		"generating new OIDC key",
@@ -224,7 +225,7 @@ func (s *Storage) cleanupOldKeys(ctx context.Context) error {
 	newKeySet := make([]op.Key, 0, keys.Len())
 
 	for key := range keys.All() {
-		if s.clock.Now().After(key.TypedSpec().Value.Expiration.AsTime()) {
+		if time.Now().After(key.TypedSpec().Value.Expiration.AsTime()) {
 			s.logger.Info(
 				"destroying expired OIDC key",
 				zap.String("key_id", key.Metadata().ID()),

--- a/internal/backend/oidc/internal/storage/keys/storage_test.go
+++ b/internal/backend/oidc/internal/storage/keys/storage_test.go
@@ -8,11 +8,11 @@ package keys_test
 import (
 	"crypto/rsa"
 	"slices"
-	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/benbjohnson/clock"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
@@ -22,139 +22,68 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/pkg/op"
 	"go.uber.org/zap/zaptest"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/siderolabs/omni/client/pkg/omni/resources/oidc"
 	"github.com/siderolabs/omni/internal/backend/oidc/external"
 	"github.com/siderolabs/omni/internal/backend/oidc/internal/storage/keys"
 )
 
 func TestStorage(t *testing.T) {
-	errCh := make(chan error, 1)
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	t.Cleanup(func() { require.NoError(t, <-errCh) })
+		st := state.WrapCore(namespaced.NewState(inmem.Build))
+		storage := keys.NewStorage(st, zaptest.NewLogger(t))
 
-	var wg sync.WaitGroup
+		errCh := make(chan error, 1)
 
-	t.Cleanup(wg.Wait)
+		go func() { errCh <- storage.RunRefreshKey(ctx) }()
 
-	ctx := t.Context()
+		t.Cleanup(func() { require.NoError(t, <-errCh) })
 
-	st := state.WrapCore(namespaced.NewState(inmem.Build))
-	clck := clock.NewMock()
+		// a key is generated on startup
+		synctest.Wait()
 
-	storage := keys.NewStorage(st, clck, zaptest.NewLogger(t))
+		firstKey, err := storage.GetCurrentSigningKey()
+		require.NoError(t, err)
 
-	wg.Add(1)
+		assert.EqualValues(t, jose.RS256, firstKey.SignatureAlgorithm())
 
-	keyCh := make(chan op.SigningKey, 1)
-
-	go func() {
-		defer wg.Done()
-
-		errCh <- storage.RunRefreshKey(ctx, keys.WithKeyCh(keyCh))
-	}()
-
-	var signingKey op.SigningKey
-
-	select {
-	case signingKey = <-keyCh:
-	case <-time.After(10 * time.Second):
-		t.Fatal("timeout waiting for key")
-	}
-
-	gotKey, err := storage.GetCurrentSigningKey()
-	require.NoError(t, err)
-	assert.Equal(t, signingKey.ID(), gotKey.ID())
-	assert.EqualValues(t, jose.RS256, signingKey.SignatureAlgorithm())
-
-	privateKey, ok := signingKey.Key().(*rsa.PrivateKey)
-	require.True(t, ok)
-
-	// get the active set of public keys, it should have exactly one key
-	// public key should match a private key
-	keySet, err := storage.KeySet()
-	require.NoError(t, err)
-
-	assert.Len(t, keySet, 1)
-	assert.Equal(t, keySet[0].ID(), signingKey.ID())
-	assert.Equal(t, *keySet[0].Key().(*rsa.PublicKey), privateKey.PublicKey) //nolint:forcetypeassert,errcheck
-
-	expectedPublicKeyIDs := []string{signingKey.ID()}
-
-	// advance time and generate one more key - will trigger one timer tick
-	clck.Add(external.KeyRotationInterval)
-
-	select {
-	case signingKey = <-keyCh:
-	case <-time.After(10 * time.Second):
-		t.Fatal("timeout waiting for key")
-	}
-
-	assert.NotEqual(t, signingKey.ID(), gotKey.ID())
-	assert.EqualValues(t, jose.RS256, signingKey.SignatureAlgorithm())
-
-	_, ok = signingKey.Key().(*rsa.PrivateKey)
-	require.True(t, ok)
-
-	expectedPublicKeyIDs = append(expectedPublicKeyIDs, signingKey.ID())
-
-	// get the active set of public keys, it should have two keys now
-	keySet, err = storage.KeySet()
-	require.NoError(t, err)
-
-	assert.Len(t, keySet, 2)
-	assert.Equal(t, sorted(expectedPublicKeyIDs), getKeyIDs(keySet))
-
-	// advance the time even more so that the first key expires
-	// this triggers at least one timer tick, but the exact number varies due to the mocked clock
-	clck.Add(external.KeyRotationInterval + storage.MaxTokenLifetime() + time.Second)
-
-	expectedKeyToExpire := expectedPublicKeyIDs[0]
-	expectedPublicKeyIDs = expectedPublicKeyIDs[1:]
-
-	// consume the newly generated keys until we reach the last one,
-	// which will cause the first (oldest) key to be removed due to expiration
-	for {
-		select {
-		case signingKey = <-keyCh:
-		case <-time.After(10 * time.Second):
-			t.Fatal("timeout waiting for key")
-		}
-
-		assert.EqualValues(t, jose.RS256, signingKey.SignatureAlgorithm())
-
-		_, ok = signingKey.Key().(*rsa.PrivateKey)
+		privateKey, ok := firstKey.Key().(*rsa.PrivateKey)
 		require.True(t, ok)
 
-		expectedPublicKeyIDs = append(expectedPublicKeyIDs, signingKey.ID())
+		// the active key set has exactly one key, whose public part matches the signing key
+		keySet, err := storage.KeySet()
+		require.NoError(t, err)
 
-		// get the active set of public keys
+		require.Len(t, keySet, 1)
+		assert.Equal(t, firstKey.ID(), keySet[0].ID())
+		assert.Equal(t, privateKey.PublicKey, *keySet[0].Key().(*rsa.PublicKey)) //nolint:forcetypeassert,errcheck
+
+		// seed an already-expired key, it must be cleaned up on the next rotation
+		expiredKey := oidc.NewJWTPublicKey("expired-key")
+		expiredKey.TypedSpec().Value.Expiration = timestamppb.New(time.Now().Add(-time.Hour))
+		require.NoError(t, st.Create(ctx, expiredKey))
+
+		// after one rotation interval, a second key is generated and the signing key changes
+		time.Sleep(external.KeyRotationInterval)
+		synctest.Wait()
+
+		secondKey, err := storage.GetCurrentSigningKey()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, firstKey.ID(), secondKey.ID())
+
+		// the two generated keys are active, and the expired key has been pruned
 		keySet, err = storage.KeySet()
 		require.NoError(t, err)
 
-		keyIDs := getKeyIDs(keySet)
+		assert.Equal(t, sorted([]string{firstKey.ID(), secondKey.ID()}), getKeyIDs(keySet))
 
-		if !slices.Contains(keyIDs, expectedKeyToExpire) {
-			t.Logf("first key is removed, stop receiving")
-
-			break
-		}
-	}
-
-	// get the active set of public keys - it should have at least two keys:
-	// - the second key from the previous set, because it shouldn't be expired yet.
-	// - the newly generated keys due to the tick(s) happened above.
-	keySet, err = storage.KeySet()
-	require.NoError(t, err)
-
-	keyIDs := getKeyIDs(keySet)
-	require.GreaterOrEqual(t, len(keyIDs), 2, "at least two keys should be present")
-
-	slices.Sort(expectedPublicKeyIDs)
-
-	// get last N key IDs, where N is the number of expected public keys
-	mostRecentKeyIDs := keyIDs[len(keyIDs)-len(expectedPublicKeyIDs):]
-
-	assert.Equal(t, expectedPublicKeyIDs, mostRecentKeyIDs)
+		_, err = safe.StateGet[*oidc.JWTPublicKey](ctx, st, expiredKey.Metadata())
+		assert.True(t, state.IsNotFoundError(err), "the expired key should have been destroyed")
+	})
 }
 
 func getKeyIDs(keySet []op.Key) []string {

--- a/internal/backend/oidc/internal/storage/storage.go
+++ b/internal/backend/oidc/internal/storage/storage.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
@@ -42,12 +41,10 @@ var _ op.Storage = &Storage{}
 func NewStorage(st state.State, logger *zap.Logger) *Storage {
 	logger = logger.With(logging.Component("oidc_storage"))
 
-	clk := clock.New()
-
 	return &Storage{
 		authRequestStorage: authrequest.NewStorage(),
-		tokenStorage:       token.NewStorage(st, clk),
-		keyStorage:         keys.NewStorage(st, clk, logger),
+		tokenStorage:       token.NewStorage(st),
+		keyStorage:         keys.NewStorage(st, logger),
 	}
 }
 

--- a/internal/backend/oidc/internal/storage/token/storage.go
+++ b/internal/backend/oidc/internal/storage/token/storage.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/go-jose/go-jose/v4"
@@ -41,16 +40,14 @@ const Lifetime = 5 * time.Minute
 //nolint:govet
 type Storage struct {
 	state state.State
-	clock clock.Clock
 
 	mu     sync.Mutex
 	tokens map[string]*models.Token
 }
 
 // NewStorage creates a new token storage.
-func NewStorage(st state.State, clk clock.Clock) *Storage {
+func NewStorage(st state.State) *Storage {
 	return &Storage{
-		clock:  clk,
 		tokens: map[string]*models.Token{},
 		state:  st,
 	}
@@ -139,7 +136,7 @@ func (s *Storage) accessToken(applicationID, refreshTokenID, subject string, aud
 		RefreshTokenID: refreshTokenID,
 		Subject:        subject,
 		Audience:       audience,
-		Expiration:     s.clock.Now().Add(Lifetime),
+		Expiration:     time.Now().Add(Lifetime),
 		Scopes:         scopes,
 	}
 
@@ -165,7 +162,7 @@ func (s *Storage) SetUserinfoFromToken(ctx context.Context, userinfo *oidc.UserI
 
 		token, ok := s.tokens[tokenID]
 
-		if ok && s.clock.Now().After(token.Expiration) {
+		if ok && time.Now().After(token.Expiration) {
 			return nil, false
 		}
 

--- a/internal/backend/oidc/internal/storage/token/storage_test.go
+++ b/internal/backend/oidc/internal/storage/token/storage_test.go
@@ -8,9 +8,9 @@ package token_test
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
@@ -32,7 +32,7 @@ func TestValidateJWTProfileScopes(t *testing.T) {
 
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 
-	s := token.NewStorage(st, clock.NewMock())
+	s := token.NewStorage(st)
 
 	scopes, err := s.ValidateJWTProfileScopes(ctx, "", []string{
 		oidc.ScopeOpenID,
@@ -85,7 +85,7 @@ func TestGetPrivateClaimsFromScopes(t *testing.T) {
 	require.NoError(t, st.Create(ctx, user))
 	require.NoError(t, st.Create(ctx, cluster))
 
-	s := token.NewStorage(st, clock.NewMock())
+	s := token.NewStorage(st)
 
 	claims, err := s.GetPrivateClaimsFromScopes(ctx, userIdentity, "", []string{
 		oidc.ScopeOpenID,
@@ -188,7 +188,7 @@ func TestSetUserinfoFromScopes(t *testing.T) {
 	require.NoError(t, st.Create(ctx, user))
 	require.NoError(t, st.Create(ctx, cluster))
 
-	s := token.NewStorage(st, clock.NewMock())
+	s := token.NewStorage(st)
 
 	ui := &oidc.UserInfo{}
 
@@ -215,57 +215,60 @@ func TestSetUserinfoFromScopes(t *testing.T) {
 }
 
 func TestTokenIntrospection(t *testing.T) {
-	ctx := t.Context()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	req := mockTokenRequest{}
+		req := mockTokenRequest{}
 
-	userIdentity := req.GetSubject()
-	userID := "test-user-id"
+		userIdentity := req.GetSubject()
+		userID := "test-user-id"
 
-	identity := auth.NewIdentity(userIdentity)
+		identity := auth.NewIdentity(userIdentity)
 
-	identity.TypedSpec().Value.UserId = userID
+		identity.TypedSpec().Value.UserId = userID
 
-	user := auth.NewUser(userID)
+		user := auth.NewUser(userID)
 
-	// will bring constants.DefaultAccessGroup scope
-	user.TypedSpec().Value.Role = string(role.Operator)
+		// will bring constants.DefaultAccessGroup scope
+		user.TypedSpec().Value.Role = string(role.Operator)
 
-	st := state.WrapCore(namespaced.NewState(inmem.Build))
+		st := state.WrapCore(namespaced.NewState(inmem.Build))
 
-	require.NoError(t, st.Create(ctx, identity))
-	require.NoError(t, st.Create(ctx, user))
+		require.NoError(t, st.Create(ctx, identity))
+		require.NoError(t, st.Create(ctx, user))
 
-	clck := clock.NewMock()
-	s := token.NewStorage(st, clck)
+		s := token.NewStorage(st)
 
-	// create token and try fetching information from it
-	tokenID, expiration, err := s.CreateAccessToken(ctx, req)
-	require.NoError(t, err)
+		// create token and try fetching information from it
+		now := time.Now()
 
-	assert.Equal(t, clck.Now().Add(token.Lifetime), expiration)
-	assert.NotEmpty(t, tokenID)
+		tokenID, expiration, err := s.CreateAccessToken(ctx, req)
+		require.NoError(t, err)
 
-	ui := &oidc.UserInfo{}
+		assert.Equal(t, now.Add(token.Lifetime), expiration)
+		assert.NotEmpty(t, tokenID)
 
-	err = s.SetUserinfoFromToken(ctx, ui, tokenID, userIdentity, "")
-	require.NoError(t, err)
+		ui := &oidc.UserInfo{}
 
-	assert.Equal(t, "some@example.com", ui.Subject)
-	assert.Equal(t, map[string]any{
-		"cluster": "cluster1",
-		"groups":  []string{constants.DefaultAccessGroup},
-	}, ui.Claims)
+		err = s.SetUserinfoFromToken(ctx, ui, tokenID, userIdentity, "")
+		require.NoError(t, err)
 
-	// advance time so that token expires
-	clck.Add(token.Lifetime + time.Second)
+		assert.Equal(t, "some@example.com", ui.Subject)
+		assert.Equal(t, map[string]any{
+			"cluster": "cluster1",
+			"groups":  []string{constants.DefaultAccessGroup},
+		}, ui.Claims)
 
-	err = s.SetUserinfoFromToken(ctx, ui, tokenID, "", "")
-	assert.Error(t, err)
+		// advance time so that token expires
+		time.Sleep(token.Lifetime + time.Second)
 
-	// invalid ID
-	err = s.SetUserinfoFromToken(ctx, ui, "invalid", "", "")
-	assert.Error(t, err)
+		err = s.SetUserinfoFromToken(ctx, ui, tokenID, "", "")
+		assert.Error(t, err)
+
+		// invalid ID
+		err = s.SetUserinfoFromToken(ctx, ui, "invalid", "", "")
+		assert.Error(t, err)
+	})
 }
 
 func TestRevokeToken(t *testing.T) {
@@ -273,8 +276,7 @@ func TestRevokeToken(t *testing.T) {
 
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 
-	clock := clock.NewMock()
-	s := token.NewStorage(st, clock)
+	s := token.NewStorage(st)
 
 	tokenID, _, err := s.CreateAccessToken(ctx, mockTokenRequest{})
 	require.NoError(t, err)
@@ -291,8 +293,7 @@ func TestTerminateSession(t *testing.T) {
 
 	st := state.WrapCore(namespaced.NewState(inmem.Build))
 
-	clock := clock.NewMock()
-	s := token.NewStorage(st, clock)
+	s := token.NewStorage(st)
 
 	tokenID, _, err := s.CreateAccessToken(ctx, mockTokenRequest{})
 	require.NoError(t, err)

--- a/internal/backend/runtime/omni/controllers/omni/discovery_affiliate_delete_task.go
+++ b/internal/backend/runtime/omni/controllers/omni/discovery_affiliate_delete_task.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/jonboulle/clockwork"
 	"github.com/siderolabs/gen/optional"
 	"go.uber.org/zap"
 
@@ -33,18 +32,12 @@ type DiscoveryClientCache interface {
 // DiscoveryAffiliateDeleteTaskController generates cluster UUID for every cluster.
 type DiscoveryAffiliateDeleteTaskController struct {
 	discoveryClientCache DiscoveryClientCache
-	clock                clockwork.Clock
 	affiliateTTL         time.Duration
 }
 
 // NewDiscoveryAffiliateDeleteTaskController creates a new DiscoveryAffiliateDeleteTaskController.
-func NewDiscoveryAffiliateDeleteTaskController(clock clockwork.Clock, discoveryClientCache DiscoveryClientCache) *DiscoveryAffiliateDeleteTaskController {
-	if clock == nil {
-		clock = clockwork.NewRealClock()
-	}
-
+func NewDiscoveryAffiliateDeleteTaskController(discoveryClientCache DiscoveryClientCache) *DiscoveryAffiliateDeleteTaskController {
 	return &DiscoveryAffiliateDeleteTaskController{
-		clock:                clock,
 		discoveryClientCache: discoveryClientCache,
 		affiliateTTL:         30 * time.Minute,
 	}
@@ -86,7 +79,7 @@ func (ctrl *DiscoveryAffiliateDeleteTaskController) Reconcile(ctx context.Contex
 		return err
 	}
 
-	expiredOnDiscoveryService := res.Metadata().Created().Add(ctrl.affiliateTTL).Before(ctrl.clock.Now())
+	expiredOnDiscoveryService := res.Metadata().Created().Add(ctrl.affiliateTTL).Before(time.Now())
 	if expiredOnDiscoveryService {
 		logger.Info(
 			"skipping affiliate delete, already expired on discovery service",

--- a/internal/backend/runtime/omni/controllers/omni/discovery_affiliate_delete_task_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/discovery_affiliate_delete_task_test.go
@@ -8,120 +8,103 @@ package omni_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
 )
 
-type DiscoveryAffiliateDeleteTaskSuite struct {
-	OmniSuite
-}
-
-func (suite *DiscoveryAffiliateDeleteTaskSuite) TestReconcile() {
-	suite.startRuntime()
-
-	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
-	defer cancel()
-
-	deleteCh := make(chan affiliateDelete)
-	clock := clockwork.NewFakeClock()
-	discoveryClientCache := &discoveryClientCacheMock{
-		deleteCh: deleteCh,
-	}
-	controller := omnictrl.NewDiscoveryAffiliateDeleteTaskController(clock, discoveryClientCache)
-
-	suite.Require().NoError(suite.runtime.RegisterQController(controller))
-
+func newDiscoveryAffiliateDeleteTask() *omni.DiscoveryAffiliateDeleteTask {
 	task := omni.NewDiscoveryAffiliateDeleteTask("affiliate1")
 	task.TypedSpec().Value.ClusterId = "cluster1"
 	task.TypedSpec().Value.DiscoveryServiceEndpoint = "endpoint1"
 
-	suite.Require().NoError(suite.state.Create(ctx, task, state.WithCreateOwner(omnictrl.ClusterMachineTeardownControllerName)))
-
-	// capture the single deletion attempt and assert the values
-	select {
-	case <-ctx.Done():
-		suite.Require().Fail("reconciliation timed out")
-	case affDelete := <-deleteCh:
-		suite.Equal("endpoint1", affDelete.endpoint)
-		suite.Equal("cluster1", affDelete.cluster)
-		suite.Equal("affiliate1", affDelete.affiliate)
-	}
-
-	// assert that the delete task is cleaned up
-	rtestutils.AssertNoResource[*omni.DiscoveryAffiliateDeleteTask](suite.ctx, suite.T(), suite.state, task.Metadata().ID())
+	return task
 }
 
-func (suite *DiscoveryAffiliateDeleteTaskSuite) TestExpiration() {
-	suite.startRuntime()
-
-	deleteCh := make(chan affiliateDelete, 128) // use a large enough buffer to not block retries of the controller
-	clock := clockwork.NewFakeClock()
-	discoveryClientCache := &discoveryClientCacheMock{
-		deleteCh:     deleteCh,
-		failDeletion: true, // block deletion - simulate discovery service being not accessible
-	}
-	controller := omnictrl.NewDiscoveryAffiliateDeleteTaskController(clock, discoveryClientCache)
-
-	suite.Require().NoError(suite.runtime.RegisterQController(controller))
-
-	task := omni.NewDiscoveryAffiliateDeleteTask("affiliate1")
-	task.TypedSpec().Value.ClusterId = "cluster1"
-	task.TypedSpec().Value.DiscoveryServiceEndpoint = "endpoint1"
-
-	suite.Require().NoError(suite.state.Create(suite.ctx, task, state.WithCreateOwner(omnictrl.ClusterMachineTeardownControllerName)))
-
-	// advance time, but not enough for the affiliate to be assumed to be pruned by the discovery service itself
-	clock.Advance(10 * time.Minute)
-
-	// capture a deletion attempt and assert the values
-	select {
-	case <-suite.ctx.Done():
-		suite.Require().Fail("timed out")
-	case affDelete := <-deleteCh:
-		suite.Equal("endpoint1", affDelete.endpoint)
-		suite.Equal("cluster1", affDelete.cluster)
-		suite.Equal("affiliate1", affDelete.affiliate)
-	}
-
-	// capture another deletion attempt, since the first one has failed, and re-assert the values
-	select {
-	case <-suite.ctx.Done():
-		suite.Require().Fail("timed out")
-	case affDelete := <-deleteCh:
-		suite.Equal("endpoint1", affDelete.endpoint)
-		suite.Equal("cluster1", affDelete.cluster)
-		suite.Equal("affiliate1", affDelete.affiliate)
-	}
-
-	// assert that the task is still there, as the deletion failed
-	rtestutils.AssertResource[*omni.DiscoveryAffiliateDeleteTask](
-		suite.ctx, suite.T(), suite.state, task.Metadata().ID(),
-		func(r *omni.DiscoveryAffiliateDeleteTask, assertion *assert.Assertions) {
-			assertion.Equal(resource.PhaseRunning, r.Metadata().Phase())
-		},
-	)
-
-	// advance the time further so that the affiliate is assumed to be pruned by the discovery service itself and a delete call will not be attempted
-	clock.Advance(21 * time.Minute)
-
-	// assert that the delete task is cleaned up
-	rtestutils.AssertNoResource[*omni.DiscoveryAffiliateDeleteTask](suite.ctx, suite.T(), suite.state, task.Metadata().ID())
-}
-
-func TestDiscoveryAffiliateDeleteTaskSuite(t *testing.T) {
+// TestDiscoveryAffiliateDeleteTaskReconcile verifies that the affiliate is deleted from the discovery service and the
+// task is cleaned up.
+func TestDiscoveryAffiliateDeleteTaskReconcile(t *testing.T) {
 	t.Parallel()
 
-	suite.Run(t, new(DiscoveryAffiliateDeleteTaskSuite))
+	synctest.Test(t, func(t *testing.T) {
+		mock := &discoveryClientCacheMock{}
+
+		testutils.WithRuntime(
+			t.Context(),
+			t,
+			testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(omnictrl.NewDiscoveryAffiliateDeleteTaskController(mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				task := newDiscoveryAffiliateDeleteTask()
+				require.NoError(t, tc.State.Create(ctx, task, state.WithCreateOwner(omnictrl.ClusterMachineTeardownControllerName)))
+
+				// the affiliate is not yet expired, so it is deleted from the discovery service and the task is cleaned up
+				rtestutils.AssertNoResource[*omni.DiscoveryAffiliateDeleteTask](ctx, t, tc.State, task.Metadata().ID())
+
+				synctest.Wait()
+
+				assert.Equal(t, []affiliateDelete{{"endpoint1", "cluster1", "affiliate1"}}, mock.calls())
+			},
+		)
+	})
+}
+
+// TestDiscoveryAffiliateDeleteTaskExpiration verifies that while the affiliate cannot be deleted the task is retained,
+// and once enough time passes for the discovery service to have pruned the affiliate itself, the task is cleaned up
+// without attempting a deletion.
+func TestDiscoveryAffiliateDeleteTaskExpiration(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		mock := &discoveryClientCacheMock{failDeletion: true}
+
+		testutils.WithRuntime(
+			t.Context(),
+			t,
+			testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(omnictrl.NewDiscoveryAffiliateDeleteTaskController(mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				task := newDiscoveryAffiliateDeleteTask()
+				require.NoError(t, tc.State.Create(ctx, task, state.WithCreateOwner(omnictrl.ClusterMachineTeardownControllerName)))
+
+				synctest.Wait()
+
+				// a deletion was attempted with the expected values, but it failed, so the task is retained
+				calls := mock.calls()
+				require.NotEmpty(t, calls)
+				assert.Equal(t, affiliateDelete{"endpoint1", "cluster1", "affiliate1"}, calls[0])
+
+				rtestutils.AssertResource[*omni.DiscoveryAffiliateDeleteTask](
+					ctx, t, tc.State, task.Metadata().ID(),
+					func(r *omni.DiscoveryAffiliateDeleteTask, assertion *assert.Assertions) {
+						assertion.Equal(resource.PhaseRunning, r.Metadata().Phase())
+					},
+				)
+
+				// advance past the TTL so that the affiliate is assumed to be pruned by the discovery service itself.
+				// while the deletion keeps failing the task is never torn down, so the task being cleaned up below proves
+				// the expired branch skipped the deletion and let the task go.
+				time.Sleep(31 * time.Minute)
+
+				rtestutils.AssertNoResource[*omni.DiscoveryAffiliateDeleteTask](ctx, t, tc.State, task.Metadata().ID())
+			},
+		)
+	})
 }
 
 type affiliateDelete struct {
@@ -131,20 +114,26 @@ type affiliateDelete struct {
 }
 
 type discoveryClientCacheMock struct {
-	deleteCh     chan affiliateDelete
+	recorded     []affiliateDelete
+	mu           sync.Mutex
 	failDeletion bool
 }
 
-func (d *discoveryClientCacheMock) AffiliateDelete(ctx context.Context, endpoint, cluster, affiliate string) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case d.deleteCh <- affiliateDelete{endpoint, cluster, affiliate}:
-	}
+func (d *discoveryClientCacheMock) AffiliateDelete(_ context.Context, endpoint, cluster, affiliate string) error {
+	d.mu.Lock()
+	d.recorded = append(d.recorded, affiliateDelete{endpoint, cluster, affiliate})
+	d.mu.Unlock()
 
 	if d.failDeletion {
 		return fmt.Errorf("deletion blocked - discovery service is not accessible")
 	}
 
 	return nil
+}
+
+func (d *discoveryClientCacheMock) calls() []affiliateDelete {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return append([]affiliateDelete(nil), d.recorded...)
 }

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -20,7 +20,6 @@ import (
 	cosiresource "github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/siderolabs/gen/optional"
@@ -266,7 +265,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 			cfg.Services.Siderolink.GetLogServerPort(),
 			cfg.Registries,
 		),
-		omnictrl.NewDiscoveryAffiliateDeleteTaskController(clockwork.NewRealClock(), discoveryClientCache),
+		omnictrl.NewDiscoveryAffiliateDeleteTaskController(discoveryClientCache),
 		omnictrl.NewServiceAccountStatusController(),
 		authctrl.NewIdentityStatusController(),
 		omnictrl.NewInfraMachineRegistrationController(),


### PR DESCRIPTION
The OIDC token storage, the OIDC signing key storage, and the discovery affiliate delete task controller no longer take an injectable clock. They read the current time directly, and their tests drive time with `synctest.Test` (using `testutils.WithRuntime` for the controller) instead of advancing a fake clock.

This removes clock injection that existed only for testing. As a side effect the discovery affiliate expiry now compares the resource creation time and the current time against the same clock, which is more consistent than before.