### PR TITLE
feat: validate user-supplied request IDs and kernel args

### DIFF
--- a/internal/backend/runtime/omni/validations/export_test.go
+++ b/internal/backend/runtime/omni/validations/export_test.go
@@ -109,6 +109,10 @@ func EulaValidationOptions(st state.State) []validated.StateOption {
 	return eulaValidationOptions(st)
 }
 
+func KernelArgsValidationOptions() []validated.StateOption {
+	return kernelArgsValidationOptions()
+}
+
 func MetadataValidationOptions() []validated.StateOption {
 	return metadataValidationOptions()
 }

--- a/internal/backend/runtime/omni/validations/infra_machine_config.go
+++ b/internal/backend/runtime/omni/validations/infra_machine_config.go
@@ -19,15 +19,37 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 )
 
+// MaxRequestIDLength caps the byte length of the request ID fields on InfraMachineConfig.
+const MaxRequestIDLength = 128
+
 func infraMachineConfigValidationOptions(st state.State) []validated.StateOption {
+	validateSpec := func(res *omni.InfraMachineConfig) error {
+		if err := validateUserString("requested reboot ID", res.TypedSpec().Value.GetRequestedRebootId(), MaxRequestIDLength); err != nil {
+			return err
+		}
+
+		if err := validateUserString("power-off request ID", res.TypedSpec().Value.GetPowerOffRequestId(), MaxRequestIDLength); err != nil {
+			return err
+		}
+
+		if err := validateUserString("extra kernel args", res.TypedSpec().Value.GetExtraKernelArgs(), MaxExtraKernelArgsLength); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
 	return []validated.StateOption{
+		validated.WithCreateValidations(validated.NewCreateValidationForType(func(_ context.Context, res *omni.InfraMachineConfig, _ ...state.CreateOption) error {
+			return validateSpec(res)
+		})),
 		validated.WithUpdateValidations(validated.NewUpdateValidationForType(func(_ context.Context, oldRes, newRes *omni.InfraMachineConfig, _ ...state.UpdateOption) error {
 			if oldRes.TypedSpec().Value.AcceptanceStatus == specs.InfraMachineConfigSpec_ACCEPTED &&
 				newRes.TypedSpec().Value.AcceptanceStatus != oldRes.TypedSpec().Value.AcceptanceStatus {
 				return errors.New("an accepted machine cannot be rejected or set back to pending acceptance")
 			}
 
-			return nil
+			return validateSpec(newRes)
 		})),
 		validated.WithDestroyValidations(validated.NewDestroyValidationForType(func(ctx context.Context, _ resource.Pointer, res *omni.InfraMachineConfig, _ ...state.DestroyOption) error {
 			if res.TypedSpec().Value.AcceptanceStatus != specs.InfraMachineConfigSpec_ACCEPTED {

--- a/internal/backend/runtime/omni/validations/installation_media_config.go
+++ b/internal/backend/runtime/omni/validations/installation_media_config.go
@@ -56,6 +56,10 @@ func installationMediaConfigValidationOptions() []validated.StateOption {
 			}
 		}
 
+		if err := validateUserString("kernel args", spec.GetKernelArgs(), MaxExtraKernelArgsLength); err != nil {
+			return err
+		}
+
 		return nil
 	}
 

--- a/internal/backend/runtime/omni/validations/kernel_args.go
+++ b/internal/backend/runtime/omni/validations/kernel_args.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package validations
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/state"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
+)
+
+const (
+	// MaxKernelArgLength caps the byte length of a single entry in a repeated kernel args list.
+	MaxKernelArgLength = 256
+
+	// MaxKernelArgsCount caps the number of entries in a repeated kernel args list.
+	MaxKernelArgsCount = 64
+
+	// MaxExtraKernelArgsLength caps the byte length of a free-form kernel cmdline string, used
+	// by the InfraMachineConfig extra kernel args and the InstallationMediaConfig kernel args.
+	MaxExtraKernelArgsLength = 4096
+)
+
+// kernelArgsValidationOptions returns the validation options for the kernel args resource.
+func kernelArgsValidationOptions() []validated.StateOption {
+	validate := func(res *omni.KernelArgs) error {
+		return validateUserStringSlice("args", res.TypedSpec().Value.GetArgs(), MaxKernelArgsCount, MaxKernelArgLength)
+	}
+
+	return []validated.StateOption{
+		validated.WithCreateValidations(validated.NewCreateValidationForType(func(_ context.Context, res *omni.KernelArgs, _ ...state.CreateOption) error {
+			return validate(res)
+		})),
+		validated.WithUpdateValidations(validated.NewUpdateValidationForType(func(_ context.Context, _, newRes *omni.KernelArgs, _ ...state.UpdateOption) error {
+			return validate(newRes)
+		})),
+	}
+}

--- a/internal/backend/runtime/omni/validations/machine_class.go
+++ b/internal/backend/runtime/omni/validations/machine_class.go
@@ -24,6 +24,8 @@ import (
 )
 
 // machineClassValidationOptions returns the validation options for the machine class resource.
+//
+//nolint:gocognit
 func machineClassValidationOptions(st state.State) []validated.StateOption {
 	validate := func(ctx context.Context, oldRes, res *omni.MachineClass) error {
 		if res.TypedSpec().Value.AutoProvision != nil && res.TypedSpec().Value.MatchLabels != nil {
@@ -41,6 +43,10 @@ func machineClassValidationOptions(st state.State) []validated.StateOption {
 				if err := validateProviderData(ctx, st, autoProvision.ProviderId, autoProvision.ProviderData); err != nil {
 					return err
 				}
+			}
+
+			if err := validateUserStringSlice("auto provision kernel args", autoProvision.GetKernelArgs(), MaxKernelArgsCount, MaxKernelArgLength); err != nil {
+				return err
 			}
 
 			return nil

--- a/internal/backend/runtime/omni/validations/machine_request_set.go
+++ b/internal/backend/runtime/omni/validations/machine_request_set.go
@@ -37,5 +37,9 @@ func validateMachineRequestSet(ctx context.Context, st state.State, oldRes, res 
 		}
 	}
 
+	if err := validateUserStringSlice("kernel args", res.TypedSpec().Value.GetKernelArgs(), MaxKernelArgsCount, MaxKernelArgLength); err != nil {
+		return err
+	}
+
 	return validateTalosVersion(ctx, st, "", res.TypedSpec().Value.TalosVersion)
 }

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -2022,6 +2022,263 @@ func TestMetadataLabelsAnnotationsValidation(t *testing.T) {
 	})
 }
 
+func TestInfraMachineConfigRequestIDValidation(t *testing.T) {
+	t.Parallel()
+
+	type setSpec func(s *specs.InfraMachineConfigSpec)
+
+	for _, tt := range []struct {
+		name        string
+		spec        setSpec
+		errContains string
+	}{
+		{
+			name: "empty",
+			spec: func(*specs.InfraMachineConfigSpec) {},
+		},
+		{
+			name: "uuid reboot id",
+			spec: func(s *specs.InfraMachineConfigSpec) { s.RequestedRebootId = "8e1e4e63-7c0c-4a3e-9b6c-7c4a4d7e4f5a" },
+		},
+		{
+			name: "uuid power off id",
+			spec: func(s *specs.InfraMachineConfigSpec) { s.PowerOffRequestId = "8e1e4e63-7c0c-4a3e-9b6c-7c4a4d7e4f5a" },
+		},
+		{
+			name: "reboot id too long",
+			spec: func(s *specs.InfraMachineConfigSpec) {
+				s.RequestedRebootId = strings.Repeat("a", validations.MaxRequestIDLength+1)
+			},
+			errContains: "requested reboot ID is too long",
+		},
+		{
+			name: "power off id too long",
+			spec: func(s *specs.InfraMachineConfigSpec) {
+				s.PowerOffRequestId = strings.Repeat("a", validations.MaxRequestIDLength+1)
+			},
+			errContains: "power-off request ID is too long",
+		},
+		{
+			name:        "reboot id with newline",
+			spec:        func(s *specs.InfraMachineConfigSpec) { s.RequestedRebootId = "abc\ndef" },
+			errContains: "requested reboot ID contains a control character",
+		},
+		{
+			name:        "power off id with NUL",
+			spec:        func(s *specs.InfraMachineConfigSpec) { s.PowerOffRequestId = "abc\x00def" },
+			errContains: "power-off request ID contains a control character",
+		},
+		{
+			name:        "reboot id with escape",
+			spec:        func(s *specs.InfraMachineConfigSpec) { s.RequestedRebootId = "\x1b[31m" },
+			errContains: "requested reboot ID contains a control character",
+		},
+		{
+			name:        "reboot id with DEL",
+			spec:        func(s *specs.InfraMachineConfigSpec) { s.RequestedRebootId = "abc\x7f" },
+			errContains: "requested reboot ID contains a control character",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+			st := validated.NewState(innerSt, validations.InfraMachineConfigValidationOptions(innerSt)...)
+
+			conf := omnires.NewInfraMachineConfig("test")
+			tt.spec(conf.TypedSpec().Value)
+
+			err := st.Create(ctx, conf)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
+func TestKernelArgsValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("infra machine config extra kernel args", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tt := range []struct {
+			name        string
+			value       string
+			errContains string
+		}{
+			{name: "empty"},
+			{name: "valid", value: "console=ttyS0,115200n8 init=/sbin/init"},
+			{
+				name:        "too long",
+				value:       strings.Repeat("a", validations.MaxExtraKernelArgsLength+1),
+				errContains: "extra kernel args is too long",
+			},
+			{
+				name:        "newline",
+				value:       "foo=bar\nbaz=qux",
+				errContains: "extra kernel args contains a control character",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+				t.Cleanup(cancel)
+
+				innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+				st := validated.NewState(innerSt, validations.InfraMachineConfigValidationOptions(innerSt)...)
+
+				conf := omnires.NewInfraMachineConfig("test")
+				conf.TypedSpec().Value.ExtraKernelArgs = tt.value
+
+				err := st.Create(ctx, conf)
+				if tt.errContains == "" {
+					require.NoError(t, err)
+
+					return
+				}
+
+				assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+				assert.ErrorContains(t, err, tt.errContains)
+			})
+		}
+	})
+
+	t.Run("kernel args resource", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tt := range []struct {
+			name        string
+			errContains string
+			args        []string
+		}{
+			{name: "empty list"},
+			{name: "valid", args: []string{"console=ttyS0", "init=/sbin/init"}},
+			{
+				name:        "element too long",
+				args:        []string{strings.Repeat("a", validations.MaxKernelArgLength+1)},
+				errContains: "args[0] is too long",
+			},
+			{
+				name:        "element with NUL",
+				args:        []string{"abc\x00def"},
+				errContains: "args[0] contains a control character",
+			},
+			{
+				name: "too many entries",
+				args: func() []string {
+					out := make([]string, validations.MaxKernelArgsCount+1)
+					for i := range out {
+						out[i] = "x"
+					}
+
+					return out
+				}(),
+				errContains: "args has too many entries",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+				t.Cleanup(cancel)
+
+				innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+				st := validated.NewState(innerSt, validations.KernelArgsValidationOptions()...)
+
+				res := omnires.NewKernelArgs("test")
+				res.TypedSpec().Value.Args = tt.args
+
+				err := st.Create(ctx, res)
+				if tt.errContains == "" {
+					require.NoError(t, err)
+
+					return
+				}
+
+				assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+				assert.ErrorContains(t, err, tt.errContains)
+			})
+		}
+	})
+
+	t.Run("kernel args resource update path", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+		st := validated.NewState(innerSt, validations.KernelArgsValidationOptions()...)
+
+		res := omnires.NewKernelArgs("test")
+		res.TypedSpec().Value.Args = []string{"console=ttyS0"}
+
+		require.NoError(t, st.Create(ctx, res))
+
+		res.TypedSpec().Value.Args = []string{"abc\x00def"}
+
+		err := st.Update(ctx, res)
+		assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+		assert.ErrorContains(t, err, "args[0] contains a control character")
+	})
+
+	t.Run("installation media config kernel args", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tt := range []struct {
+			name        string
+			value       string
+			errContains string
+		}{
+			{name: "empty"},
+			{name: "valid", value: "console=ttyS0"},
+			{
+				name:        "too long",
+				value:       strings.Repeat("a", validations.MaxExtraKernelArgsLength+1),
+				errContains: "kernel args is too long",
+			},
+			{
+				name:        "carriage return",
+				value:       "foo\rbar",
+				errContains: "kernel args contains a control character",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+				t.Cleanup(cancel)
+
+				st := validated.NewState(state.WrapCore(namespaced.NewState(inmem.Build)), validations.InstallationMediaConfigValidationOptions()...)
+
+				media := omnires.NewInstallationMediaConfig("test")
+				media.TypedSpec().Value.Architecture = specs.PlatformConfigSpec_AMD64
+				media.TypedSpec().Value.KernelArgs = tt.value
+
+				err := st.Create(ctx, media)
+				if tt.errContains == "" {
+					require.NoError(t, err)
+
+					return
+				}
+
+				assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+				assert.ErrorContains(t, err, tt.errContains)
+			})
+		}
+	})
+}
+
 func TestNodeForceDestroyRequestValidation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/runtime/omni/validations/strings.go
+++ b/internal/backend/runtime/omni/validations/strings.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package validations
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// validateUserString caps the byte length of a user-supplied string and rejects control
+// characters. Empty values are accepted.
+func validateUserString(fieldName, value string, maxLen int) error {
+	if value == "" {
+		return nil
+	}
+
+	if len(value) > maxLen {
+		return fmt.Errorf("%s is too long: %d bytes (max %d)", fieldName, len(value), maxLen)
+	}
+
+	if strings.ContainsFunc(value, unicode.IsControl) {
+		return fmt.Errorf("%s contains a control character", fieldName)
+	}
+
+	return nil
+}
+
+// validateUserStringSlice caps the number of entries in a list of user-supplied strings and
+// runs validateUserString on each entry.
+func validateUserStringSlice(fieldName string, values []string, maxCount, maxElemLen int) error {
+	if len(values) > maxCount {
+		return fmt.Errorf("%s has too many entries: %d (max %d)", fieldName, len(values), maxCount)
+	}
+
+	for i, v := range values {
+		if err := validateUserString(fmt.Sprintf("%s[%d]", fieldName, i), v, maxElemLen); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/backend/runtime/omni/validations/validations.go
+++ b/internal/backend/runtime/omni/validations/validations.go
@@ -48,5 +48,6 @@ func Options(st state.State, etcdBackupStoreFactory store.Factory, cfg *config.P
 		rotateSecretsValidationOptions(st),
 		kubernetesManifestsValidationOptions(),
 		eulaValidationOptions(st),
+		kernelArgsValidationOptions(),
 	)
 }


### PR DESCRIPTION
The resource API now rejects user-supplied request IDs and kernel arguments that are too long or that contain control characters. Lists of kernel arguments also have a cap on the number of entries. Empty values are still accepted, and the checks run on both create and update.

The fields covered are the reboot and power-off request IDs on infra machine config, the extra kernel args on infra machine config, the kernel args resource, the kernel args on installation media config, the kernel args on machine class auto-provision, and the kernel args on machine request set.