### PR TITLE
fix: get rid of the race in the UUID conflict resolution flow

### DIFF
--- a/hack/test/provisionconfig.yaml
+++ b/hack/test/provisionconfig.yaml
@@ -1,7 +1,14 @@
 ---
-count: 15
+count: 10
 provider:
   id: talemu
+---
+# provision 5 machines with fixed fake UUID to make them conflict to test UUID conflict resolution
+count: 5
+provider:
+  id: talemu
+  data: |
+    uuid: 00000000-0000-0000-0000-000000000000
 ---
 count: 15
 provider:

--- a/internal/backend/runtime/omni/controllers/omni/omni_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni_test.go
@@ -90,7 +90,8 @@ type machineService struct {
 	serviceList             *machine.ServiceListResponse
 	etcdLeaveClusterHandler func(context.Context, *machine.EtcdLeaveClusterRequest) (*machine.EtcdLeaveClusterResponse, error)
 
-	metaKeys map[uint32]string
+	metaKeys       map[uint32]string
+	metaWriteCount map[uint32]int
 
 	address      string
 	state        state.State
@@ -102,6 +103,13 @@ func (ms *machineService) getMetaKeys() map[uint32]string {
 	defer ms.lock.Unlock()
 
 	return maps.Clone(ms.metaKeys)
+}
+
+func (ms *machineService) getMetaWriteCount(key uint32) int {
+	ms.lock.Lock()
+	defer ms.lock.Unlock()
+
+	return ms.metaWriteCount[key]
 }
 
 func (ms *machineService) ApplyConfiguration(_ context.Context, req *machine.ApplyConfigurationRequest) (*machine.ApplyConfigurationResponse, error) {
@@ -266,7 +274,12 @@ func (ms *machineService) MetaWrite(_ context.Context, req *machine.MetaWriteReq
 		ms.metaKeys = map[uint32]string{}
 	}
 
+	if ms.metaWriteCount == nil {
+		ms.metaWriteCount = map[uint32]int{}
+	}
+
 	ms.metaKeys[req.Key] = string(req.Value)
+	ms.metaWriteCount[req.Key]++
 
 	return &machine.MetaWriteResponse{}, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/pending_machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/pending_machine_status.go
@@ -178,6 +178,17 @@ func (handler *pendingMachineStatusHandler) handleUUIDConflicts(
 		return nil
 	}
 
+	// Skip generating a new override UUID if one was already issued for this pending machine.
+	//
+	// The pending machine is keyed by the node public key and keeps the conflict annotation until it
+	// is cleaned up, so this handler can reconcile several times for the same machine. Generating a
+	// fresh uuid.NewString() on every reconcile makes the machine re-join under multiple UUIDs, which
+	// creates duplicate Link resources for a single physical machine (same public key and node subnet).
+	// Mirror the idempotency guard used by generateUniqueNodeToken: issue the override exactly once.
+	if existing, ok := pendingMachineStatus.Metadata().Annotations().Get(omni.MachineUUID); ok && existing != machineUUID {
+		return nil
+	}
+
 	id := uuid.NewString()
 
 	if err := c.MetaWrite(ctx, meta.UUIDOverride, []byte(id)); err != nil {

--- a/internal/backend/runtime/omni/controllers/omni/pending_machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/pending_machine_status_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -158,6 +159,71 @@ func (suite *PendingMachineStatusSuite) TestReconcile() {
 
 	metaKeys = machineServices["p4"].getMetaKeys()
 	suite.Assert().NotContains(metaKeys, meta.UUIDOverride)
+}
+
+// TestUUIDConflictGeneratedOnce ensures the override UUID is generated exactly once for a conflicting
+// pending machine, even if the controller reconciles many times while the conflict annotation is set.
+//
+// Regenerating the override on every reconcile makes the machine re-join under multiple UUIDs, which
+// produces duplicate Link resources (same public key and node subnet) for a single physical machine.
+func (suite *PendingMachineStatusSuite) TestUUIDConflictGeneratedOnce() {
+	suite.startRuntime()
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*10)
+	defer cancel()
+
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewPendingMachineStatusController()))
+
+	const (
+		name        = "conflict-once"
+		machineUUID = "dup-uuid"
+	)
+
+	ms, err := suite.newServer(name)
+	suite.Require().NoError(err)
+
+	pendingMachine := siderolink.NewPendingMachine(name, &specs.SiderolinkSpec{})
+	pendingMachine.Metadata().Labels().Set(omni.MachineUUID, machineUUID)
+	pendingMachine.Metadata().Annotations().Set(siderolink.PendingMachineUUIDConflict, "")
+	pendingMachine.TypedSpec().Value.NodeSubnet = unixSocket + suite.socketPath + name
+
+	suite.Require().NoError(suite.state.Create(ctx, pendingMachine))
+	suite.Require().NoError(suite.state.Create(ctx, siderolink.NewLinkStatus(pendingMachine)))
+
+	// wait until the controller injects a freshly generated override UUID
+	var overrideUUID string
+
+	rtestutils.AssertResource(
+		ctx, suite.T(), suite.state, name,
+		func(pms *siderolink.PendingMachineStatus, assert *assert.Assertions) {
+			id, ok := pms.Metadata().Annotations().Get(omni.MachineUUID)
+			assert.True(ok)
+			assert.NotEqual(machineUUID, id)
+
+			overrideUUID = id
+		},
+	)
+
+	suite.Require().NotEmpty(overrideUUID)
+	suite.Require().Equal(overrideUUID, ms.getMetaKeys()[meta.UUIDOverride])
+
+	// force repeated reconciles of the same pending machine, mirroring the per-provision touches that
+	// happen in production while the conflict annotation is still present
+	for i := range 10 {
+		_, err = safe.StateUpdateWithConflicts(ctx, suite.state, pendingMachine.Metadata(), func(res *siderolink.PendingMachine) error {
+			res.Metadata().Annotations().Set("reconcile-trigger", fmt.Sprintf("%d", i))
+
+			return nil
+		})
+		suite.Require().NoError(err)
+	}
+
+	// the override UUID must be written exactly once and never change
+	suite.Assert().Never(func() bool {
+		return ms.getMetaWriteCount(meta.UUIDOverride) != 1
+	}, time.Second*2, time.Millisecond*50)
+
+	suite.Assert().Equal(overrideUUID, ms.getMetaKeys()[meta.UUIDOverride])
 }
 
 func TestPendingMachineStatusSuite(t *testing.T) {


### PR DESCRIPTION
Also use Talemu to provision machines with duplicate UUIDs.

Fixes: https://github.com/siderolabs/omni/issues/2836
Fixes: https://github.com/siderolabs/omni/issues/1241

Depends on https://github.com/siderolabs/talemu/pull/65 for the tests to pass.