### PR TITLE
refactor: remove unused fields, fix print columns/comments of resources

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -3121,12 +3121,10 @@ func (x *ClusterMachineIdentitySpec) GetDiscoveryServiceEndpoint() string {
 type ClusterMachineStatusSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Ready is true if all services are healthy.
-	Ready bool                           `protobuf:"varint,1,opt,name=ready,proto3" json:"ready,omitempty"`
-	Stage ClusterMachineStatusSpec_Stage `protobuf:"varint,2,opt,name=stage,proto3,enum=specs.ClusterMachineStatusSpec_Stage" json:"stage,omitempty"`
-	// ApidAvailable is true if the node is a control plane node and the apid service is healthy.
-	ApidAvailable   bool   `protobuf:"varint,3,opt,name=apid_available,json=apidAvailable,proto3" json:"apid_available,omitempty"`
-	ConfigUpToDate  bool   `protobuf:"varint,4,opt,name=config_up_to_date,json=configUpToDate,proto3" json:"config_up_to_date,omitempty"`
-	LastConfigError string `protobuf:"bytes,5,opt,name=last_config_error,json=lastConfigError,proto3" json:"last_config_error,omitempty"`
+	Ready           bool                           `protobuf:"varint,1,opt,name=ready,proto3" json:"ready,omitempty"`
+	Stage           ClusterMachineStatusSpec_Stage `protobuf:"varint,2,opt,name=stage,proto3,enum=specs.ClusterMachineStatusSpec_Stage" json:"stage,omitempty"`
+	ConfigUpToDate  bool                           `protobuf:"varint,4,opt,name=config_up_to_date,json=configUpToDate,proto3" json:"config_up_to_date,omitempty"`
+	LastConfigError string                         `protobuf:"bytes,5,opt,name=last_config_error,json=lastConfigError,proto3" json:"last_config_error,omitempty"`
 	// Management address is copied from the machine status resource.
 	ManagementAddress string            `protobuf:"bytes,6,opt,name=management_address,json=managementAddress,proto3" json:"management_address,omitempty"`
 	ConfigApplyStatus ConfigApplyStatus `protobuf:"varint,7,opt,name=config_apply_status,json=configApplyStatus,proto3,enum=specs.ConfigApplyStatus" json:"config_apply_status,omitempty"`
@@ -3180,13 +3178,6 @@ func (x *ClusterMachineStatusSpec) GetStage() ClusterMachineStatusSpec_Stage {
 		return x.Stage
 	}
 	return ClusterMachineStatusSpec_UNKNOWN
-}
-
-func (x *ClusterMachineStatusSpec) GetApidAvailable() bool {
-	if x != nil {
-		return x.ApidAvailable
-	}
-	return false
 }
 
 func (x *ClusterMachineStatusSpec) GetConfigUpToDate() bool {
@@ -11388,11 +11379,10 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x0eetcd_member_id\x18\x02 \x01(\x04R\fetcdMemberId\x12\x1a\n" +
 	"\bnodename\x18\x03 \x01(\tR\bnodename\x12\x19\n" +
 	"\bnode_ips\x18\b \x03(\tR\anodeIps\x12<\n" +
-	"\x1adiscovery_service_endpoint\x18\t \x01(\tR\x18discoveryServiceEndpoint\"\xfb\x05\n" +
+	"\x1adiscovery_service_endpoint\x18\t \x01(\tR\x18discoveryServiceEndpoint\"\xda\x05\n" +
 	"\x18ClusterMachineStatusSpec\x12\x14\n" +
 	"\x05ready\x18\x01 \x01(\bR\x05ready\x12;\n" +
-	"\x05stage\x18\x02 \x01(\x0e2%.specs.ClusterMachineStatusSpec.StageR\x05stage\x12%\n" +
-	"\x0eapid_available\x18\x03 \x01(\bR\rapidAvailable\x12)\n" +
+	"\x05stage\x18\x02 \x01(\x0e2%.specs.ClusterMachineStatusSpec.StageR\x05stage\x12)\n" +
 	"\x11config_up_to_date\x18\x04 \x01(\bR\x0econfigUpToDate\x12*\n" +
 	"\x11last_config_error\x18\x05 \x01(\tR\x0flastConfigError\x12-\n" +
 	"\x12management_address\x18\x06 \x01(\tR\x11managementAddress\x12H\n" +
@@ -11420,7 +11410,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"DESTROYING\x10\x05\x12\x0f\n" +
 	"\vPOWERING_ON\x10\n" +
 	"\x12\x0f\n" +
-	"\vPOWERED_OFF\x10\v\"v\n" +
+	"\vPOWERED_OFF\x10\vJ\x04\b\x03\x10\x04\"v\n" +
 	"\bMachines\x12\x14\n" +
 	"\x05total\x18\x01 \x01(\rR\x05total\x12\x18\n" +
 	"\ahealthy\x18\x02 \x01(\rR\ahealthy\x12\x1c\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -528,8 +528,7 @@ message ClusterMachineStatusSpec {
 
   Stage stage = 2;
 
-  // ApidAvailable is true if the node is a control plane node and the apid service is healthy.
-  bool apid_available = 3;
+  reserved 3;
 
   bool config_up_to_date = 4;
   string last_config_error = 5;

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -860,7 +860,6 @@ func (m *ClusterMachineStatusSpec) CloneVT() *ClusterMachineStatusSpec {
 	r := new(ClusterMachineStatusSpec)
 	r.Ready = m.Ready
 	r.Stage = m.Stage
-	r.ApidAvailable = m.ApidAvailable
 	r.ConfigUpToDate = m.ConfigUpToDate
 	r.LastConfigError = m.LastConfigError
 	r.ManagementAddress = m.ManagementAddress
@@ -4425,9 +4424,6 @@ func (this *ClusterMachineStatusSpec) EqualVT(that *ClusterMachineStatusSpec) bo
 		return false
 	}
 	if this.Stage != that.Stage {
-		return false
-	}
-	if this.ApidAvailable != that.ApidAvailable {
 		return false
 	}
 	if this.ConfigUpToDate != that.ConfigUpToDate {
@@ -10145,16 +10141,6 @@ func (m *ClusterMachineStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, err
 		}
 		i--
 		dAtA[i] = 0x20
-	}
-	if m.ApidAvailable {
-		i--
-		if m.ApidAvailable {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x18
 	}
 	if m.Stage != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Stage))
@@ -17454,9 +17440,6 @@ func (m *ClusterMachineStatusSpec) SizeVT() (n int) {
 	}
 	if m.Stage != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Stage))
-	}
-	if m.ApidAvailable {
-		n += 2
 	}
 	if m.ConfigUpToDate {
 		n += 2
@@ -26259,26 +26242,6 @@ func (m *ClusterMachineStatusSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
-		case 3:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ApidAvailable", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.ApidAvailable = bool(v != 0)
 		case 4:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ConfigUpToDate", wireType)

--- a/client/pkg/infra/resources_test.go
+++ b/client/pkg/infra/resources_test.go
@@ -32,7 +32,7 @@ type TestResource = typed.Resource[TestResourceSpec, TestResourceExtension]
 // TestResourceSpec wraps specs.TestResourceSpec.
 type TestResourceSpec = protobuf.ResourceSpec[specs.MachineSpec, *specs.MachineSpec]
 
-// TestResourceExtension providers auxiliary methods for TestResource resource.
+// TestResourceExtension provides auxiliary methods for TestResource resource.
 type TestResourceExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/auth/access_policy.go
+++ b/client/pkg/omni/resources/auth/access_policy.go
@@ -38,7 +38,7 @@ type AccessPolicy = typed.Resource[AccessPolicySpec, AccessPolicyExtension]
 // AccessPolicySpec wraps specs.AccessPolicySpec.
 type AccessPolicySpec = protobuf.ResourceSpec[specs.AccessPolicySpec, *specs.AccessPolicySpec]
 
-// AccessPolicyExtension providers auxiliary methods for AccessPolicy resource.
+// AccessPolicyExtension provides auxiliary methods for AccessPolicy resource.
 type AccessPolicyExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/auth/config.go
+++ b/client/pkg/omni/resources/auth/config.go
@@ -43,7 +43,7 @@ type Config = typed.Resource[ConfigSpec, ConfigExtension]
 // ConfigSpec wraps specs.AuthConfigSpec.
 type ConfigSpec = protobuf.ResourceSpec[specs.AuthConfigSpec, *specs.AuthConfigSpec]
 
-// ConfigExtension providers auxiliary methods for Config resource.
+// ConfigExtension provides auxiliary methods for Config resource.
 type ConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/auth/identity.go
+++ b/client/pkg/omni/resources/auth/identity.go
@@ -35,7 +35,7 @@ type Identity = typed.Resource[IdentitySpec, IdentityExtension]
 // IdentitySpec wraps specs.IdentitySpec.
 type IdentitySpec = protobuf.ResourceSpec[specs.IdentitySpec, *specs.IdentitySpec]
 
-// IdentityExtension providers auxiliary methods for Identity resource.
+// IdentityExtension provides auxiliary methods for Identity resource.
 type IdentityExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/auth/public_key.go
+++ b/client/pkg/omni/resources/auth/public_key.go
@@ -41,7 +41,7 @@ type PublicKey = typed.Resource[PublicKeySpec, PublicKeyExtension]
 // PublicKeySpec wraps specs.PublicKeySpec.
 type PublicKeySpec = protobuf.ResourceSpec[specs.PublicKeySpec, *specs.PublicKeySpec]
 
-// PublicKeyExtension providers auxiliary methods for PublicKey resource.
+// PublicKeyExtension provides auxiliary methods for PublicKey resource.
 type PublicKeyExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/auth/saml_assertion.go
+++ b/client/pkg/omni/resources/auth/saml_assertion.go
@@ -33,7 +33,7 @@ type SAMLAssertion = typed.Resource[SAMLAssertionSpec, SAMLAssertionExtension]
 // SAMLAssertionSpec wraps specs.SAMLAssertionSpec.
 type SAMLAssertionSpec = protobuf.ResourceSpec[specs.SAMLAssertionSpec, *specs.SAMLAssertionSpec]
 
-// SAMLAssertionExtension providers auxiliary methods for SAMLAssertion resource.
+// SAMLAssertionExtension provides auxiliary methods for SAMLAssertion resource.
 type SAMLAssertionExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/auth/saml_label_rule.go
+++ b/client/pkg/omni/resources/auth/saml_label_rule.go
@@ -35,7 +35,7 @@ type SAMLLabelRule = typed.Resource[SAMLLabelRuleSpec, SAMLLabelRuleExtension]
 // SAMLLabelRuleSpec wraps specs.SAMLLabelRuleSpec.
 type SAMLLabelRuleSpec = protobuf.ResourceSpec[specs.SAMLLabelRuleSpec, *specs.SAMLLabelRuleSpec]
 
-// SAMLLabelRuleExtension providers auxiliary methods for SAMLLabelRule resource.
+// SAMLLabelRuleExtension provides auxiliary methods for SAMLLabelRule resource.
 type SAMLLabelRuleExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/auth/service_account_status.go
+++ b/client/pkg/omni/resources/auth/service_account_status.go
@@ -35,7 +35,7 @@ type ServiceAccountStatus = typed.Resource[ServiceAccountStatusSpec, ServiceAcco
 // ServiceAccountStatusSpec wraps specs.ServiceAccountStatusSpec.
 type ServiceAccountStatusSpec = protobuf.ResourceSpec[specs.ServiceAccountStatusSpec, *specs.ServiceAccountStatusSpec]
 
-// ServiceAccountStatusExtension providers auxiliary methods for ServiceAccountStatus resource.
+// ServiceAccountStatusExtension provides auxiliary methods for ServiceAccountStatus resource.
 type ServiceAccountStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/auth/user.go
+++ b/client/pkg/omni/resources/auth/user.go
@@ -35,7 +35,7 @@ type User = typed.Resource[UserSpec, UserExtension]
 // UserSpec wraps specs.UserSpec.
 type UserSpec = protobuf.ResourceSpec[specs.UserSpec, *specs.UserSpec]
 
-// UserExtension providers auxiliary methods for User resource.
+// UserExtension provides auxiliary methods for User resource.
 type UserExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/infra/bmc_config.go
+++ b/client/pkg/omni/resources/infra/bmc_config.go
@@ -35,7 +35,7 @@ type BMCConfig = typed.Resource[BMCConfigSpec, BMCConfigExtension]
 // BMCConfigSpec wraps specs.BMCConfigSpec.
 type BMCConfigSpec = protobuf.ResourceSpec[specs.BMCConfigSpec, *specs.BMCConfigSpec]
 
-// BMCConfigExtension providers auxiliary methods for BMCConfig resource.
+// BMCConfigExtension provides auxiliary methods for BMCConfig resource.
 type BMCConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/infra/config_patch_request.go
+++ b/client/pkg/omni/resources/infra/config_patch_request.go
@@ -23,7 +23,7 @@ func NewConfigPatchRequest(id resource.ID) *ConfigPatchRequest {
 }
 
 const (
-	// ConfigPatchRequestType is the type of the ConfigPatch resource.
+	// ConfigPatchRequestType is the type of the ConfigPatchRequest resource.
 	// tsgen:ConfigPatchRequestType
 	ConfigPatchRequestType = resource.Type("ConfigPatchRequests.omni.sidero.dev")
 )
@@ -35,7 +35,7 @@ type ConfigPatchRequest = typed.Resource[ConfigPatchRequestSpec, ConfigPatchRequ
 // ConfigPatchRequestSpec wraps specs.ConfigPatchRequestSpec.
 type ConfigPatchRequestSpec = protobuf.ResourceSpec[specs.ConfigPatchSpec, *specs.ConfigPatchSpec]
 
-// ConfigPatchRequestExtension provides auxiliary methods for ConfigPatch resource.
+// ConfigPatchRequestExtension provides auxiliary methods for ConfigPatchRequest resource.
 type ConfigPatchRequestExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/infra/machine.go
+++ b/client/pkg/omni/resources/infra/machine.go
@@ -35,7 +35,7 @@ type Machine = typed.Resource[MachineSpec, MachineExtension]
 // MachineSpec wraps specs.MachineSpec.
 type MachineSpec = protobuf.ResourceSpec[specs.InfraMachineSpec, *specs.InfraMachineSpec]
 
-// MachineExtension providers auxiliary methods for Machine resource.
+// MachineExtension provides auxiliary methods for Machine resource.
 type MachineExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/infra/machine_registration.go
+++ b/client/pkg/omni/resources/infra/machine_registration.go
@@ -32,7 +32,7 @@ const (
 // MachineRegistration contains the minimum data extracted from the machine resource required by the infra providers.
 type MachineRegistration = typed.Resource[MachineRegistrationSpec, MachineRegistrationExtension]
 
-// MachineRegistrationExtension providers auxiliary methods for MachineRegistration resource.
+// MachineRegistrationExtension provides auxiliary methods for MachineRegistration resource.
 type MachineRegistrationExtension struct{}
 
 // MachineRegistrationSpec wraps specs.MachineRegistrationSpec.

--- a/client/pkg/omni/resources/infra/machine_request.go
+++ b/client/pkg/omni/resources/infra/machine_request.go
@@ -35,7 +35,7 @@ type MachineRequest = typed.Resource[MachineRequestSpec, MachineRequestExtension
 // MachineRequestSpec wraps specs.MachineRequestSpec.
 type MachineRequestSpec = protobuf.ResourceSpec[specs.MachineRequestSpec, *specs.MachineRequestSpec]
 
-// MachineRequestExtension providers auxiliary methods for MachineRequest resource.
+// MachineRequestExtension provides auxiliary methods for MachineRequest resource.
 type MachineRequestExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.
@@ -48,10 +48,6 @@ func (MachineRequestExtension) ResourceDefinition() meta.ResourceDefinitionSpec 
 			{
 				Name:     "Talos Version",
 				JSONPath: "{.talosversion}",
-			},
-			{
-				Name:     "Schematic ID",
-				JSONPath: "{.schematicid}",
 			},
 		},
 	}

--- a/client/pkg/omni/resources/infra/machine_request_status.go
+++ b/client/pkg/omni/resources/infra/machine_request_status.go
@@ -35,7 +35,7 @@ type MachineRequestStatus = typed.Resource[MachineRequestStatusSpec, MachineRequ
 // MachineRequestStatusSpec wraps specs.MachineRequestStatusSpec.
 type MachineRequestStatusSpec = protobuf.ResourceSpec[specs.MachineRequestStatusSpec, *specs.MachineRequestStatusSpec]
 
-// MachineRequestStatusExtension providers auxiliary methods for MachineRequestStatus resource.
+// MachineRequestStatusExtension provides auxiliary methods for MachineRequestStatus resource.
 type MachineRequestStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/infra/machine_status.go
+++ b/client/pkg/omni/resources/infra/machine_status.go
@@ -35,7 +35,7 @@ type MachineStatus = typed.Resource[MachineStatusSpec, MachineStatusExtension]
 // MachineStatusSpec wraps specs.MachineStatusSpec.
 type MachineStatusSpec = protobuf.ResourceSpec[specs.InfraMachineStatusSpec, *specs.InfraMachineStatusSpec]
 
-// MachineStatusExtension providers auxiliary methods for MachineStatus resource.
+// MachineStatusExtension provides auxiliary methods for MachineStatus resource.
 type MachineStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/infra/provider.go
+++ b/client/pkg/omni/resources/infra/provider.go
@@ -35,7 +35,7 @@ type Provider = typed.Resource[ProviderSpec, ProviderExtension]
 // ProviderSpec wraps specs.ProviderSpec.
 type ProviderSpec = protobuf.ResourceSpec[specs.InfraProviderSpec, *specs.InfraProviderSpec]
 
-// ProviderExtension providers auxiliary methods for InfraProvider resource.
+// ProviderExtension provides auxiliary methods for InfraProvider resource.
 type ProviderExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/infra/provider_health_status.go
+++ b/client/pkg/omni/resources/infra/provider_health_status.go
@@ -36,7 +36,7 @@ type ProviderHealthStatus = typed.Resource[ProviderHealthStatusSpec, ProviderHea
 // ProviderHealthStatusSpec wraps specs.ProviderHealthStatusSpec.
 type ProviderHealthStatusSpec = protobuf.ResourceSpec[specs.InfraProviderHealthStatusSpec, *specs.InfraProviderHealthStatusSpec]
 
-// ProviderHealthStatusExtension providers auxiliary methods for InfraProviderHealthStatus resource.
+// ProviderHealthStatusExtension provides auxiliary methods for InfraProviderHealthStatus resource.
 type ProviderHealthStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/infra/provider_status.go
+++ b/client/pkg/omni/resources/infra/provider_status.go
@@ -36,7 +36,7 @@ type ProviderStatus = typed.Resource[ProviderStatusSpec, ProviderStatusExtension
 // ProviderStatusSpec wraps specs.ProviderStatusSpec.
 type ProviderStatusSpec = protobuf.ResourceSpec[specs.InfraProviderStatusSpec, *specs.InfraProviderStatusSpec]
 
-// ProviderStatusExtension providers auxiliary methods for InfraProviderStatus resource.
+// ProviderStatusExtension provides auxiliary methods for InfraProviderStatus resource.
 type ProviderStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/oidc/jwt_public_key.go
+++ b/client/pkg/omni/resources/oidc/jwt_public_key.go
@@ -30,7 +30,7 @@ type JWTPublicKey = typed.Resource[JWTPublicKeySpec, JWTPublicKeyExtension]
 // JWTPublicKeySpec wraps specs.JWTPublicKeySpec.
 type JWTPublicKeySpec = protobuf.ResourceSpec[specs.JWTPublicKeySpec, *specs.JWTPublicKeySpec]
 
-// JWTPublicKeyExtension providers auxiliary methods for JWTPublicKey resource.
+// JWTPublicKeyExtension provides auxiliary methods for JWTPublicKey resource.
 type JWTPublicKeyExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/cluster_bootstrap_status.go
+++ b/client/pkg/omni/resources/omni/cluster_bootstrap_status.go
@@ -23,12 +23,12 @@ func NewClusterBootstrapStatus(id resource.ID) *ClusterBootstrapStatus {
 }
 
 const (
-	// ClusterBootstrapStatusType is the type of the ClusterMachineConfigStatus resource.
+	// ClusterBootstrapStatusType is the type of the ClusterBootstrapStatus resource.
 	// tsgen:ClusterBootstrapStatusType
 	ClusterBootstrapStatusType = resource.Type("ClusterBootstrapStatuses.omni.sidero.dev")
 )
 
-// ClusterBootstrapStatus describes a cluster machine status.
+// ClusterBootstrapStatus describes a cluster bootstrap status.
 type ClusterBootstrapStatus = typed.Resource[ClusterBootstrapStatusSpec, ClusterBootstrapStatusExtension]
 
 // ClusterBootstrapStatusSpec wraps specs.ClusterBootstrapStatusSpec.

--- a/client/pkg/omni/resources/omni/cluster_machine_request_status.go
+++ b/client/pkg/omni/resources/omni/cluster_machine_request_status.go
@@ -33,7 +33,7 @@ type ClusterMachineRequestStatus = typed.Resource[ClusterMachineRequestStatusSpe
 // ClusterMachineRequestStatusSpec wraps specs.ClusterMachineRequestStatusSpec.
 type ClusterMachineRequestStatusSpec = protobuf.ResourceSpec[specs.ClusterMachineRequestStatusSpec, *specs.ClusterMachineRequestStatusSpec]
 
-// ClusterMachineRequestStatusExtension providers auxiliary methods for ClusterMachineRequestStatus resource.
+// ClusterMachineRequestStatusExtension provides auxiliary methods for ClusterMachineRequestStatus resource.
 type ClusterMachineRequestStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.
@@ -44,16 +44,8 @@ func (ClusterMachineRequestStatusExtension) ResourceDefinition() meta.ResourceDe
 		DefaultNamespace: resources.DefaultNamespace,
 		PrintColumns: []meta.PrintColumn{
 			{
-				Name:     "Ready",
-				JSONPath: "{.ready}",
-			},
-			{
 				Name:     "Stage",
 				JSONPath: "{.stage}",
-			},
-			{
-				Name:     "apid",
-				JSONPath: "{.apidavailable}",
 			},
 		},
 	}

--- a/client/pkg/omni/resources/omni/cluster_machine_status.go
+++ b/client/pkg/omni/resources/omni/cluster_machine_status.go
@@ -35,7 +35,7 @@ type ClusterMachineStatus = typed.Resource[ClusterMachineStatusSpec, ClusterMach
 // ClusterMachineStatusSpec wraps specs.ClusterMachineStatusSpec.
 type ClusterMachineStatusSpec = protobuf.ResourceSpec[specs.ClusterMachineStatusSpec, *specs.ClusterMachineStatusSpec]
 
-// ClusterMachineStatusExtension providers auxiliary methods for ClusterMachineStatus resource.
+// ClusterMachineStatusExtension provides auxiliary methods for ClusterMachineStatus resource.
 type ClusterMachineStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.
@@ -52,10 +52,6 @@ func (ClusterMachineStatusExtension) ResourceDefinition() meta.ResourceDefinitio
 			{
 				Name:     "Stage",
 				JSONPath: "{.stage}",
-			},
-			{
-				Name:     "apid",
-				JSONPath: "{.apidavailable}",
 			},
 		},
 	}

--- a/client/pkg/omni/resources/omni/cluster_machine_talos_version.go
+++ b/client/pkg/omni/resources/omni/cluster_machine_talos_version.go
@@ -33,7 +33,7 @@ type ClusterMachineTalosVersion = typed.Resource[ClusterMachineTalosVersionSpec,
 // ClusterMachineTalosVersionSpec wraps specs.ClusterMachineTalosVersionSpec.
 type ClusterMachineTalosVersionSpec = protobuf.ResourceSpec[specs.ClusterMachineTalosVersionSpec, *specs.ClusterMachineTalosVersionSpec]
 
-// ClusterMachineTalosVersionExtension providers auxiliary methods for ClusterMachineTalosVersion resource.
+// ClusterMachineTalosVersionExtension provides auxiliary methods for ClusterMachineTalosVersion resource.
 type ClusterMachineTalosVersionExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/features_config.go
+++ b/client/pkg/omni/resources/omni/features_config.go
@@ -41,7 +41,7 @@ type FeaturesConfig = typed.Resource[FeaturesConfigSpec, FeaturesConfigExtension
 // FeaturesConfigSpec wraps specs.FeaturesConfigSpec.
 type FeaturesConfigSpec = protobuf.ResourceSpec[specs.FeaturesConfigSpec, *specs.FeaturesConfigSpec]
 
-// FeaturesConfigExtension providers auxiliary methods for FeaturesConfig resource.
+// FeaturesConfigExtension provides auxiliary methods for FeaturesConfig resource.
 type FeaturesConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/image_pull_request.go
+++ b/client/pkg/omni/resources/omni/image_pull_request.go
@@ -33,7 +33,7 @@ type ImagePullRequest = typed.Resource[ImagePullRequestSpec, ImagePullRequestExt
 // ImagePullRequestSpec wraps specs.ImagePullRequestSpec.
 type ImagePullRequestSpec = protobuf.ResourceSpec[specs.ImagePullRequestSpec, *specs.ImagePullRequestSpec]
 
-// ImagePullRequestExtension providers auxiliary methods for ImagePullRequest resource.
+// ImagePullRequestExtension provides auxiliary methods for ImagePullRequest resource.
 type ImagePullRequestExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/image_pull_status.go
+++ b/client/pkg/omni/resources/omni/image_pull_status.go
@@ -33,7 +33,7 @@ type ImagePullStatus = typed.Resource[ImagePullStatusSpec, ImagePullStatusExtens
 // ImagePullStatusSpec wraps specs.ImagePullStatusSpec.
 type ImagePullStatusSpec = protobuf.ResourceSpec[specs.ImagePullStatusSpec, *specs.ImagePullStatusSpec]
 
-// ImagePullStatusExtension providers auxiliary methods for ImagePullStatus resource.
+// ImagePullStatusExtension provides auxiliary methods for ImagePullStatus resource.
 type ImagePullStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/imported_secrets.go
+++ b/client/pkg/omni/resources/omni/imported_secrets.go
@@ -37,7 +37,7 @@ type ImportedClusterSecrets = typed.Resource[ImportedClusterSecretsSpec, Importe
 // ImportedClusterSecretsSpec wraps specs.ImportedClusterSecretsSpec.
 type ImportedClusterSecretsSpec = protobuf.ResourceSpec[specs.ImportedClusterSecretsSpec, *specs.ImportedClusterSecretsSpec]
 
-// ImportedClusterSecretsExtension providers auxiliary methods for ImportedClusterSecrets resource.
+// ImportedClusterSecretsExtension provides auxiliary methods for ImportedClusterSecrets resource.
 type ImportedClusterSecretsExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/infra_machine_bmc_config.go
+++ b/client/pkg/omni/resources/omni/infra_machine_bmc_config.go
@@ -35,7 +35,7 @@ type InfraMachineBMCConfig = typed.Resource[InfraMachineBMCConfigSpec, InfraMach
 // InfraMachineBMCConfigSpec wraps specs.InfraMachineBMCConfigSpec.
 type InfraMachineBMCConfigSpec = protobuf.ResourceSpec[specs.InfraMachineBMCConfigSpec, *specs.InfraMachineBMCConfigSpec]
 
-// InfraMachineBMCConfigExtension providers auxiliary methods for InfraMachineBMCConfig resource.
+// InfraMachineBMCConfigExtension provides auxiliary methods for InfraMachineBMCConfig resource.
 type InfraMachineBMCConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/infra_machine_config.go
+++ b/client/pkg/omni/resources/omni/infra_machine_config.go
@@ -35,7 +35,7 @@ type InfraMachineConfig = typed.Resource[InfraMachineConfigSpec, InfraMachineCon
 // InfraMachineConfigSpec wraps specs.InfraMachineConfigSpec.
 type InfraMachineConfigSpec = protobuf.ResourceSpec[specs.InfraMachineConfigSpec, *specs.InfraMachineConfigSpec]
 
-// InfraMachineConfigExtension providers auxiliary methods for InfraMachineConfig resource.
+// InfraMachineConfigExtension provides auxiliary methods for InfraMachineConfig resource.
 type InfraMachineConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/infra_provider_combined_status.go
+++ b/client/pkg/omni/resources/omni/infra_provider_combined_status.go
@@ -36,7 +36,7 @@ type InfraProviderCombinedStatus = typed.Resource[InfraProviderCombinedStatusSpe
 // InfraProviderCombinedStatusSpec wraps specs.InfraProviderCombinedStatusSpec.
 type InfraProviderCombinedStatusSpec = protobuf.ResourceSpec[specs.InfraProviderCombinedStatusSpec, *specs.InfraProviderCombinedStatusSpec]
 
-// InfraProviderCombinedStatusExtension providers auxiliary methods for InfraProviderCombinedStatus resource.
+// InfraProviderCombinedStatusExtension provides auxiliary methods for InfraProviderCombinedStatus resource.
 type InfraProviderCombinedStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/installation_media.go
+++ b/client/pkg/omni/resources/omni/installation_media.go
@@ -37,7 +37,7 @@ type InstallationMedia = typed.Resource[InstallationMediaSpec, InstallationMedia
 // InstallationMediaSpec wraps specs.InstallationMediaSpec.
 type InstallationMediaSpec = protobuf.ResourceSpec[specs.InstallationMediaSpec, *specs.InstallationMediaSpec]
 
-// InstallationMediaExtension providers auxiliary methods for InstallationMedia resource.
+// InstallationMediaExtension provides auxiliary methods for InstallationMedia resource.
 type InstallationMediaExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/installation_media_config.go
+++ b/client/pkg/omni/resources/omni/installation_media_config.go
@@ -35,7 +35,7 @@ type InstallationMediaConfig = typed.Resource[InstallationMediaConfigSpec, Insta
 // InstallationMediaConfigSpec wraps specs.InstallationMediaConfigSpec.
 type InstallationMediaConfigSpec = protobuf.ResourceSpec[specs.InstallationMediaConfigSpec, *specs.InstallationMediaConfigSpec]
 
-// InstallationMediaConfigExtension providers auxiliary methods for InstallationMediaConfig resource.
+// InstallationMediaConfigExtension provides auxiliary methods for InstallationMediaConfig resource.
 type InstallationMediaConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/kubernetes_node_audit_result.go
+++ b/client/pkg/omni/resources/omni/kubernetes_node_audit_result.go
@@ -42,8 +42,8 @@ func (KubernetesNodeAuditResultExtension) ResourceDefinition() meta.ResourceDefi
 		DefaultNamespace: resources.DefaultNamespace,
 		PrintColumns: []meta.PrintColumn{
 			{
-				Name:     "Nodes",
-				JSONPath: "{.nodes}",
+				Name:     "Deleted Nodes",
+				JSONPath: "{.deletednodes}",
 			},
 		},
 	}

--- a/client/pkg/omni/resources/omni/kubernetes_status.go
+++ b/client/pkg/omni/resources/omni/kubernetes_status.go
@@ -33,7 +33,7 @@ type KubernetesStatus = typed.Resource[KubernetesStatusSpec, KubernetesStatusExt
 // KubernetesStatusSpec wraps specs.KubernetesStatusSpec.
 type KubernetesStatusSpec = protobuf.ResourceSpec[specs.KubernetesStatusSpec, *specs.KubernetesStatusSpec]
 
-// KubernetesStatusExtension providers auxiliary methods for KubernetesStatus resource.
+// KubernetesStatusExtension provides auxiliary methods for KubernetesStatus resource.
 type KubernetesStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/kubernetes_upgrade_manifest_status.go
+++ b/client/pkg/omni/resources/omni/kubernetes_upgrade_manifest_status.go
@@ -33,7 +33,7 @@ type KubernetesUpgradeManifestStatus = typed.Resource[KubernetesUpgradeManifestS
 // KubernetesUpgradeManifestStatusSpec wraps specs.KubernetesUpgradeManifestStatusSpec.
 type KubernetesUpgradeManifestStatusSpec = protobuf.ResourceSpec[specs.KubernetesUpgradeManifestStatusSpec, *specs.KubernetesUpgradeManifestStatusSpec]
 
-// KubernetesUpgradeManifestStatusExtension providers auxiliary methods for KubernetesUpgradeManifestStatus resource.
+// KubernetesUpgradeManifestStatusExtension provides auxiliary methods for KubernetesUpgradeManifestStatus resource.
 type KubernetesUpgradeManifestStatusExtension struct{}
 
 // ResourceDefinition implements typed.ResourceDefinition interface.

--- a/client/pkg/omni/resources/omni/kubernetes_upgrade_status.go
+++ b/client/pkg/omni/resources/omni/kubernetes_upgrade_status.go
@@ -33,7 +33,7 @@ type KubernetesUpgradeStatus = typed.Resource[KubernetesUpgradeStatusSpec, Kuber
 // KubernetesUpgradeStatusSpec wraps specs.KubernetesUpgradeStatusSpec.
 type KubernetesUpgradeStatusSpec = protobuf.ResourceSpec[specs.KubernetesUpgradeStatusSpec, *specs.KubernetesUpgradeStatusSpec]
 
-// KubernetesUpgradeStatusExtension providers auxiliary methods for KubernetesUpgradeStatus resource.
+// KubernetesUpgradeStatusExtension provides auxiliary methods for KubernetesUpgradeStatus resource.
 type KubernetesUpgradeStatusExtension struct{}
 
 // ResourceDefinition implements typed.ResourceDefinition interface.

--- a/client/pkg/omni/resources/omni/loadbalancer_config.go
+++ b/client/pkg/omni/resources/omni/loadbalancer_config.go
@@ -31,7 +31,7 @@ type LoadBalancerConfig = typed.Resource[LoadBalancerConfigSpec, LoadBalancerCon
 // LoadBalancerConfigSpec wraps specs.LoadBalancerConfigSpec.
 type LoadBalancerConfigSpec = protobuf.ResourceSpec[specs.LoadBalancerConfigSpec, *specs.LoadBalancerConfigSpec]
 
-// LoadBalancerConfigExtension providers auxiliary methods for LoadBalancerConfig resource.
+// LoadBalancerConfigExtension provides auxiliary methods for LoadBalancerConfig resource.
 type LoadBalancerConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/loadbalancer_status.go
+++ b/client/pkg/omni/resources/omni/loadbalancer_status.go
@@ -31,7 +31,7 @@ type LoadBalancerStatus = typed.Resource[LoadBalancerStatusSpec, LoadBalancerSta
 // LoadBalancerStatusSpec wraps specs.LoadBalancerStatusSpec.
 type LoadBalancerStatusSpec = protobuf.ResourceSpec[specs.LoadBalancerStatusSpec, *specs.LoadBalancerStatusSpec]
 
-// LoadBalancerStatusExtension providers auxiliary methods for LoadBalancerStatus resource.
+// LoadBalancerStatusExtension provides auxiliary methods for LoadBalancerStatus resource.
 type LoadBalancerStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/machine.go
+++ b/client/pkg/omni/resources/omni/machine.go
@@ -38,7 +38,7 @@ type Machine = typed.Resource[MachineSpec, MachineExtension]
 // MachineSpec wraps specs.MachineSpec.
 type MachineSpec = protobuf.ResourceSpec[specs.MachineSpec, *specs.MachineSpec]
 
-// MachineExtension providers auxiliary methods for Machine resource.
+// MachineExtension provides auxiliary methods for Machine resource.
 type MachineExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.
@@ -55,10 +55,6 @@ func (MachineExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
 			{
 				Name:     "Connected",
 				JSONPath: "{.connected}",
-			},
-			{
-				Name:     "Reboots",
-				JSONPath: "{.rebootcount}",
 			},
 		},
 	}

--- a/client/pkg/omni/resources/omni/machine_request_set.go
+++ b/client/pkg/omni/resources/omni/machine_request_set.go
@@ -33,7 +33,7 @@ type MachineRequestSet = typed.Resource[MachineRequestSetSpec, MachineRequestSet
 // MachineRequestSetSpec wraps specs.MachineRequestSetSpec.
 type MachineRequestSetSpec = protobuf.ResourceSpec[specs.MachineRequestSetSpec, *specs.MachineRequestSetSpec]
 
-// MachineRequestSetExtension providers auxiliary methods for MachineRequestSet resource.
+// MachineRequestSetExtension provides auxiliary methods for MachineRequestSet resource.
 type MachineRequestSetExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/machine_request_set_status.go
+++ b/client/pkg/omni/resources/omni/machine_request_set_status.go
@@ -33,7 +33,7 @@ type MachineRequestSetStatus = typed.Resource[MachineRequestSetStatusSpec, Machi
 // MachineRequestSetStatusSpec wraps specs.MachineRequestSetStatusSpec.
 type MachineRequestSetStatusSpec = protobuf.ResourceSpec[specs.MachineRequestSetStatusSpec, *specs.MachineRequestSetStatusSpec]
 
-// MachineRequestSetStatusExtension providers auxiliary methods for MachineRequestSetStatus resource.
+// MachineRequestSetStatusExtension provides auxiliary methods for MachineRequestSetStatus resource.
 type MachineRequestSetStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/machine_secrets.go
+++ b/client/pkg/omni/resources/omni/machine_secrets.go
@@ -35,7 +35,7 @@ type ClusterMachineSecrets = typed.Resource[ClusterMachineSecretsSpec, ClusterMa
 // ClusterMachineSecretsSpec wraps specs.ClusterMachineSecretsSpec.
 type ClusterMachineSecretsSpec = protobuf.ResourceSpec[specs.ClusterMachineSecretsSpec, *specs.ClusterMachineSecretsSpec]
 
-// ClusterMachineSecretsExtension providers auxiliary methods for the ClusterMachineSecrets resource.
+// ClusterMachineSecretsExtension provides auxiliary methods for the ClusterMachineSecrets resource.
 type ClusterMachineSecretsExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/machine_status.go
+++ b/client/pkg/omni/resources/omni/machine_status.go
@@ -43,7 +43,7 @@ type MachineStatus = typed.Resource[MachineStatusSpec, MachineStatusExtension]
 // MachineStatusSpec wraps specs.MachineStatusSpec.
 type MachineStatusSpec = protobuf.ResourceSpec[specs.MachineStatusSpec, *specs.MachineStatusSpec]
 
-// MachineStatusExtension providers auxiliary methods for MachineStatus resource.
+// MachineStatusExtension provides auxiliary methods for MachineStatus resource.
 type MachineStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/machine_status_link.go
+++ b/client/pkg/omni/resources/omni/machine_status_link.go
@@ -36,7 +36,7 @@ type MachineStatusLinkSpec = protobuf.ResourceSpec[specs.MachineStatusLinkSpec, 
 // tsgen:MachineStatusLinkType
 const MachineStatusLinkType = resource.Type("MachineStatusLinks.omni.sidero.dev")
 
-// MachineStatusLinkExtension providers auxiliary methods for MachineStatusLink resource.
+// MachineStatusLinkExtension provides auxiliary methods for MachineStatusLink resource.
 type MachineStatusLinkExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/machine_status_snapshot.go
+++ b/client/pkg/omni/resources/omni/machine_status_snapshot.go
@@ -35,7 +35,7 @@ type MachineStatusSnapshot = typed.Resource[MachineStatusSnapshotSpec, MachineSt
 // MachineStatusSnapshotSpec wraps specs.MachineStatusSnapshotSpec.
 type MachineStatusSnapshotSpec = protobuf.ResourceSpec[specs.MachineStatusSnapshotSpec, *specs.MachineStatusSnapshotSpec]
 
-// MachineStatusSnapshotExtension providers auxiliary methods for MachineStatusSnapshot resource.
+// MachineStatusSnapshotExtension provides auxiliary methods for MachineStatusSnapshot resource.
 type MachineStatusSnapshotExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/node_force_destroy_request.go
+++ b/client/pkg/omni/resources/omni/node_force_destroy_request.go
@@ -35,7 +35,7 @@ type NodeForceDestroyRequest = typed.Resource[NodeForceDestroyRequestSpec, NodeF
 // NodeForceDestroyRequestSpec wraps specs.NodeForceDestroyRequestSpec.
 type NodeForceDestroyRequestSpec = protobuf.ResourceSpec[specs.NodeForceDestroyRequestSpec, *specs.NodeForceDestroyRequestSpec]
 
-// NodeForceDestroyRequestExtension providers auxiliary methods for NodeForceDestroyRequest resource.
+// NodeForceDestroyRequestExtension provides auxiliary methods for NodeForceDestroyRequest resource.
 type NodeForceDestroyRequestExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/ongoing_task.go
+++ b/client/pkg/omni/resources/omni/ongoing_task.go
@@ -33,7 +33,7 @@ type OngoingTask = typed.Resource[OngoingTaskSpec, OngoingTaskExtension]
 // OngoingTaskSpec wraps specs.OngoingTaskSpec.
 type OngoingTaskSpec = protobuf.ResourceSpec[specs.OngoingTaskSpec, *specs.OngoingTaskSpec]
 
-// OngoingTaskExtension providers auxiliary methods for OngoingTask resource.
+// OngoingTaskExtension provides auxiliary methods for OngoingTask resource.
 type OngoingTaskExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/rotate_kubernetes_ca.go
+++ b/client/pkg/omni/resources/omni/rotate_kubernetes_ca.go
@@ -33,7 +33,7 @@ type RotateKubernetesCA = typed.Resource[RotateKubernetesCASpec, RotateKubernete
 // RotateKubernetesCASpec wraps specs.RotateKubernetesCASpec.
 type RotateKubernetesCASpec = protobuf.ResourceSpec[specs.RotateKubernetesCASpec, *specs.RotateKubernetesCASpec]
 
-// RotateKubernetesCAExtension providers auxiliary methods for RotateKubernetesCA resource.
+// RotateKubernetesCAExtension provides auxiliary methods for RotateKubernetesCA resource.
 type RotateKubernetesCAExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/rotate_talos_ca.go
+++ b/client/pkg/omni/resources/omni/rotate_talos_ca.go
@@ -33,7 +33,7 @@ type RotateTalosCA = typed.Resource[RotateTalosCASpec, RotateTalosCAExtension]
 // RotateTalosCASpec wraps specs.RotateTalosCASpec.
 type RotateTalosCASpec = protobuf.ResourceSpec[specs.RotateTalosCASpec, *specs.RotateTalosCASpec]
 
-// RotateTalosCAExtension providers auxiliary methods for RotateTalosCA resource.
+// RotateTalosCAExtension provides auxiliary methods for RotateTalosCA resource.
 type RotateTalosCAExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/secret_rotation.go
+++ b/client/pkg/omni/resources/omni/secret_rotation.go
@@ -35,7 +35,7 @@ type SecretRotation = typed.Resource[SecretRotationSpec, SecretRotationExtension
 // SecretRotationSpec wraps specs.SecretRotationSpec.
 type SecretRotationSpec = protobuf.ResourceSpec[specs.SecretRotationSpec, *specs.SecretRotationSpec]
 
-// SecretRotationExtension providers auxiliary methods for the SecretRotation resource.
+// SecretRotationExtension provides auxiliary methods for the SecretRotation resource.
 type SecretRotationExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/secrets.go
+++ b/client/pkg/omni/resources/omni/secrets.go
@@ -39,7 +39,7 @@ type ClusterSecrets = typed.Resource[ClusterSecretsSpec, ClusterSecretsExtension
 // ClusterSecretsSpec wraps specs.ClusterSecretsSpec.
 type ClusterSecretsSpec = protobuf.ResourceSpec[specs.ClusterSecretsSpec, *specs.ClusterSecretsSpec]
 
-// ClusterSecretsExtension providers auxiliary methods for ClusterSecrets resource.
+// ClusterSecretsExtension provides auxiliary methods for ClusterSecrets resource.
 type ClusterSecretsExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/secrets_rotation_status.go
+++ b/client/pkg/omni/resources/omni/secrets_rotation_status.go
@@ -33,7 +33,7 @@ type ClusterSecretsRotationStatus = typed.Resource[ClusterSecretsRotationStatusS
 // ClusterSecretsRotationStatusSpec wraps specs.ClusterSecretsRotationStatusSpec.
 type ClusterSecretsRotationStatusSpec = protobuf.ResourceSpec[specs.ClusterSecretsRotationStatusSpec, *specs.ClusterSecretsRotationStatusSpec]
 
-// ClusterSecretsRotationStatusExtension providers auxiliary methods for ClusterSecretsRotationStatus resource.
+// ClusterSecretsRotationStatusExtension provides auxiliary methods for ClusterSecretsRotationStatus resource.
 type ClusterSecretsRotationStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/talos_extensions.go
+++ b/client/pkg/omni/resources/omni/talos_extensions.go
@@ -33,7 +33,7 @@ type TalosExtensions = typed.Resource[TalosExtensionsSpec, TalosExtensionsExtens
 // TalosExtensionsSpec wraps specs.TalosExtensionsSpec.
 type TalosExtensionsSpec = protobuf.ResourceSpec[specs.TalosExtensionsSpec, *specs.TalosExtensionsSpec]
 
-// TalosExtensionsExtension providers auxiliary methods for TalosExtensions resource.
+// TalosExtensionsExtension provides auxiliary methods for TalosExtensions resource.
 type TalosExtensionsExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/omni/talos_upgrade_status.go
+++ b/client/pkg/omni/resources/omni/talos_upgrade_status.go
@@ -33,7 +33,7 @@ type TalosUpgradeStatus = typed.Resource[TalosUpgradeStatusSpec, TalosUpgradeSta
 // TalosUpgradeStatusSpec wraps specs.TalosUpgradeStatusSpec.
 type TalosUpgradeStatusSpec = protobuf.ResourceSpec[specs.TalosUpgradeStatusSpec, *specs.TalosUpgradeStatusSpec]
 
-// TalosUpgradeStatusExtension providers auxiliary methods for TalosUpgradeStatus resource.
+// TalosUpgradeStatusExtension provides auxiliary methods for TalosUpgradeStatus resource.
 type TalosUpgradeStatusExtension struct{}
 
 // ResourceDefinition implements typed.ResourceDefinition interface.

--- a/client/pkg/omni/resources/omni/upgrade_rollout.go
+++ b/client/pkg/omni/resources/omni/upgrade_rollout.go
@@ -35,7 +35,7 @@ type UpgradeRollout = typed.Resource[UpgradeRolloutSpec, UpgradeRolloutExtension
 // UpgradeRolloutSpec wraps specs.UpgradeRolloutSpec.
 type UpgradeRolloutSpec = protobuf.ResourceSpec[specs.UpgradeRolloutSpec, *specs.UpgradeRolloutSpec]
 
-// UpgradeRolloutExtension providers auxiliary methods for UpgradeRollout resource.
+// UpgradeRolloutExtension provides auxiliary methods for UpgradeRollout resource.
 type UpgradeRolloutExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/config.go
+++ b/client/pkg/omni/resources/siderolink/config.go
@@ -41,7 +41,7 @@ type Config = typed.Resource[ConfigSpec, ConfigExtension]
 // ConfigSpec wraps specs.SiderolinkConfigSpec.
 type ConfigSpec = protobuf.ResourceSpec[specs.SiderolinkConfigSpec, *specs.SiderolinkConfigSpec]
 
-// ConfigExtension providers auxiliary methods for Config resource.
+// ConfigExtension provides auxiliary methods for Config resource.
 type ConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/connection_params.go
+++ b/client/pkg/omni/resources/siderolink/connection_params.go
@@ -46,7 +46,7 @@ type ConnectionParams = typed.Resource[ConnectionParamsSpec, ConnectionParamsExt
 // ConnectionParamsSpec wraps specs.ConnectionParamsSpec.
 type ConnectionParamsSpec = protobuf.ResourceSpec[specs.ConnectionParamsSpec, *specs.ConnectionParamsSpec]
 
-// ConnectionParamsExtension providers auxiliary methods for ConnectionParams resource.
+// ConnectionParamsExtension provides auxiliary methods for ConnectionParams resource.
 type ConnectionParamsExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/default_join_token.go
+++ b/client/pkg/omni/resources/siderolink/default_join_token.go
@@ -39,7 +39,7 @@ type DefaultJoinToken = typed.Resource[DefaultJoinTokenSpec, DefaultJoinTokenExt
 // DefaultJoinTokenSpec wraps specs.DefaultJoinTokenSpec.
 type DefaultJoinTokenSpec = protobuf.ResourceSpec[specs.DefaultJoinTokenSpec, *specs.DefaultJoinTokenSpec]
 
-// DefaultJoinTokenExtension providers auxiliary methods for DefaultJoinToken resource.
+// DefaultJoinTokenExtension provides auxiliary methods for DefaultJoinToken resource.
 type DefaultJoinTokenExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/grpc_tunnel_config.go
+++ b/client/pkg/omni/resources/siderolink/grpc_tunnel_config.go
@@ -33,7 +33,7 @@ type GRPCTunnelConfig = typed.Resource[GRPCTunnelConfigSpec, GRPCTunnelConfigExt
 // GRPCTunnelConfigSpec wraps specs.GRPCTunnelConfigSpec.
 type GRPCTunnelConfigSpec = protobuf.ResourceSpec[specs.GRPCTunnelConfigSpec, *specs.GRPCTunnelConfigSpec]
 
-// GRPCTunnelConfigExtension providers auxiliary methods for GRPCTunnelConfig resource.
+// GRPCTunnelConfigExtension provides auxiliary methods for GRPCTunnelConfig resource.
 type GRPCTunnelConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/join_token.go
+++ b/client/pkg/omni/resources/siderolink/join_token.go
@@ -35,7 +35,7 @@ type JoinToken = typed.Resource[JoinTokenSpec, JoinTokenExtension]
 // JoinTokenSpec wraps specs.JoinTokenSpec.
 type JoinTokenSpec = protobuf.ResourceSpec[specs.JoinTokenSpec, *specs.JoinTokenSpec]
 
-// JoinTokenExtension providers auxiliary methods for JoinToken resource.
+// JoinTokenExtension provides auxiliary methods for JoinToken resource.
 type JoinTokenExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/join_token_status.go
+++ b/client/pkg/omni/resources/siderolink/join_token_status.go
@@ -35,7 +35,7 @@ type JoinTokenStatus = typed.Resource[JoinTokenStatusSpec, JoinTokenStatusExtens
 // JoinTokenStatusSpec wraps specs.JoinTokenStatusSpec.
 type JoinTokenStatusSpec = protobuf.ResourceSpec[specs.JoinTokenStatusSpec, *specs.JoinTokenStatusSpec]
 
-// JoinTokenStatusExtension providers auxiliary methods for JoinTokenStatus resource.
+// JoinTokenStatusExtension provides auxiliary methods for JoinTokenStatus resource.
 type JoinTokenStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/join_token_usage.go
+++ b/client/pkg/omni/resources/siderolink/join_token_usage.go
@@ -36,7 +36,7 @@ type JoinTokenUsage = typed.Resource[JoinTokenUsageSpec, JoinTokenUsageExtension
 // JoinTokenUsageSpec wraps specs.JoinTokenUsageSpec.
 type JoinTokenUsageSpec = protobuf.ResourceSpec[specs.JoinTokenUsageSpec, *specs.JoinTokenUsageSpec]
 
-// JoinTokenUsageExtension providers auxiliary methods for JoinTokenUsage resource.
+// JoinTokenUsageExtension provides auxiliary methods for JoinTokenUsage resource.
 type JoinTokenUsageExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/link.go
+++ b/client/pkg/omni/resources/siderolink/link.go
@@ -34,7 +34,7 @@ type Link = typed.Resource[LinkSpec, LinkExtension]
 // LinkSpec wraps specs.SiderolinkSpec.
 type LinkSpec = protobuf.ResourceSpec[specs.SiderolinkSpec, *specs.SiderolinkSpec]
 
-// LinkExtension providers auxiliary methods for Link resource.
+// LinkExtension provides auxiliary methods for Link resource.
 type LinkExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/link_status.go
+++ b/client/pkg/omni/resources/siderolink/link_status.go
@@ -37,7 +37,7 @@ type LinkStatus = typed.Resource[LinkStatusSpec, LinkStatusExtension]
 // LinkStatusSpec wraps specs.LinkStatusSpec.
 type LinkStatusSpec = protobuf.ResourceSpec[specs.LinkStatusSpec, *specs.LinkStatusSpec]
 
-// LinkStatusExtension providers auxiliary methods for LinkStatus resource.
+// LinkStatusExtension provides auxiliary methods for LinkStatus resource.
 type LinkStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/machine_join_config.go
+++ b/client/pkg/omni/resources/siderolink/machine_join_config.go
@@ -33,7 +33,7 @@ type MachineJoinConfig = typed.Resource[MachineJoinConfigSpec, MachineJoinConfig
 // MachineJoinConfigSpec wraps specs.MachineJoinConfigSpec.
 type MachineJoinConfigSpec = protobuf.ResourceSpec[specs.MachineJoinConfigSpec, *specs.MachineJoinConfigSpec]
 
-// MachineJoinConfigExtension providers auxiliary methods for MachineJoinConfig resource.
+// MachineJoinConfigExtension provides auxiliary methods for MachineJoinConfig resource.
 type MachineJoinConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/node_unique_token.go
+++ b/client/pkg/omni/resources/siderolink/node_unique_token.go
@@ -31,7 +31,7 @@ type NodeUniqueToken = typed.Resource[NodeUniqueTokenSpec, NodeUniqueTokenExtens
 // NodeUniqueTokenSpec wraps specs.NodeUniqueTokenSpec.
 type NodeUniqueTokenSpec = protobuf.ResourceSpec[specs.NodeUniqueTokenSpec, *specs.NodeUniqueTokenSpec]
 
-// NodeUniqueTokenExtension providers auxiliary methods for NodeUniqueToken resource.
+// NodeUniqueTokenExtension provides auxiliary methods for NodeUniqueToken resource.
 type NodeUniqueTokenExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/node_unique_token_status.go
+++ b/client/pkg/omni/resources/siderolink/node_unique_token_status.go
@@ -31,7 +31,7 @@ type NodeUniqueTokenStatus = typed.Resource[NodeUniqueTokenStatusSpec, NodeUniqu
 // NodeUniqueTokenStatusSpec wraps specs.NodeUniqueTokenStatusSpec.
 type NodeUniqueTokenStatusSpec = protobuf.ResourceSpec[specs.NodeUniqueTokenStatusSpec, *specs.NodeUniqueTokenStatusSpec]
 
-// NodeUniqueTokenStatusExtension providers auxiliary methods for NodeUniqueTokenStatus resource.
+// NodeUniqueTokenStatusExtension provides auxiliary methods for NodeUniqueTokenStatus resource.
 type NodeUniqueTokenStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/pending_machine.go
+++ b/client/pkg/omni/resources/siderolink/pending_machine.go
@@ -33,7 +33,7 @@ type PendingMachine = typed.Resource[PendingMachineSpec, PendingMachineExtension
 // PendingMachineSpec wraps specs.SiderolinkSpec.
 type PendingMachineSpec = protobuf.ResourceSpec[specs.SiderolinkSpec, *specs.SiderolinkSpec]
 
-// PendingMachineExtension providers auxiliary methods for PendingMachine resource.
+// PendingMachineExtension provides auxiliary methods for PendingMachine resource.
 type PendingMachineExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/pending_machine_status.go
+++ b/client/pkg/omni/resources/siderolink/pending_machine_status.go
@@ -33,7 +33,7 @@ type PendingMachineStatus = typed.Resource[PendingMachineStatusSpec, PendingMach
 // PendingMachineStatusSpec wraps specs.SiderolinkSpec.
 type PendingMachineStatusSpec = protobuf.ResourceSpec[specs.PendingMachineStatusSpec, *specs.PendingMachineStatusSpec]
 
-// PendingMachineStatusExtension providers auxiliary methods for PendingMachineStatus resource.
+// PendingMachineStatusExtension provides auxiliary methods for PendingMachineStatus resource.
 type PendingMachineStatusExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/provider_join_config.go
+++ b/client/pkg/omni/resources/siderolink/provider_join_config.go
@@ -33,7 +33,7 @@ type ProviderJoinConfig = typed.Resource[ProviderJoinConfigSpec, ProviderJoinCon
 // ProviderJoinConfigSpec wraps specs.ProviderJoinConfigSpec.
 type ProviderJoinConfigSpec = protobuf.ResourceSpec[specs.ProviderJoinConfigSpec, *specs.ProviderJoinConfigSpec]
 
-// ProviderJoinConfigExtension providers auxiliary methods for ProviderJoinConfig resource.
+// ProviderJoinConfigExtension provides auxiliary methods for ProviderJoinConfig resource.
 type ProviderJoinConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/siderolink/siderolink_api_config.go
+++ b/client/pkg/omni/resources/siderolink/siderolink_api_config.go
@@ -33,7 +33,7 @@ type APIConfig = typed.Resource[APIConfigSpec, APIConfigExtension]
 // APIConfigSpec wraps specs.APIConfigSpec.
 type APIConfigSpec = protobuf.ResourceSpec[specs.SiderolinkAPIConfigSpec, *specs.SiderolinkAPIConfigSpec]
 
-// APIConfigExtension providers auxiliary methods for SiderolinkAPIConfig resource.
+// APIConfigExtension provides auxiliary methods for SiderolinkAPIConfig resource.
 type APIConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/system/cert_refresh_tick.go
+++ b/client/pkg/omni/resources/system/cert_refresh_tick.go
@@ -31,7 +31,7 @@ type CertRefreshTick = typed.Resource[CertRefreshTickSpec, CertRefreshTickExtens
 // CertRefreshTickSpec wraps specs.CertRefreshTickSpec.
 type CertRefreshTickSpec = protobuf.ResourceSpec[specs.CertRefreshTickSpec, *specs.CertRefreshTickSpec]
 
-// CertRefreshTickExtension providers auxiliary methods for CertRefreshTick resource.
+// CertRefreshTickExtension provides auxiliary methods for CertRefreshTick resource.
 type CertRefreshTickExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/system/dbversion.go
+++ b/client/pkg/omni/resources/system/dbversion.go
@@ -35,7 +35,7 @@ type DBVersion = typed.Resource[DBVersionSpec, DBVersionExtension]
 // DBVersionSpec wraps specs.DBVersionSpec.
 type DBVersionSpec = protobuf.ResourceSpec[specs.DBVersionSpec, *specs.DBVersionSpec]
 
-// DBVersionExtension providers auxiliary methods for DBVersion resource.
+// DBVersionExtension provides auxiliary methods for DBVersion resource.
 type DBVersionExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/system/sysversion.go
+++ b/client/pkg/omni/resources/system/sysversion.go
@@ -39,7 +39,7 @@ type SysVersion = typed.Resource[SysVersionSpec, SysVersionExtension]
 // SysVersionSpec wraps specs.SysVersionSpec.
 type SysVersionSpec = protobuf.ResourceSpec[specs.SysVersionSpec, *specs.SysVersionSpec]
 
-// SysVersionExtension providers auxiliary methods for SysVersion resource.
+// SysVersionExtension provides auxiliary methods for SysVersion resource.
 type SysVersionExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/advertised_endpoints.go
+++ b/client/pkg/omni/resources/virtual/advertised_endpoints.go
@@ -40,7 +40,7 @@ type AdvertisedEndpoints = typed.Resource[AdvertisedEndpointsSpec, AdvertisedEnd
 // AdvertisedEndpointsSpec wraps specs.AdvertisedEndpointsSpec.
 type AdvertisedEndpointsSpec = protobuf.ResourceSpec[specs.AdvertisedEndpointsSpec, *specs.AdvertisedEndpointsSpec]
 
-// AdvertisedEndpointsExtension providers auxiliary methods for AdvertisedEndpoints resource.
+// AdvertisedEndpointsExtension provides auxiliary methods for AdvertisedEndpoints resource.
 type AdvertisedEndpointsExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/cloud_platform_config.go
+++ b/client/pkg/omni/resources/virtual/cloud_platform_config.go
@@ -35,7 +35,7 @@ type CloudPlatformConfig = typed.Resource[CloudPlatformConfigSpec, CloudPlatform
 // CloudPlatformConfigSpec wraps specs.CloudPlatformConfigSpec.
 type CloudPlatformConfigSpec = protobuf.ResourceSpec[specs.PlatformConfigSpec, *specs.PlatformConfigSpec]
 
-// CloudPlatformConfigExtension providers auxiliary methods for CloudPlatformConfig resource.
+// CloudPlatformConfigExtension provides auxiliary methods for CloudPlatformConfig resource.
 type CloudPlatformConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/cluster_permissions.go
+++ b/client/pkg/omni/resources/virtual/cluster_permissions.go
@@ -35,7 +35,7 @@ type ClusterPermissions = typed.Resource[ClusterPermissionsSpec, ClusterPermissi
 // ClusterPermissionsSpec wraps specs.ClusterPermissionsSpec.
 type ClusterPermissionsSpec = protobuf.ResourceSpec[specs.ClusterPermissionsSpec, *specs.ClusterPermissionsSpec]
 
-// ClusterPermissionsExtension providers auxiliary methods for ClusterPermissions resource.
+// ClusterPermissionsExtension provides auxiliary methods for ClusterPermissions resource.
 type ClusterPermissionsExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/current_user.go
+++ b/client/pkg/omni/resources/virtual/current_user.go
@@ -40,7 +40,7 @@ type CurrentUser = typed.Resource[CurrentUserSpec, CurrentUserExtension]
 // CurrentUserSpec wraps specs.CurrentUserSpec.
 type CurrentUserSpec = protobuf.ResourceSpec[specs.CurrentUserSpec, *specs.CurrentUserSpec]
 
-// CurrentUserExtension providers auxiliary methods for CurrentUser resource.
+// CurrentUserExtension provides auxiliary methods for CurrentUser resource.
 type CurrentUserExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/image_factory_auth.go
+++ b/client/pkg/omni/resources/virtual/image_factory_auth.go
@@ -40,7 +40,7 @@ type ImageFactoryAuth = typed.Resource[ImageFactoryAuthSpec, ImageFactoryAuthExt
 // ImageFactoryAuthSpec wraps specs.ImageFactoryAuthSpec.
 type ImageFactoryAuthSpec = protobuf.ResourceSpec[specs.ImageFactoryAuthSpec, *specs.ImageFactoryAuthSpec]
 
-// ImageFactoryAuthExtension providers auxiliary methods for ImageFactoryAuth resource.
+// ImageFactoryAuthExtension provides auxiliary methods for ImageFactoryAuth resource.
 type ImageFactoryAuthExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/kubernetes_usage.go
+++ b/client/pkg/omni/resources/virtual/kubernetes_usage.go
@@ -33,7 +33,7 @@ type KubernetesUsage = typed.Resource[KubernetesUsageSpec, KubernetesUsageExtens
 // KubernetesUsageSpec wraps specs.KubernetesUsageSpec.
 type KubernetesUsageSpec = protobuf.ResourceSpec[specs.KubernetesUsageSpec, *specs.KubernetesUsageSpec]
 
-// KubernetesUsageExtension providers auxiliary methods for KubernetesUsage resource.
+// KubernetesUsageExtension provides auxiliary methods for KubernetesUsage resource.
 type KubernetesUsageExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/metal_platform_config.go
+++ b/client/pkg/omni/resources/virtual/metal_platform_config.go
@@ -35,7 +35,7 @@ type MetalPlatformConfig = typed.Resource[MetalPlatformConfigSpec, MetalPlatform
 // MetalPlatformConfigSpec wraps specs.MetalPlatformConfigSpec.
 type MetalPlatformConfigSpec = protobuf.ResourceSpec[specs.PlatformConfigSpec, *specs.PlatformConfigSpec]
 
-// MetalPlatformConfigExtension providers auxiliary methods for MetalPlatformConfig resource.
+// MetalPlatformConfigExtension provides auxiliary methods for MetalPlatformConfig resource.
 type MetalPlatformConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/permissions.go
+++ b/client/pkg/omni/resources/virtual/permissions.go
@@ -42,7 +42,7 @@ type Permissions = typed.Resource[PermissionsSpec, PermissionsExtension]
 // PermissionsSpec wraps specs.PermissionsSpec.
 type PermissionsSpec = protobuf.ResourceSpec[specs.PermissionsSpec, *specs.PermissionsSpec]
 
-// PermissionsExtension providers auxiliary methods for Permissions resource.
+// PermissionsExtension provides auxiliary methods for Permissions resource.
 type PermissionsExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/client/pkg/omni/resources/virtual/sbc_config.go
+++ b/client/pkg/omni/resources/virtual/sbc_config.go
@@ -35,7 +35,7 @@ type SBCConfig = typed.Resource[SBCConfigSpec, SBCConfigExtension]
 // SBCConfigSpec wraps specs.SBCConfigSpec.
 type SBCConfigSpec = protobuf.ResourceSpec[specs.SBCConfigSpec, *specs.SBCConfigSpec]
 
-// SBCConfigExtension providers auxiliary methods for SBCConfig resource.
+// SBCConfigExtension provides auxiliary methods for SBCConfig resource.
 type SBCConfigExtension struct{}
 
 // ResourceDefinition implements [typed.Extension] interface.

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -472,7 +472,6 @@ export type ClusterMachineStatusSpecProvisionStatus = {
 export type ClusterMachineStatusSpec = {
   ready?: boolean
   stage?: ClusterMachineStatusSpecStage
-  apid_available?: boolean
   config_up_to_date?: boolean
   last_config_error?: string
   management_address?: string

--- a/internal/backend/runtime/omni/controllers/omni/cluster_bootstrap_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_bootstrap_status_test.go
@@ -228,7 +228,6 @@ func (suite *ClusterBootstrapStatusSuite) TestReconcile() {
 		}
 
 		clusterMachineStatus.TypedSpec().Value.ManagementAddress = suite.socketConnectionString
-		clusterMachineStatus.TypedSpec().Value.ApidAvailable = true
 
 		suite.Require().NoError(suite.state.Create(suite.ctx, clusterMachineStatus))
 	}

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status.go
@@ -77,7 +77,6 @@ func NewClusterMachineStatusController() *ClusterMachineStatusController {
 				if err != nil {
 					if state.IsNotFoundError(err) { // ignore, as another reconciliation will be triggered once it appears
 						cmsVal.Stage = specs.ClusterMachineStatusSpec_UNKNOWN
-						cmsVal.ApidAvailable = false
 						cmsVal.Ready = false
 						cmsVal.IsRemoved = true
 
@@ -150,7 +149,6 @@ func NewClusterMachineStatusController() *ClusterMachineStatusController {
 				if err != nil {
 					if state.IsNotFoundError(err) {
 						cmsVal.Stage = specs.ClusterMachineStatusSpec_UNKNOWN
-						cmsVal.ApidAvailable = false
 						cmsVal.Ready = false
 
 						return nil
@@ -188,13 +186,6 @@ func NewClusterMachineStatusController() *ClusterMachineStatusController {
 				cmsVal.ConfigApplyStatus = configApplyStatus(cmsVal)
 
 				status := statusSnapshot.TypedSpec().Value.GetMachineStatus()
-
-				cmsVal.ApidAvailable = false
-
-				_, isControlPlaneNode := clusterMachineStatus.Metadata().Labels().Get(omni.LabelControlPlaneRole)
-				if (status.GetStage() == machineapi.MachineStatusEvent_BOOTING || status.GetStage() == machineapi.MachineStatusEvent_RUNNING) && isControlPlaneNode {
-					cmsVal.ApidAvailable = machine != nil && machine.TypedSpec().Value.Connected
-				}
 
 				// should we also mark it as not ready when the clustermachine is tearing down (?)
 				cmsVal.Ready = status.GetStatus().GetReady() &&

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_test.go
@@ -46,17 +46,17 @@ func (suite *ClusterMachineStatusSuite) TearDownTest() {
 }
 
 func (suite *ClusterMachineStatusSuite) TestNoMachineStatusSnapShotClusterStatusZeroValue() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true, false)
+	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true)
 
 	// when
 	rtestutils.Destroy[*omni.MachineStatus](suite.ctx, suite.T(), suite.state, []string{testID})
 
 	// then
-	suite.assertStage(specs.ClusterMachineStatusSpec_UNKNOWN, false, false)
+	suite.assertStage(specs.ClusterMachineStatusSpec_UNKNOWN, false)
 }
 
 func (suite *ClusterMachineStatusSuite) TestApplyConfigErrorPropagation() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true, false)
+	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true)
 
 	rmock.Mock[*omni.ClusterMachineConfigStatus](
 		suite.ctx, suite.T(), suite.state, options.WithID(testID),
@@ -93,7 +93,7 @@ func (suite *ClusterMachineStatusSuite) TestApplyConfigErrorPropagation() {
 }
 
 func (suite *ClusterMachineStatusSuite) TestOutdatedConfig() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true, false)
+	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true)
 
 	rmock.Mock[*omni.ClusterMachineConfigStatus](
 		suite.ctx, suite.T(), suite.state, options.WithID(testID),
@@ -125,7 +125,7 @@ func (suite *ClusterMachineStatusSuite) TestOutdatedConfig() {
 	suite.Assert().NoError(err)
 }
 
-func (suite *ClusterMachineStatusSuite) setupStageTest(machineStatusEvent *machineapi.MachineStatusEvent, connected, isControlPlaneNode bool) {
+func (suite *ClusterMachineStatusSuite) setupStageTest(machineStatusEvent *machineapi.MachineStatusEvent, connected bool) {
 	suite.setup()
 
 	testID := "testID"
@@ -137,17 +137,11 @@ func (suite *ClusterMachineStatusSuite) setupStageTest(machineStatusEvent *machi
 	machine.TypedSpec().Value.Connected = connected
 	machineStatus := omni.NewMachineStatus(testID)
 
-	role := omni.LabelWorkerRole
-
-	if isControlPlaneNode {
-		role = omni.LabelControlPlaneRole
-	}
-
 	rmock.Mock[*omni.MachineSetNode](
 		suite.ctx, suite.T(), suite.state,
 		options.WithID(testID),
 		options.LabelCluster(cluster),
-		options.EmptyLabel(role),
+		options.EmptyLabel(omni.LabelWorkerRole),
 	)
 
 	rmock.Mock[*omni.ClusterMachine](
@@ -178,7 +172,7 @@ func (suite *ClusterMachineStatusSuite) setupStageTest(machineStatusEvent *machi
 	suite.Assert().NoError(suite.state.Create(suite.ctx, statusSnapshot))
 }
 
-func (suite *ClusterMachineStatusSuite) assertStage(expectedStage specs.ClusterMachineStatusSpec_Stage, expectedReadiness, expectedApidAvailable bool) {
+func (suite *ClusterMachineStatusSuite) assertStage(expectedStage specs.ClusterMachineStatusSpec_Stage, expectedReadiness bool) {
 	assertResource(
 		&suite.OmniSuite,
 		*omni.NewClusterMachineStatus("testID").Metadata(),
@@ -187,66 +181,56 @@ func (suite *ClusterMachineStatusSuite) assertStage(expectedStage specs.ClusterM
 
 			assertions.Equal(expectedReadiness, statusVal.Ready)
 			assertions.Equal(expectedStage, statusVal.Stage)
-			assertions.Equal(expectedApidAvailable, statusVal.ApidAvailable)
 		},
 	)
 }
 
 func (suite *ClusterMachineStatusSuite) TestDestroying() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RESETTING}, true, false)
+	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RESETTING}, true)
 
-	suite.assertStage(specs.ClusterMachineStatusSpec_DESTROYING, false, false)
+	suite.assertStage(specs.ClusterMachineStatusSpec_DESTROYING, false)
 }
 
 func (suite *ClusterMachineStatusSuite) TestInstalling() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_INSTALLING}, true, false)
+	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_INSTALLING}, true)
 
-	suite.assertStage(specs.ClusterMachineStatusSpec_INSTALLING, false, false)
+	suite.assertStage(specs.ClusterMachineStatusSpec_INSTALLING, false)
 }
 
 func (suite *ClusterMachineStatusSuite) TestBoot() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_BOOTING}, true, false)
+	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_BOOTING}, true)
 
-	suite.assertStage(specs.ClusterMachineStatusSpec_BOOTING, false, false)
+	suite.assertStage(specs.ClusterMachineStatusSpec_BOOTING, false)
 }
 
 func (suite *ClusterMachineStatusSuite) TestReboot() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_REBOOTING}, true, false)
+	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_REBOOTING}, true)
 
-	suite.assertStage(specs.ClusterMachineStatusSpec_REBOOTING, false, false)
+	suite.assertStage(specs.ClusterMachineStatusSpec_REBOOTING, false)
 }
 
 func (suite *ClusterMachineStatusSuite) TestRunning() {
 	suite.setupStageTest(&machineapi.MachineStatusEvent{
 		Stage:  machineapi.MachineStatusEvent_RUNNING,
 		Status: &machineapi.MachineStatusEvent_MachineStatus{Ready: true},
-	}, true, false)
+	}, true)
 
-	suite.assertStage(specs.ClusterMachineStatusSpec_RUNNING, true, false)
+	suite.assertStage(specs.ClusterMachineStatusSpec_RUNNING, true)
 }
 
 func (suite *ClusterMachineStatusSuite) TestRunningNotConnected() {
 	suite.setupStageTest(&machineapi.MachineStatusEvent{
 		Stage:  machineapi.MachineStatusEvent_RUNNING,
 		Status: &machineapi.MachineStatusEvent_MachineStatus{Ready: true},
-	}, false, false)
+	}, false)
 
-	suite.assertStage(specs.ClusterMachineStatusSpec_RUNNING, false, false)
+	suite.assertStage(specs.ClusterMachineStatusSpec_RUNNING, false)
 }
 
 func (suite *ClusterMachineStatusSuite) TestRunningNotReady() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true, false)
+	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true)
 
-	suite.assertStage(specs.ClusterMachineStatusSpec_RUNNING, false, false)
-}
-
-func (suite *ClusterMachineStatusSuite) TestApidAvailable() {
-	suite.setupStageTest(&machineapi.MachineStatusEvent{
-		Stage:  machineapi.MachineStatusEvent_RUNNING,
-		Status: &machineapi.MachineStatusEvent_MachineStatus{Ready: true},
-	}, true, true)
-
-	suite.assertStage(specs.ClusterMachineStatusSpec_RUNNING, true, true)
+	suite.assertStage(specs.ClusterMachineStatusSpec_RUNNING, false)
 }
 
 func TestClusterMachineStatusSuite(t *testing.T) {

--- a/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
+++ b/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
@@ -104,7 +104,6 @@ func init() {
 			helpers.CopyAllLabels(clusterMachine, res)
 		}
 
-		res.TypedSpec().Value.ApidAvailable = true
 		res.TypedSpec().Value.ConfigApplyStatus = specs.ConfigApplyStatus_APPLIED
 
 		machineStatus, err := safe.ReaderGetByID[*omni.MachineStatus](ctx, st, res.Metadata().ID())


### PR DESCRIPTION
- Remove unused apid_available field on ClusterMachineStatus
- Fix non-matching print columns from copy/paste errors
- Fix comments from copy/paste errors

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>