### PR TITLE
fix: move timeout for factory requests to controllers

### DIFF
--- a/internal/backend/imagefactory/client.go
+++ b/internal/backend/imagefactory/client.go
@@ -20,7 +20,8 @@ import (
 
 // requestTimeout caps every call to the image factory. Without it, the factory's HTTP client has
 // no internal timeout, so a stuck connection would pin a controller reconcile slot indefinitely.
-const requestTimeout = 30 * time.Second
+// 30 minutes as the scan report request can be particularly slow.
+const requestTimeout = 30 * time.Minute
 
 // serverSnifferTransport wraps an http.RoundTripper and records whether the image factory
 // identifies itself as an Enterprise instance via the Server response header.

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic"
@@ -361,7 +362,11 @@ func (ctrl *MachineStatusController) populateSchematicRaw(ctx context.Context, i
 
 		logger.Info("machine does have a schematic ID but no raw schematic, get it from image factory")
 
-		sch, err := ctrl.ImageFactoryClient.SchematicGet(ctx, info.FullID)
+		factoryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+		sch, err := ctrl.ImageFactoryClient.SchematicGet(factoryCtx, info.FullID)
+
+		cancel()
+
 		if err != nil {
 			if factoryclient.IsHTTPErrorCode(err, http.StatusNotFound) {
 				logger.Warn("raw schematic not found in image factory", zap.String("host", ctrl.ImageFactoryClient.Host()))
@@ -529,7 +534,12 @@ func (ctrl *MachineStatusController) handleNotification(ctx context.Context, r c
 			return fmt.Errorf("error patching schematic for re-upload: %w", err)
 		}
 
-		if _, _, err := ctrl.ImageFactoryClient.EnsureSchematic(ctx, machineSchematic); err != nil {
+		factoryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+		_, _, err = ctrl.ImageFactoryClient.EnsureSchematic(factoryCtx, machineSchematic)
+
+		cancel()
+
+		if err != nil {
 			return fmt.Errorf("error ensuring schematic: %w", err)
 		}
 	}

--- a/internal/backend/runtime/omni/controllers/omni/schematic/configuration.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic/configuration.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -221,7 +222,11 @@ func (ctrl *ConfigurationController) transform(ctx context.Context, r controller
 	// TODO(preserve-schematic): when the patched schematic is content-equal to the
 	// source raw (i.e. no Omni-driven customization changed anything), short-circuit
 	// the factory call and publish ms.Schematic.FullId directly.
-	id, _, err := ctrl.imageFactoryClient.EnsureSchematic(ctx, patched)
+	factoryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	id, _, err := ctrl.imageFactoryClient.EnsureSchematic(factoryCtx, patched)
+
+	cancel()
+
 	if err != nil {
 		return err
 	}

--- a/internal/backend/runtime/omni/controllers/omni/versions.go
+++ b/internal/backend/runtime/omni/controllers/omni/versions.go
@@ -157,6 +157,9 @@ func (ctrl *VersionsController) fetchVersionsFromRegistry(ctx context.Context, s
 }
 
 func (ctrl *VersionsController) fetchTalosVersions(ctx context.Context) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
 	return ctrl.imageFactoryClient.Versions(ctx)
 }
 

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -1355,6 +1355,8 @@ func makeScanHandler(imageFactoryClient *imagefactory.Client, logger *zap.Logger
 			writeResult(result{
 				Status: "failed to get scan report",
 			}, http.StatusInternalServerError)
+
+			return
 		}
 
 		writeResult(result{


### PR DESCRIPTION
Scan requests to factory take longer than 30 seconds and are timing out from the backend's baked in 30 second timeout. Moved the timeouts up to their controller calls to cater for its original purpose, but without affecting other factory calls.