### PR TITLE
refactor: derive extension list from the raw schematic manifest

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic.go
@@ -34,6 +34,9 @@ type SchematicInfo struct {
 // GetSchematicInfo lists the extension status resources on the given Talos COSI state, and computes the schematic ID
 // from the extensions found on the machine, ignoring everything else (e.g., the kernel command line args).
 //
+// If the schematic meta extension carries the raw manifest (Talos v1.7+),
+// we take the extension list from it directly instead of reconstructing it from the extension status resources, so virtual and meta extensions cannot leak into it.
+//
 // The argument fallbackKernelArgs is only used if the machine doesn't have the schematic meta extension, i.e., its installation media was created bypassing image factory -
 // in that case, we synthesize the schematic ID in a best-effort way (only if it doesn't have any extensions), and use the provided fallback kernel args as the current args of the machine.
 func GetSchematicInfo(ctx context.Context, talosState state.CoreState, fallbackKernelArgs []string) (SchematicInfo, error) {
@@ -43,7 +46,7 @@ func GetSchematicInfo(ctx context.Context, talosState state.CoreState, fallbackK
 	}
 
 	var (
-		exts         []string
+		observedExts []string
 		fullID       string
 		rawSchematic *schematic.Schematic
 		manifest     string
@@ -56,10 +59,11 @@ func GetSchematicInfo(ctx context.Context, talosState state.CoreState, fallbackK
 		case extensions.MetalAgentExtensionName:
 			return SchematicInfo{InAgentMode: true}, nil
 		case constants.SchematicIDExtensionName: // skip the meta extension
-			fullID = status.TypedSpec().Metadata.Version
+			meta := status.TypedSpec().Metadata
+			fullID = meta.Version
 
-			if status.TypedSpec().Metadata.ExtraInfo != "" {
-				manifest = status.TypedSpec().Metadata.ExtraInfo
+			if meta.ExtraInfo != "" {
+				manifest = meta.ExtraInfo
 
 				if rawSchematic, err = schematic.Unmarshal([]byte(manifest)); err != nil {
 					return SchematicInfo{}, fmt.Errorf("failed to unmarshal schematic manifest: %w", err)
@@ -72,25 +76,34 @@ func GetSchematicInfo(ctx context.Context, talosState state.CoreState, fallbackK
 				name = extensions.OfficialPrefix + name
 			}
 
-			exts = append(exts, name)
+			observedExts = append(observedExts, name)
 		}
 	}
 
+	// Prefer the raw schematic manifest as the definitive source of the extension list, since it records exactly the
+	// user-requested extensions. Otherwise reconstruct the list from the observed extension status resources. Either
+	// way, normalize the known wrong manifest names.
+	exts := observedExts
+	if rawSchematic != nil {
+		exts = rawSchematic.Customization.SystemExtensions.OfficialExtensions
+	}
+
 	exts = extensions.MapNames(exts)
+
+	if rawSchematic != nil { // the manifest also carries the definitive kernel args and raw YAML
+		return SchematicInfo{
+			FullID:     fullID,
+			Extensions: exts,
+			KernelArgs: rawSchematic.Customization.ExtraKernelArgs,
+			Raw:        manifest,
+		}, nil
+	}
 
 	if fullID == "" && len(exts) > 0 {
 		return SchematicInfo{}, ErrInvalidSchematic
 	}
 
-	var kernelArgs []string
-
-	if rawSchematic != nil {
-		kernelArgs = rawSchematic.Customization.ExtraKernelArgs
-	}
-
 	if fullID == "" { // we could not find the full ID, so we fall back to synthesizing it (and the raw YAML) using the default args
-		kernelArgs = fallbackKernelArgs
-
 		synthesized := schematic.Schematic{
 			Customization: schematic.Customization{
 				SystemExtensions: schematic.SystemExtensions{
@@ -99,8 +112,6 @@ func GetSchematicInfo(ctx context.Context, talosState state.CoreState, fallbackK
 				ExtraKernelArgs: fallbackKernelArgs,
 			},
 		}
-
-		var err error
 
 		fullID, err = synthesized.ID()
 		if err != nil {
@@ -112,13 +123,18 @@ func GetSchematicInfo(ctx context.Context, talosState state.CoreState, fallbackK
 			return SchematicInfo{}, fmt.Errorf("failed to marshal synthesized schematic: %w", err)
 		}
 
-		manifest = string(raw)
+		return SchematicInfo{
+			FullID:     fullID,
+			Extensions: exts,
+			KernelArgs: fallbackKernelArgs,
+			Raw:        string(raw),
+		}, nil
 	}
 
+	// The meta extension is present (so the full ID is known) but it carries no raw manifest: report the extension list
+	// reconstructed from the observed extension status resources, with no kernel args nor raw manifest available.
 	return SchematicInfo{
 		FullID:     fullID,
 		Extensions: exts,
-		KernelArgs: kernelArgs,
-		Raw:        manifest,
 	}, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/talos/schematic_test.go
@@ -202,8 +202,9 @@ func TestGetSchematicInfo(t *testing.T) {
 	t.Run("modules.dep is filtered out", func(t *testing.T) {
 		t.Parallel()
 
+		// No raw manifest, so the extension list is reconstructed from the extension status resources and modules.dep must be filtered out.
 		st := buildState(t, []extension{
-			{name: constants.SchematicIDExtensionName, version: factorySchematicID, extraInfo: factorySchematicYAML},
+			{name: constants.SchematicIDExtensionName, version: factorySchematicID},
 			{name: "modules.dep"},
 			{name: "siderolabs/gvisor"},
 		})
@@ -217,9 +218,10 @@ func TestGetSchematicInfo(t *testing.T) {
 	t.Run("embedded-config meta extension is filtered out", func(t *testing.T) {
 		t.Parallel()
 
-		// machines carrying an embedded machine configuration report an "embedded-config" meta extension which must not leak into the extensions list
+		// No raw manifest, so the extension list is reconstructed from the extension status resources.
+		// Machines carrying an embedded machine configuration report an "embedded-config" meta extension which must not leak into the extensions list.
 		st := buildState(t, []extension{
-			{name: constants.SchematicIDExtensionName, version: factorySchematicID, extraInfo: factorySchematicYAML},
+			{name: constants.SchematicIDExtensionName, version: factorySchematicID},
 			{name: "embedded-config"},
 			{name: "siderolabs/gvisor"},
 		})
@@ -248,8 +250,9 @@ func TestGetSchematicInfo(t *testing.T) {
 	t.Run("extension name without official prefix gets prefixed", func(t *testing.T) {
 		t.Parallel()
 
+		// No raw manifest, so the extension list is reconstructed from the extension status resources and the prefix is applied.
 		st := buildState(t, []extension{
-			{name: constants.SchematicIDExtensionName, version: factorySchematicID, extraInfo: factorySchematicYAML},
+			{name: constants.SchematicIDExtensionName, version: factorySchematicID},
 			{name: "gvisor"}, // missing "siderolabs/" prefix
 		})
 
@@ -262,9 +265,58 @@ func TestGetSchematicInfo(t *testing.T) {
 	t.Run("extension with wrong manifest name is remapped", func(t *testing.T) {
 		t.Parallel()
 
+		// No raw manifest, so the extension list is reconstructed from the extension status resources.
 		// v4l-uvc is a known wrong manifest name remapped to v4l-uvc-drivers.
 		st := buildState(t, []extension{
+			{name: constants.SchematicIDExtensionName, version: factorySchematicID},
+			{name: "siderolabs/v4l-uvc"},
+		})
+
+		info, err := talos.GetSchematicInfo(t.Context(), st, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"siderolabs/v4l-uvc-drivers"}, info.Extensions)
+	})
+
+	t.Run("raw schematic manifest is the definitive extension source", func(t *testing.T) {
+		t.Parallel()
+
+		// The raw manifest lists exactly the user-requested extensions. The extension status resources additionally
+		// report a future meta/virtual extension and a stray extension that are NOT part of the schematic. They must
+		// not leak into the result: the extension list is taken verbatim from the raw manifest.
+		st := buildState(t, []extension{
 			{name: constants.SchematicIDExtensionName, version: factorySchematicID, extraInfo: factorySchematicYAML},
+			{name: "siderolabs/gvisor"},
+			{name: "siderolabs/mdadm"},
+			{name: "some-future-meta-extension"}, // unknown meta extension we don't (yet) know to skip
+			{name: "siderolabs/stray-extension"}, // present on the machine but not part of the schematic manifest
+		})
+
+		info, err := talos.GetSchematicInfo(t.Context(), st, []string{"this-fallback-must-not-be-used"})
+		require.NoError(t, err)
+
+		assert.Equal(t, factorySchematicID, info.FullID)
+		assert.Equal(t, factorySchematicYAML, info.Raw)
+		assert.Equal(t, factorySchematic.Customization.ExtraKernelArgs, info.KernelArgs)
+		assert.Equal(t, factorySchematic.Customization.SystemExtensions.OfficialExtensions, info.Extensions)
+	})
+
+	t.Run("wrong manifest name in the raw manifest is normalized", func(t *testing.T) {
+		t.Parallel()
+
+		// A schematic can carry a known wrong manifest name (e.g. v4l-uvc instead of v4l-uvc-drivers). Even on the
+		// manifest path we normalize it, so the result stays consistent with the reconstruction path and with the
+		// desired extension list computed elsewhere.
+		wrongNameSchematic := schematic.Schematic{
+			Customization: schematic.Customization{
+				SystemExtensions: schematic.SystemExtensions{
+					OfficialExtensions: []string{"siderolabs/v4l-uvc"},
+				},
+			},
+		}
+
+		st := buildState(t, []extension{
+			{name: constants.SchematicIDExtensionName, version: schematicID(t, wrongNameSchematic), extraInfo: schematicYAML(t, wrongNameSchematic)},
 			{name: "siderolabs/v4l-uvc"},
 		})
 


### PR DESCRIPTION
When a machine reports its schematic with the raw manifest attached, take the installed extension list straight from that manifest instead of reconstructing it from the individual extension status resources.

Reconstruction has to filter out virtual and meta extensions like the kernel modules dependency one and the embedded configuration marker, so any future ones would silently leak into the list and risk spurious schematic changes. The manifest already records exactly the user-requested extensions, so trusting it avoids that problem entirely. When the manifest is absent (Talos before v1.7, or media built bypassing the image factory) the existing reconstruction path stays as is.

Kernel args already came from the manifest and still do.