### PR TITLE
fix: read machine uncached when deciding whether to reset it

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -43,6 +43,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/mappers"
 	talosutils "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/talos"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 )
 
@@ -776,7 +777,9 @@ func (ctrl *ClusterMachineConfigStatusController) shouldReset(
 		return false, fmt.Errorf("finalizer: failed to get cluster status '%s': %w", clusterName, err)
 	}
 
-	machine, err := safe.ReaderGetByID[*omni.Machine](ctx, r, machineID)
+	// Read the Machine uncached: a cached read can briefly still report a Machine that is being torn
+	// down or destroyed as present and running, so the reset decision below could be made on stale data.
+	machine, err := safe.ReaderGetByID[*omni.Machine](ctx, uncached.Reader(r), machineID)
 	if err != nil {
 		if state.IsNotFoundError(err) {
 			return false, nil


### PR DESCRIPTION
The config status controller already skips the reset of a machine whose Machine resource is gone or tearing down. That decision could be made on stale data though, since reads go through the resource cache, which may still report a just-destroyed machine as present. As a result the controller could reset a machine that is on its way out. Read the machine uncached so the decision uses current state.

This also fixes a flaky test that occasionally saw an unexpected reset request under heavy parallelism.