### PR TITLE
fix: align config outdated status in ui and cli

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status.go
@@ -176,7 +176,7 @@ func NewClusterMachineStatusController() *ClusterMachineStatusController {
 				}
 
 				if clusterMachineConfigStatus != nil && clusterMachineConfig != nil {
-					cmsVal.ConfigUpToDate = !isOutdated(clusterMachineConfig, clusterMachineConfigStatus)
+					cmsVal.ConfigUpToDate = !isOutdated(pendingMachineUpdate, clusterMachineConfigStatus)
 					cmsVal.LastConfigError = clusterMachineConfigStatus.TypedSpec().Value.LastConfigError
 				} else {
 					cmsVal.ConfigUpToDate = false
@@ -338,6 +338,6 @@ func configApplyStatus(spec *specs.ClusterMachineStatusSpec) specs.ConfigApplySt
 	}
 }
 
-func isOutdated(clusterMachineConfig *omni.ClusterMachineConfig, configStatus *omni.ClusterMachineConfigStatus) bool {
-	return configStatus.TypedSpec().Value.ClusterMachineConfigVersion != clusterMachineConfig.Metadata().Version().String() || configStatus.TypedSpec().Value.LastConfigError != ""
+func isOutdated(machinePendingUpdates *omni.MachinePendingUpdates, configStatus *omni.ClusterMachineConfigStatus) bool {
+	return machinePendingUpdates != nil || configStatus.TypedSpec().Value.LastConfigError != ""
 }

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_status_test.go
@@ -41,6 +41,7 @@ func (suite *ClusterMachineStatusSuite) TearDownTest() {
 	rtestutils.DestroyAll[*omni.MachineSetNode](suite.ctx, suite.T(), suite.state)
 	rtestutils.DestroyAll[*omni.ClusterMachineConfigStatus](suite.ctx, suite.T(), suite.state)
 	rtestutils.DestroyAll[*omni.MachineStatusSnapshot](suite.ctx, suite.T(), suite.state)
+	rtestutils.DestroyAll[*omni.MachinePendingUpdates](suite.ctx, suite.T(), suite.state)
 
 	suite.OmniSuite.TearDownTest()
 }
@@ -95,13 +96,8 @@ func (suite *ClusterMachineStatusSuite) TestApplyConfigErrorPropagation() {
 func (suite *ClusterMachineStatusSuite) TestOutdatedConfig() {
 	suite.setupStageTest(&machineapi.MachineStatusEvent{Stage: machineapi.MachineStatusEvent_RUNNING}, true)
 
-	rmock.Mock[*omni.ClusterMachineConfigStatus](
+	rmock.Mock[*omni.MachinePendingUpdates](
 		suite.ctx, suite.T(), suite.state, options.WithID(testID),
-		options.Modify(func(s *omni.ClusterMachineConfigStatus) error {
-			s.TypedSpec().Value.ClusterMachineConfigVersion = "42"
-
-			return nil
-		}),
 	)
 
 	clusterMachineStatus := omni.NewClusterMachineStatus(testID)


### PR DESCRIPTION
CLI was relying on a different strategy than the UI to determine if pending config changes are present. Changed the CLI to work the same way as UI.

Fixes #3063