### PR TITLE
fix(frontend): display correct units for byte values

### DIFF
--- a/frontend/e2e/qemu/clusters.spec.ts
+++ b/frontend/e2e/qemu/clusters.spec.ts
@@ -74,7 +74,7 @@ test('machine overview tabs', async ({ page }) => {
     await page.getByRole('tab', { name: 'Disks', exact: true }).click()
 
     await expect
-      .soft(page.getByRole('region', { name: 'vda' }).getByText('Unallocated6.00 GB'))
+      .soft(page.getByRole('region', { name: 'vda' }).getByText('Unallocated6.44 GB'))
       .toBeVisible()
   })
 
@@ -577,26 +577,26 @@ test('cluster sidebar pages', async ({ page }) => {
 
     const cpuChart = page.getByRole('figure', { name: 'CPU' })
 
-    await expect(cpuChart.getByLabel('Total')).toHaveText(/\d+\.\d{2}/)
-    await expect(cpuChart.getByLabel('Requests')).toHaveText(/\d+\.\d{2}/)
-    await expect(cpuChart.getByLabel('Limits')).toHaveText(/\d+\.\d{2}/)
+    await expect.soft(cpuChart.getByLabel('Total')).toHaveText(/^\d+(\.\d{1,2})?$/)
+    await expect.soft(cpuChart.getByLabel('Requests')).toHaveText(/^\d+(\.\d{1,2})?$/)
+    await expect.soft(cpuChart.getByLabel('Limits')).toHaveText(/^\d+(\.\d{1,2})?$/)
 
     const podsChart = page.getByRole('figure', { name: 'Pods' })
 
-    await expect(podsChart.getByLabel('Total')).toHaveText(/\d+/)
-    await expect(podsChart.getByLabel('Requests')).toHaveText(/\d+/)
+    await expect.soft(podsChart.getByLabel('Total')).toHaveText(/^\d+$/)
+    await expect.soft(podsChart.getByLabel('Requests')).toHaveText(/^\d+$/)
 
     const memoryChart = page.getByRole('figure', { name: 'Memory' })
 
-    await expect(memoryChart.getByLabel('Total')).toHaveText(/\d+\.\d{2} GB/)
-    await expect(memoryChart.getByLabel('Requests')).toHaveText(/\d+\.\d{2} GB/)
-    await expect(memoryChart.getByLabel('Limits')).toHaveText(/\d+\.\d{2} MB/)
+    await expect.soft(memoryChart.getByLabel('Total')).toHaveText(/^\d+(\.\d{1,2})? GiB$/)
+    await expect.soft(memoryChart.getByLabel('Requests')).toHaveText(/^\d+(\.\d{1,2})? GiB$/)
+    await expect.soft(memoryChart.getByLabel('Limits')).toHaveText(/^\d+(\.\d{1,2})? MiB$/)
 
     const storageChart = page.getByRole('figure', { name: 'Ephemeral Storage' })
 
-    await expect(storageChart.getByLabel('Total')).toHaveText(/\d+\.\d{2} GB/)
-    await expect(storageChart.getByLabel('Requests')).toHaveText('0 Bytes')
-    await expect(storageChart.getByLabel('Limits')).toHaveText('0 Bytes')
+    await expect.soft(storageChart.getByLabel('Total')).toHaveText(/^\d+(\.\d{1,2})? GB$/)
+    await expect.soft(storageChart.getByLabel('Requests')).toHaveText('0 B')
+    await expect.soft(storageChart.getByLabel('Limits')).toHaveText('0 B')
 
     await expect(page.getByText('Managed using cluster')).toBeVisible()
   })

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
         "monaco-yaml": "^5.5.1",
         "pluralize": "^8.0.0",
         "posthog-js": "^1.386.8",
+        "pretty-bytes": "^7.1.0",
         "reka-ui": "2.9.9",
         "semver": "^7.8.4",
         "shell-quote": "^1.8.4",
@@ -9259,6 +9260,18 @@
         "prettier-plugin-svelte": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
+      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pretty-format": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "monaco-yaml": "^5.5.1",
     "pluralize": "^8.0.0",
     "posthog-js": "^1.386.8",
+    "pretty-bytes": "^7.1.0",
     "reka-ui": "2.9.9",
     "semver": "^7.8.4",
     "shell-quote": "^1.8.4",

--- a/frontend/src/methods/index.ts
+++ b/frontend/src/methods/index.ts
@@ -70,18 +70,6 @@ export const getStatus = (item: V1Node) => {
   return NodesViewFilterOptions.NOT_READY
 }
 
-export const formatBytes = (bytes?: number | string, decimals = 2) => {
-  if (!bytes) return '0 Bytes'
-
-  const k = 1024
-  const dm = decimals < 0 ? 0 : decimals
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-
-  const i = Math.floor(Math.log(+bytes) / Math.log(k))
-
-  return (+bytes / Math.pow(k, i)).toFixed(dm) + ' ' + sizes[i]
-}
-
 export const downloadKubeconfig = async (cluster: string) => {
   try {
     const response = await ManagementService.Kubeconfig({}, withContext({ cluster }))

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/index.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/index.vue
@@ -7,6 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import type { NodeSpec as V1NodeSpec, NodeStatus as V1NodeStatus } from 'kubernetes-types/core/v1'
 import { DateTime } from 'luxon'
+import prettyBytes from 'pretty-bytes'
 import { computed, ref, useId } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -42,7 +43,7 @@ import Tag from '@/components/Tag/Tag.vue'
 import TAlert from '@/components/TAlert.vue'
 import { TCommonStatuses } from '@/constants'
 import { getContext } from '@/context'
-import { formatBytes, getStatus } from '@/methods'
+import { getStatus } from '@/methods'
 import { addMachineLabels, removeMachineLabels } from '@/methods/machine'
 import { useMachineServices } from '@/methods/useMachineServices'
 import { useResourceWatch } from '@/methods/useResourceWatch'
@@ -184,14 +185,13 @@ const getCPUInfo = () => {
 }
 
 const getMemInfo = () => {
-  const total = machineStatus.value?.spec.message_status?.hardware?.memory_modules?.reduce(
-    (prev, current) => {
-      return prev + current.size_mb!
-    },
-    0,
-  )
+  const total =
+    machineStatus.value?.spec.message_status?.hardware?.memory_modules?.reduce(
+      (prev, current) => prev + (current.size_mb ?? 0),
+      0,
+    ) ?? 0
 
-  return formatBytes(total! * 1024 * 1024)
+  return prettyBytes(total * 1024 * 1024, { binary: true })
 }
 
 const getSecureBootStatus = () => {

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.vue
@@ -6,6 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { ArrowDownIcon } from '@heroicons/vue/24/solid'
+import prettyBytes from 'pretty-bytes'
 import { computed, ref, watchEffect } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -22,7 +23,6 @@ import { MachineService, type ProcessInfo } from '@/api/talos/machine/machine.pb
 import type { CPUSpec, MemorySpec } from '@/api/talos/perf.pb'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
 import { getContext } from '@/context'
-import { formatBytes } from '@/methods'
 import NodesMonitorChart from '@/views/Nodes/components/NodesMonitorChart.vue'
 
 definePage({ name: 'NodeMonitor' })
@@ -163,7 +163,7 @@ const handleMem = (_: MemorySpec, m: MemorySpec) => {
 const handleTotalMem = (_: MemorySpec, m: MemorySpec) => {
   const used = (m.used || 0) - (m.cached || 0) - (m.buffers || 0)
 
-  return `${formatBytes(used * 1024)} / ${formatBytes((m.total || 0) * 1024)}`
+  return `${prettyBytes(used * 1024, { binary: true })} / ${prettyBytes((m.total || 0) * 1024, { binary: true })}`
 }
 
 const handleMaxMem = (_: MemorySpec, m: MemorySpec) => {
@@ -248,12 +248,7 @@ const sortBy = (id: keyof Proc) => {
             :total-fn="handleTotalMem"
             :min-fn="() => 0"
             :max-fn="handleMaxMem"
-            :formatter="
-              (input) =>
-                typeof input === 'number'
-                  ? formatBytes(input * 1024)
-                  : formatBytes(Number(input) * 1024)
-            "
+            :formatter="(input) => prettyBytes(Number(input) * 1024, { binary: true })"
           />
         </div>
       </div>
@@ -317,10 +312,10 @@ const sortBy = (id: keyof Proc) => {
             {{ process.mem.toFixed(1) }}
           </div>
           <div>
-            {{ formatBytes(process.virtualMemory) }}
+            {{ prettyBytes(process.virtualMemory, { binary: true }) }}
           </div>
           <div>
-            {{ formatBytes(process.residentMemory) }}
+            {{ prettyBytes(process.residentMemory, { binary: true }) }}
           </div>
           <div>
             {{ process.cpuTime }}

--- a/frontend/src/views/Backups/BackupsList.vue
+++ b/frontend/src/views/Backups/BackupsList.vue
@@ -6,6 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { useClipboard } from '@vueuse/core'
+import prettyBytes from 'pretty-bytes'
 import WordHighlighter from 'vue-word-highlighter'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -29,7 +30,7 @@ import TList from '@/components/List/TList.vue'
 import TListItem from '@/components/List/TListItem.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
-import { formatBytes, getDocsLink } from '@/methods'
+import { getDocsLink } from '@/methods'
 import { usePermissions } from '@/methods/auth'
 import { formatISO } from '@/methods/time'
 import { useResourceWatch } from '@/methods/useResourceWatch'
@@ -170,7 +171,7 @@ const {
                 {{ formatISO(item.spec.created_at as string, dateFormat) }}
               </div>
               <div class="text-naturals-n14">
-                {{ formatBytes(parseInt(item.spec.size ?? '0')) }}
+                {{ prettyBytes(parseInt(item.spec.size ?? '0')) }}
               </div>
               <div class="flex items-center gap-2 text-naturals-n14">
                 {{ item.spec.snapshot }}

--- a/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
@@ -7,6 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import { dump } from 'js-yaml'
 import pluralize from 'pluralize'
+import prettyBytes from 'pretty-bytes'
 import semver from 'semver'
 import { computed, ref, watch } from 'vue'
 import WordHighlighter from 'vue-word-highlighter'
@@ -21,7 +22,6 @@ import {
 import IconButton from '@/components/Button/IconButton.vue'
 import TListItem from '@/components/List/TListItem.vue'
 import TSelectList from '@/components/SelectList/TSelectList.vue'
-import { formatBytes } from '@/methods'
 import type { Label } from '@/methods/labels'
 import { addMachineLabels, removeMachineLabels } from '@/methods/machine'
 import { showModal } from '@/modal'
@@ -131,9 +131,9 @@ const options = computed(() => {
 
     if (disabled) {
       if (ms.role === LabelControlPlaneRole) {
-        tooltip = `The node must have more than ${formatBytes(cpMemoryThreshold * 1024 * 1024)} of RAM to be used as a control plane`
+        tooltip = `The node must have more than ${prettyBytes(cpMemoryThreshold * 1024 * 1024, { binary: true })} of RAM to be used as a control plane`
       } else {
-        tooltip = `The node must have more than ${formatBytes(workerMemoryTheshold * 1024 * 1024)} of RAM to be used as a worker`
+        tooltip = `The node must have more than ${prettyBytes(workerMemoryTheshold * 1024 * 1024, { binary: true })} of RAM to be used as a worker`
       }
     }
 
@@ -320,12 +320,14 @@ ${isTalos112 ? talos112 : preTalos112}
         </div>
         <div>
           <div v-for="(mem, index) in memoryModules" :key="index">
-            {{ formatBytes((mem?.size_mb || 0) * 1024 * 1024) }} {{ mem.description }}
+            {{ prettyBytes((mem?.size_mb || 0) * 1024 * 1024, { binary: true }) }}
+            {{ mem.description }}
           </div>
         </div>
         <div>
           <div v-for="(dev, index) in item?.spec?.hardware?.blockdevices" :key="index">
-            {{ dev.linux_name }} {{ formatBytes(dev.size) }} {{ dev.type }}
+            {{ dev.linux_name }} {{ prettyBytes(Number(dev.size || '0')) }}
+            {{ dev.type }}
           </div>
         </div>
         <div>

--- a/frontend/src/views/KubeSpanStatus/KubeSpanStatus.vue
+++ b/frontend/src/views/KubeSpanStatus/KubeSpanStatus.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import prettyBytes from 'pretty-bytes'
 import { computed, ref, useTemplateRef } from 'vue'
 import { useRouter } from 'vue-router'
 
@@ -24,7 +25,6 @@ import TIcon from '@/components/Icon/TIcon.vue'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
 import StatsItem from '@/components/Stats/StatsItem.vue'
 import TInput from '@/components/TInput/TInput.vue'
-import { formatBytes } from '@/methods'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import KubeSpanCanvas from '@/views/KubeSpanStatus/components/KubeSpanCanvas.vue'
 
@@ -207,7 +207,7 @@ function onPeerClick(peer: Resource<PeerStatusSpec>) {
                   <span class="font-medium tracking-wide uppercase">RX</span>
                 </span>
 
-                {{ formatBytes(peer.spec.receiveBytes) }}
+                {{ prettyBytes(peer.spec.receiveBytes ?? 0) }}
               </span>
 
               <span class="flex items-center gap-1">
@@ -216,7 +216,7 @@ function onPeerClick(peer: Resource<PeerStatusSpec>) {
                   <TIcon icon="long-arrow-top" class="size-3" />
                 </span>
 
-                {{ formatBytes(peer.spec.transmitBytes) }}
+                {{ prettyBytes(peer.spec.transmitBytes ?? 0) }}
               </span>
             </div>
           </div>

--- a/frontend/src/views/KubeSpanStatus/components/KubeSpanCanvas.vue
+++ b/frontend/src/views/KubeSpanStatus/components/KubeSpanCanvas.vue
@@ -6,13 +6,13 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { useElementBounding } from '@vueuse/core'
+import prettyBytes from 'pretty-bytes'
 import { computed, ref, useTemplateRef, watch } from 'vue'
 
 import type { Resource } from '@/api/grpc'
 import type { ClusterMachineIdentitySpec } from '@/api/omni/specs/omni.pb'
 import { LabelControlPlaneRole } from '@/api/resources'
 import type { PeerStatusSpec } from '@/api/talos/kubespan.pb'
-import { formatBytes } from '@/methods'
 
 const { selectedMachine, machineNodenameMap, peers, peerMatches } = defineProps<{
   selectedMachine: Resource<ClusterMachineIdentitySpec>
@@ -366,7 +366,7 @@ function resetView() {
           <div class="flex flex-col gap-1 text-xs">
             <span class="text-naturals-n11">Incoming / Outgoing traffic</span>
             <span class="text-naturals-n14">
-              {{ `${formatBytes(totalTrafficIn)} / ${formatBytes(totalTrafficOut)}` }}
+              {{ `${prettyBytes(totalTrafficIn)} / ${prettyBytes(totalTrafficOut)}` }}
             </span>
           </div>
         </div>

--- a/frontend/src/views/Machines/MachineDetailsPanel.vue
+++ b/frontend/src/views/Machines/MachineDetailsPanel.vue
@@ -7,6 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import { DateTime } from 'luxon'
 import pluralize from 'pluralize'
+import prettyBytes from 'pretty-bytes'
 import { computed, h } from 'vue'
 import { RouterLink } from 'vue-router'
 import WordHighlighter from 'vue-word-highlighter'
@@ -20,7 +21,6 @@ import {
   TalosSystemInformationType,
 } from '@/api/resources'
 import type { SystemInformationSpec } from '@/api/talos/hardware.pb'
-import { formatBytes } from '@/methods'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import MachineItemInfoCard from '@/views/Machines/MachineItemInfoCard.vue'
 import CloseButton from '@/views/Modals/CloseButton.vue'
@@ -68,7 +68,10 @@ const processors = computed(() =>
 const memorymodules = computed(() =>
   machine?.spec.message_status?.hardware?.memory_modules
     ?.filter((mem) => !!mem.size_mb)
-    .map(({ description, size_mb = 0 }) => `${formatBytes(size_mb * 1024 * 1024)} ${description}`),
+    .map(
+      ({ description, size_mb = 0 }) =>
+        `${prettyBytes(size_mb * 1024 * 1024, { binary: true })} ${description}`,
+    ),
 )
 
 const clusterName = computed(() => machine?.spec.message_status?.cluster)
@@ -109,7 +112,7 @@ const secureBoot = computed(() => {
           {
             title: 'Block devices',
             value: machine?.spec.message_status?.hardware?.blockdevices?.map(
-              (dev) => `${dev.linux_name} ${formatBytes(dev.size)} ${dev.type}`,
+              (dev) => `${dev.linux_name} ${prettyBytes(Number(dev.size || '0'))} ${dev.type}`,
             ),
           },
           {
@@ -138,15 +141,11 @@ const secureBoot = computed(() => {
           { title: 'Addresses', value: machine?.spec.message_status?.network?.addresses },
           {
             title: 'Bytes sent',
-            value: machine?.spec.siderolink_counter?.bytes_sent
-              ? formatBytes(machine?.spec.siderolink_counter.bytes_sent)
-              : '0B',
+            value: prettyBytes(Number(machine?.spec.siderolink_counter?.bytes_sent || '0')),
           },
           {
             title: 'Bytes received',
-            value: machine?.spec.siderolink_counter?.bytes_received
-              ? formatBytes(machine?.spec.siderolink_counter.bytes_received)
-              : '0B',
+            value: prettyBytes(Number(machine?.spec.siderolink_counter?.bytes_received || '0')),
           },
         ]"
       />

--- a/frontend/src/views/Machines/MachineDisks.vue
+++ b/frontend/src/views/Machines/MachineDisks.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import prettyBytes from 'pretty-bytes'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -142,7 +143,7 @@ const organizedDisks = computed(() =>
           </div>
           <div class="flex items-center gap-4">
             <span class="text-sm text-naturals-n14">
-              {{ diskInfo.disk.spec.pretty_size }}
+              {{ prettyBytes(diskInfo.disk.spec.size ?? 0) }}
             </span>
             <div class="flex items-center gap-2">
               <span

--- a/frontend/src/views/Nodes/components/DiskPartitionTable.vue
+++ b/frontend/src/views/Nodes/components/DiskPartitionTable.vue
@@ -5,6 +5,8 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import prettyBytes from 'pretty-bytes'
+
 import type { Resource } from '@/api/grpc'
 import type { DiscoveredVolumeSpec, VolumeStatusSpec } from '@/api/talos/block.pb'
 import { itemID } from '@/api/watch'
@@ -137,7 +139,7 @@ const getEncryptionIcon = (item?: Resource<VolumeStatusSpec>): IconType => {
             {{ volume.spec.uuid }}
           </TableCell>
 
-          <TableCell class="font-medium">{{ volume.spec.pretty_size }}</TableCell>
+          <TableCell class="font-medium">{{ prettyBytes(volume.spec.size ?? 0) }}</TableCell>
         </TableRow>
       </template>
     </TableRoot>

--- a/frontend/src/views/Nodes/components/DiskUsageBar.vue
+++ b/frontend/src/views/Nodes/components/DiskUsageBar.vue
@@ -5,12 +5,12 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import prettyBytes from 'pretty-bytes'
 import { computed } from 'vue'
 
 import type { Resource } from '@/api/grpc'
 import type { DiscoveredVolumeSpec, DiskSpec } from '@/api/talos/block.pb'
 import { itemID } from '@/api/watch'
-import { formatBytes } from '@/methods'
 
 const { disk, volumes } = defineProps<{
   disk: Resource<DiskSpec>
@@ -55,7 +55,7 @@ const getVolumeClass = (volume: Resource<DiscoveredVolumeSpec>) => {
       <div
         v-for="volume in volumes"
         :key="itemID(volume)"
-        :title="`${volume.spec.partition_label || volume.spec.label || volume.spec.dev_path} — ${volume.spec.pretty_size}`"
+        :title="`${volume.spec.partition_label || volume.spec.label || volume.spec.dev_path} — ${prettyBytes(volume.spec.size ?? 0)}`"
         :class="getVolumeClass(volume)"
         :style="{
           width: `${partitionPercent(volume.spec.size, disk.spec.size)}%`,
@@ -68,7 +68,7 @@ const getVolumeClass = (volume: Resource<DiscoveredVolumeSpec>) => {
         >
           {{ volume.spec.partition_label || volume.spec.label || '' }}
           <span class="opacity-80">
-            {{ volume.spec.pretty_size }}
+            {{ prettyBytes(volume.spec.size ?? 0) }}
           </span>
         </span>
       </div>
@@ -93,14 +93,14 @@ const getVolumeClass = (volume: Resource<DiscoveredVolumeSpec>) => {
           {{ volume.spec.partition_label || volume.spec.label || volume.spec.dev_path }}
         </span>
         <span class="font-medium text-naturals-n10">
-          {{ volume.spec.pretty_size }}
+          {{ prettyBytes(volume.spec.size ?? 0) }}
         </span>
       </div>
       <div v-if="unallocatedPercent > 0" class="flex items-center gap-1.5">
         <span class="inline-block size-2.5 rounded-sm bg-naturals-n5" />
         <span class="font-medium text-naturals-n12">Unallocated</span>
         <span class="font-medium text-naturals-n10">
-          {{ formatBytes(unallocatedSpace) }}
+          {{ prettyBytes(unallocatedSpace) }}
         </span>
       </div>
     </div>

--- a/frontend/src/views/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/Overview/components/OverviewContent.vue
@@ -6,6 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import isEqual from 'lodash/isEqual'
+import prettyBytes from 'pretty-bytes'
 import { gte } from 'semver'
 import { computed, ref, watchEffect } from 'vue'
 
@@ -37,7 +38,7 @@ import TButton from '@/components/Button/TButton.vue'
 import RadialBar from '@/components/Charts/RadialBar.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
 import TAlert from '@/components/TAlert.vue'
-import { formatBytes, setupBackupStatus } from '@/methods'
+import { setupBackupStatus } from '@/methods'
 import { useClusterPermissions } from '@/methods/auth'
 import {
   addClusterLabels,
@@ -229,7 +230,7 @@ const machineLockedForSecretRotation = computed(() => {
               { label: 'Requests', value: usage?.spec?.mem?.requests ?? 0 },
               { label: 'Limits', value: usage?.spec?.mem?.limits ?? 0 },
             ]"
-            :legend-formatter="formatBytes"
+            :legend-formatter="(bytes) => prettyBytes(bytes, { binary: true })"
           />
           <RadialBar
             title="Ephemeral Storage"
@@ -239,7 +240,7 @@ const machineLockedForSecretRotation = computed(() => {
               { label: 'Requests', value: usage?.spec?.storage?.requests ?? 0 },
               { label: 'Limits', value: usage?.spec?.storage?.limits ?? 0 },
             ]"
-            :legend-formatter="formatBytes"
+            :legend-formatter="prettyBytes"
           />
         </div>
         <div


### PR DESCRIPTION
All byte values calculated in Omni were being displayed with binary (GiB) values under SI labels (GB). Fixed this to correctly use binary values and their labels for memory calculations, and SI units and their label for non-memory (e.g. disk and network). Using pretty-bytes package for this.