### PR TITLE
fix: keep maintenance Talos clients until machine leaves maintenance

### DIFF
--- a/internal/backend/grpc/router/router.go
+++ b/internal/backend/grpc/router/router.go
@@ -497,12 +497,8 @@ func (r *Router) ResourceWatcher(ctx context.Context, s state.State, logger *zap
 		return fmt.Errorf("failed to watch ClusterEndpoints: %w", err)
 	}
 
-	if err := s.WatchKind(ctx, omni.NewMachine("").Metadata(), events); err != nil {
-		return fmt.Errorf("failed to watch Machines: %w", err)
-	}
-
-	if err := s.WatchKind(ctx, omni.NewClusterMachine("").Metadata(), events); err != nil {
-		return fmt.Errorf("failed to watch ClusterMachines: %w", err)
+	if err := s.WatchKind(ctx, omni.NewMachineStatus("").Metadata(), events); err != nil {
+		return fmt.Errorf("failed to watch MachineStatuses: %w", err)
 	}
 
 	for {
@@ -523,15 +519,8 @@ func (r *Router) ResourceWatcher(ctx context.Context, s state.State, logger *zap
 		}
 
 		switch event.Resource.Metadata().Type() {
-		case omni.MachineType:
-			if event.Type == state.Destroyed {
-				machineID := event.Resource.Metadata().ID()
-				r.releaseForMachine("", machineID)
-
-				logger.Info("remove machine talos backend", zap.String("machine", machineID))
-			}
-		case omni.ClusterMachineType:
-			r.handleClusterMachineEvent(logger, event)
+		case omni.MachineStatusType:
+			r.handleMachineStatusEvent(logger, event)
 		default: // Cluster, ClusterSecrets, or ClusterEndpoint changed: remove all backends for the cluster
 			clusterID := event.Resource.Metadata().ID()
 			r.releaseForCluster(clusterID)
@@ -541,26 +530,62 @@ func (r *Router) ResourceWatcher(ctx context.Context, s state.State, logger *zap
 	}
 }
 
-func (r *Router) handleClusterMachineEvent(logger *zap.Logger, event state.Event) {
+// handleMachineStatusEvent evicts the now-stale backends of a machine whose maintenance mode or cluster changed.
+//
+// A machine is reachable over exactly one backend: the insecure maintenance backend while in maintenance mode, or the
+// secure cluster backend otherwise. On every change the backends the machine is no longer reachable through are evicted,
+// which is idempotent and never drops the currently valid one.
+//
+// The previous cluster is read from the old version of the resource carried by the event, so the secure cluster backend
+// can be evicted even when the machine status has already cleared its cluster field as the machine leaves the cluster.
+func (r *Router) handleMachineStatusEvent(logger *zap.Logger, event state.Event) {
 	machineID := event.Resource.Metadata().ID()
 
-	switch event.Type { //nolint:exhaustive // event type is already filtered at call site
-	case state.Created: // machine joined cluster: evict stale maintenance backend
+	machineStatus, ok := event.Resource.(*omni.MachineStatus)
+	if !ok {
+		logger.Warn("unexpected resource type for machine status event", zap.String("machine", machineID))
+
+		return
+	}
+
+	// evictCluster drops the secure cluster backend for a non-empty cluster (an empty cluster would target the
+	// maintenance backend instead, which must never be evicted as a side effect here).
+	evictCluster := func(clusterID string) {
+		if clusterID != "" {
+			r.releaseForMachine(clusterID, machineID)
+
+			logger.Info("remove node talos backend", zap.String("cluster", clusterID), zap.String("machine", machineID))
+		}
+	}
+
+	if event.Type == state.Destroyed {
+		// the machine is gone: drop both its maintenance and its secure cluster backend.
 		r.releaseForMachine("", machineID)
+		evictCluster(machineStatus.TypedSpec().Value.Cluster)
 
 		logger.Info("remove maintenance talos backend", zap.String("machine", machineID))
-	case state.Destroyed: // machine left cluster: evict its cluster backend
-		clusterID, ok := event.Resource.Metadata().Labels().Get(omni.LabelCluster)
-		if !ok {
-			logger.Warn("ClusterMachine has no cluster label, skipping backend cleanup", zap.String("machine", machineID))
 
-			return
-		}
-
-		r.releaseForMachine(clusterID, machineID)
-
-		logger.Info("remove node talos backend", zap.String("cluster", clusterID), zap.String("machine", machineID))
+		return
 	}
+
+	// evict the secure backend of the previous cluster if the machine moved to a different one or left it entirely.
+	if old, ok := event.Old.(*omni.MachineStatus); ok {
+		if oldCluster := old.TypedSpec().Value.Cluster; oldCluster != machineStatus.TypedSpec().Value.Cluster {
+			evictCluster(oldCluster)
+		}
+	}
+
+	if machineStatus.TypedSpec().Value.Maintenance {
+		// the machine is in maintenance mode: its current secure cluster backend is stale.
+		evictCluster(machineStatus.TypedSpec().Value.Cluster)
+
+		return
+	}
+
+	// the machine is not in maintenance mode: the insecure maintenance backend is stale.
+	r.releaseForMachine("", machineID)
+
+	logger.Info("remove maintenance talos backend", zap.String("machine", machineID))
 }
 
 // ExtractContext reads cluster context from the supplied metadata.

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -501,7 +501,12 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 			}
 		}
 
-		spec.Maintenance = event.MaintenanceMode
+		// A machine is in maintenance mode only if the collect task actually reached it over the insecure
+		// maintenance connection. The task falls back to that connection whenever Omni has no Talos config for the
+		// machine yet, even for an already configured machine (for example during cluster import). Such a machine
+		// rejects the insecure connection and reports no access, so it must not be treated as running in
+		// maintenance mode.
+		spec.Maintenance = event.MaintenanceMode && !event.NoAccess
 
 		if err := ctrl.reconcileLabels(machineStatus, event.InfraMachineStatus); err != nil {
 			return fmt.Errorf("failed to reconcile labels: %w", err)

--- a/internal/backend/runtime/talos/clients.go
+++ b/internal/backend/runtime/talos/clients.go
@@ -162,6 +162,9 @@ type ClientFactory struct {
 	cache *expirable.LRU[string, *Client]
 	sf    singleflight.Group
 
+	// started is closed by StartCacheManager once all its watches are registered.
+	started chan struct{}
+
 	metricCacheSize     *prometheus.GaugeVec
 	metricActiveClients *prometheus.GaugeVec
 	metricCacheHits     *prometheus.CounterVec
@@ -181,6 +184,7 @@ func NewClientFactory(omniState state.State, logger *zap.Logger) *ClientFactory 
 	f := &ClientFactory{
 		omniState:       omniState,
 		logger:          logger,
+		started:         make(chan struct{}),
 		metricCacheSize: cacheSize,
 		metricActiveClients: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "omni_talos_clientfactory_active_clients",
@@ -361,7 +365,8 @@ func (factory *ClientFactory) buildForCluster(ctx context.Context, clusterID str
 }
 
 // GetForMachine constructs a Talos client connected directly to a specific node's SideroLink address.
-// It returns a maintenance or a regular client depending on whether the node is currently part of a cluster or not.
+// It returns a maintenance (insecure) or a regular (secure) client depending on whether the machine is currently in
+// maintenance mode or not, as reported by its MachineStatus.
 // Returned client is cached and must not be closed by the consumer.
 func (factory *ClientFactory) GetForMachine(ctx context.Context, machineID string) (*Client, error) {
 	return factory.getForMachine(ctx, machineID, false)
@@ -370,24 +375,46 @@ func (factory *ClientFactory) GetForMachine(ctx context.Context, machineID strin
 // GetMaintenance constructs a Talos client connected directly to a specific node's SideroLink address over the insecure
 // maintenance connection.
 //
-// Unlike GetForMachine, it never falls through to the cluster (secure) client: if the machine turns out to be part of a
-// cluster, it returns an error instead. This way a caller acting on a machine it believes to be in maintenance mode
-// (based on a possibly stale machine status) can never accidentally reconfigure an allocated machine.
+// It determines the machine mode solely from its MachineStatus: if the machine status does not exist yet, or the machine
+// is not in maintenance mode, it returns an error instead of a client. This way a caller acting on a machine it believes
+// to be in maintenance mode (based on a possibly stale view) can never accidentally reconfigure an allocated machine that
+// has already left maintenance.
 // Returned client is cached and must not be closed by the consumer.
 func (factory *ClientFactory) GetMaintenance(ctx context.Context, machineID string) (*Client, error) {
 	return factory.getForMachine(ctx, machineID, true)
 }
 
 func (factory *ClientFactory) getForMachine(ctx context.Context, machineID string, maintenanceOnly bool) (*Client, error) {
-	clusterID, idErr := factory.lookupClusterID(ctx, machineID)
-	if idErr != nil {
-		return nil, idErr
+	machineStatus, err := safe.StateGet[*omni.MachineStatus](
+		ctx, factory.omniState,
+		omni.NewMachineStatus(machineID).Metadata(),
+	)
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			return nil, NewClientNotReadyError(err)
+		}
+
+		return nil, err
 	}
+
+	spec := machineStatus.TypedSpec().Value
 
 	// when only a maintenance client was asked for, refuse to build (or return a cached) cluster client. checked before
 	// touching the cache so a concurrently cached cluster client can never leak through either.
-	if maintenanceOnly && clusterID != "" {
+	if maintenanceOnly && !spec.Maintenance {
 		return nil, fmt.Errorf("machine %q is not in maintenance mode", machineID)
+	}
+
+	// A machine in maintenance mode is reachable only over the insecure maintenance connection, even when already
+	// allocated to a cluster. Otherwise it is reachable over its cluster's secure connection. A machine that is in
+	// neither state has no reachable client, so report it as not ready rather than caching a doomed one.
+	clusterID := spec.Cluster
+
+	switch {
+	case spec.Maintenance:
+		clusterID = ""
+	case clusterID == "":
+		return nil, NewClientNotReadyError(fmt.Errorf("machine %q is neither in maintenance mode nor allocated to a cluster", machineID))
 	}
 
 	cacheKey := buildCacheKey(clusterID, machineID)
@@ -406,7 +433,7 @@ func (factory *ClientFactory) getForMachine(ctx context.Context, machineID strin
 
 		factory.metricCacheMisses.WithLabelValues(typ).Inc()
 
-		cli, err := factory.buildForMachine(ctx, clusterID, machineID)
+		cli, err := factory.buildForMachine(ctx, clusterID, machineStatus)
 		if err != nil {
 			return nil, err
 		}
@@ -443,25 +470,6 @@ func (factory *ClientFactory) getForMachine(ctx context.Context, machineID strin
 	}
 }
 
-// lookupClusterID returns the cluster name for the given machine, or an empty string if it's not in a cluster.
-func (factory *ClientFactory) lookupClusterID(ctx context.Context, machineID string) (string, error) {
-	clusterMachine, err := safe.StateGetByID[*omni.ClusterMachine](ctx, factory.omniState, machineID)
-	if err != nil {
-		if state.IsNotFoundError(err) {
-			return "", nil
-		}
-
-		return "", fmt.Errorf("failed to get ClusterMachine for machine %q: %w", machineID, err)
-	}
-
-	cluster, ok := clusterMachine.Metadata().Labels().Get(omni.LabelCluster)
-	if !ok {
-		return "", fmt.Errorf("cluster machine %q has no cluster label", machineID)
-	}
-
-	return cluster, nil
-}
-
 // buildCacheKey constructs a cache key for a client based on cluster and machine IDs.
 //
 // If no machine is specified, this is a cluster-client, and its key will be "clusterID/".
@@ -476,18 +484,8 @@ func buildCacheKey(clusterID, machineID string) string {
 	return clusterID + "/" + machineID
 }
 
-func (factory *ClientFactory) buildForMachine(ctx context.Context, clusterID, machineID string) (*Client, error) {
-	machineStatus, getErr := safe.StateGet[*omni.MachineStatus](
-		ctx, factory.omniState,
-		omni.NewMachineStatus(machineID).Metadata(),
-	)
-	if getErr != nil {
-		if state.IsNotFoundError(getErr) {
-			return nil, NewClientNotReadyError(getErr)
-		}
-
-		return nil, getErr
-	}
+func (factory *ClientFactory) buildForMachine(ctx context.Context, clusterID string, machineStatus *omni.MachineStatus) (*Client, error) {
+	machineID := machineStatus.Metadata().ID()
 
 	managementAddress := machineStatus.TypedSpec().Value.ManagementAddress
 	if managementAddress == "" {
@@ -533,13 +531,26 @@ func (factory *ClientFactory) releaseForMachine(clusterID, machineID string) {
 	factory.cache.Remove(cacheKey)
 }
 
+// WaitForCacheStart blocks until StartCacheManager has registered all its watches, or the context is done.
+//
+// A caller can use it to be sure the cache manager is live and will observe subsequent state changes before relying on
+// its cache invalidation.
+func (factory *ClientFactory) WaitForCacheStart(ctx context.Context) error {
+	select {
+	case <-factory.started:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // StartCacheManager starts watching the relevant resources to do the client cache invalidation.
 func (factory *ClientFactory) StartCacheManager(ctx context.Context) error {
 	eventCh := make(chan state.Event)
 
 	clusterEndpointMd := omni.NewClusterEndpoint("").Metadata()
 	talosconfigMd := omni.NewTalosConfig("").Metadata()
-	clusterMachineMd := omni.NewClusterMachine("").Metadata()
+	machineStatusMd := omni.NewMachineStatus("").Metadata()
 
 	err := factory.omniState.WatchKind(ctx, clusterEndpointMd, eventCh)
 	if err != nil {
@@ -551,12 +562,14 @@ func (factory *ClientFactory) StartCacheManager(ctx context.Context) error {
 		return fmt.Errorf("failed to watch TalosConfigs: %w", err)
 	}
 
-	err = factory.omniState.WatchKind(ctx, clusterMachineMd, eventCh)
+	err = factory.omniState.WatchKind(ctx, machineStatusMd, eventCh)
 	if err != nil {
-		return fmt.Errorf("failed to watch ClusterMachines: %w", err)
+		return fmt.Errorf("failed to watch MachineStatuses: %w", err)
 	}
 
 	factory.logger.Debug("started Talos client cache manager")
+
+	close(factory.started)
 
 	for {
 		var event state.Event
@@ -577,32 +590,67 @@ func (factory *ClientFactory) StartCacheManager(ctx context.Context) error {
 		case state.Created, state.Updated, state.Destroyed: // handle below
 		}
 
-		if event.Resource.Metadata().Type() == omni.ClusterMachineType {
-			factory.handleClusterMachineEvent(event)
-
-			continue
+		switch event.Resource.Metadata().Type() {
+		case omni.MachineStatusType:
+			factory.handleMachineStatusEvent(event)
+		default:
+			// ClusterEndpoint or TalosConfig changed — invalidate the cluster with all its clients.
+			clusterID := event.Resource.Metadata().ID()
+			factory.releaseForCluster(clusterID)
 		}
-
-		// ClusterEndpoint or TalosConfig changed — invalidate the cluster with all its clients.
-		clusterID := event.Resource.Metadata().ID()
-		factory.releaseForCluster(clusterID)
 	}
 }
 
-func (factory *ClientFactory) handleClusterMachineEvent(event state.Event) {
-	switch event.Type { //nolint:exhaustive // event type is already filtered at call site
-	case state.Created:
-		factory.releaseForMachine("", event.Resource.Metadata().ID())
-	case state.Destroyed:
-		clusterID, ok := event.Resource.Metadata().Labels().Get(omni.LabelCluster)
-		if !ok {
-			factory.logger.Error("cluster machine has no cluster label, cannot evict from cache", zap.String("id", event.Resource.Metadata().ID()))
+// handleMachineStatusEvent evicts the now-stale clients of a machine whose maintenance mode or cluster changed.
+//
+// A machine is reachable over exactly one client: the insecure maintenance client while in maintenance mode, or the
+// secure cluster client otherwise. On every change the clients the machine is no longer reachable through are evicted,
+// which is idempotent and never drops the currently valid one.
+//
+// The previous cluster is read from the old version of the resource carried by the event, so the secure cluster client
+// can be evicted even when the machine status has already cleared its cluster field as the machine leaves the cluster.
+func (factory *ClientFactory) handleMachineStatusEvent(event state.Event) {
+	machineID := event.Resource.Metadata().ID()
 
-			return
-		}
+	machineStatus, ok := event.Resource.(*omni.MachineStatus)
+	if !ok {
+		factory.logger.Error("unexpected resource type for machine status event", zap.String("id", machineID))
 
-		factory.releaseForMachine(clusterID, event.Resource.Metadata().ID())
+		return
 	}
+
+	// evictCluster drops the secure cluster client for a non-empty cluster (an empty cluster would target the
+	// maintenance client instead, which must never be evicted as a side effect here).
+	evictCluster := func(clusterID string) {
+		if clusterID != "" {
+			factory.releaseForMachine(clusterID, machineID)
+		}
+	}
+
+	if event.Type == state.Destroyed {
+		// the machine is gone: drop both its maintenance and its secure cluster client.
+		factory.releaseForMachine("", machineID)
+		evictCluster(machineStatus.TypedSpec().Value.Cluster)
+
+		return
+	}
+
+	// evict the secure client of the previous cluster if the machine moved to a different one or left it entirely.
+	if old, ok := event.Old.(*omni.MachineStatus); ok {
+		if oldCluster := old.TypedSpec().Value.Cluster; oldCluster != machineStatus.TypedSpec().Value.Cluster {
+			evictCluster(oldCluster)
+		}
+	}
+
+	if machineStatus.TypedSpec().Value.Maintenance {
+		// the machine is in maintenance mode: its current secure cluster client is stale.
+		evictCluster(machineStatus.TypedSpec().Value.Cluster)
+
+		return
+	}
+
+	// the machine is not in maintenance mode: the insecure maintenance client is stale.
+	factory.releaseForMachine("", machineID)
 }
 
 // Describe implements prom.Collector interface.

--- a/internal/backend/runtime/talos/clients_test.go
+++ b/internal/backend/runtime/talos/clients_test.go
@@ -7,7 +7,6 @@ package talos_test
 
 import (
 	"context"
-	"runtime"
 	"testing"
 	"time"
 
@@ -93,19 +92,25 @@ func TestGetMaintenance(t *testing.T) {
 		// and zaptest loggers panic when logging to a finished testing.T.
 		clientFactory := talos.NewClientFactory(testContext.State, zap.NewNop())
 
-		// A machine in maintenance: it has a status but is not part of any cluster.
+		// A machine in maintenance mode: it has a status with the maintenance flag set.
 		maintMachine := omni.NewMachineStatus("m-maint")
 		maintMachine.TypedSpec().Value.ManagementAddress = "127.0.0.1"
+		maintMachine.TypedSpec().Value.Maintenance = true
 		require.NoError(t, testContext.State.Create(ctx, maintMachine))
 
-		// An allocated machine: it has a status and a cluster machine.
-		allocMachine := omni.NewMachineStatus("m-alloc")
-		allocMachine.TypedSpec().Value.ManagementAddress = "127.0.0.1"
-		require.NoError(t, testContext.State.Create(ctx, allocMachine))
+		// A configured machine: it is allocated to a cluster and no longer in maintenance mode.
+		configuredMachine := omni.NewMachineStatus("m-configured")
+		configuredMachine.TypedSpec().Value.ManagementAddress = "127.0.0.1"
+		configuredMachine.TypedSpec().Value.Cluster = "alpha"
+		require.NoError(t, testContext.State.Create(ctx, configuredMachine))
 
-		cm := omni.NewClusterMachine("m-alloc")
-		cm.Metadata().Labels().Set(omni.LabelCluster, "alpha")
-		require.NoError(t, testContext.State.Create(ctx, cm))
+		// An allocated machine that is still in maintenance mode: it has a cluster set, but its initial
+		// configuration has not been applied yet, so it is only reachable over the maintenance connection.
+		allocatedMaintMachine := omni.NewMachineStatus("m-alloc-maint")
+		allocatedMaintMachine.TypedSpec().Value.ManagementAddress = "127.0.0.1"
+		allocatedMaintMachine.TypedSpec().Value.Cluster = "alpha"
+		allocatedMaintMachine.TypedSpec().Value.Maintenance = true
+		require.NoError(t, testContext.State.Create(ctx, allocatedMaintMachine))
 
 		// --- Maintenance machine: returns a maintenance (no cluster) client ---
 
@@ -124,9 +129,21 @@ func TestGetMaintenance(t *testing.T) {
 		require.NoError(t, err)
 		assert.Same(t, maint, viaForMachine)
 
-		// --- Allocated machine: refuses to return a cluster client ---
+		// --- Allocated machine still in maintenance: maintenance client, despite the cluster being set ---
 
-		_, err = clientFactory.GetMaintenance(ctx, "m-alloc")
+		allocMaint, err := clientFactory.GetMaintenance(ctx, "m-alloc-maint")
+		require.NoError(t, err)
+		assert.Empty(t, allocMaint.ClusterID())
+		assert.Equal(t, "m-alloc-maint", allocMaint.MachineID())
+
+		// GetForMachine also returns the maintenance client, not a cluster client.
+		allocMaintViaForMachine, err := clientFactory.GetForMachine(ctx, "m-alloc-maint")
+		require.NoError(t, err)
+		assert.Same(t, allocMaint, allocMaintViaForMachine)
+
+		// --- Configured machine: refuses to return a maintenance client ---
+
+		_, err = clientFactory.GetMaintenance(ctx, "m-configured")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "is not in maintenance mode")
 		assert.False(t, talos.IsClientNotReadyError(err))
@@ -174,20 +191,20 @@ func TestClientLifecycle(t *testing.T) {
 		clusterEndpoint.TypedSpec().Value.ManagementAddresses = []string{"localhost"}
 		require.NoError(t, testContext.State.Create(ctx, clusterEndpoint))
 
-		// --- Setup: 5 machines with MachineStatus ---
+		// --- Setup: m1-m3 configured in cluster, m4-m5 in maintenance ---
 
-		for _, id := range []string{"m1", "m2", "m3", "m4", "m5"} {
+		for _, id := range []string{"m1", "m2", "m3"} {
 			ms := omni.NewMachineStatus(id)
 			ms.TypedSpec().Value.ManagementAddress = "127.0.0.1"
+			ms.TypedSpec().Value.Cluster = clusterName
 			require.NoError(t, testContext.State.Create(ctx, ms))
 		}
 
-		// --- Setup: m1-m3 in cluster, m4-m5 in maintenance ---
-
-		for _, id := range []string{"m1", "m2", "m3"} {
-			cm := omni.NewClusterMachine(id)
-			cm.Metadata().Labels().Set(omni.LabelCluster, clusterName)
-			require.NoError(t, testContext.State.Create(ctx, cm))
+		for _, id := range []string{"m4", "m5"} {
+			ms := omni.NewMachineStatus(id)
+			ms.TypedSpec().Value.ManagementAddress = "127.0.0.1"
+			ms.TypedSpec().Value.Maintenance = true
+			require.NoError(t, testContext.State.Create(ctx, ms))
 		}
 
 		// Start cache manager in background.
@@ -200,6 +217,10 @@ func TestClientLifecycle(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, eg.Wait())
 		})
+
+		// Wait until the cache manager has registered its watches before mutating state below, so its eviction events
+		// are not missed.
+		require.NoError(t, clientFactory.WaitForCacheStart(ctx))
 
 		// --- Phase 1: Initial client creation ---
 
@@ -242,17 +263,18 @@ func TestClientLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		assert.Same(t, maintenanceM4, c)
 
-		// --- Phase 3: Machine joins cluster (m4) — maintenance client evicted ---
+		// --- Phase 3: Machine leaves maintenance (m4) — maintenance client evicted ---
 
-		cm4 := omni.NewClusterMachine("m4")
-		cm4.Metadata().Labels().Set(omni.LabelCluster, clusterName)
-		require.NoError(t, testContext.State.Create(ctx, cm4))
+		ms4, err := safe.StateGet[*omni.MachineStatus](ctx, testContext.State, omni.NewMachineStatus("m4").Metadata())
+		require.NoError(t, err)
+
+		ms4.TypedSpec().Value.Maintenance = false
+		ms4.TypedSpec().Value.Cluster = clusterName
+		require.NoError(t, testContext.State.Update(ctx, ms4))
 
 		var newM4 *talos.Client
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			runtime.Gosched() // allow the cache manager goroutine to process eviction events
-
 			client, clientErr := clientFactory.GetForMachine(ctx, "m4")
 			assert.NoError(collect, clientErr)
 			assert.NotSame(collect, maintenanceM4, client, "m4 maintenance client should have been evicted")
@@ -268,13 +290,17 @@ func TestClientLifecycle(t *testing.T) {
 
 		// --- Phase 4: Machine leaves cluster (m2) — client evicted ---
 
-		require.NoError(t, testContext.State.Destroy(ctx, omni.NewClusterMachine("m2").Metadata()))
+		// The machine goes back to maintenance mode and its status clears the cluster.
+		ms2, err := safe.StateGet[*omni.MachineStatus](ctx, testContext.State, omni.NewMachineStatus("m2").Metadata())
+		require.NoError(t, err)
+
+		ms2.TypedSpec().Value.Maintenance = true
+		ms2.TypedSpec().Value.Cluster = ""
+		require.NoError(t, testContext.State.Update(ctx, ms2))
 
 		var newM2 *talos.Client
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			runtime.Gosched() // allow the cache manager goroutine to process eviction events
-
 			client, clientErr := clientFactory.GetForMachine(ctx, "m2")
 			assert.NoError(collect, clientErr)
 			assert.NotSame(collect, clientM2, client, "m2 client should have been evicted")
@@ -298,8 +324,6 @@ func TestClientLifecycle(t *testing.T) {
 
 		// Cluster-wide client evicted.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			runtime.Gosched() // allow the cache manager goroutine to process eviction events
-
 			client, clientErr := clientFactory.GetForCluster(ctx, clusterName)
 			assert.NoError(collect, clientErr)
 			assert.NotSame(collect, clusterClient, client, "cluster client should have been evicted")
@@ -322,5 +346,102 @@ func TestClientLifecycle(t *testing.T) {
 		c, err = clientFactory.GetForMachine(ctx, "m2")
 		require.NoError(t, err)
 		assert.Same(t, newM2, c, "m2 (now maintenance) should be unaffected")
+	})
+}
+
+// TestClusterClientEvictedOnClusterLeave verifies that the secure cluster client of a machine is evicted when the machine
+// leaves its cluster, so that a later rejoin to the same cluster does not reuse the stale client.
+//
+// The machine status clears its cluster field as the machine leaves, so the cluster name needed to evict the secure
+// cluster client is read from the previous version of the resource carried by the update event. This is why the cache
+// manager does not need to watch cluster machines.
+func TestClusterClientEvictedOnClusterLeave(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		// Use a nop logger because runtime.AddCleanup finalizers may run after the test completes,
+		// and zaptest loggers panic when logging to a finished testing.T.
+		clientFactory := talos.NewClientFactory(testContext.State, zap.NewNop())
+
+		const clusterName = "alpha"
+
+		// Cluster credentials, required to build a secure cluster client.
+		configBundle, err := bundle.NewBundle(bundle.WithInputOptions(
+			&bundle.InputOptions{
+				ClusterName: clusterName,
+				Endpoint:    "https://127.0.0.1:6443",
+				KubeVersion: "1.36.1",
+			},
+		))
+		require.NoError(t, err)
+
+		talosconfig := omni.NewTalosConfig(clusterName)
+		bundleCtx := configBundle.TalosCfg.Contexts[configBundle.TalosCfg.Context]
+		talosconfig.TypedSpec().Value.Ca = bundleCtx.CA
+		talosconfig.TypedSpec().Value.Crt = bundleCtx.Crt
+		talosconfig.TypedSpec().Value.Key = bundleCtx.Key
+		require.NoError(t, testContext.State.Create(ctx, talosconfig))
+
+		// A machine configured in the cluster.
+		ms := omni.NewMachineStatus("m1")
+		ms.TypedSpec().Value.ManagementAddress = "127.0.0.1"
+		ms.TypedSpec().Value.Cluster = clusterName
+		require.NoError(t, testContext.State.Create(ctx, ms))
+
+		var eg errgroup.Group
+
+		eg.Go(func() error {
+			return clientFactory.StartCacheManager(ctx)
+		})
+
+		t.Cleanup(func() {
+			require.NoError(t, eg.Wait())
+		})
+
+		// Wait until the cache manager has registered its watches before mutating state. Otherwise the cluster leave
+		// below can happen before the watches exist and its eviction event would be missed.
+		require.NoError(t, clientFactory.WaitForCacheStart(ctx))
+
+		// Initial secure cluster client.
+		clusterClient, err := clientFactory.GetForMachine(ctx, "m1")
+		require.NoError(t, err)
+		require.Equal(t, clusterName, clusterClient.ClusterID())
+
+		// --- Machine leaves the cluster and goes back to maintenance: cluster field is cleared in the same update ---
+
+		ms, err = safe.StateGet[*omni.MachineStatus](ctx, testContext.State, omni.NewMachineStatus("m1").Metadata())
+		require.NoError(t, err)
+
+		ms.TypedSpec().Value.Maintenance = true
+		ms.TypedSpec().Value.Cluster = ""
+		require.NoError(t, testContext.State.Update(ctx, ms))
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			client, clientErr := clientFactory.GetForMachine(ctx, "m1")
+			assert.NoError(collect, clientErr)
+			assert.Empty(collect, client.ClusterID(), "m1 should now be a maintenance client")
+		}, time.Minute, 100*time.Millisecond)
+
+		// --- Machine rejoins the same cluster ---
+
+		ms, err = safe.StateGet[*omni.MachineStatus](ctx, testContext.State, omni.NewMachineStatus("m1").Metadata())
+		require.NoError(t, err)
+
+		ms.TypedSpec().Value.Maintenance = false
+		ms.TypedSpec().Value.Cluster = clusterName
+		require.NoError(t, testContext.State.Update(ctx, ms))
+
+		// The cluster client built before the machine left must not be reused: it was evicted on leave using the previous
+		// cluster name from the update event. Otherwise the rejoined machine would be served the stale client.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			client, clientErr := clientFactory.GetForMachine(ctx, "m1")
+			assert.NoError(collect, clientErr)
+			assert.Equal(collect, clusterName, client.ClusterID(), "m1 should be a cluster client again")
+			assert.NotSame(collect, clusterClient, client, "stale cluster client must have been evicted on cluster leave")
+		}, time.Minute, 100*time.Millisecond)
 	})
 }


### PR DESCRIPTION
The Talos client and gRPC proxy backend caches evicted a machine's maintenance client as soon as the machine was allocated to a cluster. This was wrong: a machine can be allocated while still running in maintenance mode, before its initial configuration is applied, and during that window it is only reachable over the insecure maintenance connection. Evicting too early caused the cache to hand out a secure cluster client for a machine that still spoke maintenance, which failed.

The caches now track a machine's mode from its machine status maintenance flag instead of inferring it from cluster membership. A machine in maintenance mode always gets the insecure maintenance client even when it is already allocated, and the secure cluster client is only built once the machine actually leaves maintenance. Cache invalidation watches machine status changes and evicts the client for the mode the machine is no longer in, which is idempotent and never drops the currently valid client. The cluster client is still evicted when a machine leaves its cluster entirely.

The maintenance client lookup now decides solely from the machine status: it returns an error if the status does not exist yet or the machine is not in maintenance mode, so a caller acting on a possibly stale view can never reconfigure an allocated machine that already left maintenance.