### PR TITLE
fix: ignore the embedded-config meta extension

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
@@ -51,11 +51,11 @@ func GetSchematicInfo(ctx context.Context, talosState state.CoreState, fallbackK
 
 	for status := range items.All() {
 		name := status.TypedSpec().Metadata.Name
-		if name == extensions.MetalAgentExtensionName {
-			return SchematicInfo{InAgentMode: true}, nil
-		}
 
-		if name == constants.SchematicIDExtensionName { // skip the meta extension
+		switch name {
+		case extensions.MetalAgentExtensionName:
+			return SchematicInfo{InAgentMode: true}, nil
+		case constants.SchematicIDExtensionName: // skip the meta extension
 			fullID = status.TypedSpec().Metadata.Version
 
 			if status.TypedSpec().Metadata.ExtraInfo != "" {
@@ -65,19 +65,15 @@ func GetSchematicInfo(ctx context.Context, talosState state.CoreState, fallbackK
 					return SchematicInfo{}, fmt.Errorf("failed to unmarshal schematic manifest: %w", err)
 				}
 			}
+		case "modules.dep": // ignore the virtual extension used for kernel modules dependencies
+		case "embedded-config": // ignore the meta extension reported by machines carrying an embedded machine configuration
+		default:
+			if !strings.HasPrefix(name, extensions.OfficialPrefix) {
+				name = extensions.OfficialPrefix + name
+			}
 
-			continue
+			exts = append(exts, name)
 		}
-
-		if name == "modules.dep" { // ignore the virtual extension used for kernel modules dependencies
-			continue
-		}
-
-		if !strings.HasPrefix(name, extensions.OfficialPrefix) {
-			name = extensions.OfficialPrefix + name
-		}
-
-		exts = append(exts, name)
 	}
 
 	exts = extensions.MapNames(exts)

--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic_test.go
@@ -214,6 +214,37 @@ func TestGetSchematicInfo(t *testing.T) {
 		assert.Equal(t, []string{"siderolabs/gvisor"}, info.Extensions)
 	})
 
+	t.Run("embedded-config meta extension is filtered out", func(t *testing.T) {
+		t.Parallel()
+
+		// machines carrying an embedded machine configuration report an "embedded-config" meta extension which must not leak into the extensions list
+		st := buildState(t, []extension{
+			{name: constants.SchematicIDExtensionName, version: factorySchematicID, extraInfo: factorySchematicYAML},
+			{name: "embedded-config"},
+			{name: "siderolabs/gvisor"},
+		})
+
+		info, err := talos.GetSchematicInfo(t.Context(), st, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"siderolabs/gvisor"}, info.Extensions)
+	})
+
+	t.Run("embedded-config meta extension alone does not trigger ErrInvalidSchematic", func(t *testing.T) {
+		t.Parallel()
+
+		// no real extensions, no schematic meta extension, only the embedded-config meta extension: it must be ignored, so the synthesizing fallback path is taken without error
+		st := buildState(t, []extension{
+			{name: "embedded-config"},
+		})
+
+		info, err := talos.GetSchematicInfo(t.Context(), st, nil)
+		require.NoError(t, err)
+
+		assert.Empty(t, info.Extensions)
+		assert.Equal(t, schematicID(t, schematic.Schematic{}), info.FullID)
+	})
+
 	t.Run("extension name without official prefix gets prefixed", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Machines that boot with an embedded machine configuration report an `embedded-config` meta extension alongside their real extensions. It was picked up as a regular extension and stored in the machine's detected extension list, so Omni computed schematics that listed `embedded-config` as an installable extension. Those schematics are invalid, and Talos installations using them fail with an "extension not found" error.

Filter it out when collecting the extensions, so it no longer affects the computed schematic.