### PR TITLE
feat: validate bootstrap snapshot path on machine sets

### DIFF
--- a/internal/backend/runtime/omni/validations/machine_set.go
+++ b/internal/backend/runtime/omni/validations/machine_set.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -20,6 +21,11 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/etcdbackup/store"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 )
+
+// MaxBootstrapSnapshotLength caps the length of MachineSet.bootstrap_spec.snapshot in bytes.
+// Anchored on Linux PATH_MAX, which is the most permissive of the supported backup stores'
+// path limits, so any value that could legitimately reach either backend fits.
+const MaxBootstrapSnapshotLength = 4096
 
 // machineSetValidationOptions returns the validation options for the machine set resource.
 //
@@ -228,6 +234,10 @@ func validateBootstrapSpec(ctx context.Context, st state.State, etcdBackupStoreF
 		return nil
 	}
 
+	if err := validateBootstrapSnapshot(bootstrapSpec.GetSnapshot()); err != nil {
+		return err
+	}
+
 	clusterUUIDs, err := safe.StateListAll[*omni.ClusterUUID](ctx, st, state.WithLabelQuery(resource.LabelEqual(omni.LabelClusterUUID, bootstrapSpec.GetClusterUuid())))
 	if err != nil {
 		return fmt.Errorf("error getting cluster UUIDs: %w", err)
@@ -266,6 +276,22 @@ func validateBootstrapSpec(ctx context.Context, st state.State, etcdBackupStoreF
 
 	if data.SecretboxEncryptionSecret != backupData.TypedSpec().Value.SecretboxEncryptionSecret {
 		return errors.New("secretbox encryption secret mismatch")
+	}
+
+	return nil
+}
+
+func validateBootstrapSnapshot(snapshot string) error {
+	if snapshot == "" {
+		return nil
+	}
+
+	if len(snapshot) > MaxBootstrapSnapshotLength {
+		return fmt.Errorf("bootstrap snapshot path is too long: %d bytes (max %d)", len(snapshot), MaxBootstrapSnapshotLength)
+	}
+
+	if !fs.ValidPath(snapshot) {
+		return errors.New("bootstrap snapshot must be a relative path without parent-directory references")
 	}
 
 	return nil

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -872,6 +872,80 @@ func TestMachineSetBootstrapSpecValidation(t *testing.T) {
 	assert.ErrorContains(t, err, "bootstrap spec is immutable after creation")
 }
 
+func TestMachineSetBootstrapSnapshotValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		snapshot    string
+		errContains string
+	}{
+		{
+			name:     "empty snapshot",
+			snapshot: "",
+		},
+		{
+			name:     "canonical snapshot name",
+			snapshot: "00000000FFFFFFFF.snapshot",
+		},
+		{
+			name:     "nested path under cluster prefix",
+			snapshot: "archive/2024/cluster-foo/00000000FFFFFFFF.snapshot",
+		},
+		{
+			name:        "parent directory traversal",
+			snapshot:    "../OTHER-CLUSTER/00000000FFFFFFFF.snapshot",
+			errContains: "must be a relative path",
+		},
+		{
+			name:        "absolute path",
+			snapshot:    "/etc/passwd",
+			errContains: "must be a relative path",
+		},
+		{
+			name:        "exceeds length cap",
+			snapshot:    strings.Repeat("a", validations.MaxBootstrapSnapshotLength+1),
+			errContains: "too long",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			t.Cleanup(cancel)
+
+			clusterID := "test-cluster"
+			innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+			st := validated.NewState(innerSt, validations.MachineSetValidationOptions(innerSt, &mockEtcdBackupStoreFactory{})...)
+
+			require.NoError(t, st.Create(ctx, omnires.NewCluster(clusterID)))
+
+			machineSet := omnires.NewMachineSet(omnires.ControlPlanesResourceID(clusterID))
+			machineSet.Metadata().Labels().Set(omnires.LabelCluster, clusterID)
+			machineSet.Metadata().Labels().Set(omnires.LabelControlPlaneRole, "")
+			machineSet.TypedSpec().Value.BootstrapSpec = &specs.MachineSetSpec_BootstrapSpec{
+				ClusterUuid: "70fcf307-f9be-40dc-81de-6a427adfc1d4",
+				Snapshot:    tt.snapshot,
+			}
+
+			err := st.Create(ctx, machineSet)
+			if tt.errContains == "" {
+				// the syntactic check passes; the request still fails on the cluster-UUID lookup below it,
+				// which is fine - we just need to confirm the syntactic error did not fire.
+				if err != nil {
+					assert.NotContains(t, err.Error(), "must be a relative path")
+					assert.NotContains(t, err.Error(), "too long")
+				}
+
+				return
+			}
+
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
 func TestMachineSetNodeValidations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The snapshot path on a control plane machine set's bootstrap spec must now be a local relative path within a length cap. Empty values are still accepted.