### PR TITLE
fix: stabilize flaky talemu e2e EULA setup and preset downloads

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
       name: 'talemu-setup',
       testMatch: 'talemu/talemu.setup.ts',
       teardown: 'talemu-teardown',
+      // The setup uses the auth fixture, which assumes the EULA is already
+      // accepted. Without this dependency talemu-setup races the eula project
+      // and intermittently gets stuck on the EULA gate ("setting up auth" timeout).
+      dependencies: ['eula'],
     },
     {
       name: 'talemu-teardown',

--- a/frontend/src/views/InstallationMedia/DownloadPresetModal.vue
+++ b/frontend/src/views/InstallationMedia/DownloadPresetModal.vue
@@ -212,6 +212,7 @@ async function close() {
                   <IconButton
                     is="a"
                     :href="link"
+                    :disabled="!schematicId"
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="download"
@@ -220,7 +221,12 @@ async function close() {
                 </Tooltip>
 
                 <Tooltip description="Copy link">
-                  <IconButton aria-label="copy link" icon="copy" @click="copy(link)" />
+                  <IconButton
+                    aria-label="copy link"
+                    icon="copy"
+                    :disabled="!schematicId"
+                    @click="copy(link)"
+                  />
                 </Tooltip>
               </div>
             </TableCell>


### PR DESCRIPTION
The talemu-setup Playwright project declared no dependency on the eula project, so it raced EULA acceptance; when its auth fixture logged in before the EULA was accepted it got stuck on the EULA gate and timed out, cascading failures to nearly every talemu test. It now depends on the eula project.

Separately, the preset download modal exposed its copy and download actions before the schematic finished resolving, producing image URLs with an empty schematic ID (.../image//...). Those actions are now disabled until the schematic ID is available.