### PR TITLE
chore: expose user roles in the public package to be used by scripts

### DIFF
--- a/client/pkg/access/role/role.go
+++ b/client/pkg/access/role/role.go
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Sidero Labs, Inc.
-//
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Package role contains the role definitions and checks.
 package role

--- a/client/pkg/omni/resources/omni/annotations.go
+++ b/client/pkg/omni/resources/omni/annotations.go
@@ -17,6 +17,10 @@ const (
 	// tsgen:ResourceManagedByClusterTemplates
 	ResourceManagedByClusterTemplates = SystemLabelPrefix + "managed-by-cluster-templates"
 
+	// ResourceManagedByGitopsTools is an annotation which indicates that a resource is managed by GitOps.
+	// tsgen:ResourceManagedByGitopsTools
+	ResourceManagedByGitopsTools = SystemLabelPrefix + "managed-by-gitops-tools"
+
 	// ConfigPatchName human readable patch name.
 	// tsgen:ConfigPatchName
 	ConfigPatchName = "name"

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -5,11 +5,6 @@
 
 // THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 
-export const RoleNone = "None";
-export const RoleInfraProvider = "InfraProvider";
-export const RoleReader = "Reader";
-export const RoleOperator = "Operator";
-export const RoleAdmin = "Admin";
 export const RedirectQueryParam = "redirect";
 export const AuthFlowQueryParam = "flow";
 export const CLIAuthFlow = "cli";
@@ -74,6 +69,11 @@ export const TalosNetworkNamespace = "network";
 export const TalosKubeSpanNamespace = "kubespan";
 export const ServiceAccountDomain = "serviceaccount.omni.sidero.dev";
 export const InfraProviderServiceAccountDomain = "infra-provider.serviceaccount.omni.sidero.dev";
+export const RoleNone = "None";
+export const RoleInfraProvider = "InfraProvider";
+export const RoleReader = "Reader";
+export const RoleOperator = "Operator";
+export const RoleAdmin = "Admin";
 export const DefaultNamespace = "default";
 export const EphemeralNamespace = "ephemeral";
 export const MetricsNamespace = "metrics";
@@ -84,6 +84,7 @@ export const InfraProviderEphemeralNamespace = "infra-provider-ephemeral";
 export const MachineLocked = "omni.sidero.dev/locked";
 export const UpdateLocked = "omni.sidero.dev/locked-update";
 export const ResourceManagedByClusterTemplates = "omni.sidero.dev/managed-by-cluster-templates";
+export const ResourceManagedByGitopsTools = "omni.sidero.dev/managed-by-gitops-tools";
 export const ConfigPatchName = "name";
 export const ConfigPatchDescription = "description";
 export const KubernetesManifestName = "name";

--- a/frontend/src/components/ManagedByTemplatesWarning.vue
+++ b/frontend/src/components/ManagedByTemplatesWarning.vue
@@ -11,7 +11,12 @@ import { useRoute } from 'vue-router'
 import { Runtime } from '@/api/common/omni.pb'
 import type { Resource } from '@/api/grpc'
 import type { ClusterSpec } from '@/api/omni/specs/omni.pb'
-import { ClusterType, DefaultNamespace, ResourceManagedByClusterTemplates } from '@/api/resources'
+import {
+  ClusterType,
+  DefaultNamespace,
+  ResourceManagedByClusterTemplates,
+  ResourceManagedByGitopsTools,
+} from '@/api/resources'
 import TAlert from '@/components/TAlert.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
@@ -20,13 +25,15 @@ export type WarningStyle = 'alert' | 'popup' | 'short'
 type Props = {
   resource?: Resource
   warningStyle?: WarningStyle
-  warningText?: string
+  warningTextTemplates?: string
+  warningTextOthers?: string
 }
 
 const {
   resource,
-  warningText = 'It is recommended to manage it using its template and not through this UI.',
   warningStyle = 'alert',
+  warningTextTemplates,
+  warningTextOthers,
 } = defineProps<Props>()
 
 const route = useRoute()
@@ -51,28 +58,60 @@ const resourceIsManagedByTemplates = computed(() => {
   )
 })
 
+const resourceIsManagedByGitops = computed(() => {
+  return activeResource.value?.metadata?.annotations?.[ResourceManagedByGitopsTools] !== undefined
+})
+
+const warningText = computed(() => {
+  if (resourceIsManagedByTemplates.value) {
+    if (warningTextTemplates) {
+      return warningTextTemplates
+    }
+
+    return 'It is recommended to manage it using its template and not through this UI.'
+  } else if (resourceIsManagedByGitops.value) {
+    if (warningTextOthers) {
+      return warningTextOthers
+    }
+
+    return 'It is recommended to manage it using the original scripts and not through this UI.'
+  }
+  return ''
+})
+
+const managedByString = computed(() => {
+  if (resourceIsManagedByTemplates.value) {
+    return 'cluster templates'
+  } else if (resourceIsManagedByGitops.value) {
+    const tool = activeResource.value?.metadata?.annotations?.[ResourceManagedByGitopsTools]
+
+    return tool ?? 'an external GitOps tool'
+  }
+  return ''
+})
+
 const resourceWord = computed(() => {
   return activeResource.value?.metadata?.type === ClusterType ? 'cluster' : 'resource'
 })
 </script>
 
 <template>
-  <template v-if="resourceIsManagedByTemplates">
+  <template v-if="resourceIsManagedByTemplates || resourceIsManagedByGitops">
     <div v-if="warningStyle === 'alert'" class="pb-5">
-      <TAlert type="warn" :title="`This ${resourceWord} is managed using cluster templates.`">
+      <TAlert type="warn" :title="`This ${resourceWord} is managed using ${managedByString}.`">
         {{ warningText }}
       </TAlert>
     </div>
     <div v-else-if="warningStyle === 'popup'" class="pb-5 text-xs">
       <p class="py-2 text-primary-p3">
-        This {{ resourceWord }} is managed using cluster templates.
+        This {{ resourceWord }} is managed using {{ managedByString }}.
       </p>
       <p class="py-2 font-bold text-primary-p3">
         {{ warningText }}
       </p>
     </div>
     <div v-else class="text-xs">
-      <p class="py-2 text-primary-p3">Managed using cluster templates</p>
+      <p class="py-2 text-primary-p3">Managed using {{ managedByString }}</p>
     </div>
   </template>
 </template>

--- a/frontend/src/views/Modals/ExportClusterTemplate.vue
+++ b/frontend/src/views/Modals/ExportClusterTemplate.vue
@@ -55,7 +55,8 @@ const { data: cluster } = useResourceWatch<ClusterSpec>(() => ({
     <div class="mb-5 flex flex-col gap-2 text-sm">
       <ManagedByTemplatesWarning
         :resource="cluster"
-        warning-text="This cluster is already managed using cluster templates. Make sure any external changes to templates have already been applied before exporting this template again, or your changes will be lost."
+        warning-text-templates="This cluster is already managed using cluster templates. Make sure any external changes to templates have already been applied before exporting this template again, or your changes will be lost."
+        warning-text-others="Make sure that any external changes to this cluster have already been applied before exporting the template, or your changes will be lost."
       />
 
       <p>

--- a/internal/backend/grpc/auth.go
+++ b/internal/backend/grpc/auth.go
@@ -28,13 +28,13 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/grpc/cookies"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 

--- a/internal/backend/grpc/configs_test.go
+++ b/internal/backend/grpc/configs_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/management"
 	pkgaccess "github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/client"
 	managementclient "github.com/siderolabs/omni/client/pkg/client/management"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -45,7 +46,6 @@ import (
 	omniruntime "github.com/siderolabs/omni/internal/backend/runtime/omni"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )

--- a/internal/backend/grpc/dependency_graph.go
+++ b/internal/backend/grpc/dependency_graph.go
@@ -25,9 +25,9 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/proto"
 
 	"github.com/siderolabs/omni/client/api/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 func (s *ResourceServer) Controllers(ctx context.Context, _ *resources.ControllersRequest) (*resources.ControllersResponse, error) {

--- a/internal/backend/grpc/kubernetes_manifests.go
+++ b/internal/backend/grpc/kubernetes_manifests.go
@@ -31,12 +31,12 @@ import (
 
 	"github.com/siderolabs/omni/client/api/common"
 	"github.com/siderolabs/omni/client/api/omni/management"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/panichandler"
 	"github.com/siderolabs/omni/internal/backend/grpc/router"
 	"github.com/siderolabs/omni/internal/backend/runtime/kubernetes"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 func (s *managementServer) KubernetesSyncManifests(

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -41,6 +41,7 @@ import (
 	commonOmni "github.com/siderolabs/omni/client/api/common"
 	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/jointoken"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
@@ -61,7 +62,6 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	siderolinkinternal "github.com/siderolabs/omni/internal/pkg/siderolink"
 )

--- a/internal/backend/grpc/management_lifecycle_test.go
+++ b/internal/backend/grpc/management_lifecycle_test.go
@@ -18,13 +18,13 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	grpcomni "github.com/siderolabs/omni/internal/backend/grpc"
 	omniruntime "github.com/siderolabs/omni/internal/backend/runtime/omni"
 	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 func TestMaintenanceLifecycleGuards(t *testing.T) {

--- a/internal/backend/grpc/management_power_test.go
+++ b/internal/backend/grpc/management_power_test.go
@@ -17,6 +17,7 @@ import (
 	commonOmni "github.com/siderolabs/omni/client/api/common"
 	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	omnires "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
@@ -26,7 +27,6 @@ import (
 	talosruntime "github.com/siderolabs/omni/internal/backend/runtime/talos"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/backend/grpc/management_validation_test.go
+++ b/internal/backend/grpc/management_validation_test.go
@@ -16,10 +16,10 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	grpcomni "github.com/siderolabs/omni/internal/backend/grpc"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validations"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/backend/grpc/router/talos_backend.go
+++ b/internal/backend/grpc/router/talos_backend.go
@@ -22,10 +22,10 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/internal/backend/dns"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 	"github.com/siderolabs/omni/internal/pkg/grpcutil"
 )

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -23,12 +23,12 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/meta"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/client/pkg/siderolink"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // CreateSchematic implements managementServer.

--- a/internal/backend/grpc/serviceaccount.go
+++ b/internal/backend/grpc/serviceaccount.go
@@ -27,13 +27,13 @@ import (
 	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	pkgaccess "github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/grpc/router"
 	"github.com/siderolabs/omni/internal/backend/oidc/external"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/auth/serviceaccount"
 )
 

--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -27,13 +27,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/client/pkg/panichandler"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	slink "github.com/siderolabs/omni/internal/pkg/siderolink"
 )
 

--- a/internal/backend/grpc/user.go
+++ b/internal/backend/grpc/user.go
@@ -18,9 +18,9 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/auth/user"
 )
 

--- a/internal/backend/oidc/internal/storage/token/storage.go
+++ b/internal/backend/oidc/internal/storage/token/storage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -29,7 +30,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/oidc/internal/models"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // Lifetime of the token.

--- a/internal/backend/oidc/internal/storage/token/storage_test.go
+++ b/internal/backend/oidc/internal/storage/token/storage_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/oidc/external"
 	"github.com/siderolabs/omni/internal/backend/oidc/internal/storage/token"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 func TestValidateJWTProfileScopes(t *testing.T) {

--- a/internal/backend/runtime/kubernetes/kubernetes.go
+++ b/internal/backend/runtime/kubernetes/kubernetes.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/siderolabs/omni/client/api/common"
 	"github.com/siderolabs/omni/client/api/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/k8s"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/panichandler"
@@ -51,7 +52,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/helpers"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // Name kubernetes runtime string id.

--- a/internal/backend/runtime/omni/audit/audit_test.go
+++ b/internal/backend/runtime/omni/audit/audit_test.go
@@ -31,12 +31,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/hooks"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )

--- a/internal/backend/runtime/omni/audit/auditlog/data.go
+++ b/internal/backend/runtime/omni/audit/auditlog/data.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 )
 
 const (

--- a/internal/backend/runtime/omni/audit/hooks/hooks.go
+++ b/internal/backend/runtime/omni/audit/hooks/hooks.go
@@ -17,13 +17,13 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/xslices"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/common"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // Init initializes the audit hooks.

--- a/internal/backend/runtime/omni/controllers/omni/auth/identity_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/auth/identity_status_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	authctrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/auth"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock/options"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 const (

--- a/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 type ClusterServiceAccountStatusSuite struct {

--- a/internal/backend/runtime/omni/infraprovider/state.go
+++ b/internal/backend/runtime/omni/infraprovider/state.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -26,7 +27,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // infraProviderResourceSuffix is the suffix of the infra provider specific resources.

--- a/internal/backend/runtime/omni/infraprovider/state_test.go
+++ b/internal/backend/runtime/omni/infraprovider/state_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -33,7 +34,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/backend/runtime/omni/state_access.go
+++ b/internal/backend/runtime/omni/state_access.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/common"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
@@ -28,7 +29,6 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/backend/runtime/omni/validations/auth.go
+++ b/internal/backend/runtime/omni/validations/auth.go
@@ -17,11 +17,11 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/cosi/labels"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
@@ -43,7 +44,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/etcdbackup/store"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validations"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/dnslabel"
 )

--- a/internal/backend/runtime/omni/virtual/state.go
+++ b/internal/backend/runtime/omni/virtual/state.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	omniresources "github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -31,7 +32,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/virtual/pkg/factory/configs"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )

--- a/internal/backend/saml/session.go
+++ b/internal/backend/saml/session.go
@@ -31,10 +31,10 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/cosi/labels"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/auth/user"
 )
 

--- a/internal/backend/saml/session_test.go
+++ b/internal/backend/saml/session_test.go
@@ -22,9 +22,9 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/saml"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 func TestUserInfo(t *testing.T) {

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -56,6 +56,7 @@ import (
 
 	resapi "github.com/siderolabs/omni/client/api/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
@@ -87,7 +88,6 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/auth/auth0"
 	"github.com/siderolabs/omni/internal/pkg/auth/interceptor"
 	oidcauth "github.com/siderolabs/omni/internal/pkg/auth/oidc"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	serviceaccountmgmt "github.com/siderolabs/omni/internal/pkg/auth/serviceaccount"
 	"github.com/siderolabs/omni/internal/pkg/cache"
 	"github.com/siderolabs/omni/internal/pkg/compress"

--- a/internal/backend/services/workloadproxy/accessvalidator.go
+++ b/internal/backend/services/workloadproxy/accessvalidator.go
@@ -17,11 +17,11 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/backend/services/workloadproxy/accessvalidator_test.go
+++ b/internal/backend/services/workloadproxy/accessvalidator_test.go
@@ -20,9 +20,9 @@ import (
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 type mockRoleProvider struct {

--- a/internal/integration/account_limits_test.go
+++ b/internal/integration/account_limits_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pkgaccess "github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/client"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 const (

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -56,6 +56,7 @@ import (
 	resapi "github.com/siderolabs/omni/client/api/omni/resources"
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/client"
 	managementcli "github.com/siderolabs/omni/client/pkg/client/management"
 	"github.com/siderolabs/omni/client/pkg/constants"
@@ -71,7 +72,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/infraprovider"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/grpcutil"
 )
 

--- a/internal/integration/cli_test.go
+++ b/internal/integration/cli_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pkgaccess "github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/client"
 	clientconstants "github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // AssertDownloadUsingCLI verifies generated image download using omnictl.

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -37,6 +37,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/client"
 	clientconsts "github.com/siderolabs/omni/client/pkg/constants"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
@@ -47,7 +48,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	omnisa "github.com/siderolabs/omni/internal/pkg/auth/serviceaccount"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/constants"

--- a/internal/pkg/auth/accesspolicy/accesspolicy.go
+++ b/internal/pkg/auth/accesspolicy/accesspolicy.go
@@ -16,11 +16,11 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/hashicorp/go-multierror"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/cosi/labels"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // GroupPrefix is the special prefix used in the AccessPolicy rules to denote a group of users or clusters.

--- a/internal/pkg/auth/accesspolicy/cluster.go
+++ b/internal/pkg/auth/accesspolicy/cluster.go
@@ -12,11 +12,11 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/pkg/auth/actor/actor.go
+++ b/internal/pkg/auth/actor/actor.go
@@ -9,8 +9,8 @@ package actor
 import (
 	"context"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/pkg/auth/authenticator.go
+++ b/internal/pkg/auth/authenticator.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/siderolabs/go-api-signature/pkg/message"
 
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 )
 
 // Authenticator represents an authenticator.

--- a/internal/pkg/auth/check.go
+++ b/internal/pkg/auth/check.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pkgaccess "github.com/siderolabs/omni/client/pkg/access"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/pkg/auth/check_test.go
+++ b/internal/pkg/auth/check_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/internal/pkg/auth"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/pkg/auth/context.go
+++ b/internal/pkg/auth/context.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/siderolabs/go-api-signature/pkg/message"
 
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
 )
 

--- a/internal/pkg/auth/interceptor/signature_test.go
+++ b/internal/pkg/auth/interceptor/signature_test.go
@@ -34,10 +34,10 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/siderolabs/omni/client/api/omni/resources"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/interceptor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 type testServer struct {

--- a/internal/pkg/auth/serviceaccount/serviceaccount.go
+++ b/internal/pkg/auth/serviceaccount/serviceaccount.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // Create a service account.

--- a/internal/pkg/auth/user/user.go
+++ b/internal/pkg/auth/user/user.go
@@ -19,9 +19,9 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/actor"
-	"github.com/siderolabs/omni/internal/pkg/auth/role"
 )
 
 // ErrIsServiceAccount is returned when an operation is attempted on a service account identity.


### PR DESCRIPTION
Also introduce a new generic annotation for any GitOps tools that can be used with Omni.
If set, Omni will show a warning that changing things in the UI will make it out of sync with the scripts.