### PR TITLE
fix(frontend): fix incorrect pxe boot url

### DIFF
--- a/frontend/e2e/talemu/installation_media.spec.ts
+++ b/frontend/e2e/talemu/installation_media.spec.ts
@@ -173,7 +173,9 @@ test('Download installation media', async ({ page }, testInfo) => {
     ).toBeVisible()
 
     await expect(
-      page.getByText(`https://pxe.factory.talos.dev/${schematicId}/1.12.0/metal-arm64-secureboot`),
+      page.getByText(
+        `https://pxe.factory.talos.dev/pxe/${schematicId}/1.12.0/metal-arm64-secureboot`,
+      ),
     ).toBeVisible()
 
     await expect(page.getByRole('button', { name: 'sha256' }).first()).toBeDisabled()

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.stories.ts
@@ -77,6 +77,7 @@ export const Default = {
             {
               spec: {
                 image_factory_base_url: 'https://factory-enterprise.talos.dev',
+                image_factory_pxe_base_url: 'https://pxe.factory-enterprise.talos.dev',
                 is_enterprise_image_factory: true,
               },
               metadata: {
@@ -289,6 +290,7 @@ export const NotEnterprise = {
             {
               spec: {
                 image_factory_base_url: 'https://factory.talos.dev',
+                image_factory_pxe_base_url: 'https://pxe.factory.talos.dev',
                 is_enterprise_image_factory: false,
               },
               metadata: {

--- a/frontend/src/views/InstallationMedia/usePresetDownloadLinks.ts
+++ b/frontend/src/views/InstallationMedia/usePresetDownloadLinks.ts
@@ -78,7 +78,7 @@ export function usePresetDownloadLinks(
 
   const pxeBaseURL = computed(() =>
     withImageFactoryAuth(
-      `${features.value?.spec.image_factory_pxe_base_url}/${toValue(schematicId)}/${toValue(presetRef).talos_version}`,
+      `${features.value?.spec.image_factory_pxe_base_url}/pxe/${toValue(schematicId)}/${toValue(presetRef).talos_version}`,
       auth.value,
     ),
   )

--- a/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.stories.ts
+++ b/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.stories.ts
@@ -46,6 +46,7 @@ export const Default: Story = {
             {
               spec: {
                 image_factory_base_url: 'https://factory-enterprise.talos.dev',
+                image_factory_pxe_base_url: 'https://pxe.factory-enterprise.talos.dev',
               },
               metadata: {
                 namespace: DefaultNamespace,


### PR DESCRIPTION
Fix incorrect PXE boot URL which was missing the /pxe/ path segment.

Fixes #2964 