### PR TITLE
feat(frontend): display infrastructure provider error when unhealthy

### DIFF
--- a/frontend/src/pages/(authenticated)/settings/infraproviders.vue
+++ b/frontend/src/pages/(authenticated)/settings/infraproviders.vue
@@ -31,6 +31,7 @@ import TList from '@/components/List/TList.vue'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import TStatus from '@/components/Status/TStatus.vue'
+import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { TCommonStatuses } from '@/constants'
 import { usePermissions } from '@/methods/auth'
 import type { Label } from '@/methods/labels'
@@ -164,7 +165,9 @@ const openRotateSecretKey = async (name: string) => {
                 </div>
               </div>
 
-              <TStatus :title="getStatus(item)" />
+              <Tooltip :description="item.spec.health?.error" placement="top-start">
+                <TStatus :title="getStatus(item)" />
+              </Tooltip>
               <div class="truncate text-xs">
                 {{ item.spec.description }}
               </div>


### PR DESCRIPTION
Updated the `/settings/infraproviders` page to display the infrastructure provider error when unhealthy. A tooltip was used to display the error on hover.

Without this change, users need to use `omnictl` to find the error that's registered with the `infra.WithHealthCheckFunc` function in the infrastructure provider.

```
> omnictl --omniconfig ~/Downloads/omniconfig.yaml infraprovider list
ID       NAME     DESCRIPTION                            CONNECTED    ERROR
oxide    Oxide    Oxide Omni infrastructure provider.    true         failed validating oxide api connection: GET https://oxide.sys.r3.oxide-preview.com/v1/me
----------- RESPONSE -----------
Status: 400
Message: server does not support this API version: 2026060800.0.0
RequestID: 85df61a8-a65d-4136-a1f8-f43b4aff7bb6
------- RESPONSE HEADERS -------
Date: [Wed, 10 Jun 2026 19:05:36 GMT]
Content-Length: [131]
Content-Type: [application/json]
X-Request-Id: [85df61a8-a65d-4136-a1f8-f43b4aff7bb6]
```

Here's what it looks like in the web console.

<img width="951" height="390" alt="Screenshot 2026-06-10 at 15 16 05" src="https://github.com/user-attachments/assets/64d36f6c-8c54-4cc9-b187-9430ba98f252" />