### PR TITLE
fix: recover a machine from a reverted reboot-requiring config patch

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -189,7 +189,8 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileRunning(
 		return err
 	}
 
-	if err = ctrl.computePendingUpdates(ctx, r, rc); err != nil {
+	configChanged, err := ctrl.computePendingUpdates(ctx, r, rc)
+	if err != nil {
 		return fmt.Errorf("failed to compute pending updates: %w", err)
 	}
 
@@ -236,7 +237,14 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileRunning(
 
 	mode := machineapi.ApplyConfigurationRequest_NO_REBOOT
 
-	if machineConfigStatus.TypedSpec().Value.ClusterMachineConfigSha256 != shaSumString { // latest config is not yet applied, perform config apply
+	// Re-apply when the confirmed config differs from the desired one (sha mismatch), or when the
+	// config we last pushed to the machine differs from the desired one. The second case covers a
+	// reboot-requiring change reverted before the machine confirms it: such a push is committed to
+	// the machine but its sha is recorded only after the machine comes back, so a revert in that
+	// window leaves the recorded sha matching the desired config. Comparing the last pushed config
+	// lets us notice the machine still runs the reverted change and re-apply, instead of treating it
+	// as in sync.
+	if machineConfigStatus.TypedSpec().Value.ClusterMachineConfigSha256 != shaSumString || configChanged {
 		mode, err = ctrl.applyConfig(ctx, logger, r, rc)
 		if err != nil {
 			grpcSt := client.Status(err)
@@ -1160,19 +1168,23 @@ func (ctrl *ClusterMachineConfigStatusController) releaseUpgradeLock(ctx context
 	return r.RemoveFinalizer(ctx, clusterMachine.Metadata(), UpgradeFinalizer)
 }
 
-func (ctrl *ClusterMachineConfigStatusController) computePendingUpdates(ctx context.Context, r controller.ReaderWriter, rc *ReconciliationContext) error {
+// computePendingUpdates reconciles the MachinePendingUpdates resource and reports whether the
+// config last pushed to the machine (the redacted config stored in the status) differs from the
+// desired config. The caller uses this to re-apply a machine that has drifted from the desired
+// config even when the recorded (confirmed) sha already matches it.
+func (ctrl *ClusterMachineConfigStatusController) computePendingUpdates(ctx context.Context, r controller.ReaderWriter, rc *ReconciliationContext) (bool, error) {
 	pendingUpdates := omni.NewMachinePendingUpdates(rc.machineConfig.Metadata().ID())
 
 	currentRedactedMachineConfig, err := rc.machineConfigStatus.TypedSpec().Value.GetUncompressedData()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	defer currentRedactedMachineConfig.Free()
 
 	configDiff, err := diff.Compute(currentRedactedMachineConfig.Data(), rc.redactedMachineConfig)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	var (
@@ -1194,10 +1206,10 @@ func (ctrl *ClusterMachineConfigStatusController) computePendingUpdates(ctx cont
 	if !upgradeDiff && configDiff == "" {
 		_, err = helpers.TeardownAndDestroy(ctx, r, pendingUpdates.Metadata())
 
-		return err
+		return false, err
 	}
 
-	return safe.WriterModify(ctx, r, pendingUpdates, func(res *omni.MachinePendingUpdates) error {
+	return configDiff != "", safe.WriterModify(ctx, r, pendingUpdates, func(res *omni.MachinePendingUpdates) error {
 		helpers.CopyAllLabels(rc.machineConfig, res)
 
 		if upgradeDiff {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -1686,6 +1686,129 @@ func TestConfigUpdateLockReleasedWhenUpgradeBlocked(t *testing.T) {
 	)
 }
 
+// TestRevertRebootRequiringPatchRecoversMachine is a regression test for the flaky
+// TestIntegration/Suites/ConfigPatching/InvalidConfigPatchShouldBeReverted.
+//
+// It mirrors that scenario: a reboot-requiring config patch is applied, the machine reboots into
+// it, and the patch is removed before the machine confirms it. The controller has to re-apply the
+// reverted config so the machine reboots back into a good state, rather than treating it as already
+// in sync and leaving it stuck on the removed patch.
+//
+// A reboot-mode apply records the applied config sha only after the machine comes back, so when the
+// patch is removed first the recorded sha still matches the reverted config and, before the fix, the
+// controller saw nothing to do. The mock keeps the patch in reboot mode so its sha is never
+// recorded, which makes the lost race reproduce on every run.
+func TestRevertRebootRequiringPatchRecoversMachine(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			controller := machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", testutils.NewLifecycleManagerMock())
+			require.NoError(t, tc.Runtime.RegisterQController(controller))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			st := tc.State
+
+			machineServices := testutils.NewMachineServices(t, st)
+
+			_, machines := createCluster(ctx, t, st, machineServices, "revert-wedge", 1, 0)
+			id := machines[0].Metadata().ID()
+
+			const brokenMarker = "config-patch-test-file-broken"
+
+			// The broken patch reports a reboot-requiring change, like Talos does for a machine.files
+			// change; the initial config and the revert report no reboot. Because the patch always
+			// reports reboot, the controller never records its sha through a follow-up no-op apply,
+			// which is what makes the lost race reproduce on every run.
+			machineServices.Get(id).OnApplyConfig = func(_ context.Context, req *machine.ApplyConfigurationRequest, _ state.State, _ string) (*machine.ApplyConfigurationResponse, error) {
+				mode := machine.ApplyConfigurationRequest_NO_REBOOT
+				if strings.Contains(string(req.GetData()), brokenMarker) {
+					mode = machine.ApplyConfigurationRequest_REBOOT
+				}
+
+				return &machine.ApplyConfigurationResponse{
+					Messages: []*machine.ApplyConfiguration{{Mode: mode}},
+				}, nil
+			}
+
+			// Wait for the initial (good) config to be applied and recorded.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+
+			// Capture the good config so we can revert to it byte-for-byte later.
+			goodCfg := func() []byte {
+				cmc, err := safe.ReaderGetByID[*omni.ClusterMachineConfig](ctx, st, id)
+				require.NoError(t, err)
+
+				buf, err := cmc.TypedSpec().Value.GetUncompressedData()
+				require.NoError(t, err)
+
+				defer buf.Free()
+
+				return slices.Clone(buf.Data())
+			}()
+
+			setStage := func(stage machine.MachineStatusEvent_MachineStage) {
+				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+					if res.TypedSpec().Value.MachineStatus == nil {
+						res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{}
+					}
+
+					res.TypedSpec().Value.MachineStatus.Stage = stage
+
+					return nil
+				}))
+			}
+
+			lastAppliedIsBroken := func() bool {
+				reqs := machineServices.Get(id).GetApplyRequests()
+				if len(reqs) == 0 {
+					return false
+				}
+
+				return strings.Contains(string(reqs[len(reqs)-1].GetData()), brokenMarker)
+			}
+
+			// 1. Apply the broken, reboot-requiring patch.
+			brokenCfg := "machine:\n  files:\n    - content: test\n      permissions: 0o666\n      path: /tmp/config-patch-test-file-broken-1.txt\n      op: create"
+
+			rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), options.Modify(func(r *omni.ClusterMachineConfig) error {
+				return r.TypedSpec().Value.SetUncompressedData([]byte(brokenCfg))
+			}))
+
+			// The broken config reaches the machine (it is now "rebooting into" it).
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.True(c, lastAppliedIsBroken(), "broken config should have been applied to the machine")
+			}, 5*time.Second, 20*time.Millisecond)
+
+			// 2. The machine reboots into the patch. Its sha was never recorded (the apply reported
+			// a reboot), so the controller has no confirmed record of what the machine is running.
+			setStage(machine.MachineStatusEvent_REBOOTING)
+
+			// 3. Remove the broken patch while the machine is still mid-reboot: revert to the good config.
+			rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), options.Modify(func(r *omni.ClusterMachineConfig) error {
+				return r.TypedSpec().Value.SetUncompressedData(goodCfg)
+			}))
+
+			// 4. The machine comes back up (still running the broken config on disk).
+			setStage(machine.MachineStatusEvent_RUNNING)
+
+			// 5. The controller has to recover the machine by re-applying the reverted config so it
+			// can reboot back into it. Before the fix it considered the machine in sync (recorded
+			// sha == reverted config sha) and never re-applied, leaving it stuck and timing out this
+			// assertion.
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.False(c, lastAppliedIsBroken(), "controller should re-apply the reverted config to recover the machine, but the last config applied is still the broken one")
+			}, 10*time.Second, 50*time.Millisecond)
+		},
+	)
+}
+
 // setupMaintenanceMachine creates a single-machine cluster whose machine is booted in maintenance
 // mode and needs Talos written to disk via the LifecycleService.
 func setupMaintenanceMachine(


### PR DESCRIPTION
When a reboot-requiring config patch is applied to a machine and then removed before the machine finishes rebooting into it, the machine could stay stuck and never return to a running state. Omni treated it as already in sync, because the desired config matched the config last confirmed as applied, so it never re-applied the reverted config to bring the machine back. The machine recovered by itself only after a long delay, which is how this surfaced as a flaky integration test.

Omni now re-applies the config when the config it last pushed to a machine differs from the desired one, not just when the last confirmed config differs from it. A machine that rebooted into a config that was then reverted now gets the reverted config re-applied and returns to a running state.