### PR TITLE
feat: reject control characters in join token names

### DIFF
--- a/internal/backend/runtime/omni/validations/join_token.go
+++ b/internal/backend/runtime/omni/validations/join_token.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
@@ -32,6 +33,10 @@ func joinTokenValidationOptions(st state.State) []validated.StateOption {
 
 		if len(res.TypedSpec().Value.Name) > MaxJoinTokenNameLength {
 			return fmt.Errorf("join token name cannot be longer than %d symbols", MaxJoinTokenNameLength)
+		}
+
+		if strings.ContainsFunc(res.TypedSpec().Value.Name, isControlChar) {
+			return errors.New("the join token name must not contain control characters")
 		}
 
 		return nil

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -2361,6 +2361,76 @@ func TestJoinTokenValidation(t *testing.T) {
 	assert.NoError(t, wrappedState.Destroy(ctx, normalJoinToken.Metadata()))
 }
 
+func TestJoinTokenNameControlCharsValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create rejects control character in name", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+		st := validated.NewState(innerSt, validations.JoinTokenValidationOptions(innerSt)...)
+
+		token := siderolink.NewJoinToken("token-control-char")
+		token.TypedSpec().Value.Name = "foo\nbar"
+
+		err := state.WrapCore(st).Create(ctx, token)
+		assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+		assert.ErrorContains(t, err, "control character")
+	})
+
+	t.Run("update with unchanged offending name passes", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		// Stage a token with an offending name via the inner state (bypassing validation).
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		token := siderolink.NewJoinToken("token-stale-bad-name")
+		token.TypedSpec().Value.Name = "stale\nbad"
+		require.NoError(t, innerSt.Create(ctx, token))
+
+		st := validated.NewState(innerSt, validations.JoinTokenValidationOptions(innerSt)...)
+		wrappedState := state.WrapCore(st)
+
+		// Update a different field on the spec; name unchanged.
+		_, err := safe.StateUpdateWithConflicts(ctx, wrappedState, token.Metadata(), func(t *siderolink.JoinToken) error {
+			t.TypedSpec().Value.Revoked = true
+
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("update changing name to bad value rejects", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+		st := validated.NewState(innerSt, validations.JoinTokenValidationOptions(innerSt)...)
+		wrappedState := state.WrapCore(st)
+
+		token := siderolink.NewJoinToken("token-update-bad")
+		token.TypedSpec().Value.Name = "valid-name"
+		require.NoError(t, wrappedState.Create(ctx, token))
+
+		_, err := safe.StateUpdateWithConflicts(ctx, wrappedState, token.Metadata(), func(t *siderolink.JoinToken) error {
+			t.TypedSpec().Value.Name = "freshly\nbad"
+
+			return nil
+		})
+
+		assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+		assert.ErrorContains(t, err, "control character")
+	})
+}
+
 func TestDefaultJoinTokenValidation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The join token name must not contain control characters. Creates are rejected when the name contains them. Updates are rejected only when they change the name to a value that contains them, so a token that already has a bad name can still be revoked or otherwise edited.