### PR TITLE
fix: use correct help string in the `omnictl jointoken delete` command

### DIFF
--- a/client/pkg/omnictl/jointoken.go
+++ b/client/pkg/omnictl/jointoken.go
@@ -330,7 +330,7 @@ var (
 	}
 
 	joinTokenDeleteCmd = &cobra.Command{
-		Use:     "delete <name>",
+		Use:     "delete <id>",
 		Aliases: []string{"d"},
 		Short:   "Delete a join token",
 		Args:    cobra.ExactArgs(1),


### PR DESCRIPTION
Fixes: https://github.com/siderolabs/omni/issues/2955