### PR TITLE
feat: validate Talos version on installation media config

### DIFF
--- a/client/pkg/omnictl/installationmedia/create.go
+++ b/client/pkg/omnictl/installationmedia/create.go
@@ -118,10 +118,13 @@ func createPreset(ctx context.Context, cmd *cobra.Command, client *client.Client
 		}
 	}
 
+	// Strip a leading "v" so the value matches the canonical Talos version form.
+	talosVersion := strings.TrimPrefix(createCmdFlags.talosVersion, "v")
+
 	// An empty user value means "use the server's default at download time"; for create-time
 	// validation against platform min-versions and extension catalogs, fall back to the CLI's
 	// default Talos version so the checks still run.
-	validationTalosVersion := createCmdFlags.talosVersion
+	validationTalosVersion := talosVersion
 	if validationTalosVersion == "" {
 		validationTalosVersion = constants.DefaultTalosVersion
 	}
@@ -136,7 +139,7 @@ func createPreset(ctx context.Context, cmd *cobra.Command, client *client.Client
 	}
 
 	spec := &specs.InstallationMediaConfigSpec{
-		TalosVersion:      createCmdFlags.talosVersion,
+		TalosVersion:      talosVersion,
 		Architecture:      arch,
 		InstallExtensions: createCmdFlags.extensions,
 		KernelArgs:        strings.Join(createCmdFlags.extraKernelArgs, " "),

--- a/internal/backend/runtime/omni/validations/export_test.go
+++ b/internal/backend/runtime/omni/validations/export_test.go
@@ -93,8 +93,8 @@ func RotateSecretsValidationOptions(st state.State) []validated.StateOption {
 	return rotateSecretsValidationOptions(st)
 }
 
-func InstallationMediaConfigValidationOptions() []validated.StateOption {
-	return installationMediaConfigValidationOptions()
+func InstallationMediaConfigValidationOptions(st state.State) []validated.StateOption {
+	return installationMediaConfigValidationOptions(st)
 }
 
 func AccountLimitsValidationOptions(st state.State, limits config.AuthLimits) []validated.StateOption {

--- a/internal/backend/runtime/omni/validations/installation_media_config.go
+++ b/internal/backend/runtime/omni/validations/installation_media_config.go
@@ -9,8 +9,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
@@ -20,8 +22,9 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/virtual/pkg/factory/configs"
 )
 
-func installationMediaConfigValidationOptions() []validated.StateOption {
-	validateInstallationMedia := func(res *omni.InstallationMediaConfig) error {
+//nolint:gocognit
+func installationMediaConfigValidationOptions(st state.State) []validated.StateOption {
+	validateInstallationMedia := func(ctx context.Context, res *omni.InstallationMediaConfig) error {
 		if res.Metadata().Phase() == resource.PhaseTearingDown {
 			return nil
 		}
@@ -60,16 +63,31 @@ func installationMediaConfigValidationOptions() []validated.StateOption {
 			return err
 		}
 
+		if version := spec.GetTalosVersion(); version != "" {
+			// Strip a leading "v" before the lookup so older omnictl clients that did not yet
+			// normalize the user input still validate against the canonical "1.2.3" form stored
+			// on Talos version resources.
+			lookup := strings.TrimPrefix(version, "v")
+
+			if _, err := safe.StateGet[*omni.TalosVersion](ctx, st, omni.NewTalosVersion(lookup).Metadata()); err != nil {
+				if state.IsNotFoundError(err) {
+					return fmt.Errorf("unknown Talos version %q", version)
+				}
+
+				return fmt.Errorf("failed to look up Talos version %q: %w", version, err)
+			}
+		}
+
 		return nil
 	}
 
 	return []validated.StateOption{
 		validated.WithCreateValidations(validated.NewCreateValidationForType(func(ctx context.Context, res *omni.InstallationMediaConfig, _ ...state.CreateOption) error {
-			return validateInstallationMedia(res)
+			return validateInstallationMedia(ctx, res)
 		})),
 		validated.WithUpdateValidations(validated.NewUpdateValidationForType(
 			func(ctx context.Context, _, newRes *omni.InstallationMediaConfig, _ ...state.UpdateOption) error {
-				return validateInstallationMedia(newRes)
+				return validateInstallationMedia(ctx, newRes)
 			},
 		)),
 	}

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -2259,7 +2259,8 @@ func TestKernelArgsValidation(t *testing.T) {
 				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 				t.Cleanup(cancel)
 
-				st := validated.NewState(state.WrapCore(namespaced.NewState(inmem.Build)), validations.InstallationMediaConfigValidationOptions()...)
+				innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+				st := validated.NewState(innerSt, validations.InstallationMediaConfigValidationOptions(innerSt)...)
 
 				media := omnires.NewInstallationMediaConfig("test")
 				media.TypedSpec().Value.Architecture = specs.PlatformConfigSpec_AMD64
@@ -2277,6 +2278,69 @@ func TestKernelArgsValidation(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestInstallationMediaConfigTalosVersionValidation(t *testing.T) {
+	t.Parallel()
+
+	const talosVersionID = "1.13.2"
+
+	setup := func(t *testing.T) state.State {
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		talosVersion := omnires.NewTalosVersion(talosVersionID)
+		talosVersion.TypedSpec().Value.CompatibleKubernetesVersions = []string{"1.30.0"}
+		require.NoError(t, innerSt.Create(ctx, talosVersion))
+
+		return innerSt
+	}
+
+	for _, tt := range []struct {
+		name         string
+		talosVersion string
+		errContains  string
+	}{
+		{name: "empty"},
+		{name: "canonical", talosVersion: talosVersionID},
+		{name: "v-prefixed", talosVersion: "v" + talosVersionID},
+		{
+			name:         "double-v-prefixed",
+			talosVersion: "vv" + talosVersionID,
+			errContains:  `unknown Talos version "vv1.13.2"`,
+		},
+		{
+			name:         "unknown",
+			talosVersion: "9.9.9",
+			errContains:  `unknown Talos version "9.9.9"`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setup(t)
+			st := validated.NewState(innerSt, validations.InstallationMediaConfigValidationOptions(innerSt)...)
+
+			media := omnires.NewInstallationMediaConfig("test")
+			media.TypedSpec().Value.Architecture = specs.PlatformConfigSpec_AMD64
+			media.TypedSpec().Value.TalosVersion = tt.talosVersion
+
+			err := st.Create(ctx, media)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, tt.errContains)
+		})
+	}
 }
 
 func TestNodeForceDestroyRequestValidation(t *testing.T) {
@@ -2612,7 +2676,8 @@ func TestInstallationMediaConfigValidation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	t.Cleanup(cancel)
 
-	st := validated.NewState(state.WrapCore(namespaced.NewState(inmem.Build)), validations.InstallationMediaConfigValidationOptions()...)
+	innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+	st := validated.NewState(innerSt, validations.InstallationMediaConfigValidationOptions(innerSt)...)
 
 	installationMediaConfig := omnires.NewInstallationMediaConfig("test")
 

--- a/internal/backend/runtime/omni/validations/validations.go
+++ b/internal/backend/runtime/omni/validations/validations.go
@@ -44,7 +44,7 @@ func Options(st state.State, etcdBackupStoreFactory store.Factory, cfg *config.P
 		defaultJoinTokenValidationOptions(st),
 		importedClusterSecretValidationOptions(st, cfg.Features.GetEnableClusterImport()),
 		infraProviderValidationOptions(st),
-		installationMediaConfigValidationOptions(),
+		installationMediaConfigValidationOptions(st),
 		rotateSecretsValidationOptions(st),
 		kubernetesManifestsValidationOptions(),
 		eulaValidationOptions(st),


### PR DESCRIPTION
Setting a Talos version on an installation media config now requires that the version is known to Omni. An empty value keeps its previous meaning of using the server default at download time.

The omnictl create command also strips a leading "v" from the user input before sending the request, so the typed flag matches the canonical form.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>