### PR TITLE
feat: support embedded machine config in installation media CLI

### DIFF
--- a/client/pkg/omnictl/installationmedia/create.go
+++ b/client/pkg/omnictl/installationmedia/create.go
@@ -20,18 +20,19 @@ import (
 )
 
 var createCmdFlags struct {
-	arch            string
-	talosVersion    string
-	platform        string
-	overlay         string
-	overlayOptions  string
-	joinTokenName   string
-	bootloader      string
-	extensions      []string
-	extraKernelArgs []string
-	labels          []string
-	secureBoot      bool
-	grpcTunnel      bool
+	arch                      string
+	talosVersion              string
+	platform                  string
+	overlay                   string
+	overlayOptions            string
+	joinTokenName             string
+	bootloader                string
+	embeddedMachineConfigFile string
+	extensions                []string
+	extraKernelArgs           []string
+	labels                    []string
+	secureBoot                bool
+	grpcTunnel                bool
 }
 
 var createCmd = &cobra.Command{
@@ -53,6 +54,10 @@ Examples:
     omnictl media preset create full-preset --arch amd64 \
         --extensions qemu-guest-agent --extensions intel-ucode \
         --initial-labels env=production --initial-labels team=infra
+
+    # Create a preset with an embedded machine config read from a file
+    omnictl media preset create embedded-preset --arch amd64 \
+        --embedded-machine-config-file ./machine-config.yaml
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -82,6 +87,7 @@ func init() {
 	createCmd.Flags().BoolVar(&createCmdFlags.secureBoot, flagSecureBoot, false, "Enable SecureBoot in the preset")
 	createCmd.Flags().StringVar(&createCmdFlags.joinTokenName, flagJoinTokenName, "", "Join token ID (uses default token if empty)")
 	createCmd.Flags().StringVar(&createCmdFlags.bootloader, flagBootloader, "auto", "Bootloader type (auto, uefi, bios, dual)")
+	createCmd.Flags().StringVar(&createCmdFlags.embeddedMachineConfigFile, flagEmbeddedMachineConfigFile, "", "Embedded machine config read from a file, or \"-\" for stdin")
 	createCmd.Flags().BoolVar(&createCmdFlags.grpcTunnel, flagGRPCTunnel, false,
 		"Configure Talos to use the SideroLink (WireGuard) gRPC tunnel over HTTP/2 for Omni management traffic, instead of UDP."+
 			" Only enable this if the network blocks UDP packets, as HTTP tunneling adds significant overhead for communications.")
@@ -139,14 +145,28 @@ func createPreset(ctx context.Context, cmd *cobra.Command, client *client.Client
 		return err
 	}
 
+	var embeddedMachineConfig string
+
+	if createCmdFlags.embeddedMachineConfigFile != "" {
+		if err = download.ValidateEmbeddedConfigSupport(ctx, client.Omni().State(), resolveTalosVersion); err != nil {
+			return err
+		}
+
+		embeddedMachineConfig, err = download.ReadEmbeddedMachineConfigFile(createCmdFlags.embeddedMachineConfigFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	spec := &specs.InstallationMediaConfigSpec{
-		TalosVersion:      talosVersion,
-		Architecture:      arch,
-		InstallExtensions: resolvedExtensions,
-		KernelArgs:        strings.Join(createCmdFlags.extraKernelArgs, " "),
-		JoinToken:         tokenID,
-		SecureBoot:        createCmdFlags.secureBoot,
-		Bootloader:        bootloader,
+		TalosVersion:          talosVersion,
+		Architecture:          arch,
+		InstallExtensions:     resolvedExtensions,
+		KernelArgs:            strings.Join(createCmdFlags.extraKernelArgs, " "),
+		JoinToken:             tokenID,
+		SecureBoot:            createCmdFlags.secureBoot,
+		Bootloader:            bootloader,
+		EmbeddedMachineConfig: embeddedMachineConfig,
 	}
 
 	switch {

--- a/client/pkg/omnictl/installationmedia/download.go
+++ b/client/pkg/omnictl/installationmedia/download.go
@@ -23,16 +23,17 @@ import (
 )
 
 var downloadCmdFlags struct {
-	output                  string
-	format                  string
-	arch                    string
-	talosVersion            string
-	joinTokenName           string
-	labels                  []string
-	extensions              []string
-	extraKernelArgs         []string
-	secureBoot              bool
-	useSiderolinkGRPCTunnel bool
+	output                    string
+	format                    string
+	arch                      string
+	talosVersion              string
+	joinTokenName             string
+	embeddedMachineConfigFile string
+	labels                    []string
+	extensions                []string
+	extraKernelArgs           []string
+	secureBoot                bool
+	useSiderolinkGRPCTunnel   bool
 }
 
 var downloadCmd = &cobra.Command{
@@ -107,6 +108,8 @@ func init() {
 	downloadCmd.Flags().StringSliceVar(&downloadCmdFlags.extensions, flagExtensions, nil, "Override extensions to pre-install")
 	downloadCmd.Flags().BoolVar(&downloadCmdFlags.secureBoot, flagSecureBoot, false, "Override secure boot setting")
 	downloadCmd.Flags().StringVar(&downloadCmdFlags.joinTokenName, flagJoinTokenName, "", "Join token ID override (uses preset token if empty)")
+	downloadCmd.Flags().StringVar(&downloadCmdFlags.embeddedMachineConfigFile, flagEmbeddedMachineConfigFile, "",
+		"Override the embedded machine config, reading it from a file or \"-\" for stdin")
 	downloadCmd.Flags().BoolVar(&downloadCmdFlags.useSiderolinkGRPCTunnel, flagGRPCTunnel, false,
 		"Configure Talos to use the SideroLink (WireGuard) gRPC tunnel over HTTP/2 for Omni management traffic, instead of UDP."+
 			" Only enable this if the network blocks UDP packets, as HTTP tunneling adds significant overhead for communications.")
@@ -187,6 +190,13 @@ func runDownload(ctx context.Context, cmd *cobra.Command, client *client.Client,
 		params.SecureBoot = downloadCmdFlags.secureBoot
 	}
 
+	if cmd.Flags().Changed(flagEmbeddedMachineConfigFile) {
+		params.EmbeddedMachineConfig, err = download.ReadEmbeddedMachineConfigFile(downloadCmdFlags.embeddedMachineConfigFile)
+		if err != nil {
+			return err
+		}
+	}
+
 	if err = revalidateOverrides(ctx, cmd, client.Omni().State(), spec, params, arch); err != nil {
 		return err
 	}
@@ -212,9 +222,18 @@ func revalidateOverrides(ctx context.Context, cmd *cobra.Command, st state.State
 	secureBootChanged := cmd.Flags().Changed(flagSecureBoot)
 	extensionsChanged := cmd.Flags().Changed(flagExtensions)
 	archChanged := cmd.Flags().Changed(flagArch)
+	embeddedConfigChanged := cmd.Flags().Changed(flagEmbeddedMachineConfigFile)
 
 	if talosChanged {
 		if err := download.ValidateTalosVersion(ctx, st, params.TalosVersion); err != nil {
+			return err
+		}
+	}
+
+	// Re-check embedded config support when the config itself was overridden, or when the Talos
+	// version changed under a preset that already carries an embedded config.
+	if params.EmbeddedMachineConfig != "" && (embeddedConfigChanged || talosChanged) {
+		if err := download.ValidateEmbeddedConfigSupport(ctx, st, params.TalosVersion); err != nil {
 			return err
 		}
 	}

--- a/client/pkg/omnictl/installationmedia/installationmedia.go
+++ b/client/pkg/omnictl/installationmedia/installationmedia.go
@@ -8,19 +8,20 @@ package installationmedia
 import "github.com/spf13/cobra"
 
 const (
-	flagArch            = "arch"
-	flagTalosVersion    = "talos-version"
-	flagInitialLabels   = "initial-labels"
-	flagExtraKernelArgs = "extra-kernel-args"
-	flagExtensions      = "extensions"
-	flagSecureBoot      = "secureboot"
-	flagPlatform        = "platform"
-	flagOverlay         = "overlay"
-	flagOverlayOptions  = "overlay-options"
-	flagJoinTokenName   = "join-token"
-	flagBootloader      = "bootloader"
-	flagGRPCTunnel      = "use-siderolink-grpc-tunnel"
-	flagFormat          = "format"
+	flagArch                      = "arch"
+	flagTalosVersion              = "talos-version"
+	flagInitialLabels             = "initial-labels"
+	flagExtraKernelArgs           = "extra-kernel-args"
+	flagExtensions                = "extensions"
+	flagSecureBoot                = "secureboot"
+	flagPlatform                  = "platform"
+	flagOverlay                   = "overlay"
+	flagOverlayOptions            = "overlay-options"
+	flagJoinTokenName             = "join-token"
+	flagBootloader                = "bootloader"
+	flagGRPCTunnel                = "use-siderolink-grpc-tunnel"
+	flagFormat                    = "format"
+	flagEmbeddedMachineConfigFile = "embedded-machine-config-file"
 )
 
 var cmd = &cobra.Command{

--- a/client/pkg/omnictl/installationmedia/list.go
+++ b/client/pkg/omnictl/installationmedia/list.go
@@ -63,7 +63,7 @@ func listPresets(ctx context.Context, client *client.Client, wide bool) error {
 
 	header := "NAME\tARCH\tTALOS VERSION\tTYPE\tPLATFORM/OVERLAY"
 	if wide {
-		header += "\tSECURE BOOT\tEXTENSIONS\tLABELS\tBOOTLOADER\tGRPC TUNNEL\tKERNEL ARGS"
+		header += "\tSECURE BOOT\tEXTENSIONS\tLABELS\tBOOTLOADER\tGRPC TUNNEL\tKERNEL ARGS\tEMBEDDED CONFIG"
 	}
 
 	fmt.Fprintln(w, header) //nolint:errcheck
@@ -87,13 +87,14 @@ func listPresets(ctx context.Context, client *client.Client, wide bool) error {
 
 		if wide {
 			fmt.Fprintf( //nolint:errcheck
-				w, "\t%v\t%s\t%s\t%s\t%s\t%s",
+				w, "\t%v\t%s\t%s\t%s\t%s\t%s\t%s",
 				spec.SecureBoot,
 				extensionsOrDash(spec.InstallExtensions),
 				machineLabelsOrDash(spec.MachineLabels),
 				download.BootloaderToString(spec.Bootloader),
 				download.GrpcTunnelModeToString(spec.GrpcTunnel),
 				kernelArgsOrDash(spec.KernelArgs),
+				yesOrDash(spec.EmbeddedMachineConfig != ""),
 			)
 		}
 
@@ -123,6 +124,14 @@ func platformOrOverlay(spec *specs.InstallationMediaConfigSpec) string {
 	default:
 		return "-"
 	}
+}
+
+func yesOrDash(present bool) string {
+	if present {
+		return "yes"
+	}
+
+	return "-"
 }
 
 func kernelArgsOrDash(args string) string {

--- a/client/pkg/omnictl/internal/download/download.go
+++ b/client/pkg/omnictl/internal/download/download.go
@@ -129,6 +129,8 @@ type Params struct { //nolint:govet
 	ExtraKernelArgs []string
 	Extensions      []string
 
+	EmbeddedMachineConfig string
+
 	Bootloader management.SchematicBootloader
 	PXE        bool
 	SecureBoot bool
@@ -317,6 +319,44 @@ func ValidateTalosVersion(ctx context.Context, st state.State, talosVersion stri
 	return nil
 }
 
+// ReadEmbeddedMachineConfigFile reads the embedded machine config from the given path.
+// A path of "-" reads from standard input, allowing the config to be piped in.
+func ReadEmbeddedMachineConfigFile(path string) (string, error) {
+	switch path {
+	case "":
+		return "", nil
+	case "-":
+		contents, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read embedded machine config from stdin: %w", err)
+		}
+
+		return string(contents), nil
+	default:
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to read embedded machine config file %q: %w", path, err)
+		}
+
+		return string(contents), nil
+	}
+}
+
+// ValidateEmbeddedConfigSupport verifies the given Talos version supports an embedded machine
+// configuration, using the server's Quirks resource as the source of truth.
+func ValidateEmbeddedConfigSupport(ctx context.Context, st state.State, talosVersion string) error {
+	q, err := safe.ReaderGetByID[*virtual.Quirks](ctx, st, strings.TrimLeft(talosVersion, "v"))
+	if err != nil {
+		return fmt.Errorf("failed to look up quirks for Talos version %q: %w", talosVersion, err)
+	}
+
+	if !q.TypedSpec().Value.GetSupportsEmbeddedConfig() {
+		return fmt.Errorf("embedded machine config is not supported by Talos version %q", talosVersion)
+	}
+
+	return nil
+}
+
 // ValidateExtensions verifies all requested extensions exist for the given Talos version.
 func ValidateExtensions(ctx context.Context, st state.State, talosVersion string, extensions []string) error {
 	if len(extensions) == 0 {
@@ -442,6 +482,8 @@ func BuildParamsFromPreset(spec *specs.InstallationMediaConfigSpec, arch string)
 		params.Extensions = spec.InstallExtensions
 	}
 
+	params.EmbeddedMachineConfig = spec.EmbeddedMachineConfig
+
 	if len(spec.MachineLabels) > 0 {
 		params.Labels = make([]string, 0, len(spec.MachineLabels))
 		for k, v := range spec.MachineLabels {
@@ -543,6 +585,7 @@ func createSchematic(ctx context.Context, client *client.Client, image ImageInfo
 		SiderolinkGrpcTunnelMode: params.GrpcTunnelMode,
 		JoinToken:                params.JoinToken,
 		Bootloader:               params.Bootloader,
+		EmbeddedMachineConfig:    params.EmbeddedMachineConfig,
 	}
 
 	if params.Overlay != nil {

--- a/client/pkg/omnictl/internal/download/download_test.go
+++ b/client/pkg/omnictl/internal/download/download_test.go
@@ -5,6 +5,8 @@
 package download_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -259,6 +261,88 @@ func TestBuildParamsFromPresetDefaults(t *testing.T) {
 		params, err := download.BuildParamsFromPreset(spec, "amd64")
 		require.NoError(t, err)
 		require.Empty(t, params.JoinToken)
+	})
+
+	t.Run("EmbeddedMachineConfig is carried over", func(t *testing.T) {
+		t.Parallel()
+
+		spec := &specs.InstallationMediaConfigSpec{EmbeddedMachineConfig: "version: v1alpha1\nmachine: {}\n"}
+		params, err := download.BuildParamsFromPreset(spec, "amd64")
+		require.NoError(t, err)
+		require.Equal(t, "version: v1alpha1\nmachine: {}\n", params.EmbeddedMachineConfig)
+	})
+}
+
+func TestReadEmbeddedMachineConfigFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty when no path is given", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := download.ReadEmbeddedMachineConfigFile("")
+		require.NoError(t, err)
+		require.Empty(t, out)
+	})
+
+	t.Run("reads the file when a path is given", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("version: v1alpha1\nmachine: {}\n"), 0o600))
+
+		out, err := download.ReadEmbeddedMachineConfigFile(path)
+		require.NoError(t, err)
+		require.Equal(t, "version: v1alpha1\nmachine: {}\n", out)
+	})
+
+	t.Run("errors with the path when the file is missing", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := download.ReadEmbeddedMachineConfigFile(filepath.Join(t.TempDir(), "missing.yaml"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing.yaml")
+	})
+}
+
+func TestValidateEmbeddedConfigSupport(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	newQuirks := func(version string, supported bool) *virtual.Quirks {
+		q := virtual.NewQuirks(version)
+		q.TypedSpec().Value.SupportsEmbeddedConfig = supported
+
+		return q
+	}
+
+	t.Run("passes when the version supports embedded config", func(t *testing.T) {
+		t.Parallel()
+
+		st := newTestState(t)
+		require.NoError(t, st.Create(ctx, newQuirks("1.13.0", true)))
+
+		require.NoError(t, download.ValidateEmbeddedConfigSupport(ctx, st, "1.13.0"))
+	})
+
+	t.Run("fails when the version does not support embedded config", func(t *testing.T) {
+		t.Parallel()
+
+		st := newTestState(t)
+		require.NoError(t, st.Create(ctx, newQuirks("1.11.0", false)))
+
+		err := download.ValidateEmbeddedConfigSupport(ctx, st, "1.11.0")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "embedded machine config is not supported by Talos")
+	})
+
+	t.Run("strips a leading v before the lookup", func(t *testing.T) {
+		t.Parallel()
+
+		st := newTestState(t)
+		require.NoError(t, st.Create(ctx, newQuirks("1.13.0", true)))
+
+		require.NoError(t, download.ValidateEmbeddedConfigSupport(ctx, st, "v1.13.0"))
 	})
 }
 

--- a/internal/backend/runtime/omni/validations/installation_media_config.go
+++ b/internal/backend/runtime/omni/validations/installation_media_config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -75,6 +76,12 @@ func installationMediaConfigValidationOptions(st state.State) []validated.StateO
 				}
 
 				return fmt.Errorf("failed to look up Talos version %q: %w", spec.GetTalosVersion(), err)
+			}
+
+			// An empty Talos version tracks the server default at download time, which always
+			// supports embedded config, so only gate when a concrete version is pinned.
+			if spec.GetEmbeddedMachineConfig() != "" && !quirks.New(talosVersion).SupportsEmbeddedConfig() {
+				return fmt.Errorf("embedded machine config is not supported by Talos version %q", spec.GetTalosVersion())
 			}
 		}
 

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -2346,6 +2346,76 @@ func TestInstallationMediaConfigTalosVersionValidation(t *testing.T) {
 	}
 }
 
+func TestInstallationMediaConfigEmbeddedConfigValidation(t *testing.T) {
+	t.Parallel()
+
+	const embeddedConfig = "version: v1alpha1\nmachine: {}\n"
+
+	setup := func(t *testing.T, versions ...string) state.State {
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		for _, v := range versions {
+			talosVersion := omnires.NewTalosVersion(v)
+			talosVersion.TypedSpec().Value.CompatibleKubernetesVersions = []string{"1.30.0"}
+			require.NoError(t, innerSt.Create(ctx, talosVersion))
+		}
+
+		return innerSt
+	}
+
+	for _, tt := range []struct {
+		name         string
+		talosVersion string
+		errContains  string
+		versions     []string
+	}{
+		{
+			name:         "supported version",
+			talosVersion: "1.13.2",
+			versions:     []string{"1.13.2"},
+		},
+		{
+			name:         "empty version defers to download time",
+			talosVersion: "",
+			versions:     []string{"1.13.2"},
+		},
+		{
+			name:         "unsupported version",
+			talosVersion: "1.11.0",
+			versions:     []string{"1.11.0"},
+			errContains:  `embedded machine config is not supported by Talos version "1.11.0"`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			t.Cleanup(cancel)
+
+			innerSt := setup(t, tt.versions...)
+			st := validated.NewState(innerSt, validations.InstallationMediaConfigValidationOptions(innerSt)...)
+
+			media := omnires.NewInstallationMediaConfig("test")
+			media.TypedSpec().Value.Architecture = specs.PlatformConfigSpec_AMD64
+			media.TypedSpec().Value.TalosVersion = tt.talosVersion
+			media.TypedSpec().Value.EmbeddedMachineConfig = embeddedConfig
+
+			err := st.Create(ctx, media)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			assert.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, tt.errContains)
+		})
+	}
+}
+
 //nolint:maintidx
 func TestExtensionsCatalogValidation(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Add an --embedded-machine-config-file flag (file path, or "-" for stdin) to omnictl for `media preset create` and `media download`
to support adding(or overriding) embedded machine config to installation media(schematic).

Resolves: #3017