### PR TITLE
feat(frontend): Use code editor for YAML in installation media

### DIFF
--- a/frontend/src/components/CodeEditor/CodeEditor.vue
+++ b/frontend/src/components/CodeEditor/CodeEditor.vue
@@ -109,8 +109,6 @@ import { DefaultTalosVersion } from '@/api/resources'
 import { majorMinorVersion } from '@/methods'
 
 type Props = {
-  value: string
-  editorDidMount?: (editor: monaco.editor.IStandaloneCodeEditor) => void
   options?: monaco.editor.IStandaloneEditorConstructionOptions
   validators?: ((
     model: monaco.editor.ITextModel,
@@ -119,33 +117,22 @@ type Props = {
   talosVersion?: string
 }
 
-const emit = defineEmits<{
-  'update:value': [string]
-  editorDidMount: [monaco.editor.IStandaloneCodeEditor]
-}>()
+const { options, validators, talosVersion = DefaultTalosVersion } = defineProps<Props>()
 
-const { value, options, validators, talosVersion = DefaultTalosVersion } = defineProps<Props>()
+const modelValue = defineModel<string>({ default: '' })
 
 const editor = useTemplateRef<HTMLDivElement>('editor')
 
 let instanceRef: monaco.editor.IStandaloneCodeEditor | undefined
 
-watch(
-  () => value,
-  (val) => {
-    const model = instanceRef?.getModel()
+watch(modelValue, (val) => {
+  const model = instanceRef?.getModel()
+  if (!model) return
 
-    if (!model) {
-      return
-    }
-
-    if (val === model.getValue()) {
-      return
-    }
-
+  if (val !== model.getValue()) {
     model.setValue(val)
-  },
-)
+  }
+})
 
 const modelId = useId()
 const schemaVersion = computed(() => {
@@ -171,7 +158,7 @@ watch([editor, schemaVersion], () => {
   }
 
   const model = monaco.editor.createModel(
-    value,
+    modelValue.value,
     'yaml',
     monaco.Uri.parse(
       `inmemory://${modelId}_${majorMinorVersion(schemaVersion.value.format())}.yaml`,
@@ -215,12 +202,11 @@ watch([editor, schemaVersion], () => {
     // debounce
     clearTimeout(handle)
 
-    emit('update:value', model.getValue())
+    modelValue.value = model.getValue()
 
     handle = window.setTimeout(validate, 500)
   })
 
-  emit('editorDidMount', instance)
   instanceRef = instance
 
   onWatcherCleanup(() => {

--- a/frontend/src/components/CodeEditor/CodeEditor.vue
+++ b/frontend/src/components/CodeEditor/CodeEditor.vue
@@ -85,7 +85,7 @@ monaco.editor.defineTheme(SIDERO_THEME, {
 
     'editorStickyScroll.background': styles.getPropertyValue('--color-naturals-n0'),
 
-    'editor.background': '#00000000',
+    'editor.background': styles.getPropertyValue('--color-naturals-n0'),
 
     'editorHoverWidget.background': styles.getPropertyValue('--color-naturals-n3'),
     'editorHoverWidget.border': styles.getPropertyValue('--color-naturals-n7'),
@@ -172,7 +172,16 @@ watch([editor, schemaVersion], () => {
     fontFamily: styles.getPropertyValue('--font-mono'),
     automaticLayout: true,
     tabSize: 2,
+    insertSpaces: true,
+    detectIndentation: false,
+    trimAutoWhitespace: true,
+    renderWhitespace: 'boundary',
     fixedOverflowWidgets: true,
+    lineNumbersMinChars: 3,
+    lineDecorationsWidth: 5,
+    stickyScroll: {
+      enabled: true,
+    },
     minimap: {
       enabled: false,
     },
@@ -222,5 +231,5 @@ watch([editor, schemaVersion], () => {
 </script>
 
 <template>
-  <div id="editor" ref="editor" class="h-full w-full" />
+  <div ref="editor"></div>
 </template>

--- a/frontend/src/components/CodeEditor/CodeEditor.vue
+++ b/frontend/src/components/CodeEditor/CodeEditor.vue
@@ -57,7 +57,7 @@ const schemas = configSchemaMap.map<SchemasSettings>(([version, origSchema]) => 
 
   return {
     uri: schema.$id!,
-    fileMatch: [`*_${version}.yaml`],
+    fileMatch: [`*_${version}.patch.yaml`],
     schema,
   }
 })
@@ -115,9 +115,15 @@ type Props = {
     tokens: monaco.Token[],
   ) => monaco.editor.IMarkerData[])[]
   talosVersion?: string
+  disableConfigValidation?: boolean
 }
 
-const { options, validators, talosVersion = DefaultTalosVersion } = defineProps<Props>()
+const {
+  options,
+  validators,
+  disableConfigValidation,
+  talosVersion = DefaultTalosVersion,
+} = defineProps<Props>()
 
 const modelValue = defineModel<string>({ default: '' })
 
@@ -161,7 +167,9 @@ watch([editor, schemaVersion], () => {
     modelValue.value,
     'yaml',
     monaco.Uri.parse(
-      `inmemory://${modelId}_${majorMinorVersion(schemaVersion.value.format())}.yaml`,
+      disableConfigValidation
+        ? `inmemory://${modelId}.yaml`
+        : `inmemory://${modelId}_${majorMinorVersion(schemaVersion.value.format())}.patch.yaml`,
     ),
   )
 

--- a/frontend/src/components/Expandable/Expandable.vue
+++ b/frontend/src/components/Expandable/Expandable.vue
@@ -1,0 +1,64 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { onKeyStroke } from '@vueuse/core'
+
+import IconButton from '@/components/Button/IconButton.vue'
+import { cn } from '@/methods/utils'
+
+defineOptions({ inheritAttrs: false })
+
+defineProps<{ title?: string }>()
+
+const expanded = defineModel<boolean>('expanded', { default: false })
+
+onKeyStroke('Escape', (event) => {
+  if (!expanded.value) return
+
+  event.stopPropagation()
+  expanded.value = false
+})
+</script>
+
+<template>
+  <Teleport to="body" :disabled="!expanded">
+    <Transition
+      enter-active-class="transition-opacity"
+      leave-active-class="transition-opacity"
+      enter-from-class="opacity-0"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="expanded" class="fixed inset-0 z-40 bg-naturals-n0/90" @click="expanded = false" />
+    </Transition>
+
+    <div
+      :data-state="expanded ? 'open' : 'closed'"
+      :class="
+        cn(
+          expanded &&
+            'fixed inset-0 z-50 flex flex-col gap-3 rounded-sm bg-naturals-n3 p-6 sm:inset-6',
+          $attrs.class,
+        )
+      "
+    >
+      <div v-if="expanded" class="flex shrink-0 items-center justify-between gap-4">
+        <span class="font-medium text-naturals-n14">{{ title }}</span>
+
+        <IconButton
+          icon="close"
+          class="size-8 shrink-0"
+          aria-label="Collapse"
+          @click="expanded = false"
+        />
+      </div>
+
+      <div :class="expanded ? 'min-h-0 grow' : 'contents'">
+        <slot></slot>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/config.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/config.vue
@@ -5,7 +5,6 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -36,14 +35,12 @@ const { data: cluster } = useResourceWatch<ClusterSpec>(() => ({
     id: route.params.cluster as string,
   },
 }))
-
-const config = computed(() => configResource.value?.spec.data ?? '')
 </script>
 
 <template>
   <PageContainer class="h-full">
     <CodeEditor
-      v-model:value="config"
+      :model-value="configResource?.spec.data"
       :options="{ readOnly: true }"
       :talos-version="cluster?.spec.talos_version"
     />

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/config.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/config.vue
@@ -43,6 +43,7 @@ const { data: cluster } = useResourceWatch<ClusterSpec>(() => ({
       :model-value="configResource?.spec.data"
       :options="{ readOnly: true }"
       :talos-version="cluster?.spec.talos_version"
+      class="size-full"
     />
   </PageContainer>
 </template>

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.vue
@@ -17,7 +17,6 @@ import CodeEditor from '@/components/CodeEditor/CodeEditor.vue'
 import Expandable from '@/components/Expandable/Expandable.vue'
 import RadioGroup from '@/components/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/Radio/RadioGroupOption.vue'
-import TextArea from '@/components/TextArea/TextArea.vue'
 import TInput from '@/components/TInput/TInput.vue'
 import { getDocsLink } from '@/methods'
 import { useResourceGet } from '@/methods/useResourceGet'
@@ -29,7 +28,8 @@ const formState = defineModel<FormState>({ required: true })
 
 const resolvedVersion = computed(() => resolveTalosVersion(formState.value.talosVersion!))
 
-const configEditorExpanded = ref(false)
+const embeddedConfigExpanded = ref(false)
+const overlayOptionsExpanded = ref(false)
 
 const supportsCustomisingKernelArgs = computed(() => gte(resolvedVersion.value, '1.10.0'))
 const supportsBootloaderSelection = computed(() => gte(resolvedVersion.value, '1.12.0-alpha.2'))
@@ -112,12 +112,12 @@ onBeforeMount(() => (formState.value.bootloader ??= SchematicBootloader.BOOT_AUT
           icon="fullscreen"
           class="size-6 shrink-0"
           aria-label="Expand editor"
-          @click="configEditorExpanded = true"
+          @click="embeddedConfigExpanded = true"
         />
       </div>
 
       <Expandable
-        v-model:expanded="configEditorExpanded"
+        v-model:expanded="embeddedConfigExpanded"
         title="Embedded machine configuration"
         class="data-[state=closed]:h-50 data-[state=closed]:overflow-hidden data-[state=closed]:rounded data-[state=closed]:border data-[state=closed]:border-naturals-n8"
       >
@@ -151,12 +151,29 @@ onBeforeMount(() => (formState.value.bootloader ??= SchematicBootloader.BOOT_AUT
     </template>
 
     <template v-if="selectedSBC">
-      <TextArea
-        v-model="formState.overlayOptions"
-        placeholder="configTxtAppend: 'dtoverlay=vc4-fkms-v3d'"
+      <div class="flex items-center gap-2">
+        <span class="text-sm font-medium text-naturals-n14">Extra overlay options (advanced)</span>
+
+        <IconButton
+          icon="fullscreen"
+          class="size-6 shrink-0"
+          aria-label="Expand editor"
+          @click="overlayOptionsExpanded = true"
+        />
+      </div>
+
+      <Expandable
+        v-model:expanded="overlayOptionsExpanded"
         title="Extra overlay options (advanced)"
-        overhead-title
-      />
+        class="data-[state=closed]:h-50 data-[state=closed]:overflow-hidden data-[state=closed]:rounded data-[state=closed]:border data-[state=closed]:border-naturals-n8"
+      >
+        <CodeEditor
+          v-model="formState.overlayOptions"
+          :options="{ ariaLabel: 'Extra overlay options (advanced)' }"
+          disable-config-validation
+          class="size-full"
+        />
+      </Expandable>
 
       <p>
         This step allows you to customize the overlay options for the

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/extra-args.vue
@@ -6,12 +6,15 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { gte } from 'semver'
-import { computed, onBeforeMount } from 'vue'
+import { computed, onBeforeMount, ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import { SchematicBootloader } from '@/api/omni/management/management.pb'
 import type { QuirksSpec, SBCConfigSpec } from '@/api/omni/specs/virtual.pb'
 import { QuirksType, SBCConfigType, VirtualNamespace } from '@/api/resources'
+import IconButton from '@/components/Button/IconButton.vue'
+import CodeEditor from '@/components/CodeEditor/CodeEditor.vue'
+import Expandable from '@/components/Expandable/Expandable.vue'
 import RadioGroup from '@/components/Radio/RadioGroup.vue'
 import RadioGroupOption from '@/components/Radio/RadioGroupOption.vue'
 import TextArea from '@/components/TextArea/TextArea.vue'
@@ -25,6 +28,8 @@ definePage({ name: 'InstallationMediaCreateExtraArgs' })
 const formState = defineModel<FormState>({ required: true })
 
 const resolvedVersion = computed(() => resolveTalosVersion(formState.value.talosVersion!))
+
+const configEditorExpanded = ref(false)
 
 const supportsCustomisingKernelArgs = computed(() => gte(resolvedVersion.value, '1.10.0'))
 const supportsBootloaderSelection = computed(() => gte(resolvedVersion.value, '1.12.0-alpha.2'))
@@ -100,15 +105,29 @@ onBeforeMount(() => (formState.value.bootloader ??= SchematicBootloader.BOOT_AUT
     <p>Skip this step if unsure.</p>
 
     <template v-if="quirks?.spec.supports_embedded_config">
-      <TextArea
-        v-model="formState.embeddedMachineConfig"
-        placeholder="apiVersion: v1alpha1
-kind: HostnameConfig
-hostname: my-custom-hostname
-auto: off"
+      <div class="flex items-center gap-2">
+        <span class="text-sm font-medium text-naturals-n14">Embedded machine configuration</span>
+
+        <IconButton
+          icon="fullscreen"
+          class="size-6 shrink-0"
+          aria-label="Expand editor"
+          @click="configEditorExpanded = true"
+        />
+      </div>
+
+      <Expandable
+        v-model:expanded="configEditorExpanded"
         title="Embedded machine configuration"
-        overhead-title
-      />
+        class="data-[state=closed]:h-50 data-[state=closed]:overflow-hidden data-[state=closed]:rounded data-[state=closed]:border data-[state=closed]:border-naturals-n8"
+      >
+        <CodeEditor
+          v-model="formState.embeddedMachineConfig"
+          :talos-version="resolvedVersion"
+          :options="{ ariaLabel: 'Embedded machine configuration' }"
+          class="size-full"
+        />
+      </Expandable>
 
       <p>
         This configuration will be embedded into the image. For more details see the

--- a/frontend/src/views/Config/PatchEdit.vue
+++ b/frontend/src/views/Config/PatchEdit.vue
@@ -445,6 +445,7 @@ const canManageConfigPatches = computed(() =>
           :options="{ readOnly: !canManageConfigPatches }"
           :validators="[checkEncryption]"
           :talos-version="cluster?.spec.talos_version"
+          class="size-full"
         />
       </div>
     </PageContainer>

--- a/frontend/src/views/Config/PatchEdit.vue
+++ b/frontend/src/views/Config/PatchEdit.vue
@@ -97,12 +97,6 @@ enum PatchType {
   Machine = 'Machine',
 }
 
-let codeEditor: monaco.editor.IStandaloneCodeEditor | undefined
-
-const editorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
-  codeEditor = editor
-}
-
 const { data: machine } = useResourceWatch<MachineStatusSpec>(() => ({
   skip: !machineId,
   resource: {
@@ -355,10 +349,6 @@ const getPatchLabels = () => {
 const saveConfig = async () => {
   const create = state.value === State.NotExists
 
-  if (codeEditor) {
-    config.value = codeEditor.getValue()
-  }
-
   const currentPatch: Resource<ConfigPatchSpec> = configPatch.value || {
     metadata: {
       namespace: DefaultNamespace,
@@ -451,11 +441,10 @@ const canManageConfigPatches = computed(() =>
 
         <CodeEditor
           v-else
-          v-model:value="config"
+          v-model="config"
           :options="{ readOnly: !canManageConfigPatches }"
           :validators="[checkEncryption]"
           :talos-version="cluster?.spec.talos_version"
-          @editor-did-mount="editorDidMount"
         />
       </div>
     </PageContainer>

--- a/frontend/src/views/Modals/ConfigPatchEdit.vue
+++ b/frontend/src/views/Modals/ConfigPatchEdit.vue
@@ -92,11 +92,7 @@ const saveAndClose = async () => {
         {{ err.message }}
       </TAlert>
 
-      <CodeEditor
-        :value="configChanges"
-        :talos-version="talosVersion"
-        @update:value="(updated) => (configChanges = updated)"
-      />
+      <CodeEditor v-model="configChanges" :talos-version="talosVersion" />
     </div>
     <div class="flex justify-between gap-4 rounded-b bg-naturals-n3 p-4">
       <TButton variant="secondary" @click="close">Cancel</TButton>

--- a/frontend/src/views/Modals/ConfigPatchEdit.vue
+++ b/frontend/src/views/Modals/ConfigPatchEdit.vue
@@ -92,7 +92,7 @@ const saveAndClose = async () => {
         {{ err.message }}
       </TAlert>
 
-      <CodeEditor v-model="configChanges" :talos-version="talosVersion" />
+      <CodeEditor v-model="configChanges" :talos-version="talosVersion" class="size-full" />
     </div>
     <div class="flex justify-between gap-4 rounded-b bg-naturals-n3 p-4">
       <TButton variant="secondary" @click="close">Cancel</TButton>


### PR DESCRIPTION
Use the `CodeEditor` component for editing YAML fields in installation media, i.e. embedded machine config and extra overlay options.

Closes #3015 

Closed:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/924afad2-6256-42bf-9391-0e837b2f66bf" />

Expanded:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/bad2942a-6d6b-4a21-a136-f816464a27a1" />
