### PR TITLE
test: stabilize image-factory schematic across CI runs

### DIFF
--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -95,6 +95,8 @@ if [[ "${CI:-false}" == "true" ]]; then
   WIREGUARD_IP=172.20.0.1
 fi
 
+export MACHINE_API_IP="${MACHINE_API_IP:-$LOCAL_IP}"
+
 # Prepare schematic with kernel args
 function prepare_kernel_args_schematic() {
   set_factory_curl_args

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -48,6 +48,9 @@ prepare_vault
 # Start MinIO server.
 prepare_minio access_key="access" secret_key="secret123"
 
+# QEMU machines reach Omni via the stable WireGuard IP, so advertise the machine API there to keep  Omni-generated schematic IDs constant across runs.
+export MACHINE_API_IP="${WIREGUARD_IP}"
+
 # Prepare omni config.
 prepare_omni_config
 

--- a/hack/test/integration-qemu.sh
+++ b/hack/test/integration-qemu.sh
@@ -82,6 +82,9 @@ eulaAccept:
   email: test-user@siderolabs.com
 "
 
+# QEMU machines reach Omni via the stable WireGuard IP, so advertise the machine API there to keep Omni-generated schematic IDs constant across runs.
+export MACHINE_API_IP="${WIREGUARD_IP}"
+
 # Prepare omni config.
 prepare_omni_config
 

--- a/hack/test/templates/omni-config.yaml
+++ b/hack/test/templates/omni-config.yaml
@@ -18,7 +18,7 @@ services:
     eventSinkPort: 8091
   machineAPI:
     endpoint: 0.0.0.0:8090
-    advertisedURL: grpc://${LOCAL_IP}:8090
+    advertisedURL: grpc://${MACHINE_API_IP}:8090
   workloadProxy:
     enabled: true
     subdomain: proxy-us


### PR DESCRIPTION
Reuse WIREGUARD_IP instead of LOCAL_IP  for `services.machineAPI.advertisedURL` to make the schematic ID deterministic, so  `TalosImageGeneration`  integration test doesn't attempt to create a new schematic on each CI run .
