### PR TITLE
fix(frontend): allow force-destroy when MachineSetNode is already gone

### DIFF
--- a/frontend/src/methods/cluster.ts
+++ b/frontend/src/methods/cluster.ts
@@ -329,7 +329,7 @@ export const destroyNodes = async (
 
         await ResourceService.Create(forceDeleteRequest, withRuntime(Runtime.Omni))
       }
-    } else if (!machineSetNodes[id]?.metadata) {
+    } else if (!force && !machineSetNodes[id]?.metadata) {
       // if this is not a force-delete, and the node is not found, it is an error
       throw new ClusterCommandError(
         `Failed to Destroy Node ${id}`,


### PR DESCRIPTION
A scale-down can remove a disconnected machine's MachineSetNode before the operator force-destroys it, and the guard then rejected the node with "node is not part of the cluster" before it could tear down the siderolink link. Skip that check when force is requested so the machine is removed.
