### PR TITLE
feat: install/upgrade maintenance-mode Talos during cluster create/scale-up

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -3524,8 +3524,13 @@ type ClusterMachineConfigStatusSpec struct {
 	//
 	// Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
 	CompressedRedactedMachineConfig []byte `protobuf:"bytes,10,opt,name=compressed_redacted_machine_config,json=compressedRedactedMachineConfig,proto3" json:"compressed_redacted_machine_config,omitempty"`
-	unknownFields                   protoimpl.UnknownFields
-	sizeCache                       protoimpl.SizeCache
+	// PreRebootBootId is the machine boot ID captured when an operation that requires the
+	// machine to reboot (e.g. an install/upgrade via LifecycleService) was last issued. It
+	// debounces such operations: the controller waits until the machine reboots and its boot
+	// ID changes before acting again.
+	PreRebootBootId string `protobuf:"bytes,11,opt,name=pre_reboot_boot_id,json=preRebootBootId,proto3" json:"pre_reboot_boot_id,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ClusterMachineConfigStatusSpec) Reset() {
@@ -3605,6 +3610,13 @@ func (x *ClusterMachineConfigStatusSpec) GetCompressedRedactedMachineConfig() []
 		return x.CompressedRedactedMachineConfig
 	}
 	return nil
+}
+
+func (x *ClusterMachineConfigStatusSpec) GetPreRebootBootId() string {
+	if x != nil {
+		return x.PreRebootBootId
+	}
+	return ""
 }
 
 type MachinePendingUpdatesSpec struct {
@@ -4714,6 +4726,8 @@ type MachineStatusSnapshotSpec struct {
 	state         protoimpl.MessageState               `protogen:"open.v1"`
 	MachineStatus *machine.MachineStatusEvent          `protobuf:"bytes,1,opt,name=machine_status,json=machineStatus,proto3" json:"machine_status,omitempty"`
 	PowerStage    MachineStatusSnapshotSpec_PowerStage `protobuf:"varint,2,opt,name=power_stage,json=powerStage,proto3,enum=specs.MachineStatusSnapshotSpec_PowerStage" json:"power_stage,omitempty"`
+	// BootId is the machine's kernel boot identifier (/proc/sys/kernel/random/boot_id).
+	BootId        string `protobuf:"bytes,3,opt,name=boot_id,json=bootId,proto3" json:"boot_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4760,6 +4774,13 @@ func (x *MachineStatusSnapshotSpec) GetPowerStage() MachineStatusSnapshotSpec_Po
 		return x.PowerStage
 	}
 	return MachineStatusSnapshotSpec_POWER_STAGE_NONE
+}
+
+func (x *MachineStatusSnapshotSpec) GetBootId() string {
+	if x != nil {
+		return x.BootId
+	}
+	return ""
 }
 
 // ControlPlaneStatusSpec contains the status of the MachineSets which manage control plane nodes.
@@ -11545,7 +11566,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\vClusterUUID\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\"4\n" +
 	"\x18ClusterConfigVersionSpec\x12\x18\n" +
-	"\aversion\x18\x01 \x01(\tR\aversion\"\xc2\x03\n" +
+	"\aversion\x18\x01 \x01(\tR\aversion\"\xef\x03\n" +
 	"\x1eClusterMachineConfigStatusSpec\x12C\n" +
 	"\x1ecluster_machine_config_version\x18\x03 \x01(\tR\x1bclusterMachineConfigVersion\x12A\n" +
 	"\x1dcluster_machine_config_sha256\x18\x05 \x01(\tR\x1aclusterMachineConfigSha256\x12*\n" +
@@ -11554,7 +11575,8 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\fschematic_id\x18\b \x01(\tR\vschematicId\x12E\n" +
 	"\x1fredacted_current_machine_config\x18\t \x01(\tR\x1credactedCurrentMachineConfig\x12K\n" +
 	"\"compressed_redacted_machine_config\x18\n" +
-	" \x01(\fR\x1fcompressedRedactedMachineConfigJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05\"\x98\x02\n" +
+	" \x01(\fR\x1fcompressedRedactedMachineConfig\x12+\n" +
+	"\x12pre_reboot_boot_id\x18\v \x01(\tR\x0fpreRebootBootIdJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05\"\x98\x02\n" +
 	"\x19MachinePendingUpdatesSpec\x12B\n" +
 	"\aupgrade\x18\x01 \x01(\v2(.specs.MachinePendingUpdatesSpec.UpgradeR\aupgrade\x12\x1f\n" +
 	"\vconfig_diff\x18\x02 \x01(\tR\n" +
@@ -11680,11 +11702,12 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x0fupdate_strategy\x18\x03 \x01(\x0e2$.specs.MachineSetSpec.UpdateStrategyR\x0eupdateStrategy\x12`\n" +
 	"\x16update_strategy_config\x18\x04 \x01(\v2*.specs.MachineSetSpec.UpdateStrategyConfigR\x14updateStrategyConfig\"\x14\n" +
 	"\x12MachineSetNodeSpec\"\x13\n" +
-	"\x11MachineLabelsSpec\"\x8b\x02\n" +
+	"\x11MachineLabelsSpec\"\xa4\x02\n" +
 	"\x19MachineStatusSnapshotSpec\x12B\n" +
 	"\x0emachine_status\x18\x01 \x01(\v2\x1b.machine.MachineStatusEventR\rmachineStatus\x12L\n" +
 	"\vpower_stage\x18\x02 \x01(\x0e2+.specs.MachineStatusSnapshotSpec.PowerStageR\n" +
-	"powerStage\"\\\n" +
+	"powerStage\x12\x17\n" +
+	"\aboot_id\x18\x03 \x01(\tR\x06bootId\"\\\n" +
 	"\n" +
 	"PowerStage\x12\x14\n" +
 	"\x10POWER_STAGE_NONE\x10\x00\x12\x1b\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -618,6 +618,12 @@ message ClusterMachineConfigStatusSpec {
   //
   // Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
   bytes compressed_redacted_machine_config = 10;
+
+  // PreRebootBootId is the machine boot ID captured when an operation that requires the
+  // machine to reboot (e.g. an install/upgrade via LifecycleService) was last issued. It
+  // debounces such operations: the controller waits until the machine reboots and its boot
+  // ID changes before acting again.
+  string pre_reboot_boot_id = 11;
 }
 
 message MachinePendingUpdatesSpec {
@@ -932,6 +938,8 @@ message MachineStatusSnapshotSpec {
 
   machine.MachineStatusEvent machine_status = 1;
   PowerStage power_stage = 2;
+  // BootId is the machine's kernel boot identifier (/proc/sys/kernel/random/boot_id).
+  string boot_id = 3;
 }
 
 enum ConditionType {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -960,6 +960,7 @@ func (m *ClusterMachineConfigStatusSpec) CloneVT() *ClusterMachineConfigStatusSp
 	r.TalosVersion = m.TalosVersion
 	r.SchematicId = m.SchematicId
 	r.RedactedCurrentMachineConfig = m.RedactedCurrentMachineConfig
+	r.PreRebootBootId = m.PreRebootBootId
 	if rhs := m.CompressedRedactedMachineConfig; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
@@ -1473,6 +1474,7 @@ func (m *MachineStatusSnapshotSpec) CloneVT() *MachineStatusSnapshotSpec {
 	}
 	r := new(MachineStatusSnapshotSpec)
 	r.PowerStage = m.PowerStage
+	r.BootId = m.BootId
 	if rhs := m.MachineStatus; rhs != nil {
 		if vtpb, ok := interface{}(rhs).(interface {
 			CloneVT() *machine.MachineStatusEvent
@@ -4599,6 +4601,9 @@ func (this *ClusterMachineConfigStatusSpec) EqualVT(that *ClusterMachineConfigSt
 	if string(this.CompressedRedactedMachineConfig) != string(that.CompressedRedactedMachineConfig) {
 		return false
 	}
+	if this.PreRebootBootId != that.PreRebootBootId {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -5258,6 +5263,9 @@ func (this *MachineStatusSnapshotSpec) EqualVT(that *MachineStatusSnapshotSpec) 
 		return false
 	}
 	if this.PowerStage != that.PowerStage {
+		return false
+	}
+	if this.BootId != that.BootId {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -10476,6 +10484,13 @@ func (m *ClusterMachineConfigStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (in
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.PreRebootBootId) > 0 {
+		i -= len(m.PreRebootBootId)
+		copy(dAtA[i:], m.PreRebootBootId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.PreRebootBootId)))
+		i--
+		dAtA[i] = 0x5a
+	}
 	if len(m.CompressedRedactedMachineConfig) > 0 {
 		i -= len(m.CompressedRedactedMachineConfig)
 		copy(dAtA[i:], m.CompressedRedactedMachineConfig)
@@ -11930,6 +11945,13 @@ func (m *MachineStatusSnapshotSpec) MarshalToSizedBufferVT(dAtA []byte) (int, er
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.BootId) > 0 {
+		i -= len(m.BootId)
+		copy(dAtA[i:], m.BootId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BootId)))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if m.PowerStage != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.PowerStage))
@@ -17728,6 +17750,10 @@ func (m *ClusterMachineConfigStatusSpec) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.PreRebootBootId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -18276,6 +18302,10 @@ func (m *MachineStatusSnapshotSpec) SizeVT() (n int) {
 	}
 	if m.PowerStage != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.PowerStage))
+	}
+	l = len(m.BootId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -27354,6 +27384,38 @@ func (m *ClusterMachineConfigStatusSpec) UnmarshalVT(dAtA []byte) error {
 				m.CompressedRedactedMachineConfig = []byte{}
 			}
 			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PreRebootBootId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.PreRebootBootId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -30880,6 +30942,38 @@ func (m *MachineStatusSnapshotSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BootId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BootId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/omni/resources/omni/machine_config_gen_options.go
+++ b/client/pkg/omni/resources/omni/machine_config_gen_options.go
@@ -14,6 +14,26 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 )
 
+// NewInstallImage builds an install image spec for the machine using the given target Talos version and schematic ID, deriving the platform, security state and
+// schematic-invalid flag from the machine's status.
+func NewInstallImage(machineStatus *MachineStatus, talosVersion, schematicID string, schematicInitialized bool) *specs.MachineConfigGenOptionsSpec_InstallImage {
+	spec := machineStatus.TypedSpec().Value
+
+	installImage := &specs.MachineConfigGenOptionsSpec_InstallImage{
+		TalosVersion:         talosVersion,
+		SchematicId:          schematicID,
+		SchematicInitialized: schematicInitialized,
+		SecurityState:        spec.SecurityState,
+		Platform:             spec.GetPlatformMetadata().GetPlatform(),
+	}
+
+	if schematicInitialized {
+		installImage.SchematicInvalid = spec.GetSchematic().GetInvalid()
+	}
+
+	return installImage
+}
+
 // NewMachineConfigGenOptions creates new MachineConfigGenOptions resource.
 func NewMachineConfigGenOptions(id resource.ID) *MachineConfigGenOptions {
 	return typed.NewResource[MachineConfigGenOptionsSpec, MachineConfigGenOptionsExtension](

--- a/client/pkg/omni/resources/omni/version_compat.go
+++ b/client/pkg/omni/resources/omni/version_compat.go
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package omni
+
+import (
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"github.com/cosi-project/runtime/pkg/resource"
+)
+
+// LifecycleServiceMinTalosVersion is the minimum Talos version that supports the LifecycleService API
+// tsgen:LifecycleServiceMinTalosVersion
+const LifecycleServiceMinTalosVersion = "1.13"
+
+// MachineCompatibleWithCluster reports whether a machine can join a cluster running clusterVersion.
+func MachineCompatibleWithCluster(
+	ms *MachineStatus,
+	clusterVersion semver.Version,
+) (ok bool, willAutoInstall bool, reason string) {
+	if ms.TypedSpec().Value.GetSchematic().GetInAgentMode() {
+		return true, false, ""
+	}
+
+	return MachineLabelsCompatibleWithCluster(ms.Metadata().Labels(), clusterVersion)
+}
+
+// MachineLabelsCompatibleWithCluster is a labels-only variant of MachineCompatibleWithCluster for callers with only a machine's labels (e.g. the MachineSetNode allocator).
+func MachineLabelsCompatibleWithCluster(labels *resource.Labels, clusterVersion semver.Version) (ok bool, willAutoInstall bool, reason string) {
+	versionStr, hasVersion := labels.Get(MachineStatusLabelTalosVersion)
+	if !hasVersion {
+		return false, false, "the machine has no Talos version label"
+	}
+
+	machineVersion, err := semver.Parse(strings.TrimPrefix(versionStr, "v"))
+	if err != nil {
+		return false, false, "the machine's Talos version could not be determined"
+	}
+
+	_, installed := labels.Get(MachineStatusLabelInstalled)
+
+	return versionCompatibleWithCluster(machineVersion, installed, clusterVersion)
+}
+
+// ParseTalosVersionLifecycleSupport parses a Talos version and reports whether it supports the LifecycleService install/upgrade APIs.
+func ParseTalosVersionLifecycleSupport(version string) (semver.Version, bool) {
+	parsed, err := semver.ParseTolerant(version)
+	if err != nil {
+		return semver.Version{}, false
+	}
+
+	return parsed, talosVersionSupportsLifecycleService(parsed)
+}
+
+// versionCompatibleWithCluster applies the version/installed compatibility rules to extracted inputs.
+func versionCompatibleWithCluster(machineVersion semver.Version, installed bool, clusterVersion semver.Version) (ok bool, willAutoInstall bool, reason string) {
+	// Refuse downgrade (e.g. installed at 1.14 trying to join a 1.13 cluster).
+	if machineVersion.Major > clusterVersion.Major || (machineVersion.Major == clusterVersion.Major && machineVersion.Minor > clusterVersion.Minor) {
+		return false, false, "the machine has a newer Talos version installed: downgrade is not allowed. Upgrade the machine or change the cluster Talos version"
+	}
+
+	if installed {
+		return true, false, ""
+	}
+
+	// Same major.minor: Omni applies config and Talos installs through the normal config path.
+	if machineVersion.Major == clusterVersion.Major && machineVersion.Minor == clusterVersion.Minor {
+		return true, false, ""
+	}
+
+	// Cross-minor and not-installed: Omni can support the install only if both sides are >= 1.13.
+	if talosVersionSupportsLifecycleService(machineVersion) && talosVersionSupportsLifecycleService(clusterVersion) {
+		return true, true, ""
+	}
+
+	return false, false, "the machine running from ISO or PXE must have the same major and minor version as the cluster " +
+		"it is going to be added to. Please use another ISO or change the cluster Talos version"
+}
+
+// talosVersionSupportsLifecycleService reports whether the Talos version exposes the LifecycleService install/upgrade APIs.
+func talosVersionSupportsLifecycleService(v semver.Version) bool {
+	minTalosVersion, _ := semver.ParseTolerant(LifecycleServiceMinTalosVersion) //nolint:errcheck
+	if v.Major > minTalosVersion.Major {
+		return true
+	}
+
+	if v.Major < minTalosVersion.Major {
+		return false
+	}
+
+	return v.Minor >= minTalosVersion.Minor
+}

--- a/client/pkg/omni/resources/omni/version_compat_test.go
+++ b/client/pkg/omni/resources/omni/version_compat_test.go
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package omni_test
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+func TestMachineCompatibleWithCluster(t *testing.T) {
+	t.Parallel()
+
+	mkMachine := func(version string, installed bool, agentMode bool) *omni.MachineStatus {
+		ms := omni.NewMachineStatus("machine")
+		ms.TypedSpec().Value.TalosVersion = version
+		ms.Metadata().Labels().Set(omni.MachineStatusLabelTalosVersion, version)
+
+		if installed {
+			ms.Metadata().Labels().Set(omni.MachineStatusLabelInstalled, "")
+		}
+
+		if agentMode {
+			ms.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{InAgentMode: true}
+		}
+
+		return ms
+	}
+
+	for _, tc := range []struct {
+		name        string
+		machine     *omni.MachineStatus
+		cluster     string
+		wantOK      bool
+		wantInstall bool
+	}{
+		{
+			name:    "installed same minor",
+			machine: mkMachine("1.13.4", true, false),
+			cluster: "1.13.4",
+			wantOK:  true,
+		},
+		{
+			name:    "installed older minor (upgrade path)",
+			machine: mkMachine("1.12.5", true, false),
+			cluster: "1.13.4",
+			wantOK:  true,
+		},
+		{
+			name:    "installed newer (downgrade rejected)",
+			machine: mkMachine("1.14.0", true, false),
+			cluster: "1.13.4",
+			wantOK:  false,
+		},
+		{
+			name:    "not-installed same minor",
+			machine: mkMachine("1.13.4", false, false),
+			cluster: "1.13.4",
+			wantOK:  true,
+		},
+		{
+			name:        "not-installed 1.13 maintenance to 1.13.4 (auto-install)",
+			machine:     mkMachine("1.13.0", false, false),
+			cluster:     "1.13.4",
+			wantOK:      true,
+			wantInstall: false, // same minor → no auto-install needed, normal config path
+		},
+		{
+			name:        "not-installed 1.13 to higher 1.14 cluster (auto-install)",
+			machine:     mkMachine("1.13.0", false, false),
+			cluster:     "1.14.0",
+			wantOK:      true,
+			wantInstall: true,
+		},
+		{
+			name:    "not-installed 1.12 minor mismatch (no install path)",
+			machine: mkMachine("1.12.5", false, false),
+			cluster: "1.13.4",
+			wantOK:  false,
+		},
+		{
+			name:    "agent mode always ok",
+			machine: mkMachine("1.13.4", false, true),
+			cluster: "1.14.0",
+			wantOK:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterVersion, err := semver.Parse(tc.cluster)
+			assert.NoError(t, err)
+
+			ok, willInstall, reason := omni.MachineCompatibleWithCluster(tc.machine, clusterVersion)
+			assert.Equal(t, tc.wantOK, ok, "reason: %s", reason)
+			assert.Equal(t, tc.wantInstall, willInstall, "reason: %s", reason)
+		})
+	}
+}

--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/auth/user"
@@ -100,10 +101,17 @@ func Run(ctx context.Context, state *omni.State, cfg *config.Params, logger *zap
 
 	prometheus.MustRegister(discoveryClientCache)
 
+	lifecycleManager := lifecycle.NewManager(
+		logger.With(logging.Component("talos_lifecycle")),
+		imageFactoryClient.Host(),
+		cfg.Registries.GetTalos(),
+	)
+
 	omniRuntime, err := omni.NewRuntime(
 		cfg, talosClientFactory, dnsService, workloadProxyReconciler, resourceLogger,
 		imageFactoryClient, linkCounterDeltaCh, siderolinkEventsCh, installEventCh, state,
-		prometheus.DefaultRegisterer, discoveryClientCache, kubernetesRuntime, talosRuntime, logger.With(logging.Component("omni_runtime")),
+		prometheus.DefaultRegisterer, discoveryClientCache, kubernetesRuntime, talosRuntime,
+		lifecycleManager, logger.With(logging.Component("omni_runtime")),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to set up the controller runtime: %w", err)
@@ -192,6 +200,7 @@ func Run(ctx context.Context, state *omni.State, cfg *config.Params, logger *zap
 		logger,
 		kubernetesRuntime,
 		talosRuntime,
+		lifecycleManager,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -514,6 +514,7 @@ export type ClusterMachineConfigStatusSpec = {
   schematic_id?: string
   redacted_current_machine_config?: string
   compressed_redacted_machine_config?: Uint8Array
+  pre_reboot_boot_id?: string
 }
 
 export type MachinePendingUpdatesSpecUpgrade = {
@@ -666,6 +667,7 @@ export type MachineLabelsSpec = {
 export type MachineStatusSnapshotSpec = {
   machine_status?: MachineMachine.MachineStatusEvent
   power_stage?: MachineStatusSnapshotSpecPowerStage
+  boot_id?: string
 }
 
 export type ControlPlaneStatusSpecCondition = {

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -239,6 +239,7 @@ export const TalosExtensionsType = "TalosExtensions.omni.sidero.dev";
 export const TalosUpgradeStatusType = "TalosUpgradeStatuses.omni.sidero.dev";
 export const TalosVersionType = "TalosVersions.omni.sidero.dev";
 export const UpgradeRolloutType = "UpgradeRollouts.omni.sidero.dev";
+export const LifecycleServiceMinTalosVersion = "1.13";
 export const AccessPolicyType = "AccessPolicies.omni.sidero.dev";
 export const AuthConfigID = "auth-config";
 export const AuthConfigType = "AuthConfigs.omni.sidero.dev";

--- a/frontend/src/methods/compat.ts
+++ b/frontend/src/methods/compat.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+import { parse, SemVer } from 'semver'
+
+import type { Resource } from '@/api/grpc'
+import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
+import { LifecycleServiceMinTalosVersion, MachineStatusLabelInstalled } from '@/api/resources'
+
+const [minTalosMajor, minTalosMinor] = LifecycleServiceMinTalosVersion.split('.').map(Number)
+
+export type CompatResult = {
+  ok: boolean
+  willAutoInstall: boolean
+  reason: string | null
+}
+
+const okResult: CompatResult = { ok: true, willAutoInstall: false, reason: null }
+const okWithInstall = (version: string): CompatResult => ({
+  ok: true,
+  willAutoInstall: true,
+  reason: `Omni will install Talos v${version} to this machine when it joins the cluster.`,
+})
+
+function supportsMaintenanceInstall(v: SemVer): boolean {
+  if (v.major > minTalosMajor) return true
+  if (v.major < minTalosMajor) return false
+  return v.minor >= minTalosMinor
+}
+
+export function machineCompatibleWithCluster(
+  machine: Resource<MachineStatusSpec>,
+  clusterVersionStr: string,
+): CompatResult {
+  const clusterVersion = parse(clusterVersionStr)
+  const machineVersion = parse(machine.spec.talos_version)
+
+  if (!machineVersion) {
+    return {
+      ok: false,
+      willAutoInstall: false,
+      reason: "The machine's Talos version could not be determined.",
+    }
+  }
+
+  if (!clusterVersion) {
+    return {
+      ok: false,
+      willAutoInstall: false,
+      reason: 'The cluster Talos version could not be determined.',
+    }
+  }
+
+  const inAgentMode = !!machine.spec.schematic?.in_agent_mode
+  if (inAgentMode) {
+    return okResult
+  }
+
+  // Refuse downgrade.
+  if (
+    machineVersion.major > clusterVersion.major ||
+    (machineVersion.major === clusterVersion.major && machineVersion.minor > clusterVersion.minor)
+  ) {
+    return {
+      ok: false,
+      willAutoInstall: false,
+      reason:
+        'The machine has a newer Talos version installed: downgrade is not allowed. Upgrade the machine or change the cluster Talos version.',
+    }
+  }
+
+  const installed = machine.metadata.labels?.[MachineStatusLabelInstalled] !== undefined
+  if (installed) {
+    return okResult
+  }
+
+  if (
+    machineVersion.major === clusterVersion.major &&
+    machineVersion.minor === clusterVersion.minor
+  ) {
+    return okResult
+  }
+
+  if (supportsMaintenanceInstall(machineVersion) && supportsMaintenanceInstall(clusterVersion)) {
+    return okWithInstall(clusterVersionStr.replace(/^v/, ''))
+  }
+
+  return {
+    ok: false,
+    willAutoInstall: false,
+    reason:
+      'The machine running from ISO or PXE must have the same major and minor version as the cluster it is going to be added to. Please use another ISO or change the cluster Talos version.',
+  }
+}

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/scale.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/scale.vue
@@ -6,7 +6,6 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import pluralize from 'pluralize'
-import * as semver from 'semver'
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -22,7 +21,6 @@ import {
   LabelNoManualAllocation,
   MachineConfigGenOptionsType,
   MachineStatusLabelAvailable,
-  MachineStatusLabelInstalled,
   MachineStatusLabelInvalidState,
   MachineStatusLabelReadyToUse,
   MachineStatusLabelReportingEvents,
@@ -35,6 +33,7 @@ import PageHeader from '@/components/PageHeader.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import { ClusterCommandError, clusterSync } from '@/methods/cluster'
+import { machineCompatibleWithCluster } from '@/methods/compat'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showSuccess } from '@/notification'
 import { populateExisting, state } from '@/states/cluster-management'
@@ -93,35 +92,13 @@ const scaleCluster = async () => {
 }
 
 const detectVersionMismatch = (machine: Resource<MachineStatusSpec>) => {
-  const clusterVersion = semver.parse(state.value.cluster.talosVersion)
-  const machineVersion = semver.parse(machine.spec.talos_version)
+  const compat = machineCompatibleWithCluster(machine, state.value.cluster.talosVersion!)
+  return compat.ok ? null : compat.reason
+}
 
-  const installed = machine.metadata.labels?.[MachineStatusLabelInstalled] !== undefined
-  const inAgentMode = !!machine.spec.schematic?.in_agent_mode
-
-  if (!installed) {
-    if (
-      machineVersion?.major === clusterVersion?.major &&
-      machineVersion?.minor === clusterVersion?.minor
-    ) {
-      return null
-    }
-
-    if (inAgentMode) {
-      return null
-    }
-
-    return 'The machine running from ISO or PXE must have the same major and minor version as the cluster it is going to be added to. Please use another ISO or change the cluster Talos version'
-  }
-
-  if (
-    (machineVersion?.major ?? 0) <= (clusterVersion?.major ?? 0) &&
-    (machineVersion?.minor ?? 0) <= (clusterVersion?.minor ?? 0)
-  ) {
-    return null
-  }
-
-  return 'The machine has newer Talos version installed: downgrade is not allowed. Upgrade the machine or change Talos cluster version'
+const detectAutoInstallNotice = (machine: Resource<MachineStatusSpec>) => {
+  const compat = machineCompatibleWithCluster(machine, state.value.cluster.talosVersion!)
+  return compat.ok && compat.willAutoInstall ? compat.reason : null
 }
 
 const existingResources = ref<Resource[]>([])
@@ -203,6 +180,7 @@ const data = computed(() =>
           :key="itemID(item)"
           :item="item"
           :version-mismatch="detectVersionMismatch(item)"
+          :auto-install-notice="detectAutoInstallNotice(item)"
         />
       </template>
     </div>

--- a/frontend/src/pages/(authenticated)/clusters/create.vue
+++ b/frontend/src/pages/(authenticated)/clusters/create.vue
@@ -6,7 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { dump } from 'js-yaml'
-import { compare, parse } from 'semver'
+import { compare } from 'semver'
 import type { Ref } from 'vue'
 import { computed, onMounted, ref, useTemplateRef, watch, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
@@ -24,7 +24,6 @@ import {
   LabelNoManualAllocation,
   MachineConfigGenOptionsType,
   MachineStatusLabelAvailable,
-  MachineStatusLabelInstalled,
   MachineStatusLabelInvalidState,
   MachineStatusLabelReadyToUse,
   MachineStatusLabelReportingEvents,
@@ -46,6 +45,7 @@ import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { setupBackupStatus } from '@/methods'
 import { usePermissions } from '@/methods/auth'
 import { ClusterCommandError, clusterSync, nextAvailableClusterName } from '@/methods/cluster'
+import { machineCompatibleWithCluster } from '@/methods/compat'
 import { useFeatures } from '@/methods/features'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showModal } from '@/modal'
@@ -169,38 +169,13 @@ const createCluster = async () => {
 }
 
 const detectVersionMismatch = (machine: Resource<MachineStatusSpec>) => {
-  const clusterVersion = parse(state.value.cluster.talosVersion)
-  const machineVersion = parse(machine.spec.talos_version)
+  const compat = machineCompatibleWithCluster(machine, state.value.cluster.talosVersion!)
+  return compat.ok ? null : compat.reason
+}
 
-  const installed = machine.metadata.labels?.[MachineStatusLabelInstalled] !== undefined
-  const inAgentMode = !!machine.spec.schematic?.in_agent_mode
-
-  if (!machineVersion || !clusterVersion) {
-    return null
-  }
-
-  if (!installed) {
-    if (
-      machineVersion?.major === clusterVersion?.major &&
-      machineVersion?.minor === clusterVersion?.minor
-    ) {
-      return null
-    }
-
-    if (inAgentMode) {
-      return null
-    }
-
-    return 'The machine running from ISO or PXE must have the same major and minor version as the cluster it is going to be added to. Please use another ISO or change the cluster Talos version'
-  }
-  if (
-    machineVersion?.major <= clusterVersion?.major &&
-    machineVersion?.minor <= clusterVersion?.minor
-  ) {
-    return null
-  }
-
-  return 'The machine has newer Talos version installed: downgrade is not allowed. Upgrade the machine or change Talos cluster version'
+const detectAutoInstallNotice = (machine: Resource<MachineStatusSpec>) => {
+  const compat = machineCompatibleWithCluster(machine, state.value.cluster.talosVersion!)
+  return compat.ok && compat.willAutoInstall ? compat.reason : null
 }
 
 const createCluster_ = async (untaint: boolean) => {
@@ -421,6 +396,7 @@ const list = useTemplateRef('list')
             v-for="item in items"
             :key="itemID(item)"
             :version-mismatch="detectVersionMismatch(item)"
+            :auto-install-notice="detectAutoInstallNotice(item)"
             :reset="reset"
             :item="{
               ...item,

--- a/frontend/src/pages/(authenticated)/clusters/index.stories.ts
+++ b/frontend/src/pages/(authenticated)/clusters/index.stories.ts
@@ -41,6 +41,7 @@ import {
   LabelControlPlaneRole,
   LabelMachineSet,
   LabelWorkerRole,
+  MachineLocked,
   MachineSetStatusType,
   MachineSetType,
   MachineStatusLabelConnected,
@@ -57,6 +58,56 @@ const meta: Meta<typeof Clusters> = {
 
 export default meta
 type Story = StoryObj<typeof meta>
+
+const seedFromId = (id: string) => id.split('').reduce((prev, curr) => prev + curr.charCodeAt(0), 0)
+
+// Generates the machine statuses for a single machine set. faker is a sequential
+// PRNG, so reseeding from the machine-set label makes the generated UUIDs
+// deterministic — which lets the diagnostics handler reproduce the exact machine
+// IDs that belong to a given cluster without coordinating shared state.
+const clusterMachineStatuses = (
+  clusterLabel: string,
+  machineSetLabel: string,
+): Resource<ClusterMachineStatusSpec>[] => {
+  faker.seed(seedFromId(machineSetLabel))
+
+  const roleLabel = machineSetLabel.includes(ControlPlanesIDSuffix)
+    ? LabelControlPlaneRole
+    : LabelWorkerRole
+
+  return faker.helpers.multiple<Resource<ClusterMachineStatusSpec>>(
+    () => ({
+      spec: {
+        ready: faker.datatype.boolean(),
+        stage: faker.helpers.enumValue(ClusterMachineStatusSpecStage),
+        config_apply_status: faker.helpers.enumValue(ConfigApplyStatus),
+        last_config_error: faker.helpers.maybe(() => faker.hacker.phrase()),
+      },
+      metadata: {
+        id: faker.string.uuid(),
+        annotations: faker.helpers.maybe(() => ({ [MachineLocked]: '' })),
+        labels: {
+          [LabelCluster]: clusterLabel,
+          [LabelMachineSet]: machineSetLabel,
+          [roleLabel]: '',
+          ...faker.helpers.maybe(() => ({ [MachineStatusLabelConnected]: '' })),
+          ...faker.helpers.maybe(() => ({ [UpdateLocked]: '' })),
+        },
+      },
+    }),
+    { count: { min: 0, max: 5 } },
+  )
+}
+
+// Reproduces the machine IDs of every machine set in a cluster, mirroring how
+// MachineSet handler derives the control-plane/worker machine-set IDs.
+const clusterMachineIds = (clusterLabel: string): string[] =>
+  [`${clusterLabel}-${ControlPlanesIDSuffix}`, `${clusterLabel}-${DefaultWorkersIDSuffix}`].flatMap(
+    (machineSetLabel) =>
+      clusterMachineStatuses(clusterLabel, machineSetLabel).map(
+        (machine) => machine.metadata.id ?? '',
+      ),
+  )
 
 export const Data: Story = {
   parameters: {
@@ -148,7 +199,17 @@ export const Data: Story = {
             type: ClusterDiagnosticsType,
             namespace: DefaultNamespace,
           },
-          initialResources: [{ spec: { nodes: [] }, metadata: {} }],
+          initialResources: ({ id: clusterID = '' }) => {
+            const machineIds = clusterMachineIds(clusterID)
+
+            faker.seed(seedFromId(clusterID))
+
+            const nodes = machineIds
+              .filter(() => faker.datatype.boolean())
+              .map((id) => ({ id, num_diagnostics: faker.number.int({ min: 1, max: 10 }) }))
+
+            return [{ spec: { nodes }, metadata: { id: clusterID } }]
+          },
         }).handler,
 
         createWatchStreamHandler<MachineSetStatusSpec>({
@@ -204,31 +265,7 @@ export const Data: Story = {
               [LabelCluster]: clusterLabel = '',
               [LabelMachineSet]: machineSetLabel = '',
             } = {},
-          }) => {
-            faker.seed(
-              machineSetLabel.split('').reduce((prev, curr) => prev + curr.charCodeAt(0), 0),
-            )
-
-            return faker.helpers.multiple<Resource<ClusterMachineStatusSpec>>(
-              () => ({
-                spec: {
-                  ready: faker.datatype.boolean(),
-                  stage: faker.helpers.enumValue(ClusterMachineStatusSpecStage),
-                  config_apply_status: faker.helpers.enumValue(ConfigApplyStatus),
-                },
-                metadata: {
-                  id: faker.string.uuid(),
-                  labels: {
-                    [LabelCluster]: clusterLabel,
-                    [LabelMachineSet]: machineSetLabel,
-                    ...faker.helpers.maybe(() => ({ [MachineStatusLabelConnected]: '' })),
-                    ...faker.helpers.maybe(() => ({ [UpdateLocked]: '' })),
-                  },
-                },
-              }),
-              { count: { min: 0, max: 5 } },
-            )
-          },
+          }) => clusterMachineStatuses(clusterLabel, machineSetLabel),
         }).handler,
 
         createWatchStreamHandler<ClusterMachineRequestStatusSpec>({

--- a/frontend/src/pages/(authenticated)/clusters/index.vue
+++ b/frontend/src/pages/(authenticated)/clusters/index.vue
@@ -136,7 +136,7 @@ const filterOptions = [
         />
       </template>
       <template #default="{ items, searchQuery }">
-        <div class="grid grid-cols-[repeat(4,1fr)_--spacing(18)] gap-3">
+        <div class="grid grid-cols-[repeat(4,1fr)_--spacing(24)] gap-3">
           <div
             class="col-span-full grid grid-cols-subgrid bg-naturals-n2 px-3 py-2.5 text-xs max-lg:hidden"
           >

--- a/frontend/src/views/ClusterMachines/ClusterMachine.vue
+++ b/frontend/src/views/ClusterMachines/ClusterMachine.vue
@@ -121,6 +121,10 @@ const updateLock = async () => {
     </div>
 
     <div class="flex items-center justify-end">
+      <Tooltip v-if="machine.spec.last_config_error" :description="machine.spec.last_config_error">
+        <TIcon icon="error" class="mx-1.5 h-4 w-4 text-red-400" />
+      </Tooltip>
+
       <Tooltip
         v-if="hasDiagnosticInfo"
         description="This node has diagnostic warnings. Click to see the details."

--- a/frontend/src/views/ClusterMachines/MachineSet.vue
+++ b/frontend/src/views/ClusterMachines/MachineSet.vue
@@ -175,7 +175,7 @@ function isMachineSetScalable(
     :value="machineSetId"
     class="grid border-t-8 border-naturals-n4 text-naturals-n14"
     :class="
-      isSubgrid ? 'col-span-full grid-cols-subgrid' : 'grid-cols-[repeat(4,1fr)_--spacing(18)]'
+      isSubgrid ? 'col-span-full grid-cols-subgrid' : 'grid-cols-[repeat(4,1fr)_--spacing(24)]'
     "
     :aria-labelledby="sectionHeadingId"
     v-bind="$attrs"

--- a/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
@@ -43,11 +43,13 @@ const {
   reset = undefined,
   searchQuery = undefined,
   versionMismatch,
+  autoInstallNotice = null,
 } = defineProps<{
   item: Resource<MachineStatusSpec & MachineConfigGenOptionsSpec>
   reset?: number
   searchQuery?: string
   versionMismatch: string | null
+  autoInstallNotice?: string | null
 }>()
 
 const machineSetNode = ref<MachineSetNode>({
@@ -126,31 +128,41 @@ const options = computed(() => {
   const canUseAsWorker = memoryCapacity === 0 || memoryCapacity >= workerMemoryTheshold
 
   return state.value.machineSets.map<PickerOption>((ms) => {
-    let disabled = ms.role === LabelControlPlaneRole ? !canUseAsControlPlane : !canUseAsWorker
-    let tooltip: string | undefined
+    const reasons: string[] = []
+    let disabled = false
 
-    if (disabled) {
-      if (ms.role === LabelControlPlaneRole) {
-        tooltip = `The node must have more than ${prettyBytes(cpMemoryThreshold * 1024 * 1024, { binary: true })} of RAM to be used as a control plane`
-      } else {
-        tooltip = `The node must have more than ${prettyBytes(workerMemoryTheshold * 1024 * 1024, { binary: true })} of RAM to be used as a worker`
-      }
+    if (ms.role === LabelControlPlaneRole && !canUseAsControlPlane) {
+      disabled = true
+      reasons.push(
+        `The node must have more than ${prettyBytes(cpMemoryThreshold * 1024 * 1024, { binary: true })} of RAM to be used as a control plane`,
+      )
+    } else if (ms.role !== LabelControlPlaneRole && !canUseAsWorker) {
+      disabled = true
+      reasons.push(
+        `The node must have more than ${prettyBytes(workerMemoryTheshold * 1024 * 1024, { binary: true })} of RAM to be used as a worker`,
+      )
     }
 
     if (ms.machineAllocation) {
       disabled = true
-      tooltip = `The machine class ${ms.id} is using machine class so no manual allocation is possible`
+      reasons.push(
+        `The machine class ${ms.id} is using machine class so no manual allocation is possible`,
+      )
     }
 
     if (versionMismatch) {
       disabled = true
-      tooltip = versionMismatch
+      reasons.push(versionMismatch)
+    }
+
+    if (autoInstallNotice) {
+      reasons.push(autoInstallNotice)
     }
 
     return {
       id: ms.id,
       disabled: disabled,
-      tooltip: tooltip,
+      tooltip: reasons.length > 0 ? reasons.join('\n\n') : undefined,
       labelClass: ms.labelClass,
     }
   })

--- a/frontend/src/views/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/Overview/components/OverviewContent.vue
@@ -13,6 +13,7 @@ import { computed, ref, watchEffect } from 'vue'
 import { Runtime } from '@/api/common/omni.pb'
 import { type Resource, ResourceService } from '@/api/grpc'
 import {
+  type ClusterMachineStatusSpec,
   type ClusterSecretsRotationStatusSpec,
   type ClusterSpec,
   type ClusterStatusSpec,
@@ -26,11 +27,13 @@ import {
 import { withRuntime } from '@/api/options'
 import {
   ClusterLocked,
+  ClusterMachineStatusType,
   ClusterSecretsRotationStatusType,
   ClusterStatusType,
   DefaultNamespace,
   KubernetesUpgradeStatusType,
   KubernetesUsageType,
+  LabelCluster,
   TalosUpgradeStatusType,
   VirtualNamespace,
 } from '@/api/resources'
@@ -159,6 +162,19 @@ async function setClusterEtcdBackupsConfig(spec: ClusterSpec) {
   await ResourceService.Update(resource, currentCluster.metadata.version, withRuntime(Runtime.Omni))
 }
 
+const { data: clusterMachineStatuses } = useResourceWatch<ClusterMachineStatusSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: ClusterMachineStatusType,
+  },
+  selectors: [`${LabelCluster}=${clusterId.value}`],
+}))
+
+const machinesWithErrors = computed(() =>
+  clusterMachineStatuses.value.filter((m) => !!m.spec.last_config_error),
+)
+
 const { data: secretRotationStatus } = useResourceWatch<ClusterSecretsRotationStatusSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
@@ -200,6 +216,14 @@ const machineLockedForSecretRotation = computed(() => {
       <TAlert v-if="clusterLocked" title="Cluster is Locked" type="warn" class="mb-4">
         All operations on this cluster are currently disabled. Config patches can be created,
         updated or deleted but these changes will not be applied while the cluster is locked.
+      </TAlert>
+      <TAlert
+        v-if="machinesWithErrors.length > 0"
+        :title="`${machinesWithErrors.length} ${machinesWithErrors.length === 1 ? 'machine has' : 'machines have'} configuration errors`"
+        type="error"
+        class="mb-4"
+      >
+        Open the cluster machine detail page for each affected node to view the error and recover.
       </TAlert>
       <div class="relative mb-6 min-h-25 bg-naturals-n2 p-5">
         <div
@@ -427,7 +451,7 @@ const machineLockedForSecretRotation = computed(() => {
         <div class="flex px-6 pb-4">
           <span class="text-sm text-naturals-n13">Machines</span>
         </div>
-        <div class="grid grid-cols-[repeat(4,1fr)_--spacing(18)]">
+        <div class="grid grid-cols-[repeat(4,1fr)_--spacing(24)]">
           <ClusterMachines is-subgrid :cluster-i-d="clusterId" />
         </div>
       </div>

--- a/internal/backend/grpc/configs_test.go
+++ b/internal/backend/grpc/configs_test.go
@@ -65,7 +65,7 @@ func TestGenerateConfigs(t *testing.T) {
 
 	rt, err := omniruntime.NewRuntime(config.Default(), nil, nil, nil,
 		nil, nil, nil, nil, nil, st, prometheus.NewRegistry(),
-		nil, kubernetesRuntime, nil, logging.IncreaseLevel(logger, zap.InfoLevel))
+		nil, kubernetesRuntime, nil, nil, logging.IncreaseLevel(logger, zap.InfoLevel))
 	require.NoError(t, err)
 
 	clusterName := "cluster1"

--- a/internal/backend/grpc/export_test.go
+++ b/internal/backend/grpc/export_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/siderolabs/omni/internal/backend/imagefactory"
 	"github.com/siderolabs/omni/internal/backend/runtime"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
@@ -32,6 +33,7 @@ func NewManagementServer(st state.State, imageFactoryClient *imagefactory.Client
 		cfg:                 &config.Params{Features: config.Features{EnableBreakGlassConfigs: new(enableBreakGlassConfigs)}},
 		kubernetesRuntime:   kubernetesRuntime,
 		talosconfigProvider: talosconfigProvider,
+		lifecycleManager:    lifecycle.NewManager(logger, "test-factory", "ghcr.io/siderolabs/installer"),
 	}
 
 	for _, opt := range opts {
@@ -55,14 +57,11 @@ func WithAuditLogger(auditor AuditLogger) ManagementServerOption {
 	}
 }
 
-// CheckMaintenanceLifecycleTalosVersion exposes the in-memory version gate for testing.
-func CheckMaintenanceLifecycleTalosVersion(version string) error {
-	return checkMaintenanceLifecycleTalosVersion(version)
-}
-
-// ClaimMaintenanceLifecycleSlot pre-claims the in-flight slot for a machine, simulating a concurrent lifecycle operation.
-func (s *ManagementServer) ClaimMaintenanceLifecycleSlot(machineID string) {
-	s.maintenanceLifecycleInFlight.Store(machineID, struct{}{})
+// WithLifecycleManager overrides the lifecycle manager on a test management server.
+func WithLifecycleManager(m LifecycleManager) ManagementServerOption {
+	return func(server *ManagementServer) {
+		server.lifecycleManager = m
+	}
 }
 
 func NewAuthServer(st state.State, services config.Services, logger *zap.Logger) (*AuthServer, error) {

--- a/internal/backend/grpc/grpc.go
+++ b/internal/backend/grpc/grpc.go
@@ -31,6 +31,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/monitoring"
 	"github.com/siderolabs/omni/internal/backend/runtime"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 	"github.com/siderolabs/omni/internal/memconn"
 	"github.com/siderolabs/omni/internal/pkg/compress"
 	"github.com/siderolabs/omni/internal/pkg/config"
@@ -58,6 +59,7 @@ func MakeServiceServers(
 	kubernetesRuntime KubernetesRuntime,
 	talosRuntime TalosRuntime,
 	runtimes map[string]runtime.Runtime,
+	lifecycleManager *lifecycle.Manager,
 ) iter.Seq2[ServiceServer, error] {
 	dest, err := generateDest(cfg.Services.Api.URL())
 	if err != nil {
@@ -99,6 +101,7 @@ func MakeServiceServers(
 			kubernetesRuntime,
 			talosRuntime,
 			omniRuntime,
+			lifecycleManager,
 		),
 		auth,
 		&COSIResourceServer{

--- a/internal/backend/grpc/grpc_test.go
+++ b/internal/backend/grpc/grpc_test.go
@@ -103,7 +103,7 @@ func (suite *GrpcSuite) SetupTest() {
 	suite.runtime, err = omniruntime.NewRuntime(
 		config.Default(), clientFactory, dnsService, workloadProxyReconciler, nil,
 		imageFactoryClient, nil, nil, nil, st,
-		prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, nil, logging.IncreaseLevel(logger, zap.InfoLevel),
+		prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, nil, nil, logging.IncreaseLevel(logger, zap.InfoLevel),
 	)
 	suite.Require().NoError(err)
 

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -58,6 +57,7 @@ import (
 	omniCtrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validations"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
@@ -92,9 +92,16 @@ type JWTSigningKeyProvider interface {
 	SigningKey(ctx context.Context) (op.SigningKey, error)
 }
 
+// LifecycleManager performs maintenance-mode Talos install/upgrade operations on a single machine.
+type LifecycleManager interface {
+	SupportsLifecycleManagement(version string) error
+	Run(ctx context.Context, op lifecycle.Operation, opts ...lifecycle.Option) error
+}
+
 func newManagementServer(cfg *config.Params, omniState state.State, jwtSigningKeyProvider JWTSigningKeyProvider, logHandler *siderolinkinternal.LogHandler, logger *zap.Logger,
 	dnsService *dns.Service, imageFactoryClient *imagefactory.Client, auditor AuditLogger, omniconfigDest string,
 	kubernetesRuntime KubernetesRuntime, talosRuntime TalosRuntime, talosconfigProvider TalosconfigProvider,
+	lifecycleManager LifecycleManager,
 ) *managementServer {
 	return &managementServer{
 		cfg:                   cfg,
@@ -109,25 +116,26 @@ func newManagementServer(cfg *config.Params, omniState state.State, jwtSigningKe
 		kubernetesRuntime:     kubernetesRuntime,
 		talosRuntime:          talosRuntime,
 		talosconfigProvider:   talosconfigProvider,
+		lifecycleManager:      lifecycleManager,
 	}
 }
 
 // managementServer implements omni management service.
 type managementServer struct {
+	cfg                   *config.Params
+	kubernetesRuntime     KubernetesRuntime
+	jwtSigningKeyProvider JWTSigningKeyProvider
+	auditor               AuditLogger
+	talosconfigProvider   TalosconfigProvider
+	talosRuntime          TalosRuntime
+	logHandler            *siderolinkinternal.LogHandler
+	logger                *zap.Logger
+	dnsService            *dns.Service
+	imageFactoryClient    *imagefactory.Client
+	lifecycleManager      LifecycleManager
 	management.UnimplementedManagementServiceServer
-	cfg                          *config.Params
-	kubernetesRuntime            KubernetesRuntime
-	omniState                    state.State
-	jwtSigningKeyProvider        JWTSigningKeyProvider
-	auditor                      AuditLogger
-	talosconfigProvider          TalosconfigProvider
-	talosRuntime                 TalosRuntime
-	logHandler                   *siderolinkinternal.LogHandler
-	logger                       *zap.Logger
-	dnsService                   *dns.Service
-	imageFactoryClient           *imagefactory.Client
-	omniconfigDest               string
-	maintenanceLifecycleInFlight sync.Map
+	omniState      state.State
+	omniconfigDest string
 }
 
 func (s *managementServer) register(server grpc.ServiceRegistrar) {
@@ -679,19 +687,9 @@ func (s *managementServer) MaintenanceUpgrade(ctx context.Context, req *manageme
 	return &management.MaintenanceUpgradeResponse{}, nil
 }
 
-// maintenanceLifecycleMinTalosVersion is the minimum Talos version that exposes the LifecycleService.Install/Upgrade APIs that this RPC drives.
-var maintenanceLifecycleMinTalosVersion = semver.MustParse("1.13.0")
-
-// maintenanceLifecycleTimeout caps how long a single MaintenanceLifecycle RPC can run server-side once the underlying Talos calls have been detached from the client stream.
-// It needs to cover the slowest realistic image pull plus the actual disk write.
-const maintenanceLifecycleTimeout = 15 * time.Minute
-
-// maintenanceRebootTimeout is the deadline for the post-operation reboot RPC.
-const maintenanceRebootTimeout = time.Minute
-
 // MaintenanceLifecycle installs or upgrades Talos on disk for a machine running in maintenance mode, streaming installer progress.
 //
-//nolint:gocyclo,cyclop,gocognit,maintidx
+//nolint:gocyclo,cyclop,gocognit
 func (s *managementServer) MaintenanceLifecycle(
 	req *management.MaintenanceLifecycleRequest,
 	srv grpc.ServerStreamingServer[management.MaintenanceLifecycleResponse],
@@ -717,11 +715,15 @@ func (s *managementServer) MaintenanceLifecycle(
 		return status.Error(codes.InvalidArgument, "machine id is required")
 	}
 
+	var opKind lifecycle.Kind
+
 	switch req.Operation {
 	case management.MaintenanceLifecycleRequest_OPERATION_INSTALL:
 		if req.Disk == "" {
 			return status.Error(codes.InvalidArgument, "disk is required for INSTALL")
 		}
+
+		opKind = lifecycle.KindInstall
 	case management.MaintenanceLifecycleRequest_OPERATION_UPGRADE:
 		if req.Disk != "" {
 			return status.Error(codes.InvalidArgument, "disk must not be set for UPGRADE")
@@ -730,6 +732,8 @@ func (s *managementServer) MaintenanceLifecycle(
 		if req.Version == "" {
 			return status.Error(codes.InvalidArgument, "version is required for UPGRADE")
 		}
+
+		opKind = lifecycle.KindUpgrade
 	case management.MaintenanceLifecycleRequest_OPERATION_UNSPECIFIED:
 		fallthrough
 	default:
@@ -742,14 +746,18 @@ func (s *managementServer) MaintenanceLifecycle(
 			return status.Error(codes.NotFound, "machine not found")
 		}
 
-		return wrapLifecycleErr(err, "failed to get machine status")
+		return lifecycle.WrapErr(err, "failed to get machine status")
 	}
 
 	if !machineStatus.TypedSpec().Value.Maintenance {
 		return status.Error(codes.FailedPrecondition, "machine is not in maintenance mode")
 	}
 
-	if err = checkMaintenanceLifecycleTalosVersion(machineStatus.TypedSpec().Value.TalosVersion); err != nil {
+	if _, allocated := machineStatus.Metadata().Labels().Get(omnires.LabelCluster); allocated {
+		return status.Error(codes.FailedPrecondition, "machine is allocated to a cluster; its Talos lifecycle is managed by Omni")
+	}
+
+	if err = s.lifecycleManager.SupportsLifecycleManagement(machineStatus.TypedSpec().Value.TalosVersion); err != nil {
 		return err
 	}
 
@@ -781,69 +789,17 @@ func (s *managementServer) MaintenanceLifecycle(
 		}
 	}
 
-	if _, loaded := s.maintenanceLifecycleInFlight.LoadOrStore(req.MachineId, struct{}{}); loaded {
-		return status.Errorf(codes.FailedPrecondition, "a maintenance lifecycle operation is already in progress for machine %q", req.MachineId)
-	}
-
-	defer s.maintenanceLifecycleInFlight.Delete(req.MachineId)
-
-	platform := machineStatus.TypedSpec().Value.GetPlatformMetadata().GetPlatform()
-	if platform == "" {
-		return status.Error(codes.FailedPrecondition, "machine platform is not known yet")
-	}
-
-	securityState := machineStatus.TypedSpec().Value.SecurityState
-	if securityState == nil {
-		return status.Error(codes.FailedPrecondition, "machine security state is not known yet")
-	}
-
-	version := req.Version
-	if version == "" {
-		version = strings.TrimPrefix(machineStatus.TypedSpec().Value.TalosVersion, "v")
-	}
-
-	installImage := &specs.MachineConfigGenOptionsSpec_InstallImage{
-		TalosVersion:         version,
-		SchematicId:          machineStatus.TypedSpec().Value.Schematic.FullId,
-		SchematicInitialized: true,
-		SchematicInvalid:     machineStatus.TypedSpec().Value.Schematic.Invalid,
-		Platform:             platform,
-		SecurityState:        securityState,
-	}
-
-	installImageStr, err := installimage.Build(s.imageFactoryClient.Host(), req.MachineId, installImage, s.cfg.Registries.GetTalos())
-	if err != nil {
-		return wrapLifecycleErr(err, "failed to build install image")
-	}
-
-	s.logger.Info("built maintenance lifecycle image", zap.String("image", installImageStr), zap.String("version", version))
-
-	address := machineStatus.TypedSpec().Value.ManagementAddress
-	opts := talos.GetSocketOptions(address)
-	opts = append(opts, client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}), client.WithEndpoints(address))
-
-	talosClient, err := client.New(authCtx, opts...)
-	if err != nil {
-		return wrapLifecycleErr(err, "failed to create talos client")
-	}
-
-	defer talosClient.Close() //nolint:errcheck
-
-	// Detach the operation from the client stream so that it can continue running even if the client disconnects.
-	installCtx, cancel := context.WithTimeout(context.WithoutCancel(authCtx), maintenanceLifecycleTimeout)
-	defer cancel()
-
 	// Best-effort progress send: once the client is gone we keep the operation running and just stop
 	// trying to relay events. The first send failure is logged so operators can correlate disconnects;
 	// subsequent failures are silently swallowed.
 	var disconnectLogged bool
 
-	send := func(resp *management.MaintenanceLifecycleResponse) {
+	send := func(msg string) {
 		if srv.Context().Err() != nil {
 			return
 		}
 
-		if sendErr := srv.Send(resp); sendErr != nil && !disconnectLogged {
+		if sendErr := srv.Send(&management.MaintenanceLifecycleResponse{Message: msg}); sendErr != nil && !disconnectLogged {
 			disconnectLogged = true
 
 			s.logger.Info(
@@ -854,80 +810,31 @@ func (s *managementServer) MaintenanceLifecycle(
 		}
 	}
 
-	containerd := &common.ContainerdInstance{
-		Driver:    common.ContainerDriver_CONTAINERD,
-		Namespace: common.ContainerdNamespace_NS_SYSTEM,
-	}
-
-	// LifecycleService.Install/Upgrade do not pull from a registry; they expect the image to already be present in the machine's containerd store.
-	resolvedImage, err := s.pullInstallerImage(installCtx, talosClient, containerd, installImageStr, req.MachineId, send)
-	if err != nil {
-		return wrapLifecycleErr(err, "failed to pull installer image")
-	}
-
-	switch req.Operation { //nolint:exhaustive
-	case management.MaintenanceLifecycleRequest_OPERATION_INSTALL:
-		if err = s.streamMaintenanceInstall(installCtx, talosClient, containerd, resolvedImage, req.Disk, req.MachineId, send); err != nil {
-			return err
-		}
-	case management.MaintenanceLifecycleRequest_OPERATION_UPGRADE:
-		if err = s.streamMaintenanceUpgrade(installCtx, talosClient, containerd, resolvedImage, req.MachineId, send); err != nil {
-			return err
-		}
-	}
-
-	return s.rebootAfterMaintenanceLifecycle(installCtx, talosClient, req.MachineId, send)
-}
-
-// rebootAfterMaintenanceLifecycle reboots the machine after a successful install or upgrade so it boots from disk into the freshly written Talos.
-func (s *managementServer) rebootAfterMaintenanceLifecycle(
-	ctx context.Context,
-	talosClient *client.Client,
-	machineID string,
-	send func(*management.MaintenanceLifecycleResponse),
-) error {
-	send(&management.MaintenanceLifecycleResponse{Message: "[omni] rebooting machine to boot into installed Talos"})
-
-	if err := s.auditTalosAccess(ctx, machineapi.MachineService_Reboot_FullMethodName, "", machineID); err != nil {
-		return err
-	}
-
-	// Renew the context with a new timeout to prevent the reboot operation from being cut short by the install/upgrade timeout.
-	rebootCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), maintenanceRebootTimeout)
+	// Detach the operation from the client stream so that it can continue running even if the client disconnects.
+	runCtx, cancel := context.WithTimeout(context.WithoutCancel(authCtx), lifecycle.MaintenanceLifecycleTimeout)
 	defer cancel()
 
-	if err := talosClient.Reboot(rebootCtx); err != nil {
-		return wrapLifecycleErr(err, "failed to reboot machine after lifecycle operation")
+	operation := lifecycle.Operation{
+		MachineID:     req.MachineId,
+		MachineStatus: machineStatus,
+		Kind:          opKind,
+		Version:       req.Version,
+		Disk:          req.Disk,
 	}
 
-	return nil
-}
-
-func wrapLifecycleErr(err error, prefix string) error {
-	if err == nil {
-		return nil
-	}
-
-	if s, ok := status.FromError(err); ok {
-		return status.Errorf(s.Code(), "%s: %s", prefix, s.Message())
-	}
-
-	return status.Errorf(codes.Internal, "%s: %v", prefix, err)
-}
-
-// checkMaintenanceLifecycleTalosVersion verifies the machine runs a Talos version exposing the LifecycleService.Install/Upgrade APIs.
-func checkMaintenanceLifecycleTalosVersion(version string) error {
-	parsed, err := semver.ParseTolerant(version)
+	err = s.lifecycleManager.Run(
+		runCtx, operation,
+		lifecycle.WithProgress(send),
+		lifecycle.WithAudit(func(auditCtx context.Context, fullMethodName, machineID string) error {
+			return s.auditTalosAccess(auditCtx, fullMethodName, "", machineID)
+		}),
+	)
 	if err != nil {
-		return status.Errorf(codes.FailedPrecondition, "failed to parse machine Talos version %q: %v", version, err)
-	}
+		if errors.Is(err, lifecycle.ErrAlreadyInFlight) {
+			return status.Errorf(codes.FailedPrecondition, "a maintenance lifecycle operation is already in progress for machine %q", req.MachineId)
+		}
 
-	parsed.Pre = nil
-	parsed.Build = nil
-
-	if parsed.LT(maintenanceLifecycleMinTalosVersion) {
-		return status.Errorf(codes.FailedPrecondition,
-			"the lifecycle API requires Talos %s or newer, machine is running %q", maintenanceLifecycleMinTalosVersion, version)
+		return err
 	}
 
 	return nil
@@ -947,7 +854,7 @@ func (s *managementServer) checkTalosUpgradeTarget(
 				"requested Talos version %q is not tracked by this Omni release", targetVersion)
 		}
 
-		return wrapLifecycleErr(err, fmt.Sprintf("failed to look up Talos version %q", targetID))
+		return lifecycle.WrapErr(err, fmt.Sprintf("failed to look up Talos version %q", targetID))
 	}
 
 	if targetTalosVersion.TypedSpec().Value.Unsupported {
@@ -968,7 +875,7 @@ func (s *managementServer) checkTalosUpgradeTarget(
 				"no upgrade targets available: machine is running an untracked Talos version %q", currentVersion)
 		}
 
-		return wrapLifecycleErr(err, fmt.Sprintf("failed to look up TalosVersion %q", sourceID))
+		return lifecycle.WrapErr(err, fmt.Sprintf("failed to look up TalosVersion %q", sourceID))
 	}
 
 	if slices.Contains(sourceTalosVersion.TypedSpec().Value.UpgradableTalosVersions, targetID) {
@@ -978,170 +885,6 @@ func (s *managementServer) checkTalosUpgradeTarget(
 	return status.Errorf(codes.FailedPrecondition,
 		"requested Talos version %q is not a supported target from the version running in memory (%q)",
 		targetVersion, currentVersion)
-}
-
-// pullInstallerImage pulls the installer image into the machine's containerd and returns the resolved image name, as required by LifecycleService.{Install,Upgrade}'s InstallArtifactsSource.
-func (s *managementServer) pullInstallerImage(
-	ctx context.Context,
-	talosClient *client.Client,
-	containerd *common.ContainerdInstance,
-	imageRef, machineID string,
-	send func(*management.MaintenanceLifecycleResponse),
-) (string, error) {
-	send(&management.MaintenanceLifecycleResponse{Message: fmt.Sprintf("[omni] pulling installer image %s", imageRef)})
-
-	if err := s.auditTalosAccess(ctx, machineapi.ImageService_Pull_FullMethodName, "", machineID); err != nil {
-		return "", err
-	}
-
-	pullClient, err := talosClient.ImageClient.Pull(ctx, &machineapi.ImageServicePullRequest{
-		Containerd: containerd,
-		ImageRef:   imageRef,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	if err = pullClient.CloseSend(); err != nil {
-		return "", err
-	}
-
-	var resolved string
-
-	for {
-		msg, recvErr := pullClient.Recv()
-		if recvErr != nil {
-			if errors.Is(recvErr, io.EOF) {
-				break
-			}
-
-			return "", recvErr
-		}
-
-		if name := msg.GetName(); name != "" {
-			resolved = name
-		}
-	}
-
-	if resolved == "" {
-		resolved = imageRef
-	}
-
-	send(&management.MaintenanceLifecycleResponse{Message: fmt.Sprintf("[omni] installer image pulled: %s", resolved)})
-
-	return resolved, nil
-}
-
-// streamMaintenanceInstall runs LifecycleService.Install and relays installer progress via the provided send closure.
-func (s *managementServer) streamMaintenanceInstall(
-	ctx context.Context,
-	talosClient *client.Client,
-	containerd *common.ContainerdInstance,
-	imageRef, disk, machineID string,
-	send func(*management.MaintenanceLifecycleResponse),
-) error {
-	if err := s.auditTalosAccess(ctx, machineapi.LifecycleService_Install_FullMethodName, "", machineID); err != nil {
-		return err
-	}
-
-	installClient, err := talosClient.LifecycleClient.Install(ctx, &machineapi.LifecycleServiceInstallRequest{
-		Containerd: containerd,
-		Source: &machineapi.InstallArtifactsSource{
-			ImageName: imageRef,
-		},
-		Destination: &machineapi.InstallDestination{
-			Disk: disk,
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	if err = installClient.CloseSend(); err != nil {
-		return err
-	}
-
-	for {
-		msg, recvErr := installClient.Recv()
-		if recvErr != nil {
-			if errors.Is(recvErr, io.EOF) {
-				return nil
-			}
-
-			return recvErr
-		}
-
-		if err = relayLifecycleProgress(msg.GetProgress(), "installation", send); err != nil {
-			return err
-		}
-	}
-}
-
-// streamMaintenanceUpgrade runs LifecycleService.Upgrade and relays installer progress via the provided send closure.
-func (s *managementServer) streamMaintenanceUpgrade(
-	ctx context.Context,
-	talosClient *client.Client,
-	containerd *common.ContainerdInstance,
-	imageRef, machineID string,
-	send func(*management.MaintenanceLifecycleResponse),
-) error {
-	if err := s.auditTalosAccess(ctx, machineapi.LifecycleService_Upgrade_FullMethodName, "", machineID); err != nil {
-		return err
-	}
-
-	upgradeClient, err := talosClient.LifecycleClient.Upgrade(ctx, &machineapi.LifecycleServiceUpgradeRequest{
-		Containerd: containerd,
-		Source: &machineapi.InstallArtifactsSource{
-			ImageName: imageRef,
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	if err = upgradeClient.CloseSend(); err != nil {
-		return err
-	}
-
-	for {
-		msg, recvErr := upgradeClient.Recv()
-		if recvErr != nil {
-			if errors.Is(recvErr, io.EOF) {
-				return nil
-			}
-
-			return recvErr
-		}
-
-		if err = relayLifecycleProgress(msg.GetProgress(), "upgrade", send); err != nil {
-			return err
-		}
-	}
-}
-
-func relayLifecycleProgress(
-	progress *machineapi.LifecycleServiceInstallProgress,
-	operationLabel string,
-	send func(*management.MaintenanceLifecycleResponse),
-) error {
-	switch payload := progress.GetResponse().(type) {
-	case *machineapi.LifecycleServiceInstallProgress_Message:
-		// Talos's installer container coalesces multiple log.Printf calls into a single message. Split on '\n' and trim trailing whitespace.
-		for line := range strings.SplitSeq(progress.GetMessage(), "\n") {
-			line = strings.TrimRight(line, " \t\r")
-			if line == "" {
-				continue
-			}
-
-			send(&management.MaintenanceLifecycleResponse{Message: "[talos] " + line})
-		}
-	case *machineapi.LifecycleServiceInstallProgress_ExitCode:
-		if payload.ExitCode != 0 {
-			return status.Errorf(codes.Internal, "%s failed with exit code %d", operationLabel, payload.ExitCode)
-		}
-	}
-
-	return nil
 }
 
 func (s *managementServer) GetMachineJoinConfig(ctx context.Context, request *management.GetMachineJoinConfigRequest) (*management.GetMachineJoinConfigResponse, error) {

--- a/internal/backend/grpc/management_lifecycle_test.go
+++ b/internal/backend/grpc/management_lifecycle_test.go
@@ -22,38 +22,10 @@ import (
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	grpcomni "github.com/siderolabs/omni/internal/backend/grpc"
 	omniruntime "github.com/siderolabs/omni/internal/backend/runtime/omni"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
-
-func TestCheckMaintenanceLifecycleTalosVersion(t *testing.T) {
-	for _, tt := range []struct {
-		name    string
-		version string
-		wantErr bool
-	}{
-		{name: "supported", version: "v1.13.0", wantErr: false},
-		{name: "supported without v prefix", version: "1.13.2", wantErr: false},
-		{name: "supported newer minor", version: "v1.14.0", wantErr: false},
-		{name: "supported pre-release", version: "v1.13.0-beta.1", wantErr: false},
-		{name: "too old", version: "v1.12.5", wantErr: true},
-		{name: "much older", version: "v1.9.0", wantErr: true},
-		{name: "unparseable", version: "not-a-version", wantErr: true},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			err := grpcomni.CheckMaintenanceLifecycleTalosVersion(tt.version)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				require.Equal(t, codes.FailedPrecondition, status.Code(err))
-
-				return
-			}
-
-			require.NoError(t, err)
-		})
-	}
-}
 
 func TestMaintenanceLifecycleGuards(t *testing.T) {
 	const (
@@ -237,9 +209,9 @@ func TestMaintenanceLifecycleInFlightGuard(t *testing.T) {
 	talosVersion.TypedSpec().Value.UpgradableTalosVersions = []string{"1.13.0"}
 	require.NoError(t, st.Create(actor.MarkContextAsInternalActor(t.Context()), talosVersion))
 
-	server := grpcomni.NewManagementServer(st, nil, zaptest.NewLogger(t), false, nil, nil)
+	manager := fakeLifecycleManager{runErr: lifecycle.ErrAlreadyInFlight}
 
-	server.ClaimMaintenanceLifecycleSlot(machineID)
+	server := grpcomni.NewManagementServer(st, nil, zaptest.NewLogger(t), false, nil, nil, grpcomni.WithLifecycleManager(manager))
 
 	ctx := managementPowerTestContext(t.Context(), identityID, role.Operator)
 
@@ -256,6 +228,16 @@ func TestMaintenanceLifecycleInFlightGuard(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err), "unexpected status: %v", err)
 	require.Contains(t, status.Convert(err).Message(), "already in progress")
+}
+
+type fakeLifecycleManager struct {
+	runErr error
+}
+
+func (fakeLifecycleManager) SupportsLifecycleManagement(string) error { return nil }
+
+func (f fakeLifecycleManager) Run(context.Context, lifecycle.Operation, ...lifecycle.Option) error {
+	return f.runErr
 }
 
 func newMaintenanceLifecycleTestState(

--- a/internal/backend/runtime/omni/controllers/helpers/helpers.go
+++ b/internal/backend/runtime/omni/controllers/helpers/helpers.go
@@ -9,7 +9,6 @@ package helpers
 import (
 	"context"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"iter"
@@ -201,14 +200,7 @@ func GetTalosClient[T interface {
 	opts := talos.GetSocketOptions(address)
 
 	createInsecureClient := func() (*client.Client, error) {
-		return client.New(ctx,
-			append(
-				opts,
-				client.WithTLSConfig(&tls.Config{
-					InsecureSkipVerify: true,
-				}),
-				client.WithEndpoints(address),
-			)...)
+		return talos.NewMaintenanceClient(ctx, address)
 	}
 
 	if machineResource == nil {

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/snapshot/snapshot.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/snapshot/snapshot.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -77,7 +79,7 @@ func (spec CollectTaskSpec) sendInfo(ctx context.Context, info *omni.MachineStat
 }
 
 // RunTask runs the machine status collector.
-func (spec CollectTaskSpec) RunTask(ctx context.Context, _ *zap.Logger, notifyCh InfoChan) error {
+func (spec CollectTaskSpec) RunTask(ctx context.Context, logger *zap.Logger, notifyCh InfoChan) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -96,6 +98,8 @@ func (spec CollectTaskSpec) RunTask(ctx context.Context, _ *zap.Logger, notifyCh
 	if _, registered := registeredTypes[runtime.MachineStatusType]; !registered {
 		return nil
 	}
+
+	bootID := readBootID(ctx, client, logger)
 
 	watchCh := make(chan state.Event)
 
@@ -128,12 +132,41 @@ func (spec CollectTaskSpec) RunTask(ctx context.Context, _ *zap.Logger, notifyCh
 			}
 
 			snapshot.TypedSpec().Value.MachineStatus = ev
+			snapshot.TypedSpec().Value.BootId = bootID
 
 			if !spec.sendInfo(ctx, snapshot, notifyCh) {
 				return nil
 			}
 		}
 	}
+}
+
+// readBootID reads the machine's kernel boot identifier from the node. It is best-effort: on certain scenarios boot_id might not be available, instead of failing with error it returns "".
+func readBootID(ctx context.Context, c *client.Client, logger *zap.Logger) string {
+	read := func() (string, error) {
+		r, err := c.Read(ctx, "/proc/sys/kernel/random/boot_id")
+		if err != nil {
+			return "", err
+		}
+
+		defer r.Close() //nolint:errcheck
+
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return "", err
+		}
+
+		return strings.TrimSpace(string(data)), nil
+	}
+
+	bootID, err := read()
+	if err != nil {
+		logger.Debug("failed to read boot id", zap.Error(err))
+
+		return ""
+	}
+
+	return bootID
 }
 
 func (spec CollectTaskSpec) getClient(ctx context.Context) (*client.Client, error) {

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
@@ -63,20 +63,12 @@ func NewMachineConfigGenOptionsController() *MachineConfigGenOptionsController {
 // GenInstallConfig creates a config patch with an automatically picked install disk.
 func GenInstallConfig(machineStatus *omni.MachineStatus, clusterMachineTalosVersion *omni.ClusterMachineTalosVersion, genOptions *omni.MachineConfigGenOptions) {
 	if clusterMachineTalosVersion != nil {
-		if genOptions.TypedSpec().Value.InstallImage == nil {
-			genOptions.TypedSpec().Value.InstallImage = &specs.MachineConfigGenOptionsSpec_InstallImage{}
-		}
-
-		genOptions.TypedSpec().Value.InstallImage.SchematicId = clusterMachineTalosVersion.TypedSpec().Value.SchematicId
-		genOptions.TypedSpec().Value.InstallImage.TalosVersion = clusterMachineTalosVersion.TypedSpec().Value.TalosVersion
-		genOptions.TypedSpec().Value.InstallImage.SchematicInitialized = machineStatus.TypedSpec().Value.SchematicReady()
-
-		if genOptions.TypedSpec().Value.InstallImage.SchematicInitialized {
-			genOptions.TypedSpec().Value.InstallImage.SchematicInvalid = machineStatus.TypedSpec().Value.GetSchematic().GetInvalid()
-		}
-
-		genOptions.TypedSpec().Value.InstallImage.SecurityState = machineStatus.TypedSpec().Value.SecurityState
-		genOptions.TypedSpec().Value.InstallImage.Platform = machineStatus.TypedSpec().Value.GetPlatformMetadata().GetPlatform()
+		genOptions.TypedSpec().Value.InstallImage = omni.NewInstallImage(
+			machineStatus,
+			clusterMachineTalosVersion.TypedSpec().Value.TalosVersion,
+			clusterMachineTalosVersion.TypedSpec().Value.SchematicId,
+			machineStatus.TypedSpec().Value.SchematicReady(),
+		)
 	}
 
 	if machineStatus.TypedSpec().Value.Hardware == nil {

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_node.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math"
 	"slices"
-	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -640,8 +639,6 @@ func (ctrl *MachineSetNodeController) createNodes(
 		for i := range availableMachineClassMachines.Len() {
 			machine := availableMachineClassMachines.Get(i)
 
-			var machineVersion semver.Version
-
 			machineRequestID, ok := machine.Metadata().Labels().Get(omni.LabelMachineRequest)
 			if ok {
 				var machineRequest *infra.MachineRequest
@@ -657,26 +654,8 @@ func (ctrl *MachineSetNodeController) createNodes(
 				}
 			}
 
-			version, ok := machine.Metadata().Labels().Get(omni.MachineStatusLabelTalosVersion)
-			if !ok {
-				continue
-			}
-
-			machineVersion, err = semver.Parse(strings.TrimPrefix(version, "v"))
-			if err != nil {
-				continue
-			}
-
-			// do not try to allocate the machine if it's Talos major or minor version is greater than cluster Talos version
-			// this way we don't allow downgrading the machines while allocating them
-			if machineVersion.Major > clusterVersion.Major || machineVersion.Minor > clusterVersion.Minor {
-				continue
-			}
-
-			// do not try to allocate the machine if it's running Talos from an ISO or PXE and it's major and minor version do not match.
-			_, installed := machine.Metadata().Labels().Get(omni.MachineStatusLabelInstalled)
-
-			if !installed && (machineVersion.Major != clusterVersion.Major || machineVersion.Minor != clusterVersion.Minor) {
+			compatible, _, _ := omni.MachineLabelsCompatibleWithCluster(machine.Metadata().Labels(), clusterVersion)
+			if !compatible {
 				continue
 			}
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot.go
@@ -263,6 +263,10 @@ func (ctrl *MachineStatusSnapshotController) reconcileSnapshot(ctx context.Conte
 			m.TypedSpec().Value.MachineStatus = snapshot.TypedSpec().Value.MachineStatus
 		}
 
+		if snapshot.TypedSpec().Value.BootId != "" { // only the collect task reads the boot ID; preserve the existing value for siderolink/power snapshots
+			m.TypedSpec().Value.BootId = snapshot.TypedSpec().Value.BootId
+		}
+
 		m.TypedSpec().Value.PowerStage = snapshot.TypedSpec().Value.PowerStage // always set the power stage
 
 		return nil

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
@@ -26,6 +26,23 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
+// LifecycleOp identifies which upgrade/install path the controller should follow for a given machine.
+type LifecycleOp int
+
+const (
+	// LifecycleOpNone means on-disk Talos already matches the install image; no action needed.
+	LifecycleOpNone LifecycleOp = iota
+
+	// LifecycleOpLegacyUpgrade is an in-place upgrade via MachineService.Upgrade.
+	LifecycleOpLegacyUpgrade
+
+	// LifecycleOpMaintenanceInstall is LifecycleService.Install for a maintenance machine with no Talos on disk.
+	LifecycleOpMaintenanceInstall
+
+	// LifecycleOpMaintenanceUpgrade is LifecycleService.Upgrade for a maintenance machine that has Talos on disk.
+	LifecycleOpMaintenanceUpgrade
+)
+
 // ReconciliationContext describes all related data for one reconciliation call of the machine config status controller.
 type ReconciliationContext struct {
 	machineStatus         *omni.MachineStatus
@@ -36,11 +53,18 @@ type ReconciliationContext struct {
 	installImage          *specs.MachineConfigGenOptionsSpec_InstallImage
 
 	lastConfigError       string
+	installDisk           string
+	bootID                string
 	redactedMachineConfig []byte
 
-	shouldUpgrade        bool
 	configUpdatesAllowed bool
 	locked               bool
+	lifecycleOp          LifecycleOp
+}
+
+// hasPendingLifecycleOperation returns true when an upgrade/install action needs to run before config can be applied.
+func (rc *ReconciliationContext) hasPendingLifecycleOperation() bool {
+	return rc.lifecycleOp != LifecycleOpNone
 }
 
 func checkClusterReady(ctx context.Context, r controller.Reader, machineConfig *omni.ClusterMachineConfig) (bool, error) {
@@ -191,6 +215,8 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 		return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("%q install image not found", machineConfig.Metadata().ID())
 	}
 
+	rc.installDisk = genOptions.TypedSpec().Value.InstallDisk
+
 	schematicMismatch := false
 
 	// Invalid schematic means the machine was not provisioned via image factory.
@@ -224,7 +250,51 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 		return nil, err
 	}
 
-	rc.shouldUpgrade = omni.GetMachineStatusSystemDisk(rc.machineStatus) != "" && (schematicMismatch || talosVersionMismatch)
+	rc.bootID = rc.machineStatusSnapshot.TypedSpec().Value.BootId
+
+	rc.lifecycleOp = DecideLifecycleOp(rc.machineStatus, rc.installImage, schematicMismatch, talosVersionMismatch)
+	if rc.lifecycleOp == LifecycleOpMaintenanceInstall && rc.installDisk == "" {
+		return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("%q install disk is not yet selected", machineConfig.Metadata().ID())
+	}
 
 	return rc, nil
+}
+
+// DecideLifecycleOp picks the upgrade/install path from the live machine state. Exported for tests.
+func DecideLifecycleOp(machineStatus *omni.MachineStatus, installImage *specs.MachineConfigGenOptionsSpec_InstallImage, schematicMismatch, talosVersionMismatch bool) LifecycleOp {
+	hasSystemDisk := omni.GetMachineStatusSystemDisk(machineStatus) != ""
+
+	machineVersion, machineSupportsLifecycle := omni.ParseTalosVersionLifecycleSupport(machineStatus.TypedSpec().Value.TalosVersion)
+	targetVersion, targetSupportsLifecycle := omni.ParseTalosVersionLifecycleSupport(installImage.TalosVersion)
+
+	// Maintenance path: both the machine and the target must support the LifecycleService API.
+	if machineStatus.TypedSpec().Value.Maintenance && machineSupportsLifecycle && targetSupportsLifecycle {
+		machineSchematic := machineStatus.TypedSpec().Value.GetSchematic()
+		schematicDiffers := !machineSchematic.GetInvalid() && machineSchematic.GetFullId() != installImage.SchematicId
+
+		switch {
+		case hasSystemDisk && (!machineVersion.EQ(targetVersion) || schematicDiffers):
+			// Talos is already on disk but not at the target version/schematic: upgrade it in place via LifecycleService.Upgrade.
+			return LifecycleOpMaintenanceUpgrade
+		case !hasSystemDisk && (machineVersion.Major != targetVersion.Major || machineVersion.Minor != targetVersion.Minor):
+			// Nothing on disk yet and the running (ISO/PXE) minor differs from the target: the normal config-apply install only works within the same minor, so write the target to disk via
+			// LifecycleService.Install.
+			return LifecycleOpMaintenanceInstall
+		default:
+			// Either the on-disk Talos already matches the target, or there's no disk but the running minor matches the target so the normal config-apply path installs it.
+			return LifecycleOpNone
+		}
+	}
+
+	if !schematicMismatch && !talosVersionMismatch {
+		return LifecycleOpNone
+	}
+
+	// Even though LifecycleService.Upgrade can upgrade machines that are part of a cluster, that flow has not been implemented yet. Continue to use the legacy in-place MachineService.Upgrade.
+	if hasSystemDisk {
+		return LifecycleOpLegacyUpgrade
+	}
+
+	// No Talos on disk and not eligible for a maintenance install: Omni has no way to install Talos on this machine today, so nothing is done.
+	return LifecycleOpNone
 }

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package machineconfig_test
+
+import (
+	"testing"
+
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/machineconfig"
+)
+
+func TestDecideLifecycleOp(t *testing.T) {
+	t.Parallel()
+
+	mkMachineStatus := func(version string, schematic *specs.MachineStatusSpec_Schematic, hasSystemDisk, inMaintenance bool) *omni.MachineStatus {
+		ms := omni.NewMachineStatus("m1")
+
+		ms.TypedSpec().Value.TalosVersion = version
+		ms.TypedSpec().Value.Schematic = schematic
+
+		ms.TypedSpec().Value.Maintenance = inMaintenance
+
+		if hasSystemDisk {
+			ms.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{
+				Blockdevices: []*specs.MachineStatusSpec_HardwareStatus_BlockDevice{
+					{LinuxName: "/dev/sda", SystemDisk: true},
+				},
+			}
+		}
+
+		return ms
+	}
+
+	mkSnapshot := func(stage machineapi.MachineStatusEvent_MachineStage) *omni.MachineStatusSnapshot {
+		s := omni.NewMachineStatusSnapshot("m1")
+		s.TypedSpec().Value.MachineStatus = &machineapi.MachineStatusEvent{Stage: stage}
+
+		return s
+	}
+
+	mkImage := func(targetVersion, schematic string) *specs.MachineConfigGenOptionsSpec_InstallImage {
+		return &specs.MachineConfigGenOptionsSpec_InstallImage{TalosVersion: targetVersion, SchematicId: schematic}
+	}
+
+	type tcase struct {
+		machine              *omni.MachineStatus
+		snapshot             *omni.MachineStatusSnapshot
+		image                *specs.MachineConfigGenOptionsSpec_InstallImage
+		name                 string
+		want                 machineconfig.LifecycleOp
+		schematicMismatch    bool
+		talosVersionMismatch bool
+	}
+
+	for _, tc := range []tcase{
+		{
+			name:     "in sync, nothing to do",
+			machine:  mkMachineStatus("1.13.4", nil, true, false),
+			snapshot: mkSnapshot(machineapi.MachineStatusEvent_RUNNING),
+			image:    mkImage("1.13.4", ""),
+			want:     machineconfig.LifecycleOpNone,
+		},
+		{
+			name:                 "not-installed 1.13 in maintenance, minor version mismatch → maintenance install",
+			machine:              mkMachineStatus("1.13.0", nil, false, true),
+			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:                mkImage("1.14.1", ""),
+			talosVersionMismatch: true,
+			want:                 machineconfig.LifecycleOpMaintenanceInstall,
+		},
+		{
+			name:                 "not-installed 1.13 in maintenance, patch-only mismatch → config-apply install (None)",
+			machine:              mkMachineStatus("1.13.0", nil, false, true),
+			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:                mkImage("1.13.4", ""),
+			talosVersionMismatch: true,
+			// same config contract (major.minor): the maintenance config apply installs the exact target version itself, no lifecycle install needed
+			want: machineconfig.LifecycleOpNone,
+		},
+		{
+			name:     "not-installed 1.13 in maintenance at target version → config-apply install (None) despite stale mismatch flags",
+			machine:  mkMachineStatus("1.13.4", nil, false, true),
+			snapshot: mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:    mkImage("1.13.4", ""),
+			// machineConfigStatus-based flags signal a mismatch on the first reconcile (empty status); the live machine state must win.
+			schematicMismatch:    true,
+			talosVersionMismatch: true,
+			want:                 machineconfig.LifecycleOpNone,
+		},
+		{
+			name:                 "not-installed 1.13 in maintenance, schematic-only mismatch → config-apply install (None)",
+			machine:              mkMachineStatus("1.13.4", &specs.MachineStatusSpec_Schematic{FullId: "boot-schematic"}, false, true),
+			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:                mkImage("1.13.4", "target-schematic"),
+			schematicMismatch:    true,
+			talosVersionMismatch: true,
+			want:                 machineconfig.LifecycleOpNone,
+		},
+		{
+			name:                 "installed 1.13 in maintenance with patch-only mismatch → maintenance upgrade (exact compare)",
+			machine:              mkMachineStatus("1.13.0", nil, true, true),
+			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:                mkImage("1.13.4", ""),
+			talosVersionMismatch: true,
+			// config apply cannot change the on-disk version, so installed machines compare exact versions, not just the contract
+			want: machineconfig.LifecycleOpMaintenanceUpgrade,
+		},
+		{
+			name:     "installed 1.13 in maintenance with schematic mismatch → maintenance upgrade",
+			machine:  mkMachineStatus("1.13.4", &specs.MachineStatusSpec_Schematic{FullId: "boot-schematic"}, true, true),
+			snapshot: mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:    mkImage("1.13.4", "target-schematic"),
+			want:     machineconfig.LifecycleOpMaintenanceUpgrade,
+		},
+		{
+			name:     "installed 1.13 in maintenance at target → config apply (None), the post-install state",
+			machine:  mkMachineStatus("1.13.4", &specs.MachineStatusSpec_Schematic{FullId: "target-schematic"}, true, true),
+			snapshot: mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:    mkImage("1.13.4", "target-schematic"),
+			// stale flags again: the maintenance flow never writes the config status back
+			schematicMismatch:    true,
+			talosVersionMismatch: true,
+			want:                 machineconfig.LifecycleOpNone,
+		},
+		{
+			name:                 "installed 1.12 in maintenance → legacy upgrade (machine doesn't support lifecycle)",
+			machine:              mkMachineStatus("1.12.5", nil, true, true),
+			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:                mkImage("1.12.6", ""),
+			talosVersionMismatch: true,
+			want:                 machineconfig.LifecycleOpLegacyUpgrade,
+		},
+		{
+			name:                 "installed running mode mismatch → legacy upgrade",
+			machine:              mkMachineStatus("1.13.4", nil, true, false),
+			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_RUNNING),
+			image:                mkImage("1.13.5", ""),
+			talosVersionMismatch: true,
+			want:                 machineconfig.LifecycleOpLegacyUpgrade,
+		},
+		{
+			name:                 "not-installed 1.12 in maintenance + 1.13 cluster → no path (gate stands)",
+			machine:              mkMachineStatus("1.12.5", nil, false, true),
+			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:                mkImage("1.13.4", ""),
+			talosVersionMismatch: true,
+			want:                 machineconfig.LifecycleOpNone,
+		},
+		{
+			name:                 "not-installed 1.13 in maintenance + 1.12 cluster → no path (target doesn't support lifecycle)",
+			machine:              mkMachineStatus("1.13.4", nil, false, true),
+			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
+			image:                mkImage("1.12.6", ""),
+			talosVersionMismatch: true,
+			want:                 machineconfig.LifecycleOpNone,
+		},
+		{
+			name:    "invalid schematic plays no role in the maintenance decision",
+			machine: mkMachineStatus("1.13.4", &specs.MachineStatusSpec_Schematic{Invalid: true}, true, true),
+			snapshot: mkSnapshot(
+				machineapi.MachineStatusEvent_MAINTENANCE,
+			),
+			image: mkImage("1.13.4", "target-schematic"),
+			want:  machineconfig.LifecycleOpNone,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := machineconfig.DecideLifecycleOp(tc.machine, tc.image, tc.schematicMismatch, tc.talosVersionMismatch)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -9,7 +9,6 @@ package machineconfig
 import (
 	"context"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -45,6 +44,7 @@ import (
 	talosutils "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/talos"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 )
 
 const (
@@ -57,19 +57,28 @@ const (
 	maintenanceCheckAttempts  = 5
 )
 
-// ClusterMachineConfigStatusController manages ClusterMachineStatus resource lifecycle.
+// LifecycleManager runs maintenance-mode Talos install/upgrade operations on a single machine for the controller.
+type LifecycleManager interface {
+	// CheckAlive verifies the machine is reachable over the maintenance API at the given address before committing to an operation.
+	CheckAlive(ctx context.Context, address string) error
+	// Run performs the maintenance install/upgrade flow synchronously, returning ErrAlreadyInFlight if another operation holds the machine.
+	Run(ctx context.Context, op lifecycle.Operation, opts ...lifecycle.Option) error
+}
+
+// ClusterMachineConfigStatusController manages the ClusterMachineStatus resource lifecycle.
 //
-// ClusterMachineConfigStatusController applies the generated machine config  on each corresponding machine.
+// ClusterMachineConfigStatusController applies the generated machine config on each corresponding machine.
 type ClusterMachineConfigStatusController struct {
 	*qtransform.QController[*omni.ClusterMachineConfig, *omni.ClusterMachineConfigStatus]
 	ongoingResets    *ongoingResets
+	lifecycleManager LifecycleManager
 	imageFactoryHost string
 	talosRegistry    string
 	acquireLockMu    sync.Mutex
 }
 
 // NewClusterMachineConfigStatusController initializes ClusterMachineConfigStatusController.
-func NewClusterMachineConfigStatusController(imageFactoryHost, talosRegistry string) *ClusterMachineConfigStatusController {
+func NewClusterMachineConfigStatusController(imageFactoryHost, talosRegistry string, lifecycleManager LifecycleManager) *ClusterMachineConfigStatusController {
 	ongoingResets := &ongoingResets{
 		statuses: map[string]*resetStatus{},
 	}
@@ -78,6 +87,7 @@ func NewClusterMachineConfigStatusController(imageFactoryHost, talosRegistry str
 		imageFactoryHost: imageFactoryHost,
 		talosRegistry:    talosRegistry,
 		ongoingResets:    ongoingResets,
+		lifecycleManager: lifecycleManager,
 	}
 
 	ctrl.QController = qtransform.NewQController(
@@ -337,7 +347,12 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileUpgrade(
 	r controller.ReaderWriter,
 	rc *ReconciliationContext,
 ) error {
-	if rc.shouldUpgrade {
+	// PreRebootBootId only tracks an in-flight maintenance reboot. Clear it for any non-maintenance path so a stale ID can't later debounce a fresh maintenance operation.
+	if rc.lifecycleOp != LifecycleOpMaintenanceInstall && rc.lifecycleOp != LifecycleOpMaintenanceUpgrade {
+		rc.machineConfigStatus.TypedSpec().Value.PreRebootBootId = ""
+	}
+
+	if rc.hasPendingLifecycleOperation() {
 		inSync, err := ctrl.upgrade(ctx, logger, r, rc)
 		if err != nil {
 			// Only release the config-update lock when the machine is specifically blocked
@@ -368,13 +383,23 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileUpgrade(
 	return nil
 }
 
-func (ctrl *ClusterMachineConfigStatusController) upgrade(
-	inputCtx context.Context,
-	logger *zap.Logger,
-	r controller.ReaderWriter,
-	rc *ReconciliationContext,
-) (bool, error) {
-	// use short timeout for the all API calls but upgrade to quickly skip "dead" nodes
+func (ctrl *ClusterMachineConfigStatusController) upgrade(ctx context.Context, logger *zap.Logger, r controller.ReaderWriter, rc *ReconciliationContext) (bool, error) {
+	switch rc.lifecycleOp {
+	case LifecycleOpNone:
+		return true, nil
+
+	case LifecycleOpMaintenanceInstall, LifecycleOpMaintenanceUpgrade:
+		return ctrl.runMaintenanceLifecycle(ctx, logger, r, rc)
+
+	case LifecycleOpLegacyUpgrade:
+		fallthrough
+	default:
+		return ctrl.legacyUpgrade(ctx, logger, r, rc)
+	}
+}
+
+func (ctrl *ClusterMachineConfigStatusController) legacyUpgrade(inputCtx context.Context, logger *zap.Logger, r controller.ReaderWriter, rc *ReconciliationContext) (bool, error) {
+	// use short timeout for all API calls except upgrade to quickly skip "dead" nodes
 	ctx, cancel := context.WithTimeout(inputCtx, 5*time.Second)
 	defer cancel()
 
@@ -475,6 +500,99 @@ func (ctrl *ClusterMachineConfigStatusController) upgrade(
 	}
 
 	return false, err
+}
+
+// maintenanceLifecyclePollInterval paces a retry when the operation can't make progress yet (another caller holds the in-flight slot, or the machine is still rebooting from a prior operation).
+const maintenanceLifecyclePollInterval = 30 * time.Second
+
+// runMaintenanceLifecycle performs a LifecycleService.Install or Upgrade synchronously via the Lifecycle Manager.
+func (ctrl *ClusterMachineConfigStatusController) runMaintenanceLifecycle(
+	ctx context.Context,
+	logger *zap.Logger,
+	r controller.ReaderWriter,
+	rc *ReconciliationContext,
+) (bool, error) {
+	machineID := rc.ID()
+
+	if rc.bootID == "" {
+		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine boot ID before running maintenance lifecycle operation: %s", rc.ID())
+	}
+
+	preRebootBootID := rc.machineConfigStatus.TypedSpec().Value.PreRebootBootId
+	if rc.bootID == preRebootBootID {
+		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine to reboot after maintenance lifecycle operation: %s", rc.ID())
+	}
+
+	if stage := rc.machineStatusSnapshot.TypedSpec().Value.GetMachineStatus().GetStage(); stage != machineapi.MachineStatusEvent_MAINTENANCE {
+		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine %s is not in maintenance stage (%s); skipping maintenance lifecycle operation", machineID, stage)
+	}
+
+	probeCtx, probeCancel := context.WithTimeout(ctx, lifecycle.LivenessProbeTimeout)
+	defer probeCancel()
+
+	if err := ctrl.lifecycleManager.CheckAlive(probeCtx, rc.machineStatus.TypedSpec().Value.ManagementAddress); err != nil {
+		logger.Info("maintenance lifecycle pre-flight liveness probe failed; will retry", zap.String("machine", machineID), zap.Error(err))
+
+		return false, controller.NewRequeueInterval(maintenanceLifecyclePollInterval)
+	}
+
+	if err := ctrl.acquireUpgradeLock(ctx, r, rc); err != nil {
+		return false, err
+	}
+
+	operation := lifecycle.Operation{
+		MachineID:     machineID,
+		MachineStatus: rc.machineStatus,
+		Version:       rc.installImage.TalosVersion,
+		InstallImage:  rc.installImage,
+	}
+	operationName := ""
+
+	switch rc.lifecycleOp { //nolint:exhaustive
+	case LifecycleOpMaintenanceInstall:
+		operation.Kind = lifecycle.KindInstall
+		operation.Disk = rc.installDisk
+		operationName = "maintenance install"
+	case LifecycleOpMaintenanceUpgrade:
+		operation.Kind = lifecycle.KindUpgrade
+		operationName = "maintenance upgrade"
+	}
+
+	logger.Info("running maintenance lifecycle",
+		zap.String("machine", machineID),
+		zap.Stringer("op", operation.Kind),
+		zap.String("version", operation.Version),
+		zap.String("disk", operation.Disk))
+
+	runCtx, cancel := context.WithTimeout(ctx, lifecycle.MaintenanceLifecycleTimeout)
+	defer cancel()
+
+	err := ctrl.lifecycleManager.Run(runCtx, operation, lifecycle.WithProgress(func(msg string) {
+		logger.Debug("maintenance lifecycle progress", zap.String("machine", machineID), zap.String("message", msg))
+	}))
+
+	switch {
+	case errors.Is(err, lifecycle.ErrAlreadyInFlight):
+		// The management RPC is operating on this machine; retry once it releases the slot.
+		logger.Info("maintenance lifecycle already in flight", zap.String("machine", machineID))
+
+		return false, controller.NewRequeueInterval(maintenanceLifecyclePollInterval)
+	case err != nil:
+		// Returning a raw error would make qtransform drop the output write and lose LastConfigError.
+		rc.machineConfigStatus.TypedSpec().Value.LastConfigError = lifecycle.WrapErr(err, fmt.Sprintf("%s failed", operationName)).Error()
+
+		logger.Error("maintenance lifecycle operation failed",
+			zap.String("machine", machineID),
+			zap.String("op", operationName),
+			zap.Error(err))
+
+		return false, controller.NewRequeueInterval(maintenanceLifecyclePollInterval)
+	default:
+		rc.machineConfigStatus.TypedSpec().Value.PreRebootBootId = rc.bootID
+		rc.machineConfigStatus.TypedSpec().Value.LastConfigError = ""
+
+		return false, controller.NewRequeueInterval(maintenanceLifecyclePollInterval)
+	}
 }
 
 // stageUpgrade decides if the upgrade should be staged.
@@ -859,16 +977,12 @@ func (ctrl *ClusterMachineConfigStatusController) getClient(
 	machineConfig *omni.ClusterMachineConfig,
 ) (*client.Client, error) {
 	address := machineStatus.TypedSpec().Value.ManagementAddress
-	opts := talos.GetSocketOptions(address)
 
 	if useMaintenance {
-		return client.New(ctx,
-			append(
-				opts,
-				client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
-				client.WithEndpoints(address),
-			)...)
+		return talos.NewMaintenanceClient(ctx, address)
 	}
+
+	opts := talos.GetSocketOptions(address)
 
 	clusterName, ok := machineConfig.Metadata().Labels().Get(omni.LabelCluster)
 	if !ok {
@@ -1068,7 +1182,7 @@ func (ctrl *ClusterMachineConfigStatusController) computePendingUpdates(ctx cont
 	)
 
 	if rc.machineConfigStatus != nil && rc.installImage != nil &&
-		rc.machineConfigStatus.TypedSpec().Value.TalosVersion != "" && rc.machineConfigStatus.TypedSpec().Value.SchematicId != "" && rc.shouldUpgrade {
+		rc.machineConfigStatus.TypedSpec().Value.TalosVersion != "" && rc.machineConfigStatus.TypedSpec().Value.SchematicId != "" && rc.hasPendingLifecycleOperation() {
 		currentSchematicID = rc.machineConfigStatus.TypedSpec().Value.SchematicId
 		currentTalosVersion = rc.machineConfigStatus.TypedSpec().Value.TalosVersion
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -36,10 +36,13 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock/options"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 )
 
 const (
-	imageFactoryHost = "factory-test.talos.dev"
+	imageFactoryHost          = "factory-test.talos.dev"
+	maintenanceMachineVersion = "1.13.0" // running in maintenance, supports the LifecycleService API
+	maintenanceTargetVersion  = "1.14.0" // target install version, different minor
 )
 
 //nolint:gocognit,maintidx,gocyclo,cyclop
@@ -47,7 +50,9 @@ func TestMachineConfigStatusController(t *testing.T) {
 	t.Parallel()
 
 	addControllers := func(_ context.Context, testContext testutils.TestContext) {
-		require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer")))
+		require.NoError(t, testContext.Runtime.RegisterQController(
+			machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+		))
 	}
 
 	awaitAllMachinesConfigured := func(ctx context.Context, t *testing.T, st state.State, clusterName string) {
@@ -1014,6 +1019,350 @@ func TestMachineConfigStatusController(t *testing.T) {
 			},
 		)
 	})
+
+	// maintenanceInstall verifies a maintenance machine with nothing on disk gets a
+	// LifecycleService.Install with the target version and install disk, and that the boot ID is
+	// recorded so the operation is not re-run until the machine reboots.
+	t.Run("maintenanceInstall", func(t *testing.T) {
+		t.Parallel()
+
+		mock := testutils.NewLifecycleManagerMock()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				const bootID = "boot-before-install"
+
+				id := setupMaintenanceMachine(ctx, t, st, machineServices, "maint-install", false, bootID)
+
+				// A successful operation records the boot ID and clears the error.
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+					a.Equal(bootID, res.TypedSpec().Value.PreRebootBootId)
+					a.Empty(res.TypedSpec().Value.LastConfigError)
+				})
+
+				ops := mock.RunOperations()
+				require.NotEmpty(t, ops)
+				assert.Equal(t, lifecycle.KindInstall, ops[0].Kind)
+				assert.Equal(t, maintenanceTargetVersion, ops[0].Version)
+				assert.Equal(t, "/dev/vda", ops[0].Disk)
+				assert.Equal(t, id, ops[0].MachineID)
+
+				machineStatus, err := safe.StateGetByID[*omni.MachineStatus](ctx, st, id)
+				require.NoError(t, err)
+				assert.Contains(t, mock.CheckAliveCalls(), machineStatus.TypedSpec().Value.ManagementAddress, "the machine should be probed before the operation")
+			},
+		)
+	})
+
+	// maintenanceUpgrade verifies a maintenance machine that already has Talos on disk gets a
+	// LifecycleService.Upgrade (not Install).
+	t.Run("maintenanceUpgrade", func(t *testing.T) {
+		t.Parallel()
+
+		mock := testutils.NewLifecycleManagerMock()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				const bootID = "boot-before-upgrade"
+
+				id := setupMaintenanceMachine(ctx, t, st, machineServices, "maint-upgrade", true, bootID)
+
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+					a.Equal(bootID, res.TypedSpec().Value.PreRebootBootId)
+				})
+
+				ops := mock.RunOperations()
+				require.NotEmpty(t, ops)
+				assert.Equal(t, lifecycle.KindUpgrade, ops[0].Kind)
+				assert.Equal(t, maintenanceTargetVersion, ops[0].Version)
+			},
+		)
+	})
+
+	// maintenanceLifecycleError verifies a failed operation surfaces the error in LastConfigError
+	// (returning a raw error would make qtransform drop the output write) and does not record the boot
+	// ID, so the operation is retried.
+	t.Run("maintenanceLifecycleError", func(t *testing.T) {
+		t.Parallel()
+
+		mock := testutils.NewLifecycleManagerMock()
+		mock.RunFunc = func(context.Context, lifecycle.Operation, ...lifecycle.Option) error {
+			return errors.New("installer blew up")
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				id := setupMaintenanceMachine(ctx, t, st, machineServices, "maint-error", false, "boot-error")
+
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+					a.Contains(res.TypedSpec().Value.LastConfigError, "installer blew up")
+					a.Empty(res.TypedSpec().Value.PreRebootBootId, "a failed operation must not record the boot ID")
+				})
+			},
+		)
+	})
+
+	// maintenanceLifecycleAlreadyInFlight verifies an in-flight operation requeues without surfacing an
+	// error (the management RPC is already operating on the machine, so this is not a failure).
+	t.Run("maintenanceLifecycleAlreadyInFlight", func(t *testing.T) {
+		t.Parallel()
+
+		mock := testutils.NewLifecycleManagerMock()
+		mock.RunFunc = func(context.Context, lifecycle.Operation, ...lifecycle.Option) error {
+			return lifecycle.ErrAlreadyInFlight
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				id := setupMaintenanceMachine(ctx, t, st, machineServices, "maint-inflight", false, "boot-inflight")
+
+				// Wait until Run has been attempted.
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.NotEmpty(c, mock.RunOperations())
+				}, 10*time.Second, 50*time.Millisecond)
+
+				// The in-flight result is not an error, so it must not be recorded as one, and the boot ID
+				// must not be recorded (the operation has not actually completed).
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+					a.Empty(res.TypedSpec().Value.LastConfigError)
+					a.Empty(res.TypedSpec().Value.PreRebootBootId)
+				})
+			},
+		)
+	})
+
+	// maintenanceLivenessProbeFailure verifies that when the pre-flight liveness probe fails, the
+	// operation is never started.
+	t.Run("maintenanceLivenessProbeFailure", func(t *testing.T) {
+		t.Parallel()
+
+		mock := testutils.NewLifecycleManagerMock()
+		mock.CheckAliveFunc = func(context.Context, string) error {
+			return errors.New("machine unreachable")
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				id := setupMaintenanceMachine(ctx, t, st, machineServices, "maint-dead", false, "boot-dead")
+
+				machineStatus, err := safe.StateGetByID[*omni.MachineStatus](ctx, st, id)
+				require.NoError(t, err)
+
+				// The machine is probed at its management address.
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					assert.Contains(c, mock.CheckAliveCalls(), machineStatus.TypedSpec().Value.ManagementAddress)
+				}, 10*time.Second, 50*time.Millisecond)
+
+				// The probe keeps failing, so the operation must never start. Negative assertion: give the
+				// controller time to (not) act.
+				time.Sleep(time.Second)
+
+				assert.Empty(t, mock.RunOperations(), "the operation must not start when the machine is unreachable")
+			},
+		)
+	})
+
+	// maintenanceBootIDDebounce verifies that once an operation has run, it is not re-run while the
+	// machine still reports the same boot ID (it has not rebooted yet).
+	t.Run("maintenanceBootIDDebounce", func(t *testing.T) {
+		t.Parallel()
+
+		mock := testutils.NewLifecycleManagerMock()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				const bootID = "boot-debounce"
+
+				id := setupMaintenanceMachine(ctx, t, st, machineServices, "maint-debounce", false, bootID)
+
+				// The operation runs once and the boot ID is recorded.
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+					a.Equal(bootID, res.TypedSpec().Value.PreRebootBootId)
+				})
+
+				require.Len(t, mock.RunOperations(), 1)
+
+				// Poke a declared input to force another reconcile while the boot ID is unchanged.
+				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
+					res.TypedSpec().Value.BootId = bootID
+
+					return nil
+				}))
+
+				// Negative assertion: the operation must not run again until the machine reboots.
+				time.Sleep(time.Second)
+
+				assert.Len(t, mock.RunOperations(), 1, "operation must not re-run while the boot ID is unchanged")
+			},
+		)
+	})
+
+	// maintenanceNotInMaintenanceStage verifies the operation does not run when the machine is not in
+	// the MAINTENANCE stage (e.g. it already rebooted into a normal boot).
+	t.Run("maintenanceNotInMaintenanceStage", func(t *testing.T) {
+		t.Parallel()
+
+		mock := testutils.NewLifecycleManagerMock()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				id := setupMaintenanceMachine(ctx, t, st, machineServices, "maint-wrong-stage", false, "boot-wrong-stage")
+
+				// Flip the snapshot out of the MAINTENANCE stage before the controller acts on it.
+				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_BOOTING}
+
+					return nil
+				}))
+
+				// Negative assertion: nothing to poll on, so give the controller time to (not) act.
+				time.Sleep(time.Second)
+
+				assert.Empty(t, mock.RunOperations(), "the operation must not run outside the maintenance stage")
+			},
+		)
+	})
+
+	// maintenanceUpgradeLockReleased verifies the upgrade lock taken before the operation is released
+	// once the machine reboots into the target, so it is never leaked. The lock is only taken once the
+	// machine already has an applied config (a non-empty config SHA), so we seed one.
+	t.Run("maintenanceUpgradeLockReleased", func(t *testing.T) {
+		t.Parallel()
+
+		mock := testutils.NewLifecycleManagerMock()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", mock)))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				id := setupMaintenanceMachine(ctx, t, st, machineServices, "maint-lock", true, "boot-lock")
+
+				machineStatus, err := safe.StateGetByID[*omni.MachineStatus](ctx, st, id)
+				require.NoError(t, err)
+
+				schematicID := machineStatus.TypedSpec().Value.GetSchematic().GetFullId()
+
+				// Seed an applied config SHA so acquireUpgradeLock actually takes the lock (it is a no-op
+				// while the SHA is empty, i.e. during the very first install). Seed the target
+				// version/schematic too, so that once the machine reports as upgraded the lifecycle op
+				// becomes None.
+				rmock.Mock[*omni.ClusterMachineConfigStatus](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.ClusterMachineConfigStatus) error {
+					res.TypedSpec().Value.ClusterMachineConfigSha256 = "seeded-sha"
+					res.TypedSpec().Value.TalosVersion = maintenanceTargetVersion
+					res.TypedSpec().Value.SchematicId = schematicID
+
+					return nil
+				}))
+
+				// The operation runs and the upgrade lock is held (it stays held across the reboot).
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachine, a *assert.Assertions) {
+					a.True(res.Metadata().Finalizers().Has(machineconfig.UpgradeFinalizer), "the upgrade lock must be held while the operation is in flight")
+				})
+
+				require.NotEmpty(t, mock.RunOperations())
+				assert.Equal(t, lifecycle.KindUpgrade, mock.RunOperations()[0].Kind)
+
+				// The machine reboots into the target Talos: it leaves maintenance mode and reports the
+				// target version, so there is no longer an operation to run. The upgrade lock must then be
+				// released.
+				rmock.Mock[*omni.MachineStatus](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatus) error {
+					res.TypedSpec().Value.Maintenance = false
+					res.TypedSpec().Value.TalosVersion = maintenanceTargetVersion
+
+					return nil
+				}))
+				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING}
+					res.TypedSpec().Value.BootId = "boot-after-reboot"
+
+					return nil
+				}))
+
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachine, a *assert.Assertions) {
+					a.False(res.Metadata().Finalizers().Has(machineconfig.UpgradeFinalizer), "the upgrade lock must be released once the machine reboots into the target")
+				})
+			},
+		)
+	})
 }
 
 // createClusterOption customizes the resources spawned by createCluster.
@@ -1206,7 +1555,9 @@ func TestUpgradeLockReleasedBeforeConfigApply(t *testing.T) {
 	testutils.WithRuntime(
 		ctx, t, testutils.TestOptions{},
 		func(_ context.Context, tc testutils.TestContext) {
-			require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer")))
+			require.NoError(t, tc.Runtime.RegisterQController(
+				machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+			))
 		},
 		func(ctx context.Context, tc testutils.TestContext) {
 			st := tc.State
@@ -1280,7 +1631,9 @@ func TestConfigUpdateLockReleasedWhenUpgradeBlocked(t *testing.T) {
 	testutils.WithRuntime(
 		ctx, t, testutils.TestOptions{},
 		func(_ context.Context, tc testutils.TestContext) {
-			require.NoError(t, tc.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer")))
+			require.NoError(t, tc.Runtime.RegisterQController(
+				machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+			))
 		},
 		func(ctx context.Context, tc testutils.TestContext) {
 			st := tc.State
@@ -1331,4 +1684,43 @@ func TestConfigUpdateLockReleasedWhenUpgradeBlocked(t *testing.T) {
 			})
 		},
 	)
+}
+
+// setupMaintenanceMachine creates a single-machine cluster whose machine is booted in maintenance
+// mode and needs Talos written to disk via the LifecycleService.
+func setupMaintenanceMachine(
+	ctx context.Context, t *testing.T, st state.State, machineServices *testutils.MachineServices,
+	clusterName string, hasSystemDisk bool, bootID string,
+) string {
+	_, machines := createCluster(
+		ctx, t, st, machineServices, clusterName, 1, 0,
+		withMachineStatusModifier(func(res *omni.MachineStatus) error {
+			res.TypedSpec().Value.Maintenance = true
+			res.TypedSpec().Value.TalosVersion = maintenanceMachineVersion
+
+			if !hasSystemDisk {
+				res.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{}
+			}
+
+			return nil
+		}),
+	)
+
+	id := machines[0].Metadata().ID()
+
+	// The target version differs from the machine's running version in minor and supports the API.
+	rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+		res.TypedSpec().Value.InstallImage.TalosVersion = maintenanceTargetVersion
+
+		return nil
+	}))
+
+	rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+		res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
+		res.TypedSpec().Value.BootId = bootID
+
+		return nil
+	}))
+
+	return id
 }

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/clients.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/clients.go
@@ -7,7 +7,6 @@ package machineupgrade
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 
@@ -30,10 +29,7 @@ type TalosClient interface {
 type talosCliFactory struct{}
 
 func (t *talosCliFactory) New(ctx context.Context, managementAddress string) (TalosClient, error) {
-	opts := talos.GetSocketOptions(managementAddress)
-	opts = append(opts, client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}), client.WithEndpoints(managementAddress))
-
-	talosClient, err := client.New(ctx, opts...)
+	talosClient, err := talos.NewMaintenanceClient(ctx, managementAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create talos client: %w", err)
 	}

--- a/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
@@ -65,7 +65,9 @@ func Test_TalosCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -124,7 +126,9 @@ func Test_TalosCARotation(t *testing.T) {
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretsController(nil)))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -220,7 +224,9 @@ func Test_TalosCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -284,7 +290,9 @@ func Test_TalosCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -352,7 +360,9 @@ func Test_TalosCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -424,7 +434,9 @@ func Test_TalosCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -496,7 +508,9 @@ func Test_TalosCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -626,7 +640,9 @@ func Test_KubernetesCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -685,7 +701,9 @@ func Test_KubernetesCARotation(t *testing.T) {
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretsController(nil)))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -790,7 +808,9 @@ func Test_KubernetesCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -863,7 +883,9 @@ func Test_KubernetesCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -940,7 +962,9 @@ func Test_KubernetesCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -1021,7 +1045,9 @@ func Test_KubernetesCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
 				machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -1102,7 +1128,9 @@ func Test_KubernetesCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-				require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+				require.NoError(t, testContext.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+				))
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretsController(nil)))
 			},
 			func(ctx context.Context, testContext testutils.TestContext) {
@@ -1165,7 +1193,9 @@ func Test_ConcurrentRotationRejection(t *testing.T) {
 				),
 			))
 			require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-			require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+			require.NoError(t, testContext.Runtime.RegisterQController(
+				machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+			))
 		},
 		func(ctx context.Context, testContext testutils.TestContext) {
 			machineServices := testutils.NewMachineServices(t, testContext.State)
@@ -1212,7 +1242,9 @@ func Test_ComponentIsolationDuringRotation(t *testing.T) {
 				),
 			))
 			require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController("test.factory", nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
-			require.NoError(t, testContext.Runtime.RegisterQController(machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer")))
+			require.NoError(t, testContext.Runtime.RegisterQController(
+				machineconfig.NewClusterMachineConfigStatusController("test.factory", "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock()),
+			))
 		},
 		func(ctx context.Context, testContext testutils.TestContext) {
 			machineServices := testutils.NewMachineServices(t, testContext.State)

--- a/internal/backend/runtime/omni/controllers/testutils/lifecycle_mock.go
+++ b/internal/backend/runtime/omni/controllers/testutils/lifecycle_mock.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package testutils
+
+import (
+	"context"
+	"sync"
+
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
+)
+
+// LifecycleManagerMock is a configurable test double for the maintenance lifecycle manager used by
+// ClusterMachineConfigStatusController. It implements the controller's LifecycleManager interface.
+type LifecycleManagerMock struct {
+	// CheckAliveFunc, if set, runs on each CheckAlive call. Nil reports the machine alive.
+	CheckAliveFunc func(ctx context.Context, address string) error
+	// RunFunc, if set, runs on each Run call. Nil reports the operation successful.
+	RunFunc func(ctx context.Context, op lifecycle.Operation, opts ...lifecycle.Option) error
+
+	checkAliveCalls []string
+	runOps          []lifecycle.Operation
+
+	mu sync.Mutex
+}
+
+// NewLifecycleManagerMock returns a no-op LifecycleManagerMock.
+func NewLifecycleManagerMock() *LifecycleManagerMock {
+	return &LifecycleManagerMock{}
+}
+
+// CheckAlive records the call and delegates to CheckAliveFunc, reporting the machine alive if unset.
+func (m *LifecycleManagerMock) CheckAlive(ctx context.Context, address string) error {
+	m.mu.Lock()
+	m.checkAliveCalls = append(m.checkAliveCalls, address)
+	fn := m.CheckAliveFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, address)
+	}
+
+	return nil
+}
+
+// Run records the operation and delegates to RunFunc, reporting success if unset.
+func (m *LifecycleManagerMock) Run(ctx context.Context, op lifecycle.Operation, opts ...lifecycle.Option) error {
+	m.mu.Lock()
+	m.runOps = append(m.runOps, op)
+	fn := m.RunFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, op, opts...)
+	}
+
+	return nil
+}
+
+// CheckAliveCalls returns the machine addresses CheckAlive was called with, in order.
+func (m *LifecycleManagerMock) CheckAliveCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]string(nil), m.checkAliveCalls...)
+}
+
+// RunOperations returns the operations Run was called with, in order.
+func (m *LifecycleManagerMock) RunOperations() []lifecycle.Operation {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]lifecycle.Operation(nil), m.runOps...)
+}

--- a/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
+++ b/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
@@ -412,7 +412,7 @@ machine:
 	setOwner[*omni.MachineSetStatus](omnictrl.NewMachineSetStatusController().ControllerName)
 	setOwner[*omni.UpgradeRollout](talosupgrade.NewStatusController(nil).ControllerName)
 	setOwner[*omni.TalosUpgradeStatus](talosupgrade.NewStatusController(nil).ControllerName)
-	setOwner[*omni.ClusterMachineConfigStatus](machineconfigctrl.NewClusterMachineConfigStatusController("", "").ControllerName)
+	setOwner[*omni.ClusterMachineConfigStatus](machineconfigctrl.NewClusterMachineConfigStatusController("", "", nil).ControllerName)
 }
 
 // GetOwner returns the default owner used by the mock library for the resource.

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -71,6 +71,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/virtual/pkg/producers"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	newgroup "github.com/siderolabs/omni/internal/pkg/errgroup"
@@ -106,7 +107,8 @@ type Runtime struct {
 func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dnsService *dns.Service, workloadProxyReconciler *workloadproxy.Reconciler,
 	resourceLogger *resourcelogger.Logger, imageFactoryClient *imagefactory.Client, linkCounterDeltaCh <-chan siderolink.LinkCounterDeltas,
 	siderolinkEventsCh <-chan *omni.MachineStatusSnapshot, installEventCh <-chan cosiresource.ID, st *State, metricsRegistry prometheus.Registerer,
-	discoveryClientCache omnictrl.DiscoveryClientCache, kubernetesRuntime omnictrl.KubernetesRuntime, talosRuntime omnictrl.TalosClientGetter, logger *zap.Logger,
+	discoveryClientCache omnictrl.DiscoveryClientCache, kubernetesRuntime omnictrl.KubernetesRuntime, talosRuntime omnictrl.TalosClientGetter,
+	lifecycleManager *lifecycle.Manager, logger *zap.Logger,
 ) (*Runtime, error) {
 	var opts []options.Option
 
@@ -223,7 +225,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		omnictrl.NewMachineConfigGenOptionsController(),
 		omnictrl.NewMachineStatusController(imageFactoryClient, exraKernelArgsInitializer),
 		machineconfig.NewExtractionController(machineconfig.NewReader(talosClientFactory)),
-		machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, cfg.Registries.GetTalos()),
+		machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, cfg.Registries.GetTalos(), lifecycleManager),
 		omnictrl.NewClusterMachineEncryptionKeyController(),
 		omnictrl.NewClusterMachineStatusController(),
 		omnictrl.NewClusterStatusController(cfg.Services.EmbeddedDiscoveryService.GetEnabled()),

--- a/internal/backend/runtime/omni/omni_test.go
+++ b/internal/backend/runtime/omni/omni_test.go
@@ -96,7 +96,7 @@ func (suite *OmniRuntimeSuite) SetupTest() {
 
 	suite.runtime, err = omniruntime.NewRuntime(config.Default(), clientFactory, dnsService, workloadProxyReconciler, nil,
 		nil, nil, nil, nil, mockState, prometheus.NewRegistry(),
-		discoveryClientCache, kubernetesRuntime, nil, logging.IncreaseLevel(logger, zap.InfoLevel))
+		discoveryClientCache, kubernetesRuntime, nil, nil, logging.IncreaseLevel(logger, zap.InfoLevel))
 
 	suite.Require().NoError(err)
 

--- a/internal/backend/runtime/omni/talosconfig_test.go
+++ b/internal/backend/runtime/omni/talosconfig_test.go
@@ -47,7 +47,7 @@ func TestOperatorTalosconfig(t *testing.T) {
 	kubernetesRuntime := kubernetes.New(st.Default(), logger, "", "", "")
 
 	r, err := omniruntime.NewRuntime(omniconfig.Default(), clientFactory, dnsService, workloadProxyReconciler, nil, nil, nil, nil, nil,
-		st, prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, nil, logging.IncreaseLevel(logger, zap.InfoLevel))
+		st, prometheus.NewRegistry(), discoveryClientCache, kubernetesRuntime, nil, nil, logging.IncreaseLevel(logger, zap.InfoLevel))
 
 	require.NoError(t, err)
 

--- a/internal/backend/runtime/omni/validations/machine_set_node.go
+++ b/internal/backend/runtime/omni/validations/machine_set_node.go
@@ -66,9 +66,8 @@ func machineSetNodeValidationOptions(st state.State) []validated.StateOption {
 			return err
 		}
 
-		machineTalosVersion, err := semver.Parse(strings.TrimLeft(machineStatus.TypedSpec().Value.TalosVersion, "v"))
-		if err != nil {
-			// ignore version check if it's not possible to parse machine Talos version
+		// ignore version check if it's not possible to parse machine Talos version
+		if _, parseErr := semver.Parse(strings.TrimLeft(machineStatus.TypedSpec().Value.TalosVersion, "v")); parseErr != nil {
 			return nil //nolint:nilerr
 		}
 
@@ -77,23 +76,9 @@ func machineSetNodeValidationOptions(st state.State) []validated.StateOption {
 			return err
 		}
 
-		inAgentMode := machineStatus.TypedSpec().Value.Schematic.GetInAgentMode()
-
-		if !inAgentMode && (machineTalosVersion.Major > clusterTalosVersion.Major || machineTalosVersion.Minor > clusterTalosVersion.Minor) {
-			return fmt.Errorf(
-				"cannot add machine set node to the cluster %s as it will trigger Talos downgrade on the node (%s -> %s)",
-				cluster.Metadata().ID(),
-				machineTalosVersion.String(),
-				clusterTalosVersion.String(),
-			)
-		}
-
-		installed := omni.GetMachineStatusSystemDisk(machineStatus) != ""
-
-		if !installed && !inAgentMode && (machineTalosVersion.Major != clusterTalosVersion.Major || machineTalosVersion.Minor != clusterTalosVersion.Minor) {
-			return errors.New(
-				"machines which are running Talos without installation can be added only to Talos clusters with the same major and minor versions",
-			)
+		ok, _, reason := omni.MachineCompatibleWithCluster(machineStatus, clusterTalosVersion)
+		if !ok {
+			return errors.New(reason)
 		}
 
 		return nil

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -992,6 +992,93 @@ func TestMachineSetNodeValidations(t *testing.T) {
 	}))
 }
 
+// TestMachineSetNodeMaintenanceInstallCompatibility verifies the relaxed version gate that allows
+// not-installed >=1.13 maintenance machines to join clusters at a different (compatible) Talos minor,
+// while still rejecting not-installed <1.13 minor mismatches.
+func TestMachineSetNodeMaintenanceInstallCompatibility(t *testing.T) {
+	t.Parallel()
+
+	type tcase struct {
+		name             string
+		machineVersion   string
+		clusterVersion   string
+		installedSysDisk bool
+		wantErr          bool
+	}
+
+	for _, tc := range []tcase{
+		{
+			name:           "not-installed 1.13 maintenance + 1.13 cluster - allowed (auto-install)",
+			machineVersion: "1.13.0",
+			clusterVersion: "1.13.4",
+			wantErr:        false,
+		},
+		{
+			name:           "not-installed 1.13 maintenance + 1.14 cluster - allowed (auto-install)",
+			machineVersion: "1.13.0",
+			clusterVersion: "1.14.0",
+			wantErr:        false,
+		},
+		{
+			name:           "not-installed 1.12 maintenance + 1.13 cluster - rejected (no install path)",
+			machineVersion: "1.12.5",
+			clusterVersion: "1.13.4",
+			wantErr:        true,
+		},
+		{
+			name:             "installed 1.12 + 1.13 cluster - allowed (legacy upgrade path)",
+			machineVersion:   "1.12.5",
+			installedSysDisk: true,
+			clusterVersion:   "1.13.4",
+			wantErr:          false,
+		},
+		{
+			name:             "installed 1.14 + 1.13 cluster - rejected (downgrade)",
+			machineVersion:   "1.14.0",
+			installedSysDisk: true,
+			clusterVersion:   "1.13.4",
+			wantErr:          true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+			st := state.WrapCore(validated.NewState(innerSt, validations.MachineSetNodeValidationOptions(state.WrapCore(innerSt))...))
+
+			cluster := omnires.NewCluster("c1")
+			cluster.TypedSpec().Value.TalosVersion = tc.clusterVersion
+
+			machineSet := omnires.NewMachineSet("c1-workers")
+			machineSet.Metadata().Labels().Set(omnires.LabelCluster, "c1")
+
+			machineStatus := omnires.NewMachineStatus("m1")
+			machineStatus.TypedSpec().Value.TalosVersion = tc.machineVersion
+			machineStatus.Metadata().Labels().Set(omnires.MachineStatusLabelTalosVersion, tc.machineVersion)
+
+			if tc.installedSysDisk {
+				machineStatus.Metadata().Labels().Set(omnires.MachineStatusLabelInstalled, "")
+			}
+
+			require.NoError(t, st.Create(ctx, cluster))
+			require.NoError(t, st.Create(ctx, machineSet))
+			require.NoError(t, st.Create(ctx, machineStatus))
+
+			machineSetNode := omnires.NewMachineSetNode("m1", machineSet)
+
+			err := st.Create(ctx, machineSetNode)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestMachineSetLockedAnnotation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backend/runtime/talos/clients.go
+++ b/internal/backend/runtime/talos/clients.go
@@ -126,6 +126,18 @@ func (c *Client) Connected(ctx context.Context, r controller.Reader) (bool, erro
 	return clusterStatus.TypedSpec().Value.GetAvailable(), nil
 }
 
+// NewMaintenanceClient opens an insecure Talos client to a machine's maintenance API.
+func NewMaintenanceClient(ctx context.Context, address string) (*client.Client, error) {
+	opts := GetSocketOptions(address)
+	opts = append(
+		opts,
+		client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}), //nolint:gosec
+		client.WithEndpoints(address),
+	)
+
+	return client.New(ctx, opts...)
+}
+
 // GetSocketOptions adds unix socket parameters to the client configuration
 // if the address has unix:// schema.
 func GetSocketOptions(address string) []client.OptionFunc {

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -79,6 +79,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/saml"
 	"github.com/siderolabs/omni/internal/backend/services"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 	"github.com/siderolabs/omni/internal/frontend"
 	"github.com/siderolabs/omni/internal/memconn"
 	"github.com/siderolabs/omni/internal/pkg/auth"
@@ -115,6 +116,7 @@ type Server struct {
 	dnsService              *dns.Service
 	workloadProxyReconciler *workloadproxy.Reconciler
 	imageFactoryClient      *imagefactory.Client
+	lifecycleManager        *lifecycle.Manager
 	installEventCh          chan<- resource.ID
 	linkCounterDeltaCh      chan<- siderolink.LinkCounterDeltas
 	siderolinkEventsCh      chan<- *omnires.MachineStatusSnapshot
@@ -143,6 +145,7 @@ func NewServer(
 	logger *zap.Logger,
 	kubernetesRuntime *kubernetes.Runtime,
 	talosRuntime *talosruntime.Runtime,
+	lifecycleManager *lifecycle.Manager,
 ) (*Server, error) {
 	s := &Server{
 		cfg:                     cfg,
@@ -156,6 +159,7 @@ func NewServer(
 		dnsService:              dnsService,
 		workloadProxyReconciler: workloadProxyReconciler,
 		imageFactoryClient:      imageFactoryClient,
+		lifecycleManager:        lifecycleManager,
 		linkCounterDeltaCh:      linkCounterDeltaCh,
 		siderolinkEventsCh:      siderolinkEventsCh,
 		installEventCh:          installEventCh,
@@ -234,6 +238,7 @@ func (s *Server) Run(ctx context.Context) error {
 		s.kubernetesRuntime,
 		s.talosRuntime,
 		runtimes,
+		s.lifecycleManager,
 	)
 
 	actualSrv, gtwyDialsTo, err := s.serverAndGateway(ctx, servicesServer, mux, serverOptions...)

--- a/internal/backend/talos/lifecycle/client.go
+++ b/internal/backend/talos/lifecycle/client.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/installimage"
+)
+
+// AuditFunc is invoked once for each Talos call so callers can record an audit entry. Returning an error aborts the operation. Use NoAudit when audit is not required (e.g. the controller flow).
+type AuditFunc func(ctx context.Context, fullMethodName, machineID string) error
+
+// NoAudit is an AuditFunc that does nothing.
+func NoAudit(_ context.Context, _, _ string) error { return nil }
+
+// buildInstallImage constructs the installer image reference.
+func (m *Manager) buildInstallImage(machineID string, ms *omni.MachineStatus, version string, target *specs.MachineConfigGenOptionsSpec_InstallImage) (string, error) {
+	if target != nil {
+		return installimage.Build(m.imageFactoryHost, machineID, target, m.talosRegistry)
+	}
+
+	spec := ms.TypedSpec().Value
+
+	if spec.GetPlatformMetadata().GetPlatform() == "" {
+		return "", status.Error(codes.FailedPrecondition, "machine platform is not known yet")
+	}
+
+	if spec.SecurityState == nil {
+		return "", status.Error(codes.FailedPrecondition, "machine security state is not known yet")
+	}
+
+	if version == "" {
+		version = strings.TrimPrefix(spec.TalosVersion, "v")
+	}
+
+	installImage := omni.NewInstallImage(ms, version, spec.Schematic.FullId, true)
+
+	return installimage.Build(m.imageFactoryHost, machineID, installImage, m.talosRegistry)
+}
+
+// pullInstallerImage pulls the installer image into the machine's containerd and returns the resolved image name, as required by LifecycleService.{Install,Upgrade}'s InstallArtifactsSource.
+func (m *Manager) pullInstallerImage(
+	ctx context.Context,
+	talosClient *talosclient.Client,
+	imageRef, machineID string,
+	cfg runConfig,
+) (string, error) {
+	emitf(cfg.progress, "[omni] pulling installer image %s", imageRef)
+
+	if err := cfg.audit(ctx, machineapi.ImageService_Pull_FullMethodName, machineID); err != nil {
+		return "", err
+	}
+
+	pullClient, err := talosClient.ImageClient.Pull(ctx, &machineapi.ImageServicePullRequest{
+		Containerd: m.containerdInstance,
+		ImageRef:   imageRef,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if err = pullClient.CloseSend(); err != nil {
+		return "", err
+	}
+
+	var resolved string
+
+	for {
+		msg, recvErr := pullClient.Recv()
+		if recvErr != nil {
+			if errors.Is(recvErr, io.EOF) {
+				break
+			}
+
+			return "", recvErr
+		}
+
+		if name := msg.GetName(); name != "" {
+			resolved = name
+		}
+	}
+
+	if resolved == "" {
+		resolved = imageRef
+	}
+
+	emitf(cfg.progress, "[omni] installer image pulled: %s", resolved)
+
+	return resolved, nil
+}
+
+// install runs LifecycleService.Install and relays installer progress.
+// Note: Talos rejects with AlreadyExists when the machine reports as already installed.
+func (m *Manager) install(
+	ctx context.Context,
+	talosClient *talosclient.Client,
+	resolvedImage, disk, machineID string,
+	cfg runConfig,
+) error {
+	if err := cfg.audit(ctx, machineapi.LifecycleService_Install_FullMethodName, machineID); err != nil {
+		return err
+	}
+
+	installClient, err := talosClient.LifecycleClient.Install(ctx, &machineapi.LifecycleServiceInstallRequest{
+		Containerd: m.containerdInstance,
+		Source: &machineapi.InstallArtifactsSource{
+			ImageName: resolvedImage,
+		},
+		Destination: &machineapi.InstallDestination{
+			Disk: disk,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = installClient.CloseSend(); err != nil {
+		return err
+	}
+
+	for {
+		msg, recvErr := installClient.Recv()
+		if recvErr != nil {
+			if errors.Is(recvErr, io.EOF) {
+				return nil
+			}
+
+			return recvErr
+		}
+
+		if err = relayProgress(msg.GetProgress(), "installation", cfg.progress); err != nil {
+			return err
+		}
+	}
+}
+
+// upgrade runs LifecycleService.Upgrade and relays installer progress.
+// Note: Talos rejects with FailedPrecondition when the machine reports as not installed.
+func (m *Manager) upgrade(
+	ctx context.Context,
+	talosClient *talosclient.Client,
+	resolvedImage, machineID string,
+	cfg runConfig,
+) error {
+	if err := cfg.audit(ctx, machineapi.LifecycleService_Upgrade_FullMethodName, machineID); err != nil {
+		return err
+	}
+
+	upgradeClient, err := talosClient.LifecycleClient.Upgrade(ctx, &machineapi.LifecycleServiceUpgradeRequest{
+		Containerd: m.containerdInstance,
+		Source: &machineapi.InstallArtifactsSource{
+			ImageName: resolvedImage,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	if err = upgradeClient.CloseSend(); err != nil {
+		return err
+	}
+
+	for {
+		msg, recvErr := upgradeClient.Recv()
+		if recvErr != nil {
+			if errors.Is(recvErr, io.EOF) {
+				return nil
+			}
+
+			return recvErr
+		}
+
+		if err = relayProgress(msg.GetProgress(), "upgrade", cfg.progress); err != nil {
+			return err
+		}
+	}
+}
+
+// reboot triggers a Talos reboot on the machine.
+func (m *Manager) reboot(ctx context.Context, talosClient *talosclient.Client, machineID string, cfg runConfig) error {
+	emitf(cfg.progress, "[omni] rebooting machine to boot into installed Talos")
+
+	if err := cfg.audit(ctx, machineapi.MachineService_Reboot_FullMethodName, machineID); err != nil {
+		return err
+	}
+
+	return talosClient.Reboot(ctx)
+}
+
+// emitf safely sends a formatted progress message if progress is non-nil.
+func emitf(progress func(string), format string, args ...any) {
+	if progress == nil {
+		return
+	}
+
+	progress(fmt.Sprintf(format, args...))
+}
+
+// relayProgress translates a LifecycleService progress payload into operator-visible messages.
+func relayProgress(
+	progress *machineapi.LifecycleServiceInstallProgress,
+	operationLabel string,
+	send func(string),
+) error {
+	switch payload := progress.GetResponse().(type) {
+	case *machineapi.LifecycleServiceInstallProgress_Message:
+		// Talos coalesces multiple log.Printf calls into a single message. Split on '\n' and trim trailing whitespace.
+		for line := range strings.SplitSeq(progress.GetMessage(), "\n") {
+			line = strings.TrimRight(line, " \t\r")
+			if line == "" {
+				continue
+			}
+
+			if send != nil {
+				send("[talos] " + line)
+			}
+		}
+	case *machineapi.LifecycleServiceInstallProgress_ExitCode:
+		if payload.ExitCode != 0 {
+			return status.Errorf(codes.Internal, "%s failed with exit code %d", operationLabel, payload.ExitCode)
+		}
+	}
+
+	return nil
+}

--- a/internal/backend/talos/lifecycle/client_test.go
+++ b/internal/backend/talos/lifecycle/client_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lifecycle_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
+)
+
+func TestBuildInstallImage(t *testing.T) {
+	t.Parallel()
+
+	m := lifecycle.NewManager(zapNop(t), "factory.talos.dev", "ghcr.io/siderolabs/installer")
+
+	ms := omni.NewMachineStatus("machine-1")
+	ms.TypedSpec().Value.TalosVersion = "1.13.1"
+	ms.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{Platform: "metal"}
+	ms.TypedSpec().Value.SecurityState = &specs.SecurityState{}
+	ms.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+		FullId: "current-schematic",
+	}
+
+	t.Run("target install image takes precedence over the machine's current schematic", func(t *testing.T) {
+		t.Parallel()
+
+		image, err := m.BuildInstallImageForTest("machine-1", ms, "1.13.1", &specs.MachineConfigGenOptionsSpec_InstallImage{
+			TalosVersion:         "1.14.0",
+			SchematicId:          "target-schematic",
+			SchematicInitialized: true,
+			Platform:             "metal",
+			SecurityState:        &specs.SecurityState{},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "factory.talos.dev/metal-installer/target-schematic:v1.14.0", image)
+	})
+
+	t.Run("nil target falls back to the machine's current schematic", func(t *testing.T) {
+		t.Parallel()
+
+		image, err := m.BuildInstallImageForTest("machine-1", ms, "1.14.0", nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "factory.talos.dev/metal-installer/current-schematic:v1.14.0", image)
+	})
+
+	t.Run("nil target and empty version reuses the machine's running version", func(t *testing.T) {
+		t.Parallel()
+
+		image, err := m.BuildInstallImageForTest("machine-1", ms, "", nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "factory.talos.dev/metal-installer/current-schematic:v1.13.1", image)
+	})
+
+	t.Run("missing platform metadata fails fast", func(t *testing.T) {
+		t.Parallel()
+
+		bare := omni.NewMachineStatus("machine-bare")
+		bare.TypedSpec().Value.TalosVersion = "1.13.1"
+
+		_, err := m.BuildInstallImageForTest("machine-bare", bare, "", nil)
+		require.Error(t, err)
+	})
+}

--- a/internal/backend/talos/lifecycle/export_test.go
+++ b/internal/backend/talos/lifecycle/export_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lifecycle
+
+import (
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+// BuildInstallImageForTest exposes buildInstallImage to external tests.
+func (m *Manager) BuildInstallImageForTest(
+	machineID string,
+	ms *omni.MachineStatus,
+	version string,
+	target *specs.MachineConfigGenOptionsSpec_InstallImage,
+) (string, error) {
+	return m.buildInstallImage(machineID, ms, version, target)
+}
+
+// AcquireForTest exposes acquire to external tests.
+func (m *Manager) AcquireForTest(machineID string) bool {
+	return m.acquire(machineID)
+}
+
+// ReleaseForTest exposes release to external tests.
+func (m *Manager) ReleaseForTest(machineID string) {
+	m.release(machineID)
+}

--- a/internal/backend/talos/lifecycle/lifecycle.go
+++ b/internal/backend/talos/lifecycle/lifecycle.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package lifecycle runs Talos's LifecycleService.Install/Upgrade for machines in maintenance mode.
+package lifecycle
+
+import (
+	"errors"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+// MaintenanceLifecycleTimeout caps how long a single maintenance install/upgrade can run server-side.
+// It covers the slowest realistic image pull plus the actual disk write.
+const MaintenanceLifecycleTimeout = 15 * time.Minute
+
+// RebootTimeout is the deadline for the post-operation reboot RPC.
+const RebootTimeout = time.Minute
+
+// LivenessProbeTimeout caps the pre-flight liveness probe so a stale "connected" flag can't make us
+// commit the full operation to an unresponsive machine.
+const LivenessProbeTimeout = 5 * time.Second
+
+// Kind identifies a lifecycle operation.
+type Kind int
+
+const (
+	// KindInstall writes Talos to a fresh disk on a machine with no on-disk Talos installed yet.
+	KindInstall Kind = iota + 1
+	// KindUpgrade replaces the existing on-disk Talos on a machine in maintenance mode.
+	KindUpgrade
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindInstall:
+		return "install"
+	case KindUpgrade:
+		return "upgrade"
+	default:
+		return "unknown"
+	}
+}
+
+// Operation describes a single install or upgrade to perform on one machine.
+type Operation struct {
+	// MachineStatus is the live status of the target machine; used to build the install image and to reach the machine's maintenance endpoint.
+	MachineStatus *omni.MachineStatus
+	// InstallImage is the target install image spec. When nil, the image is built from the machine's current schematic at Version (for callers without a target, e.g. the management RPC).
+	InstallImage *specs.MachineConfigGenOptionsSpec_InstallImage
+	MachineID    string
+	// Version is the Talos version to install ("" = the machine's running version). Ignored when InstallImage is set.
+	Version string
+	// Disk is the target install disk (e.g. "/dev/sda"). Required for KindInstall; ignored for KindUpgrade.
+	Disk string
+	Kind Kind
+}
+
+// ErrAlreadyInFlight is returned by Run when another operation is already in progress for the machine.
+var ErrAlreadyInFlight = errors.New("a maintenance lifecycle operation is already in progress for this machine")
+
+// WrapErr wraps an error with a prefix. If the error is a gRPC status, the returned error will have the same status code and the message will be prefixed.
+func WrapErr(err error, prefix string) error {
+	if err == nil {
+		return nil
+	}
+
+	if prefix != "" {
+		prefix += ": "
+	}
+
+	if s, ok := status.FromError(err); ok {
+		return status.Errorf(s.Code(), "%s%s", prefix, s.Message())
+	}
+
+	return status.Errorf(codes.Internal, "%s%v", prefix, err)
+}

--- a/internal/backend/talos/lifecycle/manager.go
+++ b/internal/backend/talos/lifecycle/manager.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lifecycle
+
+import (
+	"context"
+	"sync"
+
+	"github.com/siderolabs/talos/pkg/machinery/api/common"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/talos"
+)
+
+// Manager runs Talos's LifecycleService.Install/Upgrade for machines in maintenance mode. Run
+// performs the full flow (pull, install/upgrade, reboot) synchronously and allows only one in-flight operation per machine.
+type Manager struct {
+	logger             *zap.Logger
+	containerdInstance *common.ContainerdInstance
+	inFlight           map[string]struct{}
+	imageFactoryHost   string
+	talosRegistry      string
+
+	mu sync.Mutex
+}
+
+// NewManager creates a Manager.
+func NewManager(logger *zap.Logger, imageFactoryHost, talosRegistry string) *Manager {
+	return &Manager{
+		logger:           logger,
+		imageFactoryHost: imageFactoryHost,
+		talosRegistry:    talosRegistry,
+		containerdInstance: &common.ContainerdInstance{
+			Driver:    common.ContainerDriver_CONTAINERD,
+			Namespace: common.ContainerdNamespace_NS_SYSTEM,
+		},
+		inFlight: map[string]struct{}{},
+	}
+}
+
+// runConfig holds the per-call options resolved from Option values.
+type runConfig struct {
+	audit    AuditFunc
+	progress func(string)
+}
+
+// Option configures a single Run.
+type Option func(*runConfig)
+
+// WithProgress sets the sink for operator-visible progress messages (gRPC stream or logger).
+func WithProgress(fn func(string)) Option {
+	return func(c *runConfig) {
+		if fn != nil {
+			c.progress = fn
+		}
+	}
+}
+
+// WithAudit sets the audit hook invoked once per Talos call. Without it, calls are not audited.
+func WithAudit(fn AuditFunc) Option {
+	return func(c *runConfig) {
+		if fn != nil {
+			c.audit = fn
+		}
+	}
+}
+
+// SupportsLifecycleManagement verifies the machine runs a Talos version exposing the LifecycleService APIs.
+func (m *Manager) SupportsLifecycleManagement(version string) error {
+	if _, ok := omni.ParseTalosVersionLifecycleSupport(version); !ok {
+		return status.Errorf(codes.FailedPrecondition,
+			"machine Talos version %q is not supported; the lifecycle API requires Talos %s or newer",
+			version, omni.LifecycleServiceMinTalosVersion)
+	}
+
+	return nil
+}
+
+// CheckAlive verifies the machine is reachable over the maintenance API with a quick Version call, so callers can fail fast instead of committing the full operation to an unresponsive machine.
+func (m *Manager) CheckAlive(ctx context.Context, address string) error {
+	talosClient, err := talos.NewMaintenanceClient(ctx, address)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to create talos client: %v", err)
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	if _, err = talosClient.Version(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run performs the maintenance flow synchronously, returning when the machine has been rebooted into the target Talos or on error.
+// Returns ErrAlreadyInFlight if another operation holds this machine.
+func (m *Manager) Run(ctx context.Context, op Operation, opts ...Option) error {
+	cfg := runConfig{audit: NoAudit, progress: func(string) {}}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if !m.acquire(op.MachineID) {
+		return ErrAlreadyInFlight
+	}
+
+	defer m.release(op.MachineID)
+
+	installImageStr, err := m.buildInstallImage(op.MachineID, op.MachineStatus, op.Version, op.InstallImage)
+	if err != nil {
+		return WrapErr(err, "failed to build install image")
+	}
+
+	m.logger.Info("built maintenance lifecycle image",
+		zap.String("machine_id", op.MachineID),
+		zap.String("image", installImageStr),
+		zap.Stringer("operation", op.Kind))
+
+	talosClient, err := talos.NewMaintenanceClient(ctx, op.MachineStatus.TypedSpec().Value.ManagementAddress)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to create talos client: %v", err)
+	}
+
+	defer talosClient.Close() //nolint:errcheck
+
+	// Install/Upgrade expect the image already present in containerd so we pull it here.
+	resolvedImage, err := m.pullInstallerImage(ctx, talosClient, installImageStr, op.MachineID, cfg)
+	if err != nil {
+		return WrapErr(err, "failed to pull installer image")
+	}
+
+	switch op.Kind {
+	case KindInstall:
+		err = m.install(ctx, talosClient, resolvedImage, op.Disk, op.MachineID, cfg)
+
+		// AlreadyExists means Talos already has Talos on disk, which is the precondition Upgrade needs.
+		// The intent is "bring the machine to the target image", so fall back to upgrade.
+		if status.Code(err) == codes.AlreadyExists {
+			cfg.progress("[omni] Talos is already installed on disk; falling back to upgrade")
+
+			m.logger.Info("install rejected as already installed, falling back to upgrade", zap.String("machine_id", op.MachineID))
+
+			err = m.upgrade(ctx, talosClient, resolvedImage, op.MachineID, cfg)
+		}
+
+		if err != nil {
+			return err
+		}
+	case KindUpgrade:
+		if err = m.upgrade(ctx, talosClient, resolvedImage, op.MachineID, cfg); err != nil {
+			return err
+		}
+	default:
+		return status.Errorf(codes.InvalidArgument, "unknown operation kind: %d", op.Kind)
+	}
+
+	// Renew context for the reboot so it doesn't run on residual timeout budget.
+	rebootCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), RebootTimeout)
+	defer cancel()
+
+	if err = m.reboot(rebootCtx, talosClient, op.MachineID, cfg); err != nil {
+		return WrapErr(err, "failed to reboot machine after lifecycle operation")
+	}
+
+	return nil
+}
+
+// acquire claims the in-flight slot for the machine, returning false if one is already held.
+func (m *Manager) acquire(machineID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.inFlight[machineID]; ok {
+		return false
+	}
+
+	m.inFlight[machineID] = struct{}{}
+
+	return true
+}
+
+// release frees the in-flight slot for the machine.
+func (m *Manager) release(machineID string) {
+	m.mu.Lock()
+	delete(m.inFlight, machineID)
+	m.mu.Unlock()
+}

--- a/internal/backend/talos/lifecycle/manager_test.go
+++ b/internal/backend/talos/lifecycle/manager_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lifecycle_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
+)
+
+func TestCheckTalosVersion(t *testing.T) {
+	t.Parallel()
+
+	m := lifecycle.NewManager(zapNop(t), "factory", "ghcr.io/siderolabs/installer")
+
+	for _, tc := range []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{name: "supported 1.13", version: "1.13.0", wantErr: false},
+		{name: "supported with v prefix", version: "v1.13.4", wantErr: false},
+		{name: "supported 1.14 alpha", version: "1.14.0-alpha.1", wantErr: false},
+		{name: "supported next major", version: "2.0.0", wantErr: false},
+		{name: "unsupported 1.12", version: "1.12.5", wantErr: true},
+		{name: "unsupported 1.11", version: "1.11.0", wantErr: true},
+		{name: "unparseable", version: "garbage", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := m.SupportsLifecycleManagement(tc.version)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestKindString(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "install", lifecycle.KindInstall.String())
+	assert.Equal(t, "upgrade", lifecycle.KindUpgrade.String())
+}
+
+func TestInFlightGuard(t *testing.T) {
+	t.Parallel()
+
+	m := lifecycle.NewManager(zapNop(t), "factory", "ghcr.io/siderolabs/installer")
+
+	require.True(t, m.AcquireForTest("machine-1"), "first acquire should succeed")
+	require.False(t, m.AcquireForTest("machine-1"), "second acquire should be rejected while held")
+	require.True(t, m.AcquireForTest("machine-2"), "a different machine is independent")
+
+	m.ReleaseForTest("machine-1")
+	require.True(t, m.AcquireForTest("machine-1"), "acquire should succeed again after release")
+}
+
+func TestRunRejectsWhenInFlight(t *testing.T) {
+	t.Parallel()
+
+	m := lifecycle.NewManager(zapNop(t), "factory", "ghcr.io/siderolabs/installer")
+
+	require.True(t, m.AcquireForTest("machine-1"))
+
+	// MachineStatus is never touched: Run returns at the in-flight guard before building the image.
+	err := m.Run(t.Context(), lifecycle.Operation{MachineID: "machine-1", Kind: lifecycle.KindUpgrade})
+	require.ErrorIs(t, err, lifecycle.ErrAlreadyInFlight)
+}
+
+func TestRunReleasesSlotOnFailure(t *testing.T) {
+	t.Parallel()
+
+	m := lifecycle.NewManager(zapNop(t), "factory.talos.dev", "ghcr.io/siderolabs/installer")
+
+	// No platform metadata → the flow fails fast in buildInstallImage.
+	ms := omni.NewMachineStatus("machine-1")
+	ms.TypedSpec().Value.TalosVersion = "1.13.1"
+
+	err := m.Run(t.Context(), lifecycle.Operation{
+		MachineID:     "machine-1",
+		MachineStatus: ms,
+		Kind:          lifecycle.KindUpgrade,
+	})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, lifecycle.ErrAlreadyInFlight)
+
+	// The slot was released, so the machine can be acquired again.
+	require.True(t, m.AcquireForTest("machine-1"))
+}
+
+func zapNop(t *testing.T) *zap.Logger {
+	t.Helper()
+
+	return zaptest.NewLogger(t)
+}

--- a/internal/integration/talos_test.go
+++ b/internal/integration/talos_test.go
@@ -1104,7 +1104,7 @@ func AssertMachineShouldBeUpgradedInMaintenanceMode(
 }
 
 // maintenanceLifecycleMinTalosVersion is the minimum Talos version that exposes the LifecycleService APIs used by MaintenanceLifecycle.
-var maintenanceLifecycleMinTalosVersion = semver.MustParse("1.13.0")
+var maintenanceLifecycleMinTalosVersion, _ = semver.ParseTolerant(omni.LifecycleServiceMinTalosVersion) //nolint:errcheck
 
 // AssertMachineShouldBeInstalledInMaintenanceMode verifies that Talos can be installed to disk on a
 // machine running in maintenance mode (in memory) via the MaintenanceLifecycle management API with


### PR DESCRIPTION
Cluster creation and scale-up can now bring a maintenance-mode machine to the cluster's Talos version when they differ by a minor version.

Resolves: #2838
