### PR TITLE
feat: allow opt-in skip of Kubernetes node audit

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -9302,8 +9302,12 @@ type ClusterSpec_Features struct {
 	DiskEncryption bool `protobuf:"varint,2,opt,name=disk_encryption,json=diskEncryption,proto3" json:"disk_encryption,omitempty"`
 	// UseEmbeddedDiscoveryService enables the embedded discovery service.
 	UseEmbeddedDiscoveryService bool `protobuf:"varint,3,opt,name=use_embedded_discovery_service,json=useEmbeddedDiscoveryService,proto3" json:"use_embedded_discovery_service,omitempty"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	// EnableNodeAuditSkip allows the omni.sidero.dev/node-audit-skip annotation on Kubernetes nodes
+	// to exempt them from the Kubernetes node audit. Disabled by default to prevent unauthorized
+	// node hijacking by anyone with permissions to annotate nodes inside the cluster.
+	EnableNodeAuditSkip bool `protobuf:"varint,4,opt,name=enable_node_audit_skip,json=enableNodeAuditSkip,proto3" json:"enable_node_audit_skip,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *ClusterSpec_Features) Reset() {
@@ -9353,6 +9357,13 @@ func (x *ClusterSpec_Features) GetDiskEncryption() bool {
 func (x *ClusterSpec_Features) GetUseEmbeddedDiscoveryService() bool {
 	if x != nil {
 		return x.UseEmbeddedDiscoveryService
+	}
+	return false
+}
+
+func (x *ClusterSpec_Features) GetEnableNodeAuditSkip() bool {
+	if x != nil {
+		return x.EnableNodeAuditSkip
 	}
 	return false
 }
@@ -9934,6 +9945,7 @@ type KubernetesStatusSpec_NodeStatus struct {
 	Nodename       string                 `protobuf:"bytes,1,opt,name=nodename,proto3" json:"nodename,omitempty"`
 	KubeletVersion string                 `protobuf:"bytes,2,opt,name=kubelet_version,json=kubeletVersion,proto3" json:"kubelet_version,omitempty"`
 	Ready          bool                   `protobuf:"varint,3,opt,name=ready,proto3" json:"ready,omitempty"`
+	SkipAudit      bool                   `protobuf:"varint,4,opt,name=skip_audit,json=skipAudit,proto3" json:"skip_audit,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -9985,6 +9997,13 @@ func (x *KubernetesStatusSpec_NodeStatus) GetKubeletVersion() string {
 func (x *KubernetesStatusSpec_NodeStatus) GetReady() bool {
 	if x != nil {
 		return x.Ready
+	}
+	return false
+}
+
+func (x *KubernetesStatusSpec_NodeStatus) GetSkipAudit() bool {
+	if x != nil {
+		return x.SkipAudit
 	}
 	return false
 }
@@ -11257,16 +11276,17 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x0fTalosConfigSpec\x12\x0e\n" +
 	"\x02ca\x18\x01 \x01(\tR\x02ca\x12\x10\n" +
 	"\x03crt\x18\x02 \x01(\tR\x03crt\x12\x10\n" +
-	"\x03key\x18\x03 \x01(\tR\x03key\"\x99\x03\n" +
+	"\x03key\x18\x03 \x01(\tR\x03key\"\xce\x03\n" +
 	"\vClusterSpec\x12-\n" +
 	"\x12kubernetes_version\x18\x02 \x01(\tR\x11kubernetesVersion\x12#\n" +
 	"\rtalos_version\x18\x03 \x01(\tR\ftalosVersion\x127\n" +
 	"\bfeatures\x18\x04 \x01(\v2\x1b.specs.ClusterSpec.FeaturesR\bfeatures\x12H\n" +
-	"\x14backup_configuration\x18\x05 \x01(\v2\x15.specs.EtcdBackupConfR\x13backupConfiguration\x1a\xac\x01\n" +
+	"\x14backup_configuration\x18\x05 \x01(\v2\x15.specs.EtcdBackupConfR\x13backupConfiguration\x1a\xe1\x01\n" +
 	"\bFeatures\x122\n" +
 	"\x15enable_workload_proxy\x18\x01 \x01(\bR\x13enableWorkloadProxy\x12'\n" +
 	"\x0fdisk_encryption\x18\x02 \x01(\bR\x0ediskEncryption\x12C\n" +
-	"\x1euse_embedded_discovery_service\x18\x03 \x01(\bR\x1buseEmbeddedDiscoveryServiceJ\x04\b\x01\x10\x02\"\x12\n" +
+	"\x1euse_embedded_discovery_service\x18\x03 \x01(\bR\x1buseEmbeddedDiscoveryService\x123\n" +
+	"\x16enable_node_audit_skip\x18\x04 \x01(\bR\x13enableNodeAuditSkipJ\x04\b\x01\x10\x02\"\x12\n" +
 	"\x10ClusterTaintSpec\"a\n" +
 	"\x0eEtcdBackupConf\x125\n" +
 	"\binterval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\binterval\x12\x18\n" +
@@ -11557,16 +11577,18 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\aWarning\x10\x01\x12\t\n" +
 	"\x05Error\x10\x02\"H\n" +
 	"\x13ClusterEndpointSpec\x121\n" +
-	"\x14management_addresses\x18\x01 \x03(\tR\x13managementAddresses\"\xdb\x03\n" +
+	"\x14management_addresses\x18\x01 \x03(\tR\x13managementAddresses\"\xfb\x03\n" +
 	"\x14KubernetesStatusSpec\x12<\n" +
 	"\x05nodes\x18\x01 \x03(\v2&.specs.KubernetesStatusSpec.NodeStatusR\x05nodes\x12K\n" +
 	"\vstatic_pods\x18\x02 \x03(\v2*.specs.KubernetesStatusSpec.NodeStaticPodsR\n" +
-	"staticPods\x1ag\n" +
+	"staticPods\x1a\x86\x01\n" +
 	"\n" +
 	"NodeStatus\x12\x1a\n" +
 	"\bnodename\x18\x01 \x01(\tR\bnodename\x12'\n" +
 	"\x0fkubelet_version\x18\x02 \x01(\tR\x0ekubeletVersion\x12\x14\n" +
-	"\x05ready\x18\x03 \x01(\bR\x05ready\x1aS\n" +
+	"\x05ready\x18\x03 \x01(\bR\x05ready\x12\x1d\n" +
+	"\n" +
+	"skip_audit\x18\x04 \x01(\bR\tskipAudit\x1aS\n" +
 	"\x0fStaticPodStatus\x12\x10\n" +
 	"\x03app\x18\x01 \x01(\tR\x03app\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\x14\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -289,6 +289,10 @@ message ClusterSpec {
     bool disk_encryption = 2;
     // UseEmbeddedDiscoveryService enables the embedded discovery service.
     bool use_embedded_discovery_service = 3;
+    // EnableNodeAuditSkip allows the omni.sidero.dev/node-audit-skip annotation on Kubernetes nodes
+    // to exempt them from the Kubernetes node audit. Disabled by default to prevent unauthorized
+    // node hijacking by anyone with permissions to annotate nodes inside the cluster.
+    bool enable_node_audit_skip = 4;
   }
 
   reserved 1;
@@ -972,6 +976,7 @@ message KubernetesStatusSpec {
     string nodename = 1;
     string kubelet_version = 2;
     bool ready = 3;
+    bool skip_audit = 4;
   }
 
   // status of each node, sorted by nodename

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -442,6 +442,7 @@ func (m *ClusterSpec_Features) CloneVT() *ClusterSpec_Features {
 	r.EnableWorkloadProxy = m.EnableWorkloadProxy
 	r.DiskEncryption = m.DiskEncryption
 	r.UseEmbeddedDiscoveryService = m.UseEmbeddedDiscoveryService
+	r.EnableNodeAuditSkip = m.EnableNodeAuditSkip
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1564,6 +1565,7 @@ func (m *KubernetesStatusSpec_NodeStatus) CloneVT() *KubernetesStatusSpec_NodeSt
 	r.Nodename = m.Nodename
 	r.KubeletVersion = m.KubeletVersion
 	r.Ready = m.Ready
+	r.SkipAudit = m.SkipAudit
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -3892,6 +3894,9 @@ func (this *ClusterSpec_Features) EqualVT(that *ClusterSpec_Features) bool {
 	if this.UseEmbeddedDiscoveryService != that.UseEmbeddedDiscoveryService {
 		return false
 	}
+	if this.EnableNodeAuditSkip != that.EnableNodeAuditSkip {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -5326,6 +5331,9 @@ func (this *KubernetesStatusSpec_NodeStatus) EqualVT(that *KubernetesStatusSpec_
 		return false
 	}
 	if this.Ready != that.Ready {
+		return false
+	}
+	if this.SkipAudit != that.SkipAudit {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -8937,6 +8945,16 @@ func (m *ClusterSpec_Features) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.EnableNodeAuditSkip {
+		i--
+		if m.EnableNodeAuditSkip {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
 	if m.UseEmbeddedDiscoveryService {
 		i--
 		if m.UseEmbeddedDiscoveryService {
@@ -12026,6 +12044,16 @@ func (m *KubernetesStatusSpec_NodeStatus) MarshalToSizedBufferVT(dAtA []byte) (i
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.SkipAudit {
+		i--
+		if m.SkipAudit {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
 	}
 	if m.Ready {
 		i--
@@ -16934,6 +16962,9 @@ func (m *ClusterSpec_Features) SizeVT() (n int) {
 	if m.UseEmbeddedDiscoveryService {
 		n += 2
 	}
+	if m.EnableNodeAuditSkip {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -18118,6 +18149,9 @@ func (m *KubernetesStatusSpec_NodeStatus) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.Ready {
+		n += 2
+	}
+	if m.SkipAudit {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -23387,6 +23421,26 @@ func (m *ClusterSpec_Features) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.UseEmbeddedDiscoveryService = bool(v != 0)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EnableNodeAuditSkip", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.EnableNodeAuditSkip = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -31024,6 +31078,26 @@ func (m *KubernetesStatusSpec_NodeStatus) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Ready = bool(v != 0)
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SkipAudit", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SkipAudit = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/omni/resources/omni/annotations.go
+++ b/client/pkg/omni/resources/omni/annotations.go
@@ -90,4 +90,10 @@ const (
 
 	// KubernetesManifestOwner is added to the kubernetes resources which are created by a KubernetesManifest resource.
 	KubernetesManifestOwner = SystemLabelPrefix + "owned-by-kubernetes-manifest"
+
+	// KubernetesNodeAuditSkip is an annotation set on a Kubernetes node object to request exemption from Omni's node audit.
+	// When present (with any value) and ClusterSpec.Features.EnableNodeAuditSkip is enabled for the cluster, the node will
+	// not be deleted by the KubernetesNodeAuditController even if it has no corresponding ClusterMachine.
+	// Use this for virtual nodes such as those created by VirtualKubelet.
+	KubernetesNodeAuditSkip = SystemLabelPrefix + "node-audit-skip"
 )

--- a/client/pkg/template/testdata/cluster-valid-bootstrapspec-resources.yaml
+++ b/client/pkg/template/testdata/cluster-valid-bootstrapspec-resources.yaml
@@ -16,6 +16,7 @@ spec:
         enableworkloadproxy: false
         diskencryption: false
         useembeddeddiscoveryservice: false
+        enablenodeauditskip: false
     backupconfiguration: null
 ---
 metadata:

--- a/client/pkg/template/testdata/cluster-with-kernel-args-resources.yaml
+++ b/client/pkg/template/testdata/cluster-with-kernel-args-resources.yaml
@@ -16,6 +16,7 @@ spec:
         enableworkloadproxy: false
         diskencryption: false
         useembeddeddiscoveryservice: false
+        enablenodeauditskip: false
     backupconfiguration: null
 ---
 metadata:

--- a/client/pkg/template/testdata/cluster-with-manifests-resources.yaml
+++ b/client/pkg/template/testdata/cluster-with-manifests-resources.yaml
@@ -16,6 +16,7 @@ spec:
         enableworkloadproxy: false
         diskencryption: false
         useembeddeddiscoveryservice: false
+        enablenodeauditskip: false
     backupconfiguration: null
 ---
 metadata:

--- a/client/pkg/template/testdata/cluster1-resources.yaml
+++ b/client/pkg/template/testdata/cluster1-resources.yaml
@@ -16,6 +16,7 @@ spec:
         enableworkloadproxy: false
         diskencryption: true
         useembeddeddiscoveryservice: false
+        enablenodeauditskip: false
     backupconfiguration: null
 ---
 metadata:

--- a/client/pkg/template/testdata/cluster2-resources.yaml
+++ b/client/pkg/template/testdata/cluster2-resources.yaml
@@ -16,6 +16,7 @@ spec:
         enableworkloadproxy: true
         diskencryption: false
         useembeddeddiscoveryservice: true
+        enablenodeauditskip: false
     backupconfiguration: null
 ---
 metadata:

--- a/client/pkg/template/testdata/cluster3-resources.yaml
+++ b/client/pkg/template/testdata/cluster3-resources.yaml
@@ -16,6 +16,7 @@ spec:
         enableworkloadproxy: false
         diskencryption: false
         useembeddeddiscoveryservice: false
+        enablenodeauditskip: false
     backupconfiguration: null
 ---
 metadata:

--- a/internal/backend/runtime/omni/controllers/omni/cluster_metrics.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_metrics.go
@@ -106,12 +106,14 @@ func (ctrl *ClusterMetricsController) FeatureMetrics(clusters iter.Seq[*omni.Clu
 		featureWorkloadProxy            = "workload_proxy"
 		featureDiskEncryption           = "disk_encryption"
 		featureEmbeddedDiscoveryService = "embedded_discovery_service"
+		featureEnableNodeAuditSkip      = "node_audit_skip"
 	)
 
 	featuresByCluster := map[string]uint32{
 		featureWorkloadProxy:            0,
 		featureDiskEncryption:           0,
 		featureEmbeddedDiscoveryService: 0,
+		featureEnableNodeAuditSkip:      0,
 	}
 
 	for cluster := range clusters {
@@ -125,6 +127,10 @@ func (ctrl *ClusterMetricsController) FeatureMetrics(clusters iter.Seq[*omni.Clu
 
 		if cluster.TypedSpec().Value.GetFeatures().GetUseEmbeddedDiscoveryService() {
 			featuresByCluster[featureEmbeddedDiscoveryService]++
+		}
+
+		if cluster.TypedSpec().Value.GetFeatures().GetEnableNodeAuditSkip() {
+			featuresByCluster[featureEnableNodeAuditSkip]++
 		}
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_node_audit.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_node_audit.go
@@ -66,9 +66,34 @@ func NewKubernetesNodeAuditController(getKubernetesClientFunc GetKubernetesClien
 				}
 
 				cluster := nodes.Metadata().ID()
-				actualNodes := xslices.Map(status.TypedSpec().Value.GetNodes(), func(nodeStatus *specs.KubernetesStatusSpec_NodeStatus) string {
-					return nodeStatus.Nodename
-				})
+
+				// EnableNodeAuditSkip is a cluster-level feature flag that must be set by the cluster owner
+				// in Omni before the omni.sidero.dev/node-audit-skip annotation on a Kubernetes node is honored.
+				// This prevents a workload with nodes/patch RBAC from hijacking the audit by self-annotating.
+				honorSkipAudit := false
+
+				clusterRes, err := safe.ReaderGetByID[*omni.Cluster](ctx, r, cluster)
+				if err != nil && !state.IsNotFoundError(err) {
+					return fmt.Errorf("failed to get cluster: %w", err)
+				}
+
+				if clusterRes != nil {
+					honorSkipAudit = clusterRes.TypedSpec().Value.GetFeatures().GetEnableNodeAuditSkip()
+				}
+
+				nodeStatuses := status.TypedSpec().Value.GetNodes()
+				if honorSkipAudit {
+					nodeStatuses = xslices.Filter(status.TypedSpec().Value.GetNodes(), func(nodeStatus *specs.KubernetesStatusSpec_NodeStatus) bool {
+						return !nodeStatus.SkipAudit
+					})
+				}
+
+				actualNodes := xslices.Map(
+					nodeStatuses,
+					func(nodeStatus *specs.KubernetesStatusSpec_NodeStatus) string {
+						return nodeStatus.Nodename
+					},
+				)
 				desiredNodes := nodes.TypedSpec().Value.Nodes
 
 				if slices.Contains(desiredNodes, "") {
@@ -120,6 +145,7 @@ func NewKubernetesNodeAuditController(getKubernetesClientFunc GetKubernetesClien
 		},
 		qtransform.WithConcurrency(2),
 		qtransform.WithExtraMappedInput[*omni.KubernetesStatus](qtransform.MapperSameID[*omni.ClusterKubernetesNodes]()),
+		qtransform.WithExtraMappedInput[*omni.Cluster](qtransform.MapperSameID[*omni.ClusterKubernetesNodes]()),
 	)
 }
 

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_node_audit_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_node_audit_test.go
@@ -121,6 +121,111 @@ func (suite *KubernetesNodeAuditSuite) TestReconcile() {
 	require.ElementsMatch(suite.T(), []string{"cluster1-node4", "cluster1-node5", "cluster2-node2", "cluster2-node3"}, kubernetesClient.getDeleted())
 }
 
+func (suite *KubernetesNodeAuditSuite) TestSkipAudit() {
+	suite.startRuntime()
+
+	kubernetesClient := &kubernetesClientMock{}
+	getKubernetesClient := func(context.Context, string) (omnictrl.KubernetesClient, error) {
+		return kubernetesClient, nil
+	}
+
+	kubernetesNodeAuditController := omnictrl.NewKubernetesNodeAuditController(getKubernetesClient, 2*time.Second)
+
+	suite.Require().NoError(suite.runtime.RegisterQController(kubernetesNodeAuditController))
+
+	// cluster has a virtual node (e.g. VirtualKubelet) that is not in the desired list but is annotated to skip the audit
+	clusterID := "skip-audit-cluster"
+	cluster := omni.NewCluster(clusterID)
+	cluster.TypedSpec().Value.Features = &specs.ClusterSpec_Features{EnableNodeAuditSkip: true}
+
+	clusterKubernetesNodes := omni.NewClusterKubernetesNodes(clusterID)
+	clusterKubernetesStatus := omni.NewKubernetesStatus(clusterID)
+
+	clusterKubernetesNodes.TypedSpec().Value.Nodes = []string{"node1", "node2"}
+	clusterKubernetesStatus.TypedSpec().Value.Nodes = []*specs.KubernetesStatusSpec_NodeStatus{
+		{Nodename: "node1"},
+		{Nodename: "node2"},
+		{Nodename: "virtual-node", SkipAudit: true}, // must be preserved (feature enabled)
+		{Nodename: "orphan-node"},                   // must be deleted
+	}
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cluster))
+	suite.Require().NoError(suite.state.Create(suite.ctx, clusterKubernetesNodes))
+	suite.Require().NoError(suite.state.Create(suite.ctx, clusterKubernetesStatus))
+
+	// only orphan-node should be deleted; virtual-node must remain
+	assertResource[*omni.KubernetesNodeAuditResult](&suite.OmniSuite, omni.NewKubernetesNodeAuditResult(clusterID).Metadata(),
+		func(res *omni.KubernetesNodeAuditResult, assertion *assert.Assertions) {
+			assertion.Equal([]string{"orphan-node"}, res.TypedSpec().Value.DeletedNodes)
+		})
+
+	require.ElementsMatch(suite.T(), []string{"orphan-node"}, kubernetesClient.getDeleted())
+
+	// remove deleted orphan-node from the status (simulating that it was actually removed from Kubernetes)
+	_, err := safe.StateUpdateWithConflicts[*omni.KubernetesStatus](suite.ctx, suite.state, clusterKubernetesStatus.Metadata(), func(res *omni.KubernetesStatus) error {
+		res.TypedSpec().Value.Nodes = []*specs.KubernetesStatusSpec_NodeStatus{
+			{Nodename: "node1"},
+			{Nodename: "node2"},
+			{Nodename: "virtual-node", SkipAudit: true},
+		}
+
+		return nil
+	})
+	suite.Require().NoError(err)
+
+	// disable the cluster feature - virtual-node must now be deleted because the annotation is no longer honored
+	_, err = safe.StateUpdateWithConflicts[*omni.Cluster](suite.ctx, suite.state, cluster.Metadata(), func(res *omni.Cluster) error {
+		res.TypedSpec().Value.Features = &specs.ClusterSpec_Features{EnableNodeAuditSkip: false}
+
+		return nil
+	})
+	suite.Require().NoError(err)
+
+	assertResource[*omni.KubernetesNodeAuditResult](&suite.OmniSuite, omni.NewKubernetesNodeAuditResult(clusterID).Metadata(),
+		func(res *omni.KubernetesNodeAuditResult, assertion *assert.Assertions) {
+			assertion.Equal([]string{"virtual-node"}, res.TypedSpec().Value.DeletedNodes)
+		})
+
+	require.ElementsMatch(suite.T(), []string{"orphan-node", "virtual-node"}, kubernetesClient.getDeleted())
+}
+
+func (suite *KubernetesNodeAuditSuite) TestSkipAuditDisabledByDefault() {
+	suite.startRuntime()
+
+	kubernetesClient := &kubernetesClientMock{}
+	getKubernetesClient := func(context.Context, string) (omnictrl.KubernetesClient, error) {
+		return kubernetesClient, nil
+	}
+
+	kubernetesNodeAuditController := omnictrl.NewKubernetesNodeAuditController(getKubernetesClient, 2*time.Second)
+
+	suite.Require().NoError(suite.runtime.RegisterQController(kubernetesNodeAuditController))
+
+	// cluster exists but has no Features set - SkipAudit annotation must NOT be honored
+	clusterID := "no-feature-cluster"
+	cluster := omni.NewCluster(clusterID)
+
+	clusterKubernetesNodes := omni.NewClusterKubernetesNodes(clusterID)
+	clusterKubernetesStatus := omni.NewKubernetesStatus(clusterID)
+
+	clusterKubernetesNodes.TypedSpec().Value.Nodes = []string{"node1"}
+	clusterKubernetesStatus.TypedSpec().Value.Nodes = []*specs.KubernetesStatusSpec_NodeStatus{
+		{Nodename: "node1"},
+		{Nodename: "rogue-node", SkipAudit: true}, // self-annotated but feature is off, must be deleted
+	}
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cluster))
+	suite.Require().NoError(suite.state.Create(suite.ctx, clusterKubernetesNodes))
+	suite.Require().NoError(suite.state.Create(suite.ctx, clusterKubernetesStatus))
+
+	assertResource[*omni.KubernetesNodeAuditResult](&suite.OmniSuite, omni.NewKubernetesNodeAuditResult(clusterID).Metadata(),
+		func(res *omni.KubernetesNodeAuditResult, assertion *assert.Assertions) {
+			assertion.Equal([]string{"rogue-node"}, res.TypedSpec().Value.DeletedNodes)
+		})
+
+	require.ElementsMatch(suite.T(), []string{"rogue-node"}, kubernetesClient.getDeleted())
+}
+
 type kubernetesClientMock struct {
 	deleted []string
 	mu      sync.Mutex

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_status.go
@@ -513,9 +513,12 @@ func (w *kubernetesWatcher) nodesSync(ctx context.Context, notifyCh chan<- kuber
 	status.Nodes = make([]*specs.KubernetesStatusSpec_NodeStatus, len(nodes))
 
 	for i, node := range nodes {
+		_, skipAudit := node.Annotations[omni.KubernetesNodeAuditSkip]
+
 		status.Nodes[i] = &specs.KubernetesStatusSpec_NodeStatus{
 			Nodename:       node.Name,
 			KubeletVersion: strings.TrimLeft(node.Status.NodeInfo.KubeletVersion, "v"),
+			SkipAudit:      skipAudit,
 		}
 
 		for _, condition := range node.Status.Conditions {


### PR DESCRIPTION
KubernetesNodeAuditController deletes any node not backed by a
ClusterMachine after one minute, which tears down virtual nodes
(e.g. VirtualKubelet) on every NotReady transition.

Add a two-part opt-out:
- omni.sidero.dev/node-audit-skip annotation on the Kubernetes node
  surfaces as ClusterSpec.Features.EnableNodeAuditSkip -> NodeStatus.SkipAudit
- ClusterSpec.Features.EnableNodeAuditSkip gates whether the annotation
  is honored

Gating on the cluster Feature prevents a workload with nodes/patch RBAC
from self-annotating to escape the audit; the cluster owner must enable
the feature in Omni first.

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
