### PR TITLE
fix: prevent API requests from hanging after idle periods

### DIFF
--- a/internal/backend/grpc/grpc.go
+++ b/internal/backend/grpc/grpc.go
@@ -142,6 +142,11 @@ func RegisterGateway(
 			return memtrans.DialContext(dctx)
 		}),
 		grpc.WithSharedWriteBuffer(true),
+		// Disable idle mode: this is a permanent in-process loopback connection,
+		// so there is nothing to reclaim by going idle, and it avoids the
+		// first-request latency of re-establishing the connection after a quiet
+		// period.
+		grpc.WithIdleTimeout(0),
 	}
 
 	for srv, err := range servers {

--- a/internal/backend/grpc/router/router.go
+++ b/internal/backend/grpc/router/router.go
@@ -100,6 +100,11 @@ func NewRouter(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32),
 			grpc.ForceCodecV2(proxy.Codec()),
 		),
+		// Disable idle mode: this is a permanent in-process loopback connection,
+		// so there is nothing to reclaim by going idle, and it avoids the
+		// first-request latency of re-establishing the connection after a quiet
+		// period.
+		grpc.WithIdleTimeout(0),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial omni backend: %w", err)


### PR DESCRIPTION
Omni could stop responding to all API requests after a period without API activity, leaving the web UI on a blank page while static assets still loaded, and required a restart to recover.

The connections that carry the API gateway and internal proxy traffic run in-process and relied on gRPC idle mode, which tears down and later re-establishes a connection that has been inactive. A bug in gRPC could leave such a connection permanently stuck once it went idle, so every subsequent request blocked forever.

Idle mode provides no benefit for these connections because they are in-process and live for the whole lifetime of the process, so disable it. This avoids the stuck connection and also removes the latency of re-establishing it on the first request after a quiet period.

A fix for the underlying gRPC issue has been submitted upstream in grpc/grpc-go#9191, but disabling idle mode here is the correct configuration regardless.