### PR TITLE
feat(frontend): add embedded machine config UI

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -1448,6 +1448,7 @@ type CreateSchematicRequest struct {
 	JoinToken                string                                          `protobuf:"bytes,8,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
 	Overlay                  *CreateSchematicRequest_Overlay                 `protobuf:"bytes,9,opt,name=overlay,proto3" json:"overlay,omitempty"`
 	Bootloader               SchematicBootloader                             `protobuf:"varint,10,opt,name=bootloader,proto3,enum=management.SchematicBootloader" json:"bootloader,omitempty"`
+	EmbeddedMachineConfig    string                                          `protobuf:"bytes,11,opt,name=embedded_machine_config,json=embeddedMachineConfig,proto3" json:"embedded_machine_config,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -1543,6 +1544,13 @@ func (x *CreateSchematicRequest) GetBootloader() SchematicBootloader {
 		return x.Bootloader
 	}
 	return SchematicBootloader_BOOT_AUTO
+}
+
+func (x *CreateSchematicRequest) GetEmbeddedMachineConfig() string {
+	if x != nil {
+		return x.EmbeddedMachineConfig
+	}
+	return ""
 }
 
 type CreateSchematicFromRawRequest struct {
@@ -3457,7 +3465,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\fResponseType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\f\n" +
 	"\bMANIFEST\x10\x01\x12\v\n" +
-	"\aROLLOUT\x10\x02\"\xf0\x05\n" +
+	"\aROLLOUT\x10\x02\"\xa8\x06\n" +
 	"\x16CreateSchematicRequest\x12\x1e\n" +
 	"\n" +
 	"extensions\x18\x01 \x03(\tR\n" +
@@ -3474,7 +3482,8 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\n" +
 	"bootloader\x18\n" +
 	" \x01(\x0e2\x1f.management.SchematicBootloaderR\n" +
-	"bootloader\x1aM\n" +
+	"bootloader\x126\n" +
+	"\x17embedded_machine_config\x18\v \x01(\tR\x15embeddedMachineConfig\x1aM\n" +
 	"\aOverlay\x12\x14\n" +
 	"\x05image\x18\x01 \x01(\tR\x05image\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -173,6 +173,7 @@ message CreateSchematicRequest {
   string join_token = 8;
   Overlay overlay = 9;
   SchematicBootloader bootloader = 10;
+  string embedded_machine_config = 11;
 }
 
 message CreateSchematicFromRawRequest {

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -456,6 +456,7 @@ func (m *CreateSchematicRequest) CloneVT() *CreateSchematicRequest {
 	r.JoinToken = m.JoinToken
 	r.Overlay = m.Overlay.CloneVT()
 	r.Bootloader = m.Bootloader
+	r.EmbeddedMachineConfig = m.EmbeddedMachineConfig
 	if rhs := m.Extensions; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -1662,6 +1663,9 @@ func (this *CreateSchematicRequest) EqualVT(that *CreateSchematicRequest) bool {
 		return false
 	}
 	if this.Bootloader != that.Bootloader {
+		return false
+	}
+	if this.EmbeddedMachineConfig != that.EmbeddedMachineConfig {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -3563,6 +3567,13 @@ func (m *CreateSchematicRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.EmbeddedMachineConfig) > 0 {
+		i -= len(m.EmbeddedMachineConfig)
+		copy(dAtA[i:], m.EmbeddedMachineConfig)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.EmbeddedMachineConfig)))
+		i--
+		dAtA[i] = 0x5a
 	}
 	if m.Bootloader != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Bootloader))
@@ -5582,6 +5593,10 @@ func (m *CreateSchematicRequest) SizeVT() (n int) {
 	}
 	if m.Bootloader != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Bootloader))
+	}
+	l = len(m.EmbeddedMachineConfig)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9141,6 +9156,38 @@ func (m *CreateSchematicRequest) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EmbeddedMachineConfig", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EmbeddedMachineConfig = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -7782,20 +7782,21 @@ func (x *MachineConfigDiffSpec) GetDiff() string {
 }
 
 type InstallationMediaConfigSpec struct {
-	state             protoimpl.MessageState             `protogen:"open.v1"`
-	TalosVersion      string                             `protobuf:"bytes,1,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
-	Architecture      PlatformConfigSpec_Arch            `protobuf:"varint,2,opt,name=architecture,proto3,enum=specs.PlatformConfigSpec_Arch" json:"architecture,omitempty"`
-	InstallExtensions []string                           `protobuf:"bytes,3,rep,name=install_extensions,json=installExtensions,proto3" json:"install_extensions,omitempty"`
-	KernelArgs        string                             `protobuf:"bytes,4,opt,name=kernel_args,json=kernelArgs,proto3" json:"kernel_args,omitempty"`
-	Cloud             *InstallationMediaConfigSpec_Cloud `protobuf:"bytes,5,opt,name=cloud,proto3" json:"cloud,omitempty"`
-	Sbc               *InstallationMediaConfigSpec_SBC   `protobuf:"bytes,6,opt,name=sbc,proto3" json:"sbc,omitempty"`
-	JoinToken         string                             `protobuf:"bytes,7,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
-	SecureBoot        bool                               `protobuf:"varint,8,opt,name=secure_boot,json=secureBoot,proto3" json:"secure_boot,omitempty"`
-	GrpcTunnel        GrpcTunnelMode                     `protobuf:"varint,9,opt,name=grpc_tunnel,json=grpcTunnel,proto3,enum=specs.GrpcTunnelMode" json:"grpc_tunnel,omitempty"`
-	MachineLabels     map[string]string                  `protobuf:"bytes,10,rep,name=machine_labels,json=machineLabels,proto3" json:"machine_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Bootloader        management.SchematicBootloader     `protobuf:"varint,11,opt,name=bootloader,proto3,enum=management.SchematicBootloader" json:"bootloader,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	state                 protoimpl.MessageState             `protogen:"open.v1"`
+	TalosVersion          string                             `protobuf:"bytes,1,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
+	Architecture          PlatformConfigSpec_Arch            `protobuf:"varint,2,opt,name=architecture,proto3,enum=specs.PlatformConfigSpec_Arch" json:"architecture,omitempty"`
+	InstallExtensions     []string                           `protobuf:"bytes,3,rep,name=install_extensions,json=installExtensions,proto3" json:"install_extensions,omitempty"`
+	KernelArgs            string                             `protobuf:"bytes,4,opt,name=kernel_args,json=kernelArgs,proto3" json:"kernel_args,omitempty"`
+	Cloud                 *InstallationMediaConfigSpec_Cloud `protobuf:"bytes,5,opt,name=cloud,proto3" json:"cloud,omitempty"`
+	Sbc                   *InstallationMediaConfigSpec_SBC   `protobuf:"bytes,6,opt,name=sbc,proto3" json:"sbc,omitempty"`
+	JoinToken             string                             `protobuf:"bytes,7,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
+	SecureBoot            bool                               `protobuf:"varint,8,opt,name=secure_boot,json=secureBoot,proto3" json:"secure_boot,omitempty"`
+	GrpcTunnel            GrpcTunnelMode                     `protobuf:"varint,9,opt,name=grpc_tunnel,json=grpcTunnel,proto3,enum=specs.GrpcTunnelMode" json:"grpc_tunnel,omitempty"`
+	MachineLabels         map[string]string                  `protobuf:"bytes,10,rep,name=machine_labels,json=machineLabels,proto3" json:"machine_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Bootloader            management.SchematicBootloader     `protobuf:"varint,11,opt,name=bootloader,proto3,enum=management.SchematicBootloader" json:"bootloader,omitempty"`
+	EmbeddedMachineConfig string                             `protobuf:"bytes,12,opt,name=embedded_machine_config,json=embeddedMachineConfig,proto3" json:"embedded_machine_config,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *InstallationMediaConfigSpec) Reset() {
@@ -7903,6 +7904,13 @@ func (x *InstallationMediaConfigSpec) GetBootloader() management.SchematicBootlo
 		return x.Bootloader
 	}
 	return management.SchematicBootloader(0)
+}
+
+func (x *InstallationMediaConfigSpec) GetEmbeddedMachineConfig() string {
+	if x != nil {
+		return x.EmbeddedMachineConfig
+	}
+	return ""
 }
 
 // RotateTalosCASpec is used to initiate Talos CA rotation.
@@ -12021,7 +12029,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12 \n" +
 	"\vinitialized\x18\x03 \x01(\bR\vinitialized\"+\n" +
 	"\x15MachineConfigDiffSpec\x12\x12\n" +
-	"\x04diff\x18\x01 \x01(\tR\x04diff\"\x98\x06\n" +
+	"\x04diff\x18\x01 \x01(\tR\x04diff\"\xd0\x06\n" +
 	"\x1bInstallationMediaConfigSpec\x12#\n" +
 	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12B\n" +
 	"\farchitecture\x18\x02 \x01(\x0e2\x1e.specs.PlatformConfigSpec.ArchR\farchitecture\x12-\n" +
@@ -12040,7 +12048,8 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	" \x03(\v25.specs.InstallationMediaConfigSpec.MachineLabelsEntryR\rmachineLabels\x12?\n" +
 	"\n" +
 	"bootloader\x18\v \x01(\x0e2\x1f.management.SchematicBootloaderR\n" +
-	"bootloader\x1a#\n" +
+	"bootloader\x126\n" +
+	"\x17embedded_machine_config\x18\f \x01(\tR\x15embeddedMachineConfig\x1a#\n" +
 	"\x05Cloud\x12\x1a\n" +
 	"\bplatform\x18\x01 \x01(\tR\bplatform\x1aH\n" +
 	"\x03SBC\x12\x18\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1563,6 +1563,7 @@ message InstallationMediaConfigSpec {
   GrpcTunnelMode grpc_tunnel = 9;
   map<string, string> machine_labels = 10;
   management.SchematicBootloader bootloader = 11;
+  string embedded_machine_config = 12;
 }
 
 // RotateTalosCASpec is used to initiate Talos CA rotation.

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -2960,6 +2960,7 @@ func (m *InstallationMediaConfigSpec) CloneVT() *InstallationMediaConfigSpec {
 	r.SecureBoot = m.SecureBoot
 	r.GrpcTunnel = m.GrpcTunnel
 	r.Bootloader = m.Bootloader
+	r.EmbeddedMachineConfig = m.EmbeddedMachineConfig
 	if rhs := m.InstallExtensions; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -7350,6 +7351,9 @@ func (this *InstallationMediaConfigSpec) EqualVT(that *InstallationMediaConfigSp
 		}
 	}
 	if this.Bootloader != that.Bootloader {
+		return false
+	}
+	if this.EmbeddedMachineConfig != that.EmbeddedMachineConfig {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -15746,6 +15750,13 @@ func (m *InstallationMediaConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.EmbeddedMachineConfig) > 0 {
+		i -= len(m.EmbeddedMachineConfig)
+		copy(dAtA[i:], m.EmbeddedMachineConfig)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.EmbeddedMachineConfig)))
+		i--
+		dAtA[i] = 0x62
+	}
 	if m.Bootloader != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Bootloader))
 		i--
@@ -19804,6 +19815,10 @@ func (m *InstallationMediaConfigSpec) SizeVT() (n int) {
 	}
 	if m.Bootloader != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Bootloader))
+	}
+	l = len(m.EmbeddedMachineConfig)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -40647,6 +40662,38 @@ func (m *InstallationMediaConfigSpec) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EmbeddedMachineConfig", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EmbeddedMachineConfig = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/api/omni/specs/virtual.pb.go
+++ b/client/api/omni/specs/virtual.pb.go
@@ -939,6 +939,7 @@ type QuirksSpec struct {
 	state                    protoimpl.MessageState `protogen:"open.v1"`
 	SupportsUnifiedInstaller bool                   `protobuf:"varint,1,opt,name=supports_unified_installer,json=supportsUnifiedInstaller,proto3" json:"supports_unified_installer,omitempty"`
 	SupportsFactoryTalosctl  bool                   `protobuf:"varint,2,opt,name=supports_factory_talosctl,json=supportsFactoryTalosctl,proto3" json:"supports_factory_talosctl,omitempty"`
+	SupportsEmbeddedConfig   bool                   `protobuf:"varint,3,opt,name=supports_embedded_config,json=supportsEmbeddedConfig,proto3" json:"supports_embedded_config,omitempty"`
 	unknownFields            protoimpl.UnknownFields
 	sizeCache                protoimpl.SizeCache
 }
@@ -983,6 +984,13 @@ func (x *QuirksSpec) GetSupportsUnifiedInstaller() bool {
 func (x *QuirksSpec) GetSupportsFactoryTalosctl() bool {
 	if x != nil {
 		return x.SupportsFactoryTalosctl
+	}
+	return false
+}
+
+func (x *QuirksSpec) GetSupportsEmbeddedConfig() bool {
+	if x != nil {
+		return x.SupportsEmbeddedConfig
 	}
 	return false
 }
@@ -1181,11 +1189,12 @@ const file_omni_specs_virtual_proto_rawDesc = "" +
 	"\bmeet_url\x18\b \x01(\tR\ameetUrl\"s\n" +
 	"\vSupportSpec\x12'\n" +
 	"\x0fsupport_enabled\x18\x01 \x01(\bR\x0esupportEnabled\x12;\n" +
-	"\foffice_hours\x18\x02 \x01(\v2\x18.specs.OfficeHoursConfigR\vofficeHours\"\x86\x01\n" +
+	"\foffice_hours\x18\x02 \x01(\v2\x18.specs.OfficeHoursConfigR\vofficeHours\"\xc0\x01\n" +
 	"\n" +
 	"QuirksSpec\x12<\n" +
 	"\x1asupports_unified_installer\x18\x01 \x01(\bR\x18supportsUnifiedInstaller\x12:\n" +
-	"\x19supports_factory_talosctl\x18\x02 \x01(\bR\x17supportsFactoryTalosctl\"N\n" +
+	"\x19supports_factory_talosctl\x18\x02 \x01(\bR\x17supportsFactoryTalosctl\x128\n" +
+	"\x18supports_embedded_config\x18\x03 \x01(\bR\x16supportsEmbeddedConfig\"N\n" +
 	"\x14ImageFactoryAuthSpec\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x1a\n" +
 	"\bpassword\x18\x02 \x01(\tR\bpasswordB2Z0github.com/siderolabs/omni/client/api/omni/specsb\x06proto3"

--- a/client/api/omni/specs/virtual.proto
+++ b/client/api/omni/specs/virtual.proto
@@ -112,6 +112,7 @@ message SupportSpec {
 message QuirksSpec {
   bool supports_unified_installer = 1;
   bool supports_factory_talosctl = 2;
+  bool supports_embedded_config = 3;
 }
 
 message ImageFactoryAuthSpec {

--- a/client/api/omni/specs/virtual_vtproto.pb.go
+++ b/client/api/omni/specs/virtual_vtproto.pb.go
@@ -267,6 +267,7 @@ func (m *QuirksSpec) CloneVT() *QuirksSpec {
 	r := new(QuirksSpec)
 	r.SupportsUnifiedInstaller = m.SupportsUnifiedInstaller
 	r.SupportsFactoryTalosctl = m.SupportsFactoryTalosctl
+	r.SupportsEmbeddedConfig = m.SupportsEmbeddedConfig
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -687,6 +688,9 @@ func (this *QuirksSpec) EqualVT(that *QuirksSpec) bool {
 		return false
 	}
 	if this.SupportsFactoryTalosctl != that.SupportsFactoryTalosctl {
+		return false
+	}
+	if this.SupportsEmbeddedConfig != that.SupportsEmbeddedConfig {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1678,6 +1682,16 @@ func (m *QuirksSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.SupportsEmbeddedConfig {
+		i--
+		if m.SupportsEmbeddedConfig {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
 	if m.SupportsFactoryTalosctl {
 		i--
 		if m.SupportsFactoryTalosctl {
@@ -2088,6 +2102,9 @@ func (m *QuirksSpec) SizeVT() (n int) {
 		n += 2
 	}
 	if m.SupportsFactoryTalosctl {
+		n += 2
+	}
+	if m.SupportsEmbeddedConfig {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -4430,6 +4447,26 @@ func (m *QuirksSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.SupportsFactoryTalosctl = bool(v != 0)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SupportsEmbeddedConfig", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SupportsEmbeddedConfig = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -194,6 +194,7 @@ export type CreateSchematicRequest = {
   join_token?: string
   overlay?: CreateSchematicRequestOverlay
   bootloader?: SchematicBootloader
+  embedded_machine_config?: string
 }
 
 export type CreateSchematicFromRawRequest = {

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -1067,6 +1067,7 @@ export type InstallationMediaConfigSpec = {
   grpc_tunnel?: GrpcTunnelMode
   machine_labels?: {[key: string]: string}
   bootloader?: ManagementManagement.SchematicBootloader
+  embedded_machine_config?: string
 }
 
 export type RotateTalosCASpec = {

--- a/frontend/src/api/omni/specs/virtual.pb.ts
+++ b/frontend/src/api/omni/specs/virtual.pb.ts
@@ -112,6 +112,7 @@ export type SupportSpec = {
 export type QuirksSpec = {
   supports_unified_installer?: boolean
   supports_factory_talosctl?: boolean
+  supports_embedded_config?: boolean
 }
 
 export type ImageFactoryAuthSpec = {

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.vue
@@ -10,8 +10,8 @@ import { computed, onBeforeMount } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { SchematicBootloader } from '@/api/omni/management/management.pb'
-import type { SBCConfigSpec } from '@/api/omni/specs/virtual.pb'
-import { SBCConfigType, VirtualNamespace } from '@/api/resources'
+import type { QuirksSpec, SBCConfigSpec } from '@/api/omni/specs/virtual.pb'
+import { QuirksType, SBCConfigType, VirtualNamespace } from '@/api/resources'
 import RadioGroup from '@/components/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/Radio/RadioGroupOption.vue'
 import TextArea from '@/components/TextArea/TextArea.vue'
@@ -27,8 +27,16 @@ const formState = defineModel<FormState>({ required: true })
 const resolvedVersion = computed(() => resolveTalosVersion(formState.value.talosVersion!))
 
 const supportsCustomisingKernelArgs = computed(() => gte(resolvedVersion.value, '1.10.0'))
-
 const supportsBootloaderSelection = computed(() => gte(resolvedVersion.value, '1.12.0-alpha.2'))
+
+const { data: quirks } = useResourceGet<QuirksSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: VirtualNamespace,
+    type: QuirksType,
+    id: resolvedVersion.value,
+  },
+}))
 
 const { data: selectedSBC } = useResourceGet<SBCConfigSpec>(() => ({
   skip: formState.value.hardwareType !== 'sbc',
@@ -90,6 +98,38 @@ onBeforeMount(() => (formState.value.bootloader ??= SchematicBootloader.BOOT_AUT
     </p>
 
     <p>Skip this step if unsure.</p>
+
+    <template v-if="quirks?.spec.supports_embedded_config">
+      <TextArea
+        v-model="formState.embeddedMachineConfig"
+        placeholder="apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: my-custom-hostname
+auto: off"
+        title="Embedded machine configuration"
+        overhead-title
+      />
+
+      <p>
+        This configuration will be embedded into the image. For more details see the
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          :href="
+            getDocsLink(
+              'talos',
+              '/configure-your-talos-cluster/system-configuration/acquire#embedded-configuration',
+              { talosVersion: resolvedVersion },
+            )
+          "
+          class="link-primary"
+        >
+          documentation.
+        </a>
+      </p>
+
+      <p>Skip this step if unsure.</p>
+    </template>
 
     <template v-if="selectedSBC">
       <TextArea

--- a/frontend/src/views/InstallationMedia/formStateToPreset.spec.ts
+++ b/frontend/src/views/InstallationMedia/formStateToPreset.spec.ts
@@ -54,6 +54,7 @@ describe('form<->preset conversion', () => {
         'user/label': { value: 'test', canRemove: true },
       },
       secureBoot: true,
+      embeddedMachineConfig: 'version: v1alpha1',
     }
 
     const preset: InstallationMediaConfigSpec = {
@@ -71,6 +72,7 @@ describe('form<->preset conversion', () => {
         'user/label': 'test',
       },
       secure_boot: true,
+      embedded_machine_config: 'version: v1alpha1',
     }
 
     expect(formStateToPreset(formState)).toEqual(preset)
@@ -93,6 +95,7 @@ describe('form<->preset conversion', () => {
         'user/label': { value: 'test', canRemove: true },
       },
       secureBoot: false,
+      embeddedMachineConfig: 'version: v1alpha1',
     }
 
     const preset: InstallationMediaConfigSpec = {
@@ -111,6 +114,7 @@ describe('form<->preset conversion', () => {
         'user/label': 'test',
       },
       secure_boot: false,
+      embedded_machine_config: 'version: v1alpha1',
     }
 
     expect(formStateToPreset(formState)).toEqual(preset)
@@ -131,6 +135,7 @@ describe('form<->preset conversion', () => {
         'user/label': { value: 'test', canRemove: true },
       },
       secureBoot: false,
+      embeddedMachineConfig: 'version: v1alpha1',
     }
 
     const preset: InstallationMediaConfigSpec = {
@@ -145,6 +150,7 @@ describe('form<->preset conversion', () => {
         'user/label': 'test',
       },
       secure_boot: false,
+      embedded_machine_config: 'version: v1alpha1',
     }
 
     expect(formStateToPreset(formState)).toEqual(preset)

--- a/frontend/src/views/InstallationMedia/formStateToPreset.ts
+++ b/frontend/src/views/InstallationMedia/formStateToPreset.ts
@@ -23,6 +23,7 @@ export function formStateToPreset(formState: FormState): InstallationMediaConfig
             overlay_options: formState.overlayOptions,
           }
         : undefined,
+    embedded_machine_config: formState.embeddedMachineConfig,
     grpc_tunnel: formState.useGrpcTunnel ? GrpcTunnelMode.ENABLED : GrpcTunnelMode.DISABLED,
     talos_version: formState.talosVersion === AUTOMATIC_VERSION ? '' : formState.talosVersion,
     install_extensions: formState.systemExtensions,
@@ -46,6 +47,7 @@ export function presetToFormState(preset: InstallationMediaConfigSpec): FormStat
     cloudPlatform: preset.cloud?.platform,
     sbcType: preset.sbc?.overlay,
     overlayOptions: preset.sbc?.overlay_options,
+    embeddedMachineConfig: preset.embedded_machine_config,
     useGrpcTunnel: preset.grpc_tunnel === GrpcTunnelMode.ENABLED,
     talosVersion: !preset.talos_version ? AUTOMATIC_VERSION : preset.talos_version,
     systemExtensions: preset.install_extensions,

--- a/frontend/src/views/InstallationMedia/useFormState.ts
+++ b/frontend/src/views/InstallationMedia/useFormState.ts
@@ -29,6 +29,7 @@ export interface FormState {
   sbcType?: string
   systemExtensions?: string[]
   cmdline?: string
+  embeddedMachineConfig?: string
   overlayOptions?: string
   bootloader?: SchematicBootloader
 }

--- a/frontend/src/views/InstallationMedia/usePresetSchematic.ts
+++ b/frontend/src/views/InstallationMedia/usePresetSchematic.ts
@@ -57,6 +57,7 @@ export function usePresetSchematic(presetRef: MaybeRefOrGetter<InstallationMedia
             ? { [LabelsMeta]: dump({ machineLabels: preset.machine_labels }) }
             : undefined,
         overlay,
+        embedded_machine_config: preset.embedded_machine_config,
         talos_version: preset.talos_version,
         siderolink_grpc_tunnel_mode:
           preset.grpc_tunnel === GrpcTunnelMode.ENABLED

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -51,6 +51,7 @@ func (s *managementServer) CreateSchematic(ctx context.Context, request *managem
 		SystemExtensions: schematic.SystemExtensions{
 			OfficialExtensions: request.Extensions,
 		},
+		EmbeddedMachineConfiguration: request.EmbeddedMachineConfig,
 	}
 
 	if request.Bootloader != management.SchematicBootloader_BOOT_AUTO {

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -102,8 +102,6 @@ func (s *managementServer) CreateSchematic(ctx context.Context, request *managem
 		Customization: customization,
 	}
 
-	s.logger.Info("ensure schematic", zap.Reflect("schematic", schematicRequest))
-
 	schematicRequest.Overlay, err = s.getOverlay(ctx, request)
 	if err != nil {
 		return nil, err
@@ -113,6 +111,8 @@ func (s *managementServer) CreateSchematic(ctx context.Context, request *managem
 	if err != nil {
 		return nil, fmt.Errorf("failed to ensure schematic: %w", err)
 	}
+
+	s.logger.Info("ensure schematic succeeded", zap.String("schematic_id", schematicID), zap.String("factory_host", s.imageFactoryClient.Host()))
 
 	schematicYML, err := schematicData.Marshal()
 	if err != nil {
@@ -137,12 +137,12 @@ func (s *managementServer) CreateSchematicFromRaw(ctx context.Context, request *
 		return nil, fmt.Errorf("failed to unmarshal raw schematic: %w", err)
 	}
 
-	s.logger.Info("ensure schematic from raw", zap.Reflect("schematic", schematicRequest))
-
 	schematicID, _, err := s.imageFactoryClient.EnsureSchematic(ctx, *schematicRequest)
 	if err != nil {
-		return nil, fmt.Errorf("failed to ensure schematic: %w", err)
+		return nil, fmt.Errorf("failed to ensure raw schematic: %w", err)
 	}
+
+	s.logger.Info("ensure raw schematic succeeded", zap.String("schematic_id", schematicID), zap.String("factory_host", s.imageFactoryClient.Host()))
 
 	return &management.CreateSchematicResponse{
 		SchematicId: schematicID,

--- a/internal/backend/runtime/omni/virtual/state.go
+++ b/internal/backend/runtime/omni/virtual/state.go
@@ -475,6 +475,7 @@ func (v *State) quirks(_ context.Context, ptr resource.Pointer) (*virtual.Quirks
 	res.TypedSpec().Value = &specs.QuirksSpec{
 		SupportsUnifiedInstaller: q.SupportsUnifiedInstaller(),
 		SupportsFactoryTalosctl:  q.SupportsFactoryTalosctlDownload(),
+		SupportsEmbeddedConfig:   q.SupportsEmbeddedConfig(),
 	}
 
 	return res, nil


### PR DESCRIPTION
Add UI for adding embedded machine config to installation media UI. For now, just using a textarea. Will update to be a code editor in future PR.

Closes #3016 

<img width="581" height="581" alt="image" src="https://github.com/user-attachments/assets/7e0b0cfb-9fd1-4d73-8089-3e25a810bebb" />

