### PR TITLE
fix: allow empty list of extensions in cluster templates

### DIFF
--- a/client/pkg/template/internal/models/cluster.go
+++ b/client/pkg/template/internal/models/cluster.go
@@ -24,8 +24,10 @@ const KindCluster = "Cluster"
 
 // Cluster is a top-level template object.
 type Cluster struct { //nolint:govet
-	Meta             `yaml:",inline"`
-	SystemExtensions `yaml:",inline"`
+	Meta `yaml:",inline"`
+
+	// SystemExtensions are the system extensions to install on the machines of the cluster.
+	SystemExtensions OptionalList `yaml:"systemExtensions,omitempty"`
 
 	// Name is the name of the cluster.
 	Name string `yaml:"name"`
@@ -46,7 +48,7 @@ type Cluster struct { //nolint:govet
 	Patches PatchList `yaml:"patches,omitempty"`
 
 	// KernelArgs are the additional kernel arguments.
-	KernelArgs KernelArgs `yaml:",inline"`
+	KernelArgs OptionalList `yaml:"kernelArgs,omitempty"`
 }
 
 // Features defines cluster-wide features.
@@ -174,7 +176,8 @@ func (cluster *Cluster) Translate(ctx TranslateContext) ([]resource.Resource, er
 	resourceList = append(resourceList, manifests...)
 	resourceList = append(resourceList, healthchecks...)
 
-	schematicConfigurations := cluster.translate(
+	schematicConfigurations := translateExtensions(
+		cluster.SystemExtensions,
 		ctx,
 		cluster.Name,
 	)

--- a/client/pkg/template/internal/models/extensions_test.go
+++ b/client/pkg/template/internal/models/extensions_test.go
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package models_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/template/internal/models"
+)
+
+// TestSystemExtensionsTranslate verifies that the system extensions list distinguishes between an
+// unset list (no extensions configuration is produced, the machine keeps its current extensions) and
+// an explicitly empty list (an extensions configuration with no extensions is produced, which clears
+// the extensions instead of falling back to the initially discovered set).
+func TestSystemExtensionsTranslate(t *testing.T) {
+	for _, tt := range []struct { //nolint:govet
+		name               string
+		extensions         models.OptionalList
+		expectConfig       bool
+		expectedExtensions []string
+	}{
+		{
+			name:         "unset",
+			extensions:   models.OptionalList{},
+			expectConfig: false,
+		},
+		{
+			name:               "explicit empty",
+			extensions:         models.NewOptionalList([]string{}),
+			expectConfig:       true,
+			expectedExtensions: []string{},
+		},
+		{
+			name:               "populated",
+			extensions:         models.NewOptionalList([]string{"siderolabs/hello-world-service"}),
+			expectConfig:       true,
+			expectedExtensions: []string{"siderolabs/hello-world-service"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := models.Cluster{
+				Meta:             models.Meta{Kind: models.KindCluster},
+				Name:             "test-cluster",
+				Kubernetes:       models.KubernetesCluster{Version: "v1.30.0"},
+				Talos:            models.TalosCluster{Version: "v1.7.0"},
+				SystemExtensions: tt.extensions,
+			}
+
+			resources, err := cluster.Translate(models.TranslateContext{ClusterName: "test-cluster"})
+			require.NoError(t, err)
+
+			var configs []*omni.ExtensionsConfiguration
+
+			for _, res := range resources {
+				if config, ok := res.(*omni.ExtensionsConfiguration); ok {
+					configs = append(configs, config)
+				}
+			}
+
+			if !tt.expectConfig {
+				require.Empty(t, configs)
+
+				return
+			}
+
+			require.Len(t, configs, 1)
+			require.Equal(t, tt.expectedExtensions, configs[0].TypedSpec().Value.Extensions)
+
+			clusterLabel, ok := configs[0].Metadata().Labels().Get(omni.LabelCluster)
+			require.True(t, ok)
+			require.Equal(t, "test-cluster", clusterLabel)
+		})
+	}
+}

--- a/client/pkg/template/internal/models/kernelargs.go
+++ b/client/pkg/template/internal/models/kernelargs.go
@@ -10,27 +10,6 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
-// KernelArgs is a wrapper type for the kernel args, which can be specified at a Cluster, MachineSet, or Machine level in cluster templates.
-//
-// This type needs to be included in the models as an inline YAML, e.g., via `yaml:",inline"`.
-type KernelArgs struct {
-	Value *[]string `yaml:"kernelArgs,omitempty"`
-}
-
-// Get returns the kernel args value and whether they are actually defined.
-func (ka *KernelArgs) Get() (args []string, defined bool) {
-	if ka.Value != nil {
-		return *ka.Value, true
-	}
-
-	return nil, false
-}
-
-// Set sets the kernel args value.
-func (ka *KernelArgs) Set(args []string) {
-	ka.Value = &args
-}
-
 func buildKernelArgsResource(id MachineID, args []string) *omni.KernelArgs {
 	kernelArgsRes := omni.NewKernelArgs(resource.ID(id))
 

--- a/client/pkg/template/internal/models/list.go
+++ b/client/pkg/template/internal/models/list.go
@@ -126,7 +126,7 @@ func (l List) Translate(fc FileContext) ([]resource.Resource, error) {
 		FileContext:               fc,
 		LockedMachines:            map[MachineID]struct{}{},
 		MachineDescriptors:        map[MachineID]Descriptors{},
-		MachineSetLevelKernelArgs: map[MachineID]KernelArgs{},
+		MachineSetLevelKernelArgs: map[MachineID]OptionalList{},
 	}
 
 	for _, model := range l {

--- a/client/pkg/template/internal/models/machine.go
+++ b/client/pkg/template/internal/models/machine.go
@@ -27,8 +27,10 @@ const KindMachine = "Machine"
 
 // Machine provides customization for a specific machine.
 type Machine struct { //nolint:govet
-	Meta             `yaml:",inline"`
-	SystemExtensions `yaml:",inline"`
+	Meta `yaml:",inline"`
+
+	// SystemExtensions are the system extensions to install on the machine.
+	SystemExtensions OptionalList `yaml:"systemExtensions,omitempty"`
 
 	// Machine name (ID).
 	Name MachineID `yaml:"name"`
@@ -46,7 +48,7 @@ type Machine struct { //nolint:govet
 	Patches PatchList `yaml:"patches,omitempty"`
 
 	// KernelArgs are the additional kernel arguments.
-	KernelArgs KernelArgs `yaml:",inline"`
+	KernelArgs OptionalList `yaml:"kernelArgs,omitempty"`
 }
 
 // MachineInstall provides machine install configuration.
@@ -144,7 +146,8 @@ func (machine *Machine) Translate(ctx TranslateContext) ([]resource.Resource, er
 
 	resourceList = append(resourceList, patches...)
 
-	schematicConfigurations := machine.translate(
+	schematicConfigurations := translateExtensions(
+		machine.SystemExtensions,
 		ctx,
 		string(machine.Name),
 		pair.MakePair(omni.LabelClusterMachine, string(machine.Name)),

--- a/client/pkg/template/internal/models/machineset.go
+++ b/client/pkg/template/internal/models/machineset.go
@@ -19,8 +19,10 @@ import (
 
 // MachineSet is a base model for controlplane and workers.
 type MachineSet struct { //nolint:govet
-	Meta             `yaml:",inline"`
-	SystemExtensions `yaml:",inline"`
+	Meta `yaml:",inline"`
+
+	// SystemExtensions are the system extensions to install on the machines of the machine set.
+	SystemExtensions OptionalList `yaml:"systemExtensions,omitempty"`
 
 	// Name is the name of the machine set. When empty, the default name will be used.
 	Name string `yaml:"name,omitempty"`
@@ -48,7 +50,7 @@ type MachineSet struct { //nolint:govet
 	Patches PatchList `yaml:"patches,omitempty"`
 
 	// KernelArgs are the additional kernel arguments.
-	KernelArgs KernelArgs `yaml:",inline"`
+	KernelArgs OptionalList `yaml:"kernelArgs,omitempty"`
 }
 
 // BootstrapSpec defines the model for setting the bootstrap specification, i.e. restoring from a backup, in the machine set.
@@ -285,7 +287,8 @@ func (machineset *MachineSet) translate(ctx TranslateContext, nameSuffix, roleLa
 
 	resourceList = append(resourceList, patches...)
 
-	schematicConfigurations := machineset.SystemExtensions.translate(
+	schematicConfigurations := translateExtensions(
+		machineset.SystemExtensions,
 		ctx,
 		id,
 		pair.MakePair(omni.LabelMachineSet, id),

--- a/client/pkg/template/internal/models/models.go
+++ b/client/pkg/template/internal/models/models.go
@@ -38,18 +38,19 @@ type TranslateContext struct {
 	FileContext
 	LockedMachines            map[MachineID]struct{}
 	MachineDescriptors        map[MachineID]Descriptors
-	MachineSetLevelKernelArgs map[MachineID]KernelArgs
-	ClusterLevelKernelArgs    KernelArgs
+	MachineSetLevelKernelArgs map[MachineID]OptionalList
 	ClusterName               string
+	ClusterLevelKernelArgs    OptionalList
 }
 
-// SystemExtensions is embedded in Cluster, MachineSet and Machine objects.
-type SystemExtensions struct {
-	SystemExtensions []string `yaml:"systemExtensions,omitempty"`
-}
-
-func (s *SystemExtensions) translate(ctx TranslateContext, nameSuffix string, labels ...pair.Pair[string, string]) []resource.Resource {
-	if len(s.SystemExtensions) == 0 {
+// translateExtensions translates a system extensions list, defined at a cluster, machine set, or
+// machine level, into an extensions configuration resource.
+//
+// An unset list leaves the machine's current extensions untouched, while an empty list clears them
+// instead of falling back to the set of extensions discovered when the machine first connected.
+func translateExtensions(extensions OptionalList, ctx TranslateContext, nameSuffix string, labels ...pair.Pair[string, string]) []resource.Resource {
+	values, defined := extensions.Get()
+	if !defined {
 		return nil
 	}
 
@@ -63,7 +64,7 @@ func (s *SystemExtensions) translate(ctx TranslateContext, nameSuffix string, la
 		}
 	})
 
-	configuration.TypedSpec().Value.Extensions = s.SystemExtensions
+	configuration.TypedSpec().Value.Extensions = values
 
 	return []resource.Resource{
 		configuration,

--- a/client/pkg/template/internal/models/optionallist.go
+++ b/client/pkg/template/internal/models/optionallist.go
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package models
+
+import "go.yaml.in/yaml/v4"
+
+// OptionalList is a list of strings that tells an unset list apart from an explicitly empty one.
+//
+// An unset list is omitted from YAML, while a defined list is rendered as a sequence, including the
+// empty `[]`. This lets a template express "leave this as it is" separately from "clear it".
+//
+//nolint:recvcheck
+type OptionalList struct {
+	value   []string
+	defined bool
+}
+
+// NewOptionalList returns a defined OptionalList holding the given values.
+func NewOptionalList(values []string) OptionalList {
+	return OptionalList{value: values, defined: true}
+}
+
+// Get returns the list and whether it is defined.
+func (l OptionalList) Get() (values []string, defined bool) {
+	return l.value, l.defined
+}
+
+// Set sets the list, marking it as defined.
+func (l *OptionalList) Set(values []string) {
+	l.value = values
+	l.defined = true
+}
+
+// IsZero reports whether the list is unset, so that it is omitted from YAML.
+func (l OptionalList) IsZero() bool {
+	return !l.defined
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (l *OptionalList) UnmarshalYAML(node *yaml.Node) error {
+	var values []string
+
+	if err := node.Decode(&values); err != nil {
+		return err
+	}
+
+	l.value = values
+	l.defined = true
+
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (l OptionalList) MarshalYAML() (any, error) {
+	return l.value, nil
+}

--- a/client/pkg/template/operations/export.go
+++ b/client/pkg/template/operations/export.go
@@ -617,12 +617,16 @@ func transformKubernetesHealthChecksToModels(healthchecks []*omni.KubernetesHeal
 	return result
 }
 
-func transformExtensions(extensions []*omni.ExtensionsConfiguration) models.SystemExtensions {
+func transformExtensions(extensions []*omni.ExtensionsConfiguration) models.OptionalList {
 	if len(extensions) == 0 {
-		return models.SystemExtensions{}
+		// No extensions configuration at this level: leave the list unset.
+		return models.OptionalList{}
 	}
 
-	return models.SystemExtensions{SystemExtensions: extensions[0].TypedSpec().Value.Extensions}
+	// An extensions configuration exists at this level: export the list explicitly, even when it
+	// is empty, so that a re-applied template keeps clearing the extensions instead of falling back
+	// to the machine's initially discovered set.
+	return models.NewOptionalList(extensions[0].TypedSpec().Value.Extensions)
 }
 
 type layeredResources[T meta.ResourceWithRD] struct {

--- a/client/pkg/template/operations/extensions_export_test.go
+++ b/client/pkg/template/operations/extensions_export_test.go
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package operations_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/template/operations"
+)
+
+// TestExportTemplateEmptyExtensions verifies that an extensions configuration with an empty list is
+// exported as an explicitly empty list, so a re-applied template keeps the extensions cleared instead
+// of falling back to the machine's initially discovered set.
+func TestExportTemplateEmptyExtensions(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	st := buildState(ctx, t)
+
+	// clear the extensions of the cluster-level extensions configuration
+	_, err := safe.StateUpdateWithConflicts(
+		ctx, st, omni.NewExtensionsConfiguration("schematic-export-test").Metadata(),
+		func(res *omni.ExtensionsConfiguration) error {
+			res.TypedSpec().Value.Extensions = []string{}
+
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	var sb strings.Builder
+
+	_, err = operations.ExportTemplate(ctx, st, "export-test", false, &sb)
+	require.NoError(t, err)
+
+	require.Contains(t, sb.String(), "systemExtensions: []")
+}

--- a/internal/backend/runtime/omni/controllers/omni/schematic/configuration.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic/configuration.go
@@ -110,7 +110,7 @@ func NewConfigurationController(imageFactoryClient Ensurer) *ConfigurationContro
 
 func (ctrl *ConfigurationController) saveMachineExtensionStatus(ctx context.Context, r controller.ReaderWriter, status *omni.MachineExtensionsStatus) error {
 	return safe.WriterModify(ctx, r, omni.NewMachineExtensionsStatus(status.Metadata().ID()), func(res *omni.MachineExtensionsStatus) error {
-		helpers.CopyAllLabels(status, res)
+		helpers.SyncAllLabels(status, res)
 
 		res.TypedSpec().Value = status.TypedSpec().Value
 

--- a/internal/backend/runtime/omni/controllers/omni/schematic/configuration_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic/configuration_test.go
@@ -115,6 +115,20 @@ func TestSchematicConfigurationReconcile(t *testing.T) {
 				},
 			)
 
+			// while allocated to a cluster, the machine extensions status carries the cluster-related labels
+			rtestutils.AssertResources(
+				ctx, t, st, []string{machineName},
+				func(machineExtensionsStatus *omni.MachineExtensionsStatus, assertion *assert.Assertions) {
+					cl, hasClusterLabel := machineExtensionsStatus.Metadata().Labels().Get(omni.LabelCluster)
+					assertion.True(hasClusterLabel)
+					assertion.Equal(clusterName, cl)
+
+					ms, hasMachineSetLabel := machineExtensionsStatus.Metadata().Labels().Get(omni.LabelMachineSet)
+					assertion.True(hasMachineSetLabel)
+					assertion.Equal(machineSet, ms)
+				},
+			)
+
 			// set empty extensions list for the cluster
 			extensionsConfiguration := omni.NewExtensionsConfiguration("test")
 			extensionsConfiguration.TypedSpec().Value.Extensions = nil
@@ -406,6 +420,15 @@ func TestSchematicConfigurationReconcile(t *testing.T) {
 			rtestutils.AssertResources(ctx, t, st, []string{machineName}, func(schematicConfiguration *omni.SchematicConfiguration, assertion *assert.Assertions) {
 				_, hasClusterLabel := schematicConfiguration.Metadata().Labels().Get(omni.LabelCluster)
 				assertion.False(hasClusterLabel)
+			})
+
+			// once deallocated, the machine extensions status must drop the cluster-related labels as well
+			rtestutils.AssertResources(ctx, t, st, []string{machineName}, func(machineExtensionsStatus *omni.MachineExtensionsStatus, assertion *assert.Assertions) {
+				_, hasClusterLabel := machineExtensionsStatus.Metadata().Labels().Get(omni.LabelCluster)
+				assertion.False(hasClusterLabel)
+
+				_, hasMachineSetLabel := machineExtensionsStatus.Metadata().Labels().Get(omni.LabelMachineSet)
+				assertion.False(hasMachineSetLabel)
 			})
 
 			// Change the extensions in the ExtensionsConfiguration: because the machine is no more allocated, it should be no-op, and the existing list of extensions should be preserved.


### PR DESCRIPTION
Cluster templates could not distinguish an unset extensions list from an explicitly empty one, so extensions could not be cleared through a template. The list is now optional, like kernel arguments: omitting it keeps the current extensions, while setting it to empty clears them. The exporter preserves this distinction too.

Also, a machine removed from a cluster kept its cluster and machine set labels on the extensions status, because label updates never dropped stale entries. They are now synchronized on each update.

Part of siderolabs/omni#2972.