### PR TITLE
fix(frontend): allow in-minor patch upgrades in update kubernetes on Omni

### DIFF
--- a/frontend/src/views/Overview/components/UpdateKubernetesModal.vue
+++ b/frontend/src/views/Overview/components/UpdateKubernetesModal.vue
@@ -128,7 +128,7 @@ const groupedK8sVersions = computed(() => {
           allTalosVersions.value.find((v) =>
             v.spec.compatible_kubernetes_versions?.some((v) => satisfies(v, majorMinor)),
           )?.spec.version ?? 'unknown',
-        upgradeable: isVersionUpgradeable(`${major}.${minor}.0`),
+        upgradeable: supportedK8sVersions.value.some((v) => satisfies(v, majorMinor)),
         versions: [],
       }
 


### PR DESCRIPTION
Group-level upgradeability in the Update Kubernetes modal was computed
against a hardcoded `.0` patch (`isVersionUpgradeable(`${major}.${minor}.0`)`).
When a cluster runs a patch higher than `.0` of its current minor (e.g.
1.36.1), `1.36.0` is neither the current version nor an upgrade target, so
the whole minor group was marked non-upgradeable. The modal then showed a
misleading "Can't skip minor version upgrades" label and offered no
selectable versions, blocking valid in-minor patch upgrades such as
1.36.1 -> 1.36.2 from the UI.

Compute group upgradeability from whether any supported version falls
within that minor instead. Since supportedK8sVersions always contains
last_upgrade_version, the current minor group is always upgradeable and
its patch versions become selectable. Other minor groups still depend on
the backend-provided upgrade_versions, so the skip-minor guard is
preserved (e.g. 1.34.x -> 1.36 stays blocked).

Closes #3057 