### PR TITLE
fix(frontend): fix double command in processes and format CPU chart better

### DIFF
--- a/frontend/e2e/qemu/clusters.spec.ts
+++ b/frontend/e2e/qemu/clusters.spec.ts
@@ -475,10 +475,10 @@ test('node overview tabs', async ({ page }) => {
 
   await test.step('Validate monitor tab', async () => {
     await page.getByRole('tab', { name: 'Monitor', exact: true }).click()
-    await expect(page.getByText('CPU usage')).toBeVisible()
-    await expect(page.getByText('Memory', { exact: true })).toBeVisible()
-    await expect(page.getByText('Processes')).toBeVisible()
-    await expect(page.getByText('init /sbin/init')).toBeVisible()
+    await expect.soft(page.getByText('CPU usage')).toBeVisible()
+    await expect.soft(page.getByText('Memory', { exact: true })).toBeVisible()
+    await expect.soft(page.getByText('Processes')).toBeVisible()
+    await expect.soft(page.getByText('/sbin/init')).toBeVisible()
   })
 
   await test.step('Validate console logs tab', async () => {

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.stories.ts
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.stories.ts
@@ -188,18 +188,24 @@ const processesHandler = http.post('/machine.MachineService/Processes', () => {
     messages: [
       {
         metadata: {},
-        processes: baseProcs.map(
-          (proc): ProcessInfo => ({
+        processes: baseProcs.map((proc): ProcessInfo => {
+          // argv[0]: absolute paths stay as-is, bare names get a plausible
+          // install path so `executable` mirrors what real Talos reports.
+          const argv0 = proc.args.split(' ')[0]
+          const executable = argv0.startsWith('/') ? argv0 : `/usr/bin/${argv0}`
+
+          return {
             pid: proc.pid,
             state: proc.state,
             threads: proc.threads,
             virtual_memory: String(proc.virtualMemory),
             resident_memory: String(proc.residentMemory),
             args: proc.args,
-            command: proc.args.split(' ')[0].split('/').pop(),
+            executable,
+            command: executable.split('/').pop(),
             cpu_time: Number((proc.baseCpuTime + tick * proc.cpuRate).toFixed(2)),
-          }),
-        ),
+          }
+        }),
       },
     ],
   } satisfies ProcessesResponse)

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.stories.ts
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.stories.ts
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import { createBootstrapEvent, createCreatedEvent, createUpdatedEvent } from '@msw/helpers'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+
+import type { Resource } from '@/api/grpc'
+import type { WatchRequest, WatchResponse } from '@/api/omni/resources/resources.pb'
+import { TalosCPUType, TalosMemoryType } from '@/api/resources'
+import type {
+  ProcessesResponse,
+  ProcessInfo,
+  SystemStatResponse,
+} from '@/api/talos/machine/machine.pb'
+import type { CPUSpec, MemorySpec } from '@/api/talos/perf.pb'
+
+import NodeMonitor from './monitor.vue'
+
+const meta: Meta<typeof NodeMonitor> = {
+  component: NodeMonitor,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const POINTS = 30
+
+// The monitor charts only ever plot UPDATED events (see NodesMonitorChart), and
+// the process table stays empty until the memory chart's point-fn observes a
+// total — so a bootstrap-only handler would render a blank page. This streams a
+// CREATED + BOOTSTRAPPED pair followed by a steady trickle of UPDATED events so
+// every chart animates and `memTotal` gets populated. Each watch request gets its
+// own stream, so the duplicated CPU watch (CPU + Processes charts) animates too.
+function perfStreamHandler<T>(type: string, specAt: (tick: number) => T) {
+  const encode = (response: WatchResponse) =>
+    new TextEncoder().encode(JSON.stringify(response) + '\n')
+
+  return http.post<never, WatchRequest>(
+    '/omni.resources.ResourceService/Watch',
+    async ({ request }) => {
+      const { type: requestType, namespace, id } = await request.clone().json()
+
+      // Let other watch handlers (or the next matching one) respond.
+      if (requestType !== type) return
+
+      const makeResource = (tick: number): Resource<T> => ({
+        spec: specAt(tick),
+        metadata: {
+          namespace,
+          type,
+          id,
+          version: String(tick + 1),
+          updated: new Date().toISOString(),
+        },
+      })
+
+      let intervalId: number
+      let tick = 0
+      let prev = makeResource(tick)
+
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encode(createCreatedEvent(prev, 1)))
+          controller.enqueue(encode(createBootstrapEvent(1)))
+          tick = 1
+
+          intervalId = window.setInterval(() => {
+            if (tick > POINTS) {
+              clearInterval(intervalId)
+              return
+            }
+
+            const next = makeResource(tick)
+            controller.enqueue(encode(createUpdatedEvent(next, prev)))
+            prev = next
+            tick++
+          }, 1000)
+        },
+        cancel() {
+          clearInterval(intervalId)
+        },
+      })
+
+      return new HttpResponse(stream, {
+        headers: {
+          'content-type': 'application/json',
+          'Grpc-metadata-content-type': 'application/grpc',
+        },
+      })
+    },
+  )
+}
+
+// Monotonically increasing CPU counters (like /proc/stat) so the chart's
+// per-interval deltas stay positive.
+const cpuSpecAt = (tick: number): CPUSpec => {
+  let user = 0
+  let system = 0
+  let idle = 0
+  let iowait = 0
+
+  // Each interval spends a fixed ~50-unit budget split between busy time
+  // (user + system) and idle. `load` oscillates up to ~0.85 so the charted
+  // user + system total peaks above 80% during the busy stretches.
+  for (let k = 0; k < tick; k++) {
+    const load = Math.max(0.05, 0.45 + Math.sin(k / 3) * 0.4)
+    const busy = 50 * load
+
+    user += busy * 0.7
+    system += busy * 0.3
+    iowait += 0.3 + (k % 4) * 0.1
+    idle += 50 - busy
+  }
+
+  return {
+    cpu: Array.from({ length: 8 }, () => ({})),
+    cpuTotal: {
+      user,
+      system,
+      idle,
+      iowait,
+      nice: tick * 0.4,
+      irq: tick * 0.05,
+      softIrq: tick * 0.05,
+      steal: 0,
+    },
+    processCreated: tick * 13,
+    processRunning: 3 + Math.round(Math.abs(Math.sin(tick / 2)) * 5),
+    processBlocked: tick % 2,
+  }
+}
+
+const TOTAL_KIB = 16 * 1024 * 1024 // 16 GiB worth of KiB, matching /proc/meminfo units
+const memSpecAt = (tick: number): MemorySpec => ({
+  total: TOTAL_KIB,
+  used: Math.round((7 + Math.abs(Math.sin(tick / 4)) * 4) * 1024 * 1024),
+  cached: Math.round((2 + Math.abs(Math.cos(tick / 6))) * 1024 * 1024),
+  buffers: Math.round(0.4 * 1024 * 1024),
+})
+
+const PROC_COMMANDS = [
+  '/sbin/init',
+  '/usr/local/bin/kubelet --config=/etc/kubernetes/kubelet.yaml --kubeconfig=/etc/kubernetes/kubeconfig',
+  '/usr/bin/containerd',
+  '/usr/local/bin/etcd --data-dir=/var/lib/etcd --advertise-client-urls=https://10.5.0.2:2379',
+  'kube-apiserver --advertise-address=10.5.0.2 --secure-port=6443 --etcd-servers=https://127.0.0.1:2379',
+  'kube-controller-manager --bind-address=127.0.0.1 --leader-elect=true',
+  'kube-scheduler --bind-address=127.0.0.1 --leader-elect=true',
+  '/usr/bin/dashboard',
+  '/sbin/dhcpcd --quiet --waitip',
+  'runc init',
+  '/pause',
+  '/coredns -conf /etc/coredns/Corefile',
+  '/bin/flanneld --ip-masq --kube-subnet-mgr',
+  '/usr/local/bin/talosctl-apid',
+  '/usr/local/bin/trustd',
+]
+
+// Built once at module load so the table is stable across the 5s polling
+// interval; only `cpu_time` advances (driven by `processTick`) so CPU% animates.
+faker.seed(42)
+const baseProcs = faker.helpers.multiple(
+  () => {
+    const resident = faker.number.int({ min: 1, max: 2048 }) * 1024 * 1024
+
+    return {
+      pid: faker.number.int({ min: 1, max: 32768 }),
+      state: faker.helpers.arrayElement(['R', 'S', 'D', 'I', 'Z']),
+      threads: faker.number.int({ min: 1, max: 64 }),
+      virtualMemory: resident * faker.number.int({ min: 2, max: 8 }),
+      residentMemory: resident,
+      args: faker.helpers.arrayElement(PROC_COMMANDS),
+      baseCpuTime: faker.number.float({ min: 0, max: 80000, fractionDigits: 2 }),
+      cpuRate: faker.number.float({ min: 0, max: 4.5, fractionDigits: 3 }),
+    }
+  },
+  { count: 36 },
+)
+
+let processTick = 0
+const processesHandler = http.post('/machine.MachineService/Processes', () => {
+  const tick = ++processTick
+
+  return HttpResponse.json({
+    messages: [
+      {
+        metadata: {},
+        processes: baseProcs.map(
+          (proc): ProcessInfo => ({
+            pid: proc.pid,
+            state: proc.state,
+            threads: proc.threads,
+            virtual_memory: String(proc.virtualMemory),
+            resident_memory: String(proc.residentMemory),
+            args: proc.args,
+            command: proc.args.split(' ')[0].split('/').pop(),
+            cpu_time: Number((proc.baseCpuTime + tick * proc.cpuRate).toFixed(2)),
+          }),
+        ),
+      },
+    ],
+  } satisfies ProcessesResponse)
+})
+
+let statTick = 0
+const systemStatHandler = http.post('/machine.MachineService/SystemStat', () => {
+  const tick = ++statTick
+
+  return HttpResponse.json({
+    messages: [
+      {
+        metadata: {},
+        cpu_total: {
+          user: tick * 7,
+          nice: tick * 0.5,
+          system: tick * 2.5,
+          idle: tick * 29,
+          iowait: tick * 0.4,
+          irq: tick * 0.05,
+          soft_irq: tick * 0.05,
+          steal: 0,
+        },
+        cpu: Array.from({ length: 8 }, () => ({})),
+        process_created: String(tick * 14),
+        process_running: '4',
+        process_blocked: '1',
+      },
+    ],
+  } satisfies SystemStatResponse)
+})
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        perfStreamHandler(TalosCPUType, cpuSpecAt),
+        perfStreamHandler(TalosMemoryType, memSpecAt),
+        processesHandler,
+        systemStatHandler,
+      ],
+    },
+  },
+}

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.vue
@@ -95,9 +95,8 @@ const getProcs = async () => {
         state: proc.state!,
         virtualMemory: parseInt(proc.virtual_memory || '0'),
         residentMemory: parseInt(proc.resident_memory || '0'),
-        command: proc.command!,
+        command: proc.args!,
         cpuTime: proc.cpu_time || 0,
-        args: proc.args!,
       }
     }),
   )
@@ -294,7 +293,7 @@ const sortBy = (id: keyof Proc) => {
           v-for="process in sortedProcesses"
           :key="process.pid"
           class="grid grid-cols-12 py-2 text-xs text-naturals-n12"
-          :title="process.command + ' ' + process.args"
+          :title="process.command"
         >
           <div>
             {{ process.pid }}
@@ -320,7 +319,7 @@ const sortBy = (id: keyof Proc) => {
           <div>
             {{ process.cpuTime }}
           </div>
-          <div class="col-span-4 truncate">{{ process.command }} {{ process.args }}</div>
+          <div class="col-span-4 truncate">{{ process.command }}</div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/monitor.vue
@@ -21,8 +21,8 @@ import {
 } from '@/api/resources'
 import { MachineService, type ProcessInfo } from '@/api/talos/machine/machine.pb'
 import type { CPUSpec, MemorySpec } from '@/api/talos/perf.pb'
+import type { WatchContext } from '@/api/watch'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
-import { getContext } from '@/context'
 import NodesMonitorChart from '@/views/Nodes/components/NodesMonitorChart.vue'
 
 definePage({ name: 'NodeMonitor' })
@@ -30,7 +30,11 @@ definePage({ name: 'NodeMonitor' })
 const route = useRoute()
 
 const processes = ref<Proc[]>([])
-const context = computed(() => getContext(route))
+const context = computed<WatchContext>(() => ({
+  cluster: route.params.cluster,
+  node: route.params.machine,
+}))
+
 const headers = [
   { id: 'pid' },
   { id: 'state' },
@@ -95,7 +99,7 @@ const getProcs = async () => {
         state: proc.state!,
         virtualMemory: parseInt(proc.virtual_memory || '0'),
         residentMemory: parseInt(proc.resident_memory || '0'),
-        command: proc.args!,
+        command: processArgs(proc),
         cpuTime: proc.cpu_time || 0,
       }
     }),
@@ -104,6 +108,26 @@ const getProcs = async () => {
   prevCPU = cpuTotal
 
   return procs
+}
+
+// Based on talosctl processes cmd -> https://github.com/siderolabs/talos/blob/e9e027c6317aef55b8eb3463993ae6e856dcfc1c/cmd/talosctl/cmd/talos/processes.go#L105-L125
+function processArgs(p: ProcessInfo) {
+  const argsCmd = p.args?.trim().split(/\s+/).at(0)
+  const execCmd = p.executable?.trim().split(/\s+/).at(0)
+
+  let command
+
+  if (!p.executable) {
+    command = p.command
+  } else if (argsCmd && argsCmd === execCmd?.split('/').pop()) {
+    // Always use full command path if available
+    command = p.args!.replace(argsCmd, execCmd)
+  } else {
+    command = p.args
+  }
+
+  // Replace control characters with spaces
+  return command?.replace(/\p{Cc}/gu, ' ') ?? ''
 }
 
 async function loadProcs() {
@@ -143,10 +167,17 @@ const handleCPU = (oldObj: CPUSpec, newObj: CPUSpec) => {
   }
 }
 
-const handleTotalCPU = (oldObj: CPUSpec, newObj: CPUSpec) => {
-  const point = handleCPU(oldObj, newObj)
+function formatPct(input: string | number) {
+  // Double Number() to format to 1 DP, with a re-parse to drop .0
+  const pct = Number(Number(input).toFixed(1))
 
-  return `${(point.user + point.system).toFixed(1)} %`
+  return `${pct} %`
+}
+
+const handleTotalCPU = (oldObj: CPUSpec, newObj: CPUSpec) => {
+  const { user, system } = handleCPU(oldObj, newObj)
+
+  return formatPct(user + system)
 }
 
 const handleMem = (_: MemorySpec, m: MemorySpec) => {
@@ -207,6 +238,7 @@ const sortBy = (id: keyof Proc) => {
             class="h-full"
             name="cpu"
             title="CPU usage"
+            :colors="['var(--color-yellow-y1)', 'var(--color-primary-p3)']"
             :watch-opts="{
               runtime: Runtime.Talos,
               resource: {
@@ -220,6 +252,8 @@ const sortBy = (id: keyof Proc) => {
             :total-fn="handleTotalCPU"
             :min-fn="() => 0"
             :max-fn="() => 100"
+            :formatter="(input) => formatPct(input)"
+            stacked
           />
         </div>
         <div class="monitor-chart">

--- a/frontend/src/views/Nodes/components/NodesMonitorChart.vue
+++ b/frontend/src/views/Nodes/components/NodesMonitorChart.vue
@@ -168,6 +168,7 @@ const options = computed(() => {
     stroke: stroke,
     tooltip: {
       theme: 'dark',
+      inverseOrder: stacked,
       x: {
         format: 'HH:mm:ss',
       },


### PR DESCRIPTION
- Stack the CPU usage chart areas and add a `%` symbol
- Remove duplicate command output from processes list command clumn
- Also add [stories](https://frontend-monitor-fixes--68d664245076e2bb623d98f3.chromatic.com/?path=/story/pages-authenticated-clusters-cluster-machine-machine-monitor--default)

Closes #3059
Closes #3060