### PR TITLE
fix: properly handle empty provider data in the common module

### DIFF
--- a/client/pkg/infra/provision/context.go
+++ b/client/pkg/infra/provision/context.go
@@ -143,6 +143,10 @@ func (context *Context[T]) SetMachineInfraID(value string) {
 
 // UnmarshalProviderData reads provider data string from the machine request into the dest.
 func (context *Context[T]) UnmarshalProviderData(dest any) error {
+	if context.machineRequest.TypedSpec().Value.ProviderData == "" {
+		return nil
+	}
+
 	return yaml.Unmarshal([]byte(context.machineRequest.TypedSpec().Value.ProviderData), dest)
 }
 

--- a/hack/test/provisionconfig.yaml
+++ b/hack/test/provisionconfig.yaml
@@ -2,6 +2,8 @@
 count: 15
 provider:
   id: talemu
+  data: |
+    secure_boot: false
 ---
 count: 15
 provider:


### PR DESCRIPTION
Looks like the behavior has changed from v3 -> v4 and now YAML parser crashes if the provider data is the empty string.

Update the common module to not try to parse the data if it's empty.