### PR TITLE
feat: validate Talos extensions against the catalog

### DIFF
--- a/client/pkg/omnictl/installationmedia/create.go
+++ b/client/pkg/omnictl/installationmedia/create.go
@@ -121,19 +121,20 @@ func createPreset(ctx context.Context, cmd *cobra.Command, client *client.Client
 	// Strip a leading "v" so the value matches the canonical Talos version form.
 	talosVersion := strings.TrimPrefix(createCmdFlags.talosVersion, "v")
 
-	// An empty user value means "use the server's default at download time"; for create-time
-	// validation against platform min-versions and extension catalogs, fall back to the CLI's
-	// default Talos version so the checks still run.
-	validationTalosVersion := talosVersion
-	if validationTalosVersion == "" {
-		validationTalosVersion = constants.DefaultTalosVersion
-	}
-
-	if err = download.ValidateTalosVersion(ctx, client.Omni().State(), validationTalosVersion); err != nil {
+	bootloader, err := download.ParseBootloader(createCmdFlags.bootloader)
+	if err != nil {
 		return err
 	}
 
-	bootloader, err := download.ParseBootloader(createCmdFlags.bootloader)
+	// Resolve short or partial extension names to full catalog names. Falls back to the default
+	// Talos version when the user left it empty, since a concrete catalog is needed to look the
+	// names up. The server still validates the result.
+	resolveTalosVersion := talosVersion
+	if resolveTalosVersion == "" {
+		resolveTalosVersion = constants.DefaultTalosVersion
+	}
+
+	resolvedExtensions, err := download.ResolveExtensions(ctx, client.Omni().State(), resolveTalosVersion, createCmdFlags.extensions)
 	if err != nil {
 		return err
 	}
@@ -141,7 +142,7 @@ func createPreset(ctx context.Context, cmd *cobra.Command, client *client.Client
 	spec := &specs.InstallationMediaConfigSpec{
 		TalosVersion:      talosVersion,
 		Architecture:      arch,
-		InstallExtensions: createCmdFlags.extensions,
+		InstallExtensions: resolvedExtensions,
 		KernelArgs:        strings.Join(createCmdFlags.extraKernelArgs, " "),
 		JoinToken:         tokenID,
 		SecureBoot:        createCmdFlags.secureBoot,
@@ -158,7 +159,7 @@ func createPreset(ctx context.Context, cmd *cobra.Command, client *client.Client
 	}
 
 	if createCmdFlags.platform != "" {
-		if err = download.ValidateCloudPlatform(ctx, client.Omni().State(), createCmdFlags.platform, arch, createCmdFlags.secureBoot, validationTalosVersion); err != nil {
+		if err = download.ValidateCloudPlatform(ctx, client.Omni().State(), createCmdFlags.platform, arch, createCmdFlags.secureBoot, resolveTalosVersion); err != nil {
 			return err
 		}
 
@@ -168,7 +169,7 @@ func createPreset(ctx context.Context, cmd *cobra.Command, client *client.Client
 	}
 
 	if createCmdFlags.overlay != "" {
-		if err = download.ValidateSBC(ctx, client.Omni().State(), createCmdFlags.overlay, validationTalosVersion); err != nil {
+		if err = download.ValidateSBC(ctx, client.Omni().State(), createCmdFlags.overlay, resolveTalosVersion); err != nil {
 			return err
 		}
 
@@ -176,10 +177,6 @@ func createPreset(ctx context.Context, cmd *cobra.Command, client *client.Client
 			Overlay:        createCmdFlags.overlay,
 			OverlayOptions: createCmdFlags.overlayOptions,
 		}
-	}
-
-	if err = download.ValidateExtensions(ctx, client.Omni().State(), validationTalosVersion, createCmdFlags.extensions); err != nil {
-		return err
 	}
 
 	if createCmdFlags.labels != nil {

--- a/client/pkg/omnictl/internal/download/download.go
+++ b/client/pkg/omnictl/internal/download/download.go
@@ -328,6 +328,16 @@ func ValidateExtensions(ctx context.Context, st state.State, talosVersion string
 	return err
 }
 
+// ResolveExtensions expands short or partial extension names into full catalog names for the
+// given Talos version. Returns an error if any name has no match.
+func ResolveExtensions(ctx context.Context, st state.State, talosVersion string, extensions []string) ([]string, error) {
+	if len(extensions) == 0 {
+		return nil, nil
+	}
+
+	return lookupExtensions(ctx, st, talosVersion, extensions, false)
+}
+
 func checkMinTalosVersion(actual, minVersion, source string) error {
 	if minVersion == "" {
 		return nil

--- a/internal/backend/runtime/omni/validations/export_test.go
+++ b/internal/backend/runtime/omni/validations/export_test.go
@@ -120,3 +120,7 @@ func MetadataValidationOptions() []validated.StateOption {
 func KubernetesHealthCheckValidationOptions() []validated.StateOption {
 	return kubernetesHealthcheckValidationOptions()
 }
+
+func ExtensionsConfigurationValidationOptions(st state.State) []validated.StateOption {
+	return extensionsConfigurationValidationOptions(st)
+}

--- a/internal/backend/runtime/omni/validations/extensions.go
+++ b/internal/backend/runtime/omni/validations/extensions.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package validations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+
+	"github.com/siderolabs/omni/client/pkg/constants"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/extensions"
+)
+
+// MaxExtensionsCount caps the number of entries in a repeated extensions list. The value is
+// arbitrary, picked well above what real callers would send. Bump if needed.
+const MaxExtensionsCount = 256
+
+// validateExtensions checks each requested extension name against the TalosExtensions catalog. An
+// empty list is accepted. An empty Talos version is the "automatic" sentinel used by resources
+// like InstallationMediaConfig, in which case the default Talos version's catalog is used.
+// Names without a slash are looked up under the official extensions namespace so older clients
+// that send the documented short form keep working. The list is rejected if it exceeds MaxExtensionsCount or
+// contains duplicate entries.
+func validateExtensions(ctx context.Context, st state.State, talosVersion string, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+
+	if len(names) > MaxExtensionsCount {
+		return fmt.Errorf("extensions list has %d entries, exceeds maximum of %d", len(names), MaxExtensionsCount)
+	}
+
+	if talosVersion == "" {
+		talosVersion = constants.DefaultTalosVersion
+	}
+
+	catalog, err := safe.StateGet[*omni.TalosExtensions](ctx, st, omni.NewTalosExtensions(talosVersion).Metadata())
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return fmt.Errorf("no Talos extensions catalog for version %q", talosVersion)
+		}
+
+		return fmt.Errorf("failed to look up Talos extensions catalog for version %q: %w", talosVersion, err)
+	}
+
+	available := make(map[string]struct{}, len(catalog.TypedSpec().Value.GetItems()))
+	for _, item := range catalog.TypedSpec().Value.GetItems() {
+		available[item.GetName()] = struct{}{}
+	}
+
+	seen := make(map[string]struct{}, len(names))
+
+	for i, name := range names {
+		lookup := name
+		if !strings.Contains(lookup, "/") {
+			lookup = extensions.OfficialPrefix + lookup
+		}
+
+		if _, ok := available[lookup]; !ok {
+			return fmt.Errorf("extension %q (entry %d) is not available for Talos version %q", name, i, talosVersion)
+		}
+
+		if _, ok := seen[lookup]; ok {
+			return fmt.Errorf("extension %q (entry %d) is listed more than once", name, i)
+		}
+
+		seen[lookup] = struct{}{}
+	}
+
+	return nil
+}

--- a/internal/backend/runtime/omni/validations/extensions_configuration.go
+++ b/internal/backend/runtime/omni/validations/extensions_configuration.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package validations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
+)
+
+func extensionsConfigurationValidationOptions(st state.State) []validated.StateOption {
+	validate := func(ctx context.Context, res *omni.ExtensionsConfiguration) error {
+		extensions := res.TypedSpec().Value.GetExtensions()
+		if len(extensions) == 0 {
+			return nil
+		}
+
+		clusterID, ok := res.Metadata().Labels().Get(omni.LabelCluster)
+		if !ok || clusterID == "" {
+			return errors.New("extensions configuration with a non-empty extensions list must target a cluster via the cluster label")
+		}
+
+		cluster, err := safe.StateGet[*omni.Cluster](ctx, st, omni.NewCluster(clusterID).Metadata())
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				return fmt.Errorf("cluster %q does not exist", clusterID)
+			}
+
+			return fmt.Errorf("failed to look up cluster %q: %w", clusterID, err)
+		}
+
+		return validateExtensions(ctx, st, cluster.TypedSpec().Value.GetTalosVersion(), extensions)
+	}
+
+	return []validated.StateOption{
+		validated.WithCreateValidations(validated.NewCreateValidationForType(func(ctx context.Context, res *omni.ExtensionsConfiguration, _ ...state.CreateOption) error {
+			return validate(ctx, res)
+		})),
+		validated.WithUpdateValidations(validated.NewUpdateValidationForType(func(ctx context.Context, _, newRes *omni.ExtensionsConfiguration, _ ...state.UpdateOption) error {
+			return validate(ctx, newRes)
+		})),
+	}
+}

--- a/internal/backend/runtime/omni/validations/infra_machine_config.go
+++ b/internal/backend/runtime/omni/validations/infra_machine_config.go
@@ -19,7 +19,8 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 )
 
-// MaxRequestIDLength caps the byte length of the request ID fields on InfraMachineConfig.
+// MaxRequestIDLength caps the byte length of the request ID fields on InfraMachineConfig. The
+// value is arbitrary, picked well above what real callers would send. Bump if needed.
 const MaxRequestIDLength = 128
 
 func infraMachineConfigValidationOptions(st state.State) []validated.StateOption {

--- a/internal/backend/runtime/omni/validations/installation_media_config.go
+++ b/internal/backend/runtime/omni/validations/installation_media_config.go
@@ -63,22 +63,22 @@ func installationMediaConfigValidationOptions(st state.State) []validated.StateO
 			return err
 		}
 
-		if version := spec.GetTalosVersion(); version != "" {
-			// Strip a leading "v" before the lookup so older omnictl clients that did not yet
-			// normalize the user input still validate against the canonical "1.2.3" form stored
-			// on Talos version resources.
-			lookup := strings.TrimPrefix(version, "v")
+		// Strip a leading "v" so older omnictl clients that did not yet normalize the user input
+		// still validate against the canonical "1.2.3" form stored on Talos version resources and
+		// the extensions catalog.
+		talosVersion := strings.TrimPrefix(spec.GetTalosVersion(), "v")
 
-			if _, err := safe.StateGet[*omni.TalosVersion](ctx, st, omni.NewTalosVersion(lookup).Metadata()); err != nil {
+		if talosVersion != "" {
+			if _, err := safe.StateGet[*omni.TalosVersion](ctx, st, omni.NewTalosVersion(talosVersion).Metadata()); err != nil {
 				if state.IsNotFoundError(err) {
-					return fmt.Errorf("unknown Talos version %q", version)
+					return fmt.Errorf("unknown Talos version %q", spec.GetTalosVersion())
 				}
 
-				return fmt.Errorf("failed to look up Talos version %q: %w", version, err)
+				return fmt.Errorf("failed to look up Talos version %q: %w", spec.GetTalosVersion(), err)
 			}
 		}
 
-		return nil
+		return validateExtensions(ctx, st, talosVersion, spec.GetInstallExtensions())
 	}
 
 	return []validated.StateOption{

--- a/internal/backend/runtime/omni/validations/kernel_args.go
+++ b/internal/backend/runtime/omni/validations/kernel_args.go
@@ -14,6 +14,8 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 )
 
+// The caps below are arbitrary, picked well above what real callers would send.
+// They bound user input. Bump if needed.
 const (
 	// MaxKernelArgLength caps the byte length of a single entry in a repeated kernel args list.
 	MaxKernelArgLength = 256

--- a/internal/backend/runtime/omni/validations/machine_request_set.go
+++ b/internal/backend/runtime/omni/validations/machine_request_set.go
@@ -41,5 +41,9 @@ func validateMachineRequestSet(ctx context.Context, st state.State, oldRes, res 
 		return err
 	}
 
-	return validateTalosVersion(ctx, st, "", res.TypedSpec().Value.TalosVersion)
+	if err := validateTalosVersion(ctx, st, "", res.TypedSpec().Value.TalosVersion); err != nil {
+		return err
+	}
+
+	return validateExtensions(ctx, st, res.TypedSpec().Value.TalosVersion, res.TypedSpec().Value.GetExtensions())
 }

--- a/internal/backend/runtime/omni/validations/metadata.go
+++ b/internal/backend/runtime/omni/validations/metadata.go
@@ -18,6 +18,8 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 )
 
+// The caps below are arbitrary, picked well above what real callers would send.
+// They bound user input. Bump if needed.
 const (
 	// MaxResourceIDLength caps the byte length of a resource ID.
 	MaxResourceIDLength = 1024

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"iter"
 	"math/big"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -2342,6 +2344,288 @@ func TestInstallationMediaConfigTalosVersionValidation(t *testing.T) {
 			assert.ErrorContains(t, err, tt.errContains)
 		})
 	}
+}
+
+//nolint:maintidx
+func TestExtensionsCatalogValidation(t *testing.T) {
+	t.Parallel()
+
+	// Use the same default Talos version as the validator so empty-version cases (where the
+	// validator falls back to constants.DefaultTalosVersion) still find a catalog in the test
+	// state.
+	talosVersionID := constants.DefaultTalosVersion
+
+	setupBaseState := func(t *testing.T) state.State {
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		talosVersion := omnires.NewTalosVersion(talosVersionID)
+		talosVersion.TypedSpec().Value.CompatibleKubernetesVersions = []string{"1.30.0"}
+		require.NoError(t, innerSt.Create(ctx, talosVersion))
+
+		catalog := omnires.NewTalosExtensions(talosVersionID)
+		catalog.TypedSpec().Value.Items = []*specs.TalosExtensionsSpec_Info{
+			{Name: "siderolabs/qemu-guest-agent"},
+			{Name: "siderolabs/i915-ucode"},
+		}
+		require.NoError(t, innerSt.Create(ctx, catalog))
+
+		return innerSt
+	}
+
+	t.Run("installation media config", func(t *testing.T) {
+		t.Parallel()
+
+		// An empty Talos version is the "automatic" sentinel. The validator falls back to the
+		// default Talos version's catalog so extension names are still checked. With a concrete
+		// version, the catalog for that version is used as for any other resource.
+		for _, tt := range []struct {
+			name         string
+			talosVersion string
+			errContains  string
+			extensions   []string
+		}{
+			{name: "empty extensions, no version"},
+			{name: "valid extension without version (automatic)", extensions: []string{"siderolabs/qemu-guest-agent"}},
+			{
+				name:        "unknown extension without version (automatic)",
+				extensions:  []string{"siderolabs/typo-extension"},
+				errContains: "is not available",
+			},
+			{name: "valid extension with version", talosVersion: talosVersionID, extensions: []string{"siderolabs/qemu-guest-agent"}},
+			{name: "valid extension with v-prefixed version", talosVersion: "v" + talosVersionID, extensions: []string{"siderolabs/qemu-guest-agent"}},
+			{
+				name:         "unknown extension with version",
+				talosVersion: talosVersionID,
+				extensions:   []string{"siderolabs/typo-extension"},
+				errContains:  "is not available",
+			},
+			{
+				name:         "short extension name accepted via siderolabs fallback",
+				talosVersion: talosVersionID,
+				extensions:   []string{"qemu-guest-agent"},
+			},
+			{
+				name:         "short unknown extension rejected",
+				talosVersion: talosVersionID,
+				extensions:   []string{"does-not-exist"},
+				errContains:  "is not available",
+			},
+			{
+				name:         "foreign-namespace extension rejected",
+				talosVersion: talosVersionID,
+				extensions:   []string{"someorg/qemu-guest-agent"},
+				errContains:  "is not available",
+			},
+			{
+				name:         "duplicate extension rejected",
+				talosVersion: talosVersionID,
+				extensions:   []string{"siderolabs/qemu-guest-agent", "siderolabs/qemu-guest-agent"},
+				errContains:  "is listed more than once",
+			},
+			{
+				name:         "short and full of the same extension rejected as duplicate",
+				talosVersion: talosVersionID,
+				extensions:   []string{"qemu-guest-agent", "siderolabs/qemu-guest-agent"},
+				errContains:  "is listed more than once",
+			},
+			{
+				name:         "too many extensions rejected",
+				talosVersion: talosVersionID,
+				extensions:   slices.Repeat([]string{"siderolabs/qemu-guest-agent"}, validations.MaxExtensionsCount+1),
+				errContains:  "exceeds maximum",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+				t.Cleanup(cancel)
+
+				innerSt := setupBaseState(t)
+				st := validated.NewState(innerSt, validations.InstallationMediaConfigValidationOptions(innerSt)...)
+
+				media := omnires.NewInstallationMediaConfig("test")
+				media.TypedSpec().Value.Architecture = specs.PlatformConfigSpec_AMD64
+				media.TypedSpec().Value.TalosVersion = tt.talosVersion
+				media.TypedSpec().Value.InstallExtensions = tt.extensions
+
+				err := st.Create(ctx, media)
+				if tt.errContains == "" {
+					require.NoError(t, err)
+
+					return
+				}
+
+				assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+				assert.ErrorContains(t, err, tt.errContains)
+			})
+		}
+	})
+
+	t.Run("extensions configuration", func(t *testing.T) {
+		t.Parallel()
+
+		const clusterID = "test-cluster"
+
+		setupClusterState := func(t *testing.T) state.State {
+			innerSt := setupBaseState(t)
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			cluster := omnires.NewCluster(clusterID)
+			cluster.TypedSpec().Value.TalosVersion = talosVersionID
+			cluster.TypedSpec().Value.KubernetesVersion = "1.30.0"
+			require.NoError(t, innerSt.Create(ctx, cluster))
+
+			return innerSt
+		}
+
+		t.Run("empty extensions", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setupClusterState(t)
+			st := validated.NewState(innerSt, validations.ExtensionsConfigurationValidationOptions(innerSt)...)
+
+			res := omnires.NewExtensionsConfiguration("test")
+			res.Metadata().Labels().Set(omnires.LabelCluster, clusterID)
+
+			require.NoError(t, st.Create(ctx, res))
+		})
+
+		t.Run("valid extension", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setupClusterState(t)
+			st := validated.NewState(innerSt, validations.ExtensionsConfigurationValidationOptions(innerSt)...)
+
+			res := omnires.NewExtensionsConfiguration("test")
+			res.Metadata().Labels().Set(omnires.LabelCluster, clusterID)
+			res.TypedSpec().Value.Extensions = []string{"siderolabs/qemu-guest-agent"}
+
+			require.NoError(t, st.Create(ctx, res))
+		})
+
+		t.Run("unknown extension", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setupClusterState(t)
+			st := validated.NewState(innerSt, validations.ExtensionsConfigurationValidationOptions(innerSt)...)
+
+			res := omnires.NewExtensionsConfiguration("test")
+			res.Metadata().Labels().Set(omnires.LabelCluster, clusterID)
+			res.TypedSpec().Value.Extensions = []string{"siderolabs/typo-extension"}
+
+			err := st.Create(ctx, res)
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, "is not available")
+		})
+
+		t.Run("missing cluster label", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setupClusterState(t)
+			st := validated.NewState(innerSt, validations.ExtensionsConfigurationValidationOptions(innerSt)...)
+
+			res := omnires.NewExtensionsConfiguration("test")
+			res.TypedSpec().Value.Extensions = []string{"siderolabs/qemu-guest-agent"}
+
+			err := st.Create(ctx, res)
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, "must target a cluster via the cluster label")
+		})
+
+		t.Run("cluster does not exist", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setupClusterState(t)
+			st := validated.NewState(innerSt, validations.ExtensionsConfigurationValidationOptions(innerSt)...)
+
+			res := omnires.NewExtensionsConfiguration("test")
+			res.Metadata().Labels().Set(omnires.LabelCluster, "nonexistent")
+			res.TypedSpec().Value.Extensions = []string{"siderolabs/qemu-guest-agent"}
+
+			err := st.Create(ctx, res)
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, `cluster "nonexistent" does not exist`)
+		})
+	})
+
+	t.Run("machine request set", func(t *testing.T) {
+		t.Parallel()
+
+		setupRequestState := func(t *testing.T) state.State {
+			innerSt := setupBaseState(t)
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			providerStatus := infra.NewProviderStatus("talemu")
+			providerStatus.TypedSpec().Value.Schema = string(schema)
+			require.NoError(t, innerSt.Create(ctx, providerStatus))
+
+			return innerSt
+		}
+
+		newRequestSet := func() *omnires.MachineRequestSet {
+			res := omnires.NewMachineRequestSet("test")
+			res.TypedSpec().Value.ProviderId = "talemu"
+			res.TypedSpec().Value.TalosVersion = talosVersionID
+			res.TypedSpec().Value.ProviderData = "size: t2.small\n"
+
+			return res
+		}
+
+		t.Run("valid extension", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setupRequestState(t)
+			st := validated.NewState(innerSt, validations.MachineRequestSetValidationOptions(innerSt)...)
+
+			res := newRequestSet()
+			res.TypedSpec().Value.Extensions = []string{"siderolabs/i915-ucode"}
+
+			require.NoError(t, st.Create(ctx, res))
+		})
+
+		t.Run("unknown extension", func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setupRequestState(t)
+			st := validated.NewState(innerSt, validations.MachineRequestSetValidationOptions(innerSt)...)
+
+			res := newRequestSet()
+			res.TypedSpec().Value.Extensions = []string{"siderolabs/typo-extension"}
+
+			err := st.Create(ctx, res)
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, "is not available")
+		})
+	})
 }
 
 func TestNodeForceDestroyRequestValidation(t *testing.T) {

--- a/internal/backend/runtime/omni/validations/validations.go
+++ b/internal/backend/runtime/omni/validations/validations.go
@@ -50,5 +50,6 @@ func Options(st state.State, etcdBackupStoreFactory store.Factory, cfg *config.P
 		eulaValidationOptions(st),
 		kernelArgsValidationOptions(),
 		kubernetesHealthcheckValidationOptions(),
+		extensionsConfigurationValidationOptions(st),
 	)
 }


### PR DESCRIPTION
Extension names on installation media configs, machine request sets, and extensions configurations are now validated against the Talos extensions catalog for the relevant Talos version. Unknown names, duplicates, and oversized lists are rejected. When no Talos version is set, the default version's catalog is used so the names still get checked. Names without a namespace are looked up under siderolabs/ so older clients that send the documented short form keep working.

The omnictl installation media create command also resolves short or partial extension names to canonical form before sending, replacing the client-side catalog check it used to do.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>