### PR TITLE
fix: prevent removal of node unique tokens that still have a link

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/node_unique_token_cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/node_unique_token_cleanup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/cosi/helpers"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 )
 
 // NodeUniqueTokenCleanupControllerName is the name of the NodeUniqueTokenCleanupController.
@@ -101,7 +102,10 @@ func (ctrl *NodeUniqueTokenCleanupController) Reconcile(ctx context.Context,
 }
 
 func (ctrl *NodeUniqueTokenCleanupController) reconcileRunning(ctx context.Context, r controller.QRuntime, logger *zap.Logger, nodeUniqueToken *siderolink.NodeUniqueToken) error {
-	link, err := safe.ReaderGetByID[*siderolink.Link](ctx, r, nodeUniqueToken.Metadata().ID())
+	// Read the link uncached. The cached input replica is fed by a separate watch stream and can lag
+	// real state, so a link that already exists may not yet be visible when the token's reconcile fires.
+	// Acting on a stale "no link" view here would wrongly tear down a token that actually has a link.
+	link, err := safe.ReaderGetByID[*siderolink.Link](ctx, uncached.Reader(r), nodeUniqueToken.Metadata().ID())
 	if err != nil && !state.IsNotFoundError(err) {
 		return err
 	}

--- a/internal/backend/runtime/omni/controllers/omni/node_unique_token_cleanup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/node_unique_token_cleanup_test.go
@@ -43,10 +43,8 @@ func (suite *MachineStatusSnapshotControllerSuite) TestNodeUniqueTokenCleanup() 
 
 	link := siderolink.NewLink(token.Metadata().ID(), &specs.SiderolinkSpec{})
 
-	// Create the link first so that by the time the controller sees the recreated token,
-	// the link already exists and the token is not treated as orphaned. If the token is
-	// created first, a CI-loaded test goroutine can be preempted long enough between the
-	// two creates for the controller's orphan-TTL requeue to fire and destroy the token.
+	// Create the link before recreating the token. The controller reads the link uncached, so an
+	// existing link is always observed and the token is never treated as orphaned, even on a busy runner.
 	suite.Require().NoError(suite.state.Create(ctx, link))
 	suite.Require().NoError(suite.state.Create(ctx, token))
 


### PR DESCRIPTION
The node unique token cleanup removes tokens that have no associated link for longer than a grace period. It looked up the link through the cached reader, which is populated by a separate watch and can trail real state. On a loaded runner the link could already exist while being invisible through the cache, so a token that had just regained its link was wrongly treated as orphaned and torn down.

Read the link bypassing the cache so an existing link is always observed even when the watch is behind. This fixes the flaky cleanup test that timed out when the recreated token got removed.