### PR TITLE
feat(frontend): add a cluster security page for vulns

### DIFF
--- a/frontend/src/components/SideBar/TSideBar.vue
+++ b/frontend/src/components/SideBar/TSideBar.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { gte } from 'semver'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
@@ -342,6 +343,18 @@ const clusterItems = computed(() => {
       icon: 'settings',
     },
   ]
+
+  if (
+    featuresConfig.value?.spec.is_enterprise_image_factory &&
+    cluster.value?.spec.talos_version &&
+    gte(cluster.value.spec.talos_version, '1.13.0')
+  ) {
+    result.push({
+      name: 'Security',
+      route: getRoute('/security'),
+      icon: 'key',
+    })
+  }
 
   if (canSyncKubernetesManifests.value) {
     result.push({

--- a/frontend/src/methods/useResourceList.ts
+++ b/frontend/src/methods/useResourceList.ts
@@ -33,7 +33,7 @@ export type ListOptions = ListOptionsCommon &
 export function useResourceList<TSpec = unknown, TStatus = unknown>(
   opts: MaybeRefOrGetter<ListOptions>,
 ) {
-  const data = ref<Resource<TSpec, TStatus>[]>()
+  const data = ref<Resource<TSpec, TStatus>[]>([])
   const loading = ref(true)
   const error = ref<Error>()
 

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/security.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/security.vue
@@ -1,0 +1,18 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import PageContainer from '@/components/PageContainer/PageContainer.vue'
+import ClusterSecurity from '@/views/ClusterSecurity/ClusterSecurity.vue'
+
+definePage({ name: 'ClusterSecurity' })
+</script>
+
+<template>
+  <PageContainer>
+    <ClusterSecurity :cluster-id="$route.params.cluster" />
+  </PageContainer>
+</template>

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/cloud-provider.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/cloud-provider.vue
@@ -34,7 +34,7 @@ const resolvedVersion = computed(() => resolveTalosVersion(formState.value.talos
 
 const platforms = computed(() =>
   data.value
-    ?.filter((p) => !p.spec.min_version || gte(resolvedVersion.value, p.spec.min_version))
+    .filter((p) => !p.spec.min_version || gte(resolvedVersion.value, p.spec.min_version))
     .map((p) => ({
       ...p,
       spec: {

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/sbc-type.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/sbc-type.vue
@@ -34,7 +34,7 @@ const resolvedVersion = computed(() => resolveTalosVersion(formState.value.talos
 
 const SBCs = computed(() =>
   data.value
-    ?.filter((sbc) => !sbc.spec.min_version || gte(resolvedVersion.value, sbc.spec.min_version))
+    .filter((sbc) => !sbc.spec.min_version || gte(resolvedVersion.value, sbc.spec.min_version))
     .map((sbc) => ({
       ...sbc,
       spec: {

--- a/frontend/src/views/ClusterSecurity/ClusterSecurity.stories.ts
+++ b/frontend/src/views/ClusterSecurity/ClusterSecurity.stories.ts
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { createWatchStreamHandler } from '@msw/helpers'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+
+import type { Resource } from '@/api/grpc'
+import type { ListRequest, ListResponse } from '@/api/omni/resources/resources.pb'
+import type {
+  ClusterMachineConfigStatusSpec,
+  ClusterStatusSpec,
+  FeaturesConfigSpec,
+  MachineStatusSpec,
+  TalosVersionSpec,
+} from '@/api/omni/specs/omni.pb'
+import {
+  ClusterMachineConfigStatusType,
+  ClusterStatusType,
+  DefaultNamespace,
+  FeaturesConfigID,
+  FeaturesConfigType,
+  LabelCluster,
+  LabelControlPlaneRole,
+  LabelWorkerRole,
+  MachineStatusType,
+  TalosVersionType,
+} from '@/api/resources'
+import ClusterSecurity from '@/views/ClusterSecurity/ClusterSecurity.vue'
+import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+
+import sampleReport from '../InstallationMedia/vulnerabilities/sample-report.json'
+
+const CLUSTER = 'demo-cluster'
+const CURRENT_VERSION = '1.9.0'
+const PATCH_VERSION = '1.9.3'
+const MINOR_VERSION = '1.10.2'
+
+const SCHEMATIC_CP = 'a'.repeat(64)
+const SCHEMATIC_WORKER = 'b'.repeat(64)
+
+const allMatches = sampleReport.matches as Match[]
+
+// A fabricated finding used to demonstrate a vulnerability *introduced* by an upgrade.
+const introducedMatch: Match = {
+  vulnerability: {
+    id: 'CVE-2025-99999',
+    dataSource: 'https://nvd.nist.gov/vuln/detail/CVE-2025-99999',
+    namespace: 'nvd:cpe',
+    severity: 'High',
+    urls: [],
+    description: 'A vulnerability newly introduced in this Talos release (demo data).',
+    cvss: [
+      {
+        type: 'Primary',
+        version: '3.1',
+        vector: '',
+        metrics: { baseScore: 7.5 },
+        vendorMetadata: {},
+      },
+    ],
+    fix: { versions: [], state: 'unknown' },
+    advisories: [],
+    risk: 0,
+  },
+  relatedVulnerabilities: [],
+  matchDetails: [],
+  artifact: {
+    id: 'demo',
+    name: 'github.com/example/newly-introduced',
+    version: '2.1.0',
+    type: 'go-module',
+    locations: null,
+    language: 'go',
+    licenses: [],
+    cpes: [],
+    purl: '',
+    upstreams: [],
+  },
+}
+
+// Each upgrade target removes some findings (fixed) — the minor bump additionally
+// introduces one new finding — so the diff has something to show.
+function matchesForVersion(version: string): Match[] {
+  switch (version) {
+    case PATCH_VERSION:
+      return allMatches.slice(8)
+    case MINOR_VERSION:
+      return [...allMatches.slice(25), introducedMatch]
+    default:
+      return allMatches
+  }
+}
+
+function machineStatus(id: string, arch: string): Resource<MachineStatusSpec> {
+  return {
+    metadata: {
+      namespace: DefaultNamespace,
+      type: MachineStatusType,
+      id,
+      labels: { [LabelCluster]: CLUSTER },
+    },
+    spec: { hardware: { arch } },
+  }
+}
+
+function configStatus(
+  id: string,
+  schematicId: string,
+  role: string,
+): Resource<ClusterMachineConfigStatusSpec> {
+  return {
+    metadata: {
+      namespace: DefaultNamespace,
+      type: ClusterMachineConfigStatusType,
+      id,
+      labels: { [LabelCluster]: CLUSTER, [role]: '' },
+    },
+    spec: { schematic_id: schematicId, talos_version: CURRENT_VERSION },
+  }
+}
+
+const featuresHandler = createWatchStreamHandler<FeaturesConfigSpec>({
+  expectedOptions: { namespace: DefaultNamespace, type: FeaturesConfigType, id: FeaturesConfigID },
+  initialResources: [
+    {
+      metadata: { namespace: DefaultNamespace, type: FeaturesConfigType, id: FeaturesConfigID },
+      spec: {
+        is_enterprise_image_factory: true,
+        image_factory_base_url: 'https://factory-enterprise.talos.dev',
+      },
+    },
+  ],
+}).handler
+
+const clusterStatusHandler = createWatchStreamHandler<ClusterStatusSpec>({
+  expectedOptions: { namespace: DefaultNamespace, type: ClusterStatusType, id: CLUSTER },
+  initialResources: [
+    {
+      metadata: { namespace: DefaultNamespace, type: ClusterStatusType, id: CLUSTER },
+      spec: { talos_version: CURRENT_VERSION, available: true },
+    },
+  ],
+}).handler
+
+const TALOS_VERSIONS = ['1.8.5', CURRENT_VERSION, '1.9.1', PATCH_VERSION, '1.10.0', MINOR_VERSION]
+
+const talosVersionsHandler = http.post<never, ListRequest, ListResponse>(
+  '/omni.resources.ResourceService/List',
+  async ({ request }) => {
+    const { type, namespace } = await request.clone().json()
+
+    if (type !== TalosVersionType || namespace !== DefaultNamespace) return
+
+    return HttpResponse.json({
+      total: TALOS_VERSIONS.length,
+      items: TALOS_VERSIONS.map((version) =>
+        JSON.stringify({
+          metadata: { namespace, type, id: version },
+          spec: { version },
+        } satisfies Resource<TalosVersionSpec>),
+      ),
+    })
+  },
+)
+
+// Resolves a vulnerability report for any (schematic, version, arch) the page asks for.
+const scanHandler = http.get('/api/vulns/:schematic/:version/:arch/report.json', ({ params }) => {
+  return HttpResponse.json({
+    status: 'done',
+    report: { matches: matchesForVersion(params.version as string) },
+  })
+})
+
+const meta: Meta<typeof ClusterSecurity> = {
+  component: ClusterSecurity,
+  args: {
+    clusterId: CLUSTER,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** A homogeneous cluster: one schematic, one architecture, three machines. */
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        featuresHandler,
+        clusterStatusHandler,
+        talosVersionsHandler,
+        createWatchStreamHandler<ClusterMachineConfigStatusSpec>({
+          expectedOptions: {
+            namespace: DefaultNamespace,
+            type: ClusterMachineConfigStatusType,
+            selectors: { [LabelCluster]: CLUSTER },
+          },
+          initialResources: [
+            configStatus('machine-1', SCHEMATIC_CP, LabelControlPlaneRole),
+            configStatus('machine-2', SCHEMATIC_CP, LabelWorkerRole),
+            configStatus('machine-3', SCHEMATIC_CP, LabelWorkerRole),
+          ],
+        }).handler,
+        createWatchStreamHandler<MachineStatusSpec>({
+          expectedOptions: {
+            namespace: DefaultNamespace,
+            type: MachineStatusType,
+            selectors: { [LabelCluster]: CLUSTER },
+          },
+          initialResources: [
+            machineStatus('machine-1', 'amd64'),
+            machineStatus('machine-2', 'amd64'),
+            machineStatus('machine-3', 'amd64'),
+          ],
+        }).handler,
+        scanHandler,
+      ],
+    },
+  },
+}
+
+/** A heterogeneous cluster: control plane and workers use different schematics and architectures. */
+export const HeterogeneousCluster: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        featuresHandler,
+        clusterStatusHandler,
+        talosVersionsHandler,
+        createWatchStreamHandler<ClusterMachineConfigStatusSpec>({
+          expectedOptions: {
+            namespace: DefaultNamespace,
+            type: ClusterMachineConfigStatusType,
+            selectors: { [LabelCluster]: CLUSTER },
+          },
+          initialResources: [
+            configStatus('machine-1', SCHEMATIC_CP, LabelControlPlaneRole),
+            configStatus('machine-2', SCHEMATIC_WORKER, LabelWorkerRole),
+            configStatus('machine-3', SCHEMATIC_WORKER, LabelWorkerRole),
+          ],
+        }).handler,
+        createWatchStreamHandler<MachineStatusSpec>({
+          expectedOptions: {
+            namespace: DefaultNamespace,
+            type: MachineStatusType,
+            selectors: { [LabelCluster]: CLUSTER },
+          },
+          initialResources: [
+            machineStatus('machine-1', 'amd64'),
+            machineStatus('machine-2', 'arm64'),
+            machineStatus('machine-3', 'arm64'),
+          ],
+        }).handler,
+        scanHandler,
+      ],
+    },
+  },
+}
+
+/** A cluster already on the latest available Talos version — no upgrade paths. */
+export const NoUpgradesAvailable: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        featuresHandler,
+        createWatchStreamHandler<ClusterStatusSpec>({
+          expectedOptions: { namespace: DefaultNamespace, type: ClusterStatusType, id: CLUSTER },
+          initialResources: [
+            {
+              metadata: { namespace: DefaultNamespace, type: ClusterStatusType, id: CLUSTER },
+              spec: { talos_version: MINOR_VERSION, available: true },
+            },
+          ],
+        }).handler,
+        talosVersionsHandler,
+        createWatchStreamHandler<ClusterMachineConfigStatusSpec>({
+          expectedOptions: {
+            namespace: DefaultNamespace,
+            type: ClusterMachineConfigStatusType,
+            selectors: { [LabelCluster]: CLUSTER },
+          },
+          initialResources: [configStatus('machine-1', SCHEMATIC_CP, LabelControlPlaneRole)],
+        }).handler,
+        createWatchStreamHandler<MachineStatusSpec>({
+          expectedOptions: {
+            namespace: DefaultNamespace,
+            type: MachineStatusType,
+            selectors: { [LabelCluster]: CLUSTER },
+          },
+          initialResources: [machineStatus('machine-1', 'amd64')],
+        }).handler,
+        scanHandler,
+      ],
+    },
+  },
+}

--- a/frontend/src/views/ClusterSecurity/ClusterSecurity.vue
+++ b/frontend/src/views/ClusterSecurity/ClusterSecurity.vue
@@ -1,0 +1,329 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import pluralize from 'pluralize'
+import { computed, ref } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import type {
+  ClusterMachineConfigStatusSpec,
+  ClusterStatusSpec,
+  MachineStatusSpec,
+  TalosVersionSpec,
+} from '@/api/omni/specs/omni.pb'
+import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
+import {
+  ClusterMachineConfigStatusType,
+  ClusterStatusType,
+  DefaultNamespace,
+  LabelCluster,
+  LabelControlPlaneRole,
+  MachineStatusType,
+  TalosVersionType,
+} from '@/api/resources'
+import TButton from '@/components/Button/TButton.vue'
+import TIcon from '@/components/Icon/TIcon.vue'
+import TSpinner from '@/components/Spinner/TSpinner.vue'
+import TAlert from '@/components/TAlert.vue'
+import Tooltip from '@/components/Tooltip/Tooltip.vue'
+import { getDocsLink } from '@/methods'
+import { useFeatures } from '@/methods/features'
+import { useResourceList } from '@/methods/useResourceList'
+import { useResourceWatch } from '@/methods/useResourceWatch'
+import SeverityBadges from '@/views/ClusterSecurity/components/SeverityBadges.vue'
+import UpgradePathCard from '@/views/ClusterSecurity/components/UpgradePathCard.vue'
+import {
+  scanKey,
+  type ScanRequest,
+  useClusterVulnerabilityScans,
+} from '@/views/ClusterSecurity/util/useClusterVulnerabilityScans'
+import { computeUpgradeTargets, diffMatches } from '@/views/ClusterSecurity/util/vulnerabilityDiff'
+import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+import ScanDetailsModal from '@/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue'
+
+const { clusterId } = defineProps<{ clusterId: string }>()
+
+const { data: features } = useFeatures()
+const isEnterpriseFactory = computed(() => !!features.value?.spec.is_enterprise_image_factory)
+
+const { data: clusterStatus, loading: statusLoading } = useResourceWatch<ClusterStatusSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: ClusterStatusType,
+    id: clusterId,
+  },
+}))
+
+const { data: configStatuses, loading: configLoading } =
+  useResourceWatch<ClusterMachineConfigStatusSpec>(() => ({
+    skip: !isEnterpriseFactory.value,
+    runtime: Runtime.Omni,
+    resource: {
+      namespace: DefaultNamespace,
+      type: ClusterMachineConfigStatusType,
+    },
+    selectors: [`${LabelCluster}=${clusterId}`],
+  }))
+
+const { data: machineStatuses } = useResourceWatch<MachineStatusSpec>(() => ({
+  skip: !isEnterpriseFactory.value,
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: MachineStatusType,
+  },
+  selectors: [`${LabelCluster}=${clusterId}`],
+}))
+
+const { data: talosVersions } = useResourceList<TalosVersionSpec>(() => ({
+  skip: !isEnterpriseFactory.value,
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: TalosVersionType,
+  },
+}))
+
+const currentVersion = computed(() => clusterStatus.value?.spec.talos_version)
+
+const archByMachine = computed(
+  () => new Map(machineStatuses.value.map((m) => [m.metadata.id!, m.spec.hardware?.arch])),
+)
+
+interface Combo {
+  key: string
+  schematicId: string
+  arch: string
+  machineCount: number
+  includesControlPlane: boolean
+}
+
+// Unique (schematic, arch) combinations across the cluster's machines.
+const combos = computed(() => {
+  const map = new Map<string, Combo>()
+
+  for (const cfg of configStatuses.value) {
+    const schematicId = cfg.spec.schematic_id
+    const arch = archByMachine.value.get(cfg.metadata.id!)
+
+    if (!schematicId || !arch) continue
+
+    const key = `${schematicId}|${arch}`
+    const existing = map.get(key)
+    const isControlPlane = LabelControlPlaneRole in (cfg.metadata.labels ?? {})
+
+    if (existing) {
+      existing.machineCount += 1
+      existing.includesControlPlane ||= isControlPlane
+    } else {
+      map.set(key, {
+        key,
+        schematicId,
+        arch,
+        machineCount: 1,
+        includesControlPlane: isControlPlane,
+      })
+    }
+  }
+
+  return map.values().toArray()
+})
+
+const upgradeTargets = computed(() =>
+  currentVersion.value
+    ? computeUpgradeTargets(
+        currentVersion.value,
+        talosVersions.value
+          .filter((v) => !v.spec.deprecated && !v.spec.unsupported)
+          .map((v) => v.spec.version!),
+      )
+    : [],
+)
+
+// Every (combo, version) pair that needs a scan.
+const scanRequests = computed<ScanRequest[]>(() => {
+  if (!currentVersion.value) return []
+
+  const versions = [
+    ...new Set([currentVersion.value, ...upgradeTargets.value.map((t) => t.version)]),
+  ]
+
+  return combos.value.flatMap((combo) =>
+    versions.map((version) => ({ schematicId: combo.schematicId, arch: combo.arch, version })),
+  )
+})
+
+const { results } = useClusterVulnerabilityScans(scanRequests)
+
+function scanFor(combo: Combo, version: string) {
+  return results.value.get(scanKey({ schematicId: combo.schematicId, arch: combo.arch, version }))
+}
+
+// Per-combo view model: current scan plus a diff per upgrade target.
+const comboReports = computed(() =>
+  combos.value.map((combo) => {
+    const current = currentVersion.value ? scanFor(combo, currentVersion.value) : undefined
+
+    return {
+      combo,
+      current,
+      upgrades: upgradeTargets.value.map((target) => {
+        const scan = scanFor(combo, target.version)
+        const diff =
+          current?.matches && scan?.matches ? diffMatches(current.matches, scan.matches) : undefined
+
+        return { target, diff, loading: scan?.loading ?? true, error: scan?.error }
+      }),
+    }
+  }),
+)
+
+const initialLoading = computed(() => statusLoading.value || configLoading.value)
+
+function archEnum(arch: string) {
+  return arch === 'arm64' ? PlatformConfigSpecArch.ARM64 : PlatformConfigSpecArch.AMD64
+}
+
+const detailsModal = ref<{
+  open: boolean
+  schematicId: string
+  arch: string
+  version: string
+  matches: Match[]
+}>()
+
+function openDetails(schematicId: string, arch: string, version: string, matches: Match[]) {
+  detailsModal.value = { open: true, schematicId, arch, version, matches }
+}
+</script>
+
+<template>
+  <section class="flex flex-col gap-6">
+    <header class="flex flex-col items-start">
+      <h1 class="text-lg text-naturals-n14">
+        Vulnerabilities for {{ clusterId }}
+
+        <span class="resource-label label-red inline-flex items-center gap-1">
+          <TIcon class="size-3.5 shrink-0" icon="talos" aria-label="Talos version" />
+          {{ currentVersion }}
+        </span>
+      </h1>
+
+      <p class="text-sm text-naturals-n11">
+        Vulnerabilities detected for the cluster's running Talos version, and how upgrading would
+        change them. More information available on our
+        <a
+          class="link-primary"
+          :href="getDocsLink('talos', '/advanced-guides/SBOM', { talosVersion: currentVersion })"
+        >
+          docs
+        </a>
+        page.
+      </p>
+    </header>
+
+    <TAlert v-if="!isEnterpriseFactory" type="info" title="Vulnerability scanning unavailable">
+      Vulnerability scanning requires the enterprise image factory.
+    </TAlert>
+
+    <p v-else-if="initialLoading" class="flex items-center gap-1.5 text-sm text-naturals-n11">
+      <TSpinner class="size-4" />
+      Loading cluster information…
+    </p>
+
+    <TAlert v-else-if="!currentVersion" type="error" title="Unknown Talos version">
+      Could not determine the cluster's running Talos version.
+    </TAlert>
+
+    <TAlert v-else-if="!comboReports.length" type="info" title="No machines to scan">
+      This cluster has no machines with a known schematic and architecture yet.
+    </TAlert>
+
+    <template v-else>
+      <article
+        v-for="{ combo, current, upgrades } in comboReports"
+        :key="combo.key"
+        class="flex flex-col gap-4 rounded border border-naturals-n5 p-4"
+      >
+        <header class="flex flex-col gap-1">
+          <h2 class="flex items-center gap-1 text-sm text-naturals-n13">
+            <TIcon aria-hidden="true" icon="document-text" class="size-4" />
+            Schematic
+            <Tooltip :description="combo.schematicId">
+              <span class="font-mono">{{ combo.schematicId.slice(0, 12) }}…</span>
+            </Tooltip>
+          </h2>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="resource-label label-orange">{{ combo.arch }}</span>
+            <span class="resource-label label-blue">
+              {{ combo.includesControlPlane ? 'control plane' : 'worker' }}
+            </span>
+            <span class="text-xs text-naturals-n11">
+              applies to {{ combo.machineCount }}
+              {{ pluralize('machine', combo.machineCount) }}
+            </span>
+          </div>
+        </header>
+
+        <div class="flex flex-col gap-3">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div class="flex flex-col gap-1.5">
+              <div
+                v-if="current?.loading"
+                class="flex items-center gap-1.5 text-xs text-naturals-n11"
+              >
+                <TSpinner class="size-4" />
+                Running scan…
+              </div>
+              <TAlert v-else-if="current?.error" type="error" title="Scan failed">
+                {{ current.error }}
+              </TAlert>
+              <SeverityBadges v-else-if="current?.matches" :matches="current.matches" />
+            </div>
+
+            <TButton
+              v-if="current?.matches?.length"
+              size="sm"
+              icon="document-text"
+              icon-position="left"
+              @click="openDetails(combo.schematicId, combo.arch, currentVersion!, current.matches)"
+            >
+              View report
+            </TButton>
+          </div>
+
+          <div v-if="upgrades.length" class="flex flex-col gap-3">
+            <h3 class="text-sm text-naturals-n11">Upgrade paths</h3>
+            <UpgradePathCard
+              v-for="upgrade in upgrades"
+              :key="upgrade.target.version"
+              :target="upgrade.target"
+              :diff="upgrade.diff"
+              :loading="upgrade.loading"
+              :error="upgrade.error"
+            />
+          </div>
+          <p v-else class="flex items-center gap-1.5 text-xs text-green-g1">
+            <TIcon icon="check-in-circle" class="size-4 shrink-0" aria-hidden="true" />
+            Already on the latest available Talos version.
+          </p>
+        </div>
+      </article>
+    </template>
+
+    <ScanDetailsModal
+      v-if="detailsModal"
+      v-model:open="detailsModal.open"
+      :matches="detailsModal.matches"
+      :schematic-id="detailsModal.schematicId"
+      :talos-version="detailsModal.version"
+      :arch="archEnum(detailsModal.arch)"
+    />
+  </section>
+</template>

--- a/frontend/src/views/ClusterSecurity/components/SeverityBadges.vue
+++ b/frontend/src/views/ClusterSecurity/components/SeverityBadges.vue
@@ -1,0 +1,41 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import TIcon from '@/components/Icon/TIcon.vue'
+import { cn } from '@/methods/utils'
+import { countBySeverity } from '@/views/InstallationMedia/vulnerabilities/matchUtils'
+import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+
+const { matches } = defineProps<{ matches: Match[] }>()
+
+const counts = computed(() => countBySeverity(matches))
+</script>
+
+<template>
+  <p v-if="!matches.length" class="flex items-center gap-1.5 text-xs text-green-g1">
+    <TIcon icon="check-in-circle" class="size-4 shrink-0" aria-hidden="true" />
+    No vulnerabilities
+  </p>
+  <ul v-else class="flex flex-wrap items-center gap-1.5">
+    <li
+      v-for="[sev, count] in counts"
+      :key="sev"
+      :class="
+        cn('rounded-sm bg-naturals-n4 px-2 py-1 text-xs text-naturals-n11', {
+          'bg-red-600 text-white': sev === 'Critical',
+          'bg-orange-700 text-white': sev === 'High',
+          'bg-orange-500 text-white': sev === 'Medium',
+          'bg-yellow-500 text-black': sev === 'Low',
+        })
+      "
+    >
+      {{ count }} {{ sev }}
+    </li>
+  </ul>
+</template>

--- a/frontend/src/views/ClusterSecurity/components/SeverityBadges.vue
+++ b/frontend/src/views/ClusterSecurity/components/SeverityBadges.vue
@@ -12,9 +12,17 @@ import { cn } from '@/methods/utils'
 import { countBySeverity } from '@/views/InstallationMedia/vulnerabilities/matchUtils'
 import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
 
-const { matches } = defineProps<{ matches: Match[] }>()
+const { matches, activeFilter } = defineProps<{
+  matches: Match[]
+  activeFilter?: string
+  clickable?: boolean
+}>()
 
 const counts = computed(() => countBySeverity(matches))
+
+defineEmits<{
+  clickSeverity: [string]
+}>()
 </script>
 
 <template>
@@ -32,8 +40,12 @@ const counts = computed(() => countBySeverity(matches))
           'bg-orange-700 text-white': sev === 'High',
           'bg-orange-500 text-white': sev === 'Medium',
           'bg-yellow-500 text-black': sev === 'Low',
+          'transition-[filter] hover:brightness-120 active:brightness-80': clickable,
+          'opacity-30': activeFilter && activeFilter !== sev,
         })
       "
+      :role="clickable ? 'button' : undefined"
+      @click="$emit('clickSeverity', sev)"
     >
       {{ count }} {{ sev }}
     </li>

--- a/frontend/src/views/ClusterSecurity/components/UpgradePathCard.vue
+++ b/frontend/src/views/ClusterSecurity/components/UpgradePathCard.vue
@@ -1,0 +1,104 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import TButton from '@/components/Button/TButton.vue'
+import TIcon from '@/components/Icon/TIcon.vue'
+import TSpinner from '@/components/Spinner/TSpinner.vue'
+import TAlert from '@/components/TAlert.vue'
+import VulnerabilityList from '@/views/ClusterSecurity/components/VulnerabilityList.vue'
+import type { UpgradeDiff, UpgradeTarget } from '@/views/ClusterSecurity/util/vulnerabilityDiff'
+
+const { target, diff, loading, error } = defineProps<{
+  target: UpgradeTarget
+  diff?: UpgradeDiff
+  loading: boolean
+  error?: string
+}>()
+
+const expanded = ref(false)
+
+const kindLabel = computed(() => (target.kind === 'patch' ? 'Latest patch' : 'Next minor version'))
+
+const canExpand = computed(() => !!diff && (diff.resolved.length > 0 || diff.introduced.length > 0))
+</script>
+
+<template>
+  <div class="rounded border border-naturals-n5 bg-naturals-n2">
+    <div class="flex flex-wrap items-center gap-3 px-4 py-3">
+      <TIcon icon="upgrade" class="size-5 shrink-0 text-naturals-n11" aria-hidden="true" />
+
+      <div class="flex flex-1 flex-col">
+        <span class="text-sm font-medium text-naturals-n14">Upgrade to {{ target.version }}</span>
+        <span class="text-xs text-naturals-n11">{{ kindLabel }}</span>
+      </div>
+
+      <TSpinner v-if="loading" class="size-4" />
+
+      <template v-else-if="diff">
+        <ul class="flex flex-wrap items-center gap-1.5 text-xs">
+          <li
+            v-if="diff.resolved.length"
+            class="rounded-sm bg-green-700 px-2 py-1 font-medium text-white"
+          >
+            {{ diff.resolved.length }} fixed
+          </li>
+          <li class="rounded-sm bg-naturals-n4 px-2 py-1 text-naturals-n11">
+            {{ diff.remaining.length }} remaining
+          </li>
+          <li
+            v-if="diff.introduced.length"
+            class="rounded-sm bg-red-700 px-2 py-1 font-medium text-white"
+          >
+            {{ diff.introduced.length }} new
+          </li>
+          <li
+            v-if="!diff.resolved.length && !diff.introduced.length"
+            class="rounded-sm bg-naturals-n4 px-2 py-1 text-naturals-n11"
+          >
+            No change
+          </li>
+        </ul>
+
+        <TButton
+          v-if="canExpand"
+          size="sm"
+          variant="secondary"
+          :icon="expanded ? 'arrow-up' : 'arrow-down'"
+          icon-position="right"
+          @click="expanded = !expanded"
+        >
+          Details
+        </TButton>
+      </template>
+    </div>
+
+    <TAlert v-if="error" type="error" title="Scan failed" class="mx-4 mb-3">{{ error }}</TAlert>
+
+    <div
+      v-else-if="expanded && diff"
+      class="flex flex-col gap-4 border-t border-naturals-n5 px-4 py-3"
+    >
+      <section v-if="diff.resolved.length" class="flex flex-col gap-2">
+        <h4 class="flex items-center gap-1.5 text-xs font-medium text-green-g1">
+          <TIcon icon="check-in-circle" class="size-4 shrink-0" aria-hidden="true" />
+          Fixed by this upgrade ({{ diff.resolved.length }})
+        </h4>
+        <VulnerabilityList :matches="diff.resolved" />
+      </section>
+
+      <section v-if="diff.introduced.length" class="flex flex-col gap-2">
+        <h4 class="flex items-center gap-1.5 text-xs font-medium text-red-r1">
+          <TIcon icon="warning" class="size-4 shrink-0" aria-hidden="true" />
+          Introduced by this upgrade ({{ diff.introduced.length }})
+        </h4>
+        <VulnerabilityList :matches="diff.introduced" />
+      </section>
+    </div>
+  </div>
+</template>

--- a/frontend/src/views/ClusterSecurity/components/VulnerabilityList.vue
+++ b/frontend/src/views/ClusterSecurity/components/VulnerabilityList.vue
@@ -1,0 +1,112 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import TIcon from '@/components/Icon/TIcon.vue'
+import TListItem from '@/components/List/TListItem.vue'
+import { cn } from '@/methods/utils'
+import {
+  getCveId,
+  getPreferredVulnURL,
+  getScore,
+  sortMatches,
+} from '@/views/InstallationMedia/vulnerabilities/matchUtils'
+import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+
+const { matches } = defineProps<{ matches: Match[] }>()
+
+const sortedMatches = computed(() =>
+  sortMatches(matches).map((m) => ({
+    ...m,
+    score: getScore(m),
+    url: getPreferredVulnURL(m.vulnerability, m.relatedVulnerabilities),
+    cveID: getCveId(m),
+  })),
+)
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-1 bg-naturals-n2 px-2 py-2 text-xs text-naturals-n13">
+      <div class="w-6 shrink-0"></div>
+      <div class="grid flex-1 grid-cols-5 items-center gap-x-4 text-xs uppercase">
+        <div>CVE</div>
+        <div>Score</div>
+        <div>Package</div>
+        <div>Version</div>
+        <div>Fix</div>
+      </div>
+    </div>
+
+    <TListItem
+      v-for="{ vulnerability, artifact, url, cveID, score } in sortedMatches"
+      :key="cveID"
+      disable-border-on-expand
+    >
+      <template #default>
+        <div class="grid grid-cols-5 items-center gap-x-4 text-xs">
+          <div class="whitespace-nowrap">
+            <a
+              v-if="url"
+              target="_blank"
+              rel="noopener noreferrer"
+              :href="url"
+              class="link-primary inline-flex items-center gap-1 font-mono"
+            >
+              {{ cveID }}
+              <TIcon icon="external-link" class="size-3 shrink-0" aria-hidden="true" />
+            </a>
+            <span v-else class="font-mono text-naturals-n11">{{ cveID }}</span>
+          </div>
+
+          <div class="font-mono">
+            {{ score?.toFixed(1) ?? '---' }}
+
+            <span
+              :class="
+                cn('rounded-sm bg-naturals-n7 px-1 py-0.5 text-xs font-medium text-naturals-n11', {
+                  'bg-red-600 text-white': vulnerability.severity === 'Critical',
+                  'bg-orange-700 text-white': vulnerability.severity === 'High',
+                  'bg-orange-500 text-white': vulnerability.severity === 'Medium',
+                  'bg-yellow-500 text-black': vulnerability.severity === 'Low',
+                })
+              "
+            >
+              {{ vulnerability.severity.charAt(0).toUpperCase() }}
+            </span>
+          </div>
+
+          <div class="truncate font-medium">{{ artifact.name }}</div>
+
+          <div class="whitespace-nowrap">
+            <span class="resource-label label-red font-mono">{{ artifact.version }}</span>
+          </div>
+
+          <div class="flex flex-wrap gap-1">
+            <template v-if="vulnerability.fix.versions.length">
+              <span
+                v-for="v in vulnerability.fix.versions"
+                :key="v"
+                class="resource-label label-green font-mono"
+              >
+                {{ v }}
+              </span>
+            </template>
+            <span v-else class="text-naturals-n8">—</span>
+          </div>
+        </div>
+      </template>
+
+      <template v-if="vulnerability.description" #details>
+        <p class="text-xs whitespace-pre-wrap text-naturals-n11">
+          {{ vulnerability.description }}
+        </p>
+      </template>
+    </TListItem>
+  </div>
+</template>

--- a/frontend/src/views/ClusterSecurity/components/VulnerabilityList.vue
+++ b/frontend/src/views/ClusterSecurity/components/VulnerabilityList.vue
@@ -45,7 +45,7 @@ const sortedMatches = computed(() =>
 
     <TListItem
       v-for="{ vulnerability, artifact, url, cveID, score } in sortedMatches"
-      :key="cveID"
+      :key="`${vulnerability.id}-${artifact.id}`"
       disable-border-on-expand
     >
       <template #default>

--- a/frontend/src/views/ClusterSecurity/util/useClusterVulnerabilityScans.ts
+++ b/frontend/src/views/ClusterSecurity/util/useClusterVulnerabilityScans.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { computed, type MaybeRefOrGetter, ref, toValue, watch } from 'vue'
+
+import type {
+  Match,
+  VulnerabilityReport,
+} from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+
+export interface ScanRequest {
+  schematicId: string
+  /** Architecture as the factory expects it in the URL, e.g. `amd64` or `arm64`. */
+  arch: string
+  version: string
+}
+
+export interface ScanResult extends ScanRequest {
+  key: string
+  loading: boolean
+  /** The factory scan status, e.g. `done` / `pending`. */
+  status?: string
+  matches?: Match[]
+  error?: string
+}
+
+interface ScansResponse {
+  status: string
+  report?: VulnerabilityReport
+}
+
+export function scanKey(r: ScanRequest): string {
+  return `${r.schematicId}/${r.version}/${r.arch}`
+}
+
+async function fetchScan(r: ScanRequest) {
+  const resp = await fetch(`/api/vulns/${r.schematicId}/${r.version}/${r.arch}/report.json`)
+
+  try {
+    const data: ScansResponse = await resp.json()
+
+    if (!resp.ok) throw new Error(data.status)
+
+    return {
+      loading: false,
+      status: data.status,
+      matches: data.report?.matches ?? [],
+    }
+  } catch (e) {
+    throw new Error(
+      `Scan request failed with status ${resp.status}: ${e instanceof Error ? e.message : String(e)}`,
+    )
+  }
+}
+
+/**
+ * Runs vulnerability scans for an arbitrary, reactive set of (schematic, arch,
+ * version) requests, fetching each report from the image factory in parallel.
+ *
+ * Results are cached by request key, so recomputing the request list (e.g. when
+ * the Talos version list finishes loading) never refetches a report already in
+ * flight or resolved.
+ */
+export function useClusterVulnerabilityScans(getter: MaybeRefOrGetter<ScanRequest[]>) {
+  const cache = new Map<string, ScanResult>()
+  const results = ref<Map<string, ScanResult>>(new Map())
+
+  const publish = () => {
+    results.value = new Map(cache)
+  }
+
+  watch(
+    () => toValue(getter),
+    async (requests) => {
+      const unique = new Map<string, ScanRequest>()
+      for (const r of requests) unique.set(scanKey(r), r)
+
+      await Promise.all(
+        [...unique.values()].map(async (r) => {
+          const key = scanKey(r)
+          if (cache.has(key)) return
+
+          cache.set(key, { ...r, key, loading: true })
+          publish()
+
+          try {
+            cache.set(key, { ...r, key, ...(await fetchScan(r)) })
+          } catch (e) {
+            cache.set(key, {
+              ...r,
+              key,
+              loading: false,
+              error: e instanceof Error ? e.message : String(e),
+            })
+          }
+
+          publish()
+        }),
+      )
+    },
+    { immediate: true, deep: true },
+  )
+
+  const loading = computed(() => [...results.value.values()].some((r) => r.loading))
+
+  return { results, loading }
+}

--- a/frontend/src/views/ClusterSecurity/util/vulnerabilityDiff.spec.ts
+++ b/frontend/src/views/ClusterSecurity/util/vulnerabilityDiff.spec.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { describe, expect, it } from 'vitest'
+
+import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+
+import { computeUpgradeTargets, diffMatches } from './vulnerabilityDiff'
+
+function match(cve: string, pkg: string): Match {
+  return {
+    vulnerability: {
+      id: cve,
+      severity: 'High',
+      cvss: [],
+    },
+    relatedVulnerabilities: [],
+    artifact: { name: pkg, version: '1.0.0' },
+  } as unknown as Match
+}
+
+describe('computeUpgradeTargets', () => {
+  const available = ['1.8.0', '1.8.3', '1.8.4', '1.9.0', '1.9.2', '1.10.0', '1.10.1']
+
+  it('returns latest patch of current minor and latest patch of next minor', () => {
+    expect(computeUpgradeTargets('1.9.0', available)).toEqual([
+      { version: '1.9.2', kind: 'patch' },
+      { version: '1.10.1', kind: 'minor' },
+    ])
+  })
+
+  it('omits the patch target when already on the latest patch of the minor', () => {
+    expect(computeUpgradeTargets('1.9.2', available)).toEqual([
+      { version: '1.10.1', kind: 'minor' },
+    ])
+  })
+
+  it('omits the minor target when on the newest minor', () => {
+    expect(computeUpgradeTargets('1.10.0', available)).toEqual([
+      { version: '1.10.1', kind: 'patch' },
+    ])
+  })
+
+  it('handles gaps in available minors', () => {
+    expect(computeUpgradeTargets('1.8.4', ['1.8.4', '1.10.0', '1.10.2'])).toEqual([
+      { version: '1.10.2', kind: 'minor' },
+    ])
+  })
+
+  it('tolerates leading v prefixes', () => {
+    expect(computeUpgradeTargets('v1.9.0', ['v1.9.1', 'v1.10.0'])).toEqual([
+      { version: 'v1.9.1', kind: 'patch' },
+      { version: 'v1.10.0', kind: 'minor' },
+    ])
+  })
+
+  it('returns nothing for an unparseable current version', () => {
+    expect(computeUpgradeTargets('garbage', available)).toEqual([])
+  })
+})
+
+describe('diffMatches', () => {
+  it('partitions findings into resolved, remaining and introduced', () => {
+    const current = [match('CVE-1', 'a'), match('CVE-2', 'b'), match('CVE-3', 'c')]
+    const target = [match('CVE-2', 'b'), match('CVE-4', 'd')]
+
+    const diff = diffMatches(current, target)
+
+    expect(diff.resolved.map((m) => m.vulnerability.id)).toEqual(['CVE-1', 'CVE-3'])
+    expect(diff.remaining.map((m) => m.vulnerability.id)).toEqual(['CVE-2'])
+    expect(diff.introduced.map((m) => m.vulnerability.id)).toEqual(['CVE-4'])
+  })
+
+  it('treats the same CVE in different packages as distinct findings', () => {
+    const current = [match('CVE-1', 'a')]
+    const target = [match('CVE-1', 'b')]
+
+    const diff = diffMatches(current, target)
+
+    expect(diff.resolved).toHaveLength(1)
+    expect(diff.introduced).toHaveLength(1)
+    expect(diff.remaining).toHaveLength(0)
+  })
+})

--- a/frontend/src/views/ClusterSecurity/util/vulnerabilityDiff.ts
+++ b/frontend/src/views/ClusterSecurity/util/vulnerabilityDiff.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { coerce, compare } from 'semver'
+
+import { matchKey } from '@/views/InstallationMedia/vulnerabilities/matchUtils'
+import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+
+export type UpgradeKind = 'patch' | 'minor'
+
+export interface UpgradeTarget {
+  version: string
+  /**
+   * `patch` — the latest patch of the cluster's current minor version.
+   * `minor` — the latest patch of the next minor version.
+   */
+  kind: UpgradeKind
+}
+
+/**
+ * Given the cluster's current Talos version and the list of available Talos
+ * versions, return the upgrade targets to scan against:
+ *   - the latest patch of the current minor version, and
+ *   - the latest patch of the next available minor version.
+ *
+ * Targets that aren't strictly newer than the current version are omitted (so a
+ * cluster already on the latest patch of its minor won't get a redundant target).
+ */
+export function computeUpgradeTargets(current: string, available: string[]): UpgradeTarget[] {
+  const cur = coerce(current, { includePrerelease: true })
+  if (!cur) return []
+
+  const parsed = available
+    .map((raw) => ({ raw, sv: coerce(raw, { includePrerelease: true }) }))
+    .filter((x): x is { raw: string; sv: NonNullable<typeof x.sv> } => !!x.sv)
+
+  const targets: UpgradeTarget[] = []
+
+  // Latest patch of the current minor version.
+  const sameMinor = parsed.filter((x) => x.sv.major === cur.major && x.sv.minor === cur.minor)
+  const latestPatch = sameMinor.toSorted((a, b) => compare(b.sv, a.sv))[0]
+
+  if (latestPatch && compare(latestPatch.sv, cur) > 0) {
+    targets.push({ version: latestPatch.raw, kind: 'patch' })
+  }
+
+  // Latest patch of the *next* minor version — the smallest major.minor strictly
+  // greater than the current one (handles gaps in the available minors).
+  const higher = parsed.filter(
+    (x) => x.sv.major > cur.major || (x.sv.major === cur.major && x.sv.minor > cur.minor),
+  )
+
+  if (higher.length) {
+    const nextKey = Math.min(...higher.map((x) => x.sv.major * 1_000 + x.sv.minor))
+    const nextMinor = higher.filter((x) => x.sv.major * 1_000 + x.sv.minor === nextKey)
+    const latestNext = nextMinor.toSorted((a, b) => compare(b.sv, a.sv))[0]
+
+    if (latestNext) targets.push({ version: latestNext.raw, kind: 'minor' })
+  }
+
+  return targets
+}
+
+export interface UpgradeDiff {
+  /** Findings present in the current version but gone after the upgrade. */
+  resolved: Match[]
+  /** Findings present both before and after the upgrade. */
+  remaining: Match[]
+  /** Findings not present in the current version but introduced by the upgrade. */
+  introduced: Match[]
+}
+
+/** Diff a target version's findings against the current version's findings. */
+export function diffMatches(current: Match[], target: Match[]): UpgradeDiff {
+  const currentKeys = new Set(current.map(matchKey))
+  const targetKeys = new Set(target.map(matchKey))
+
+  return {
+    resolved: current.filter((m) => !targetKeys.has(matchKey(m))),
+    remaining: current.filter((m) => targetKeys.has(matchKey(m))),
+    introduced: target.filter((m) => !currentKeys.has(matchKey(m))),
+  }
+}

--- a/frontend/src/views/Home/components/DownloadTalosctl.vue
+++ b/frontend/src/views/Home/components/DownloadTalosctl.vue
@@ -72,7 +72,7 @@ const versionsList = computed(() =>
     .filter(
       (v) =>
         !v.spec.deprecated &&
-        quirks.value?.find((q) => q.metadata.id === v.spec.version)?.spec.supports_factory_talosctl,
+        quirks.value.find((q) => q.metadata.id === v.spec.version)?.spec.supports_factory_talosctl,
     )
     .map((v) => v.spec.version!)
     .sort(compare),

--- a/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue
+++ b/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue
@@ -14,11 +14,14 @@ import TListItem from '@/components/List/TListItem.vue'
 import Modal from '@/components/Modals/Modal.vue'
 import { useFeatures } from '@/methods/features'
 import { cn } from '@/methods/utils'
-import type {
-  Match,
-  RelatedVulnerability,
-  Vulnerability,
-} from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+import {
+  countBySeverity,
+  getCveId,
+  getPreferredVulnURL,
+  getScore,
+  sortMatches,
+} from '@/views/InstallationMedia/vulnerabilities/matchUtils'
+import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
 
 const {
   matches,
@@ -47,56 +50,16 @@ const arch = computed(() => {
   }
 })
 
-function compileVulnURLs(v: Vulnerability) {
-  return [v.dataSource, ...(v.urls ?? [])].filter((s): s is string => !!s)
-}
-
-function getPreferredVulnURL(v: Vulnerability, relatedVulnerabilities: RelatedVulnerability[]) {
-  const pool: string[] = []
-
-  if (v.id.startsWith('CVE-')) pool.push(...compileVulnURLs(v))
-
-  if (relatedVulnerabilities)
-    pool.push(
-      ...relatedVulnerabilities.filter((r) => r.id.startsWith('CVE-')).flatMap(compileVulnURLs),
-    )
-
-  if (!pool.length) pool.push(...compileVulnURLs(v))
-
-  return pool.find((p) => p.includes('nvd.nist.gov')) || pool[0] || ''
-}
-
 const sortedMatches = computed(() =>
-  matches
-    .map((m) => {
-      const score =
-        m.vulnerability.cvss.find((c) => c.type === 'Primary')?.metrics.baseScore ||
-        m.vulnerability.cvss.at(0)?.metrics.baseScore
-
-      return {
-        ...m,
-        score,
-        url: getPreferredVulnURL(m.vulnerability, m.relatedVulnerabilities),
-        cveID: m.vulnerability.id.startsWith('CVE-')
-          ? m.vulnerability.id
-          : m.relatedVulnerabilities.find((r) => r.id.startsWith('CVE-'))?.id || m.vulnerability.id,
-      }
-    })
-    .toSorted((a, b) => {
-      if (!a.score || !b.score || a.score === b.score) return b.cveID.localeCompare(a.cveID)
-
-      return b.score - a.score
-    }),
+  sortMatches(matches).map((m) => ({
+    ...m,
+    score: getScore(m),
+    url: getPreferredVulnURL(m.vulnerability, m.relatedVulnerabilities),
+    cveID: getCveId(m),
+  })),
 )
 
-const counts = computed(() =>
-  sortedMatches.value.reduce((prev, curr) => {
-    const sev = curr.vulnerability.severity
-    const count = prev.get(sev) ?? 0
-
-    return prev.set(sev, count + 1)
-  }, new Map<string, number>()),
-)
+const counts = computed(() => countBySeverity(matches))
 </script>
 
 <template>

--- a/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue
+++ b/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watchEffect } from 'vue'
 
 import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
 import TButton from '@/components/Button/TButton.vue'
@@ -30,6 +30,13 @@ const {
 const open = defineModel<boolean>('open', { default: false })
 
 const { data: features } = useFeatures()
+const severityFilter = ref<string>()
+
+watchEffect(() => {
+  if (open.value) return
+
+  severityFilter.value = undefined
+})
 
 const arch = computed(() => {
   switch (archEnum) {
@@ -41,12 +48,28 @@ const arch = computed(() => {
       throw new Error(`Unexpected arch "${archEnum}" received`)
   }
 })
+
+const filteredMatches = computed(() =>
+  severityFilter.value
+    ? matches.filter((m) => m.vulnerability.severity === severityFilter.value)
+    : matches,
+)
+
+function toggleSeverityFilter(severity: string) {
+  severityFilter.value = severityFilter.value === severity ? undefined : severity
+}
 </script>
 
 <template>
   <Modal v-model:open="open" title="Scan details" cancel-label="Close">
     <template #description>
-      <SeverityBadges :matches class="mt-2" />
+      <SeverityBadges
+        :matches
+        :active-filter="severityFilter"
+        class="mt-2"
+        clickable
+        @click-severity="toggleSeverityFilter"
+      />
     </template>
 
     <div class="flex flex-col">
@@ -77,7 +100,7 @@ const arch = computed(() => {
         </ul>
       </div>
 
-      <VulnerabilityList :matches />
+      <VulnerabilityList :matches="filteredMatches" />
     </div>
   </Modal>
 </template>

--- a/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue
+++ b/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue
@@ -9,18 +9,10 @@ import { computed } from 'vue'
 
 import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
 import TButton from '@/components/Button/TButton.vue'
-import TIcon from '@/components/Icon/TIcon.vue'
-import TListItem from '@/components/List/TListItem.vue'
 import Modal from '@/components/Modals/Modal.vue'
 import { useFeatures } from '@/methods/features'
-import { cn } from '@/methods/utils'
-import {
-  countBySeverity,
-  getCveId,
-  getPreferredVulnURL,
-  getScore,
-  sortMatches,
-} from '@/views/InstallationMedia/vulnerabilities/matchUtils'
+import SeverityBadges from '@/views/ClusterSecurity/components/SeverityBadges.vue'
+import VulnerabilityList from '@/views/ClusterSecurity/components/VulnerabilityList.vue'
 import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
 
 const {
@@ -49,38 +41,12 @@ const arch = computed(() => {
       throw new Error(`Unexpected arch "${archEnum}" received`)
   }
 })
-
-const sortedMatches = computed(() =>
-  sortMatches(matches).map((m) => ({
-    ...m,
-    score: getScore(m),
-    url: getPreferredVulnURL(m.vulnerability, m.relatedVulnerabilities),
-    cveID: getCveId(m),
-  })),
-)
-
-const counts = computed(() => countBySeverity(matches))
 </script>
 
 <template>
   <Modal v-model:open="open" title="Scan details" cancel-label="Close">
     <template #description>
-      <ul v-if="counts" class="mt-2 flex flex-wrap items-center gap-1.5">
-        <li
-          v-for="[sev, count] in counts"
-          :key="sev"
-          :class="
-            cn('rounded-sm bg-naturals-n4 px-2 py-1 text-xs text-naturals-n11', {
-              'bg-red-600 text-white': sev === 'Critical',
-              'bg-orange-700 text-white': sev === 'High',
-              'bg-orange-500 text-white': sev === 'Medium',
-              'bg-yellow-500 text-black': sev === 'Low',
-            })
-          "
-        >
-          {{ count }} {{ sev }}
-        </li>
-      </ul>
+      <SeverityBadges :matches class="mt-2" />
     </template>
 
     <div class="flex flex-col">
@@ -111,85 +77,7 @@ const counts = computed(() => countBySeverity(matches))
         </ul>
       </div>
 
-      <div class="flex items-center gap-1 bg-naturals-n2 px-2 py-2 text-xs text-naturals-n13">
-        <div class="w-6 shrink-0"></div>
-        <div class="grid flex-1 grid-cols-5 items-center gap-x-4 text-xs uppercase">
-          <div>CVE</div>
-          <div>Score</div>
-          <div>Package</div>
-          <div>Version</div>
-          <div>Fix</div>
-        </div>
-      </div>
-
-      <TListItem
-        v-for="{ vulnerability, artifact, url, cveID, score } in sortedMatches"
-        :key="cveID"
-        disable-border-on-expand
-      >
-        <template #default>
-          <div class="grid grid-cols-5 items-center gap-x-4 text-xs">
-            <div class="whitespace-nowrap">
-              <a
-                v-if="url"
-                target="_blank"
-                rel="noopener noreferrer"
-                :href="url"
-                class="link-primary inline-flex items-center gap-1 font-mono"
-              >
-                {{ cveID }}
-                <TIcon icon="external-link" class="size-3 shrink-0" aria-hidden="true" />
-              </a>
-              <span v-else class="font-mono text-naturals-n11">{{ cveID }}</span>
-            </div>
-
-            <div class="font-mono">
-              {{ score?.toFixed(1) ?? '---' }}
-
-              <span
-                :class="
-                  cn(
-                    'rounded-sm bg-naturals-n7 px-1 py-0.5 text-xs font-medium text-naturals-n11',
-                    {
-                      'bg-red-600 text-white': vulnerability.severity === 'Critical',
-                      'bg-orange-700 text-white': vulnerability.severity === 'High',
-                      'bg-orange-500 text-white': vulnerability.severity === 'Medium',
-                      'bg-yellow-500 text-black': vulnerability.severity === 'Low',
-                    },
-                  )
-                "
-              >
-                {{ vulnerability.severity.charAt(0).toUpperCase() }}
-              </span>
-            </div>
-
-            <div class="truncate font-medium">{{ artifact.name }}</div>
-
-            <div class="whitespace-nowrap">
-              <span class="resource-label label-red font-mono">{{ artifact.version }}</span>
-            </div>
-
-            <div class="flex flex-wrap gap-1">
-              <template v-if="vulnerability.fix.versions.length">
-                <span
-                  v-for="v in vulnerability.fix.versions"
-                  :key="v"
-                  class="resource-label label-green font-mono"
-                >
-                  {{ v }}
-                </span>
-              </template>
-              <span v-else class="text-naturals-n8">—</span>
-            </div>
-          </div>
-        </template>
-
-        <template v-if="vulnerability.description" #details>
-          <p class="text-xs whitespace-pre-wrap text-naturals-n11">
-            {{ vulnerability.description }}
-          </p>
-        </template>
-      </TListItem>
+      <VulnerabilityList :matches />
     </div>
   </Modal>
 </template>

--- a/frontend/src/views/InstallationMedia/vulnerabilities/matchUtils.ts
+++ b/frontend/src/views/InstallationMedia/vulnerabilities/matchUtils.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type {
+  Match,
+  RelatedVulnerability,
+  Vulnerability,
+} from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
+
+// Severities ordered from most to least important, used for sorting and grouping.
+const SEVERITY_ORDER = ['Critical', 'High', 'Medium', 'Low', 'Negligible', 'Unknown'] as const
+
+function severityRank(severity: string): number {
+  const idx = SEVERITY_ORDER.indexOf(severity as (typeof SEVERITY_ORDER)[number])
+
+  return idx === -1 ? SEVERITY_ORDER.length : idx
+}
+
+/** The CVSS base score for a match, preferring the primary CVSS entry. */
+export function getScore(m: Match): number | undefined {
+  return (
+    m.vulnerability.cvss.find((c) => c.type === 'Primary')?.metrics.baseScore ||
+    m.vulnerability.cvss.at(0)?.metrics.baseScore
+  )
+}
+
+/** The human-facing CVE identifier for a match, falling back to a related CVE or the raw id. */
+export function getCveId(m: Match): string {
+  if (m.vulnerability.id.startsWith('CVE-')) return m.vulnerability.id
+
+  return m.relatedVulnerabilities.find((r) => r.id.startsWith('CVE-'))?.id || m.vulnerability.id
+}
+
+function compileVulnURLs(v: Vulnerability) {
+  return [v.dataSource, ...(v.urls ?? [])].filter((s): s is string => !!s)
+}
+
+export function getPreferredVulnURL(
+  v: Vulnerability,
+  relatedVulnerabilities: RelatedVulnerability[],
+) {
+  const pool: string[] = []
+
+  if (v.id.startsWith('CVE-')) pool.push(...compileVulnURLs(v))
+
+  if (relatedVulnerabilities)
+    pool.push(
+      ...relatedVulnerabilities.filter((r) => r.id.startsWith('CVE-')).flatMap(compileVulnURLs),
+    )
+
+  if (!pool.length) pool.push(...compileVulnURLs(v))
+
+  return pool.find((p) => p.includes('nvd.nist.gov')) || pool[0] || ''
+}
+
+/**
+ * A stable identity for a finding across Talos versions: the CVE plus the affected
+ * package name. Package versions are intentionally excluded so the same CVE in the
+ * same package is recognised as "the same finding" even when the package is bumped.
+ */
+export function matchKey(m: Match): string {
+  return `${getCveId(m)}::${m.artifact.name}`
+}
+
+/** Sort matches by CVSS score (desc), then severity, then CVE id for stable ordering. */
+export function sortMatches(matches: Match[]): Match[] {
+  return matches.toSorted((a, b) => {
+    const scoreA = getScore(a)
+    const scoreB = getScore(b)
+
+    if (scoreA && scoreB && scoreA !== scoreB) return scoreB - scoreA
+
+    const sevDiff = severityRank(a.vulnerability.severity) - severityRank(b.vulnerability.severity)
+    if (sevDiff !== 0) return sevDiff
+
+    return getCveId(b).localeCompare(getCveId(a))
+  })
+}
+
+/** Count matches by severity, preserving severity ordering. */
+export function countBySeverity(matches: Match[]): Map<string, number> {
+  const counts = new Map<string, number>()
+
+  for (const m of matches) {
+    const sev = m.vulnerability.severity
+    counts.set(sev, (counts.get(sev) ?? 0) + 1)
+  }
+
+  return new Map([...counts.entries()].sort(([a], [b]) => severityRank(a) - severityRank(b)))
+}

--- a/frontend/typed-router.d.ts
+++ b/frontend/typed-router.d.ts
@@ -47,6 +47,7 @@ declare module 'vue-router/auto-routes' {
       | 'ClusterOverview'
       | 'ClusterPatchEdit'
       | 'ClusterScale'
+      | 'ClusterSecurity'
       | 'Clusters'
       | 'Home'
       | 'InfraProviders'
@@ -124,6 +125,7 @@ declare module 'vue-router/auto-routes' {
       | 'ClusterOverview'
       | 'ClusterPatchEdit'
       | 'ClusterScale'
+      | 'ClusterSecurity'
       | 'KubernetesManifestSync'
       | 'NodeConfig'
       | 'NodeConfigDiffs'
@@ -309,6 +311,13 @@ declare module 'vue-router/auto-routes' {
     'ClusterScale': RouteRecordInfo<
       'ClusterScale',
       '/clusters/:cluster/scale',
+      { cluster: ParamValue<true> },
+      { cluster: ParamValue<false> },
+      | never
+    >,
+    'ClusterSecurity': RouteRecordInfo<
+      'ClusterSecurity',
+      '/clusters/:cluster/security',
       { cluster: ParamValue<true> },
       { cluster: ParamValue<false> },
       | never
@@ -644,6 +653,7 @@ declare module 'vue-router/auto-routes' {
         | 'ClusterOverview'
         | 'ClusterPatchEdit'
         | 'ClusterScale'
+        | 'ClusterSecurity'
         | 'Clusters'
         | 'Home'
         | 'InfraProviders'
@@ -713,6 +723,7 @@ declare module 'vue-router/auto-routes' {
         | 'ClusterOverview'
         | 'ClusterPatchEdit'
         | 'ClusterScale'
+        | 'ClusterSecurity'
         | 'Clusters'
         | 'Home'
         | 'InfraProviders'
@@ -794,6 +805,7 @@ declare module 'vue-router/auto-routes' {
         | 'ClusterOverview'
         | 'ClusterPatchEdit'
         | 'ClusterScale'
+        | 'ClusterSecurity'
         | 'KubernetesManifestSync'
         | 'NodeConfig'
         | 'NodeConfigDiffs'
@@ -1006,6 +1018,14 @@ declare module 'vue-router/auto-routes' {
     'src/pages/(authenticated)/clusters/[cluster]/scale.vue': {
       routes:
         | 'ClusterScale'
+      views:
+        | never
+      pathParamNames:
+        | never
+    }
+    'src/pages/(authenticated)/clusters/[cluster]/security.vue': {
+      routes:
+        | 'ClusterSecurity'
       views:
         | never
       pathParamNames:


### PR DESCRIPTION
Add a cluster security page to show vulnerabilities for currently running clusters.

[📖 Storybook](https://cluster-vulns--68d664245076e2bb623d98f3.chromatic.com/?path=/story/views-clustersecurity--default)

Closes #2887

<img width="300" alt="image" src="https://github.com/user-attachments/assets/944ea194-30a1-4055-a340-07aa094fd209" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/844c2944-5d4f-4ce3-a599-8c90270bed21" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c6c7df88-b216-4800-b350-a54280d97e47" />
