### PR TITLE
fix: validate infra provider name as DNS-1123 label

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -27,10 +26,8 @@ import (
 
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/pkg/dnslabel"
 )
-
-// dnsLabelRegexp validates an RFC 1123 DNS label: lowercase alphanumeric with optional dashes, no leading/trailing dash, max 63 chars.
-var dnsLabelRegexp = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 
 // Reconciler is the reconciler for ExposedService resources.
 type Reconciler struct {
@@ -324,10 +321,9 @@ func (reconciler *Reconciler) buildExposedServiceURL(alias string) (string, erro
 		return "", errors.New("empty alias")
 	}
 
-	// Validate alias as an RFC 1123 DNS label: lowercase alphanumeric with optional dashes,
-	// no leading/trailing dash, max 63 chars.
-	if !dnsLabelRegexp.MatchString(alias) {
-		return "", fmt.Errorf("alias %q is not a valid DNS label (must be lowercase alphanumeric with optional dashes, no leading/trailing dash, max 63 chars)", alias)
+	// The alias becomes a DNS label of the workload proxy URL, so it has to satisfy RFC 1123.
+	if err := dnslabel.Validate(alias); err != nil {
+		return "", fmt.Errorf("invalid alias: %w", err)
 	}
 
 	if reconciler.useOmniSubdomain {

--- a/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/exposedservice/reconciler_test.go
@@ -224,10 +224,10 @@ func TestReconcilerInvalidAliases(t *testing.T) {
 		expectError      string
 		useOmniSubdomain bool
 	}{
-		{name: "dot in alias - useOmniSubdomain", prefix: "my.service", useOmniSubdomain: true, expectError: "not a valid DNS label"},
-		{name: "dot in alias - default mode", prefix: "my.service", useOmniSubdomain: false, expectError: "not a valid DNS label"},
-		{name: "underscore in alias - useOmniSubdomain", prefix: "my_service", useOmniSubdomain: true, expectError: "not a valid DNS label"},
-		{name: "underscore in alias - default mode", prefix: "my_service", useOmniSubdomain: false, expectError: "not a valid DNS label"},
+		{name: "dot in alias - useOmniSubdomain", prefix: "my.service", useOmniSubdomain: true, expectError: "not a valid DNS-1123 label"},
+		{name: "dot in alias - default mode", prefix: "my.service", useOmniSubdomain: false, expectError: "not a valid DNS-1123 label"},
+		{name: "underscore in alias - useOmniSubdomain", prefix: "my_service", useOmniSubdomain: true, expectError: "not a valid DNS-1123 label"},
+		{name: "underscore in alias - default mode", prefix: "my_service", useOmniSubdomain: false, expectError: "not a valid DNS-1123 label"},
 		{name: "dash in alias - default mode", prefix: "my-service", useOmniSubdomain: false, expectError: "contains a dash"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/backend/runtime/omni/validations/infra_provider.go
+++ b/internal/backend/runtime/omni/validations/infra_provider.go
@@ -16,10 +16,20 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
+	"github.com/siderolabs/omni/internal/pkg/dnslabel"
 )
 
 func infraProviderValidationOptions(st state.State) []validated.StateOption {
 	return []validated.StateOption{
+		validated.WithCreateValidations(validated.NewCreateValidationForType(func(_ context.Context, res *infra.Provider, _ ...state.CreateOption) error {
+			// The ID becomes the local part of the matching service account identity, so it has
+			// to be a DNS-1123 label or PGP identity construction rejects it later.
+			if err := dnslabel.Validate(res.Metadata().ID()); err != nil {
+				return fmt.Errorf("invalid infra provider name: %w", err)
+			}
+
+			return nil
+		})),
 		validated.WithDestroyValidations(validated.NewDestroyValidationForType(func(ctx context.Context, ptr resource.Pointer, res *infra.Provider, _ ...state.DestroyOption) error {
 			if res == nil {
 				return nil

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validations"
 	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/dnslabel"
 )
 
 //go:embed testdata/infra.json
@@ -2981,6 +2982,58 @@ func TestInfraProviderValidation(t *testing.T) {
 
 	require.NoError(t, st.Destroy(ctx, machine.Metadata()))
 	require.NoError(t, st.Destroy(ctx, provider.Metadata()))
+}
+
+func TestInfraProviderNameValidation(t *testing.T) {
+	t.Parallel()
+
+	newState := func(t *testing.T) (context.Context, state.CoreState) {
+		t.Helper()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		t.Cleanup(cancel)
+
+		innerSt := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		return ctx, validated.NewState(innerSt, validations.InfraProviderValidationOptions(innerSt)...)
+	}
+
+	for _, name := range []string{"a", "aws-1", "qemu-1", "abc123", "abc-123-def"} {
+		t.Run("accept/"+name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, st := newState(t)
+
+			require.NoError(t, st.Create(ctx, infra.NewProvider(name)))
+		})
+	}
+
+	rejectCases := []struct {
+		name    string
+		id      string
+		message string
+	}{
+		{"whitespace", "foo bar", "not a valid DNS-1123 label"},
+		{"uppercase", "AWS-1", "not a valid DNS-1123 label"},
+		{"underscore", "aws_1", "not a valid DNS-1123 label"},
+		{"colon", "infra-provider:foo", "not a valid DNS-1123 label"},
+		{"leading hyphen", "-aws", "not a valid DNS-1123 label"},
+		{"trailing hyphen", "aws-", "not a valid DNS-1123 label"},
+		{"non-ascii", "qemü-1", "not a valid DNS-1123 label"},
+		{"too long", strings.Repeat("a", dnslabel.MaxLength+1), "DNS-1123 label is too long"},
+	}
+
+	for _, tc := range rejectCases {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, st := newState(t)
+
+			err := st.Create(ctx, infra.NewProvider(tc.id))
+			require.True(t, validated.IsValidationError(err), "expected validation error, got %v", err)
+			assert.ErrorContains(t, err, tc.message)
+		})
+	}
 }
 
 func TestRotateSecretsValidation(t *testing.T) {

--- a/internal/pkg/dnslabel/dnslabel.go
+++ b/internal/pkg/dnslabel/dnslabel.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package dnslabel provides a check for RFC 1123 DNS labels. Use it for user-supplied
+// names that have to appear in a DNS label, a Kubernetes name, or the local part of an
+// email-style identity.
+package dnslabel
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// MaxLength is the maximum length of an RFC 1123 DNS label.
+const MaxLength = 63
+
+// dnsLabelRegexp matches the charset shape of an RFC 1123 DNS label: lowercase
+// alphanumeric and hyphens, starting and ending with an alphanumeric. The length cap is
+// enforced separately by IsValid and Validate.
+var dnsLabelRegexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// IsValid reports whether s is a valid RFC 1123 DNS label.
+func IsValid(s string) bool {
+	return len(s) <= MaxLength && dnsLabelRegexp.MatchString(s)
+}
+
+// Validate returns nil if s is a valid RFC 1123 DNS label, and a descriptive error
+// otherwise. The error for an over-length input intentionally omits the value to avoid
+// echoing arbitrarily large user input back into logs and responses.
+func Validate(s string) error {
+	if len(s) > MaxLength {
+		return fmt.Errorf("DNS-1123 label is too long: %d bytes (max %d)", len(s), MaxLength)
+	}
+
+	if !dnsLabelRegexp.MatchString(s) {
+		return fmt.Errorf("%q is not a valid DNS-1123 label (lowercase alphanumeric and hyphens, starting and ending with alphanumeric, max %d characters)", s, MaxLength)
+	}
+
+	return nil
+}

--- a/internal/pkg/dnslabel/dnslabel_test.go
+++ b/internal/pkg/dnslabel/dnslabel_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package dnslabel_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/internal/pkg/dnslabel"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"a", "ab", "aws-1", "qemu-1", "abc123", "abc-123-def", strings.Repeat("a", dnslabel.MaxLength)} {
+		t.Run("accept/"+name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NoError(t, dnslabel.Validate(name))
+			assert.True(t, dnslabel.IsValid(name))
+		})
+	}
+
+	rejectCases := []struct {
+		name    string
+		input   string
+		message string
+	}{
+		{"empty", "", "not a valid DNS-1123 label"},
+		{"whitespace", "foo bar", "not a valid DNS-1123 label"},
+		{"uppercase", "AWS-1", "not a valid DNS-1123 label"},
+		{"underscore", "aws_1", "not a valid DNS-1123 label"},
+		{"dot", "foo.bar", "not a valid DNS-1123 label"},
+		{"colon", "infra-provider:foo", "not a valid DNS-1123 label"},
+		{"leading hyphen", "-aws", "not a valid DNS-1123 label"},
+		{"trailing hyphen", "aws-", "not a valid DNS-1123 label"},
+		{"non-ascii", "qemü-1", "not a valid DNS-1123 label"},
+		{"too long", strings.Repeat("a", dnslabel.MaxLength+1), "DNS-1123 label is too long"},
+	}
+
+	for _, tc := range rejectCases {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := dnslabel.Validate(tc.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.message)
+			assert.False(t, dnslabel.IsValid(tc.input))
+		})
+	}
+
+	t.Run("error for over-length input does not echo the value", func(t *testing.T) {
+		t.Parallel()
+
+		input := strings.Repeat("a", dnslabel.MaxLength*10)
+
+		err := dnslabel.Validate(input)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), input)
+	})
+}


### PR DESCRIPTION
Creating an infra provider with whitespace or other invalid characters in the name leaves a half-created state. The provider resource is created first, then the service account creation fails because PGP cannot build an identity from the malformed name.

Reject these names up front by validating the infra provider ID as a DNS-1123 label on create. This is the same regex the exposed service alias check enforces today, so move it into a shared helper next to the service account name handling and have both callers go through it.

Closes siderolabs/omni#2789.