### PR TITLE
fix(frontend): prevent copying double newlines in machine logs

### DIFF
--- a/frontend/src/views/Machines/MachineLogsContainer.vue
+++ b/frontend/src/views/Machines/MachineLogsContainer.vue
@@ -149,7 +149,7 @@ watchEffect((onCleanup) => {
 
           return {
             date: formatISO(data['talos-time'], 'dd/MM/yyyy HH:mm:ss'),
-            msg: data.msg,
+            msg: data.msg.replace(/\n$/, ''),
           }
         }),
       )


### PR DESCRIPTION
Trim newlines off the end of machine logs. They are not required for display, and copy functionality adds its own newlines. Service logs do not contain newlines which is why copy must continue to add them.