### PR TITLE
feat(frontend): use machine status link snapshot for recent machines phase

### DIFF
--- a/frontend/src/components/Status/MachineStage.vue
+++ b/frontend/src/components/Status/MachineStage.vue
@@ -1,0 +1,44 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import type { Resource } from '@/api/grpc'
+import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
+import TIcon from '@/components/Icon/TIcon.vue'
+import Tooltip from '@/components/Tooltip/Tooltip.vue'
+import { useDerivedMachineStage } from '@/methods/useDerivedMachineStage'
+
+defineOptions({ inheritAttrs: false })
+
+const { machine, iconOnly } = defineProps<{
+  machine: Resource<MachineStatusLinkSpec>
+  iconOnly?: boolean
+}>()
+
+const { status } = useDerivedMachineStage(() => machine.spec.snapshot)
+</script>
+
+<template>
+  <Tooltip
+    v-if="status"
+    :disabled="!iconOnly"
+    :description="status.name"
+    :class="{ 'opacity-50': machine.spec.tearing_down }"
+  >
+    <div class="flex items-center gap-1" v-bind="$attrs" :class="status.class">
+      <!-- Wrapper to prevent tooltip bounce when icon is animated e.g. loading -->
+      <span class="size-4 shrink-0">
+        <TIcon
+          :icon="status.icon"
+          class="size-full"
+          :aria-label="`status: ${status.name.toLowerCase()}`"
+        />
+      </span>
+
+      <span v-if="!iconOnly" class="text-xs">{{ status.name }}</span>
+    </div>
+  </Tooltip>
+</template>

--- a/frontend/src/views/Home/HomeContent.vue
+++ b/frontend/src/views/Home/HomeContent.vue
@@ -6,8 +6,14 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { Runtime } from '@/api/common/omni.pb'
-import type { ClusterStatusSpec, MachineStatusSpec } from '@/api/omni/specs/omni.pb'
-import { ClusterStatusType, DefaultNamespace, MachineStatusType } from '@/api/resources'
+import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
+import type { ClusterStatusSpec } from '@/api/omni/specs/omni.pb'
+import {
+  ClusterStatusType,
+  DefaultNamespace,
+  MachineStatusLinkType,
+  MetricsNamespace,
+} from '@/api/resources'
 import { usePermissions } from '@/methods/auth'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import HomeClustersChart from '@/views/Home/HomeClustersChart.vue'
@@ -31,16 +37,18 @@ const { data: clusters, loading: clustersLoading } = useResourceWatch<ClusterSta
   sortDescending: true,
 }))
 
-const { data: machines, loading: machinesLoading } = useResourceWatch<MachineStatusSpec>(() => ({
-  skip: !canReadMachines.value,
-  resource: {
-    namespace: DefaultNamespace,
-    type: MachineStatusType,
-  },
-  runtime: Runtime.Omni,
-  sortByField: 'created',
-  sortDescending: true,
-}))
+const { data: machines, loading: machinesLoading } = useResourceWatch<MachineStatusLinkSpec>(
+  () => ({
+    skip: !canReadMachines.value,
+    resource: {
+      namespace: MetricsNamespace,
+      type: MachineStatusLinkType,
+    },
+    runtime: Runtime.Omni,
+    sortByField: 'created',
+    sortDescending: true,
+  }),
+)
 
 // Disabled entirely until we decide where to get the information from
 const showReleaseNotes = false

--- a/frontend/src/views/Home/HomeRecentMachines.vue
+++ b/frontend/src/views/Home/HomeRecentMachines.vue
@@ -6,16 +6,17 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import type { Resource } from '@/api/grpc'
-import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
+import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
+import { LabelCluster } from '@/api/resources'
 import { itemID } from '@/api/watch'
 import TButton from '@/components/Button/TButton.vue'
 import Card from '@/components/Card/Card.vue'
 import CopyButton from '@/components/CopyButton/CopyButton.vue'
-import TIcon from '@/components/Icon/TIcon.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
+import MachineStage from '@/components/Status/MachineStage.vue'
 
 defineProps<{
-  machines: Resource<MachineStatusSpec>[]
+  machines: Resource<MachineStatusLinkSpec>[]
   loading: boolean
 }>()
 </script>
@@ -58,24 +59,15 @@ defineProps<{
       </div>
 
       <div class="flex min-w-0 justify-center">
-        <span v-if="item.spec.cluster" class="resource-label label-blue truncate">
-          cluster:{{ item.spec.cluster }}
+        <span
+          v-if="item.metadata.labels?.[LabelCluster]"
+          class="resource-label label-blue truncate"
+        >
+          cluster:{{ item.metadata.labels[LabelCluster] }}
         </span>
       </div>
 
-      <div
-        class="flex items-center gap-1 place-self-end"
-        :class="item.metadata.phase === 'running' ? 'text-green-g1' : 'text-red-r1'"
-      >
-        <TIcon
-          class="h-4"
-          :icon="item.metadata.phase === 'running' ? 'check-in-circle' : 'delete'"
-        />
-
-        <span class="contents max-sm:hidden">
-          {{ item.metadata.phase === 'running' ? 'Running' : 'Destroying' }}
-        </span>
-      </div>
+      <MachineStage :machine="item" class="place-self-end" />
     </div>
   </Card>
 </template>

--- a/frontend/src/views/Machines/MachineItem.vue
+++ b/frontend/src/views/Machines/MachineItem.vue
@@ -20,6 +20,7 @@ import TActionsBoxItem from '@/components/ActionsBox/TActionsBoxItem.vue'
 import TCheckbox from '@/components/Checkbox/TCheckbox.vue'
 import CopyButton from '@/components/CopyButton/CopyButton.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
+import MachineStage from '@/components/Status/MachineStage.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { useClusterPermissions, usePermissions } from '@/methods/auth'
 import type { Label } from '@/methods/labels'
@@ -65,7 +66,7 @@ const machineName = computed(() => {
 
 const clusterName = computed(() => machine.spec.message_status?.cluster)
 
-const { installing, upgrading, status } = useDerivedMachineStage(() => machine.spec.snapshot)
+const { installing, upgrading } = useDerivedMachineStage(() => machine.spec.snapshot)
 
 const canDoMaintenanceUpdate = computed(() => {
   if (machine.spec.message_status?.cluster) {
@@ -189,21 +190,7 @@ const canUseLifecycleUpgrade = computed(() => {
           />
         </Tooltip>
 
-        <Tooltip
-          v-if="status"
-          :description="status.name"
-          :class="{ 'opacity-50': machine.spec.tearing_down }"
-        >
-          <!-- Wrapper to prevent tooltip bounce when icon is animated e.g. loading -->
-          <span class="size-4 shrink-0">
-            <TIcon
-              :icon="status.icon"
-              class="size-full"
-              :class="status.class"
-              :aria-label="`status: ${status.name.toLowerCase()}`"
-            />
-          </span>
-        </Tooltip>
+        <MachineStage :machine icon-only />
 
         <div class="grow" />
 


### PR DESCRIPTION
On the home page, for the recent machines list, use MachineStatusLink snapshot to generate the phase information, which is more detailed.

Closes #3007 