### PR TITLE
feat(frontend): standardise machine display in omni

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -121,11 +121,6 @@
       "count": 5
     }
   },
-  "src/views/MachineClasses/MachineMatchItem.vue": {
-    "vue/define-props-destructuring": {
-      "count": 1
-    }
-  },
   "src/views/MachineClasses/MachineTemplate.vue": {
     "vue/custom-event-name-casing": {
       "count": 6

--- a/frontend/src/components/Modals/NodeDestroyCancelModal.vue
+++ b/frontend/src/components/Modals/NodeDestroyCancelModal.vue
@@ -12,7 +12,7 @@ import type { ClusterMachineSpec } from '@/api/omni/specs/omni.pb'
 import { ClusterMachineType, DefaultNamespace } from '@/api/resources'
 import ConfirmModal from '@/components/Modals/ConfirmModal.vue'
 import { ClusterCommandError, restoreNode } from '@/methods/cluster'
-import { useNodeName } from '@/methods/node'
+import { useMachineName } from '@/methods/node'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showSuccess } from '@/notification'
 
@@ -22,7 +22,7 @@ const { machineId } = defineProps<{
 
 const open = defineModel<boolean>('open', { default: false })
 
-const nodeName = useNodeName(
+const nodeName = useMachineName(
   () => machineId,
   () => ({ skip: !open.value }),
 )

--- a/frontend/src/components/Modals/NodeRebootModal.vue
+++ b/frontend/src/components/Modals/NodeRebootModal.vue
@@ -12,7 +12,7 @@ import { withContext, withRuntime } from '@/api/options'
 import { MachineService } from '@/api/talos/machine/machine.pb'
 import ConfirmModal from '@/components/Modals/ConfirmModal.vue'
 import { useClusterPermissions } from '@/methods/auth'
-import { useNodeName } from '@/methods/node'
+import { useMachineName } from '@/methods/node'
 import { showError, showSuccess } from '@/notification'
 
 const { clusterId, machineId } = defineProps<{
@@ -22,7 +22,7 @@ const { clusterId, machineId } = defineProps<{
 
 const open = defineModel<boolean>('open', { default: false })
 
-const nodeName = useNodeName(
+const nodeName = useMachineName(
   () => machineId,
   () => ({ skip: !open.value }),
 )

--- a/frontend/src/components/Modals/NodeShutdownModal.vue
+++ b/frontend/src/components/Modals/NodeShutdownModal.vue
@@ -10,7 +10,7 @@ import { ref, watchEffect } from 'vue'
 import { ManagementService } from '@/api/omni/management/management.pb'
 import ConfirmModal from '@/components/Modals/ConfirmModal.vue'
 import { useClusterPermissions } from '@/methods/auth'
-import { useNodeName } from '@/methods/node'
+import { useMachineName } from '@/methods/node'
 import { showError, showSuccess } from '@/notification'
 
 const { clusterId, machineId } = defineProps<{
@@ -21,7 +21,7 @@ const { clusterId, machineId } = defineProps<{
 const open = defineModel<boolean>('open', { default: false })
 const isShuttingDown = ref(false)
 
-const nodeName = useNodeName(
+const nodeName = useMachineName(
   () => machineId,
   () => ({ skip: !open.value }),
 )

--- a/frontend/src/methods/node.ts
+++ b/frontend/src/methods/node.ts
@@ -5,29 +5,55 @@
 import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { ClusterMachineStatusSpec } from '@/api/omni/specs/omni.pb'
-import {
-  ClusterMachineStatusLabelNodeName,
-  ClusterMachineStatusType,
-  DefaultNamespace,
-} from '@/api/resources'
+import type { Resource } from '@/api/grpc'
+import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
+import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
+import { DefaultNamespace, MachineStatusType } from '@/api/resources'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
-export function useNodeName(
-  machineId: MaybeRefOrGetter<string>,
+type MachineResource = Resource<MachineStatusSpec> | Resource<MachineStatusLinkSpec>
+
+export function getMachineName(resource: MachineResource): string
+export function getMachineName(resource: MachineResource | undefined): string | undefined
+export function getMachineName(resource: MachineResource | undefined): string | undefined {
+  const name = resource && (machineStatus(resource)?.network?.hostname || resource.metadata.id)
+
+  return name ?? ''
+}
+
+export function useMachineName(
+  machine: MaybeRefOrGetter<string | MachineResource | undefined>,
   options?: MaybeRefOrGetter<{ skip?: boolean }>,
 ) {
-  const { data } = useResourceWatch<ClusterMachineStatusSpec>(() => ({
-    skip: toValue(options)?.skip,
+  const machineId = computed(() => {
+    const value = toValue(machine)
+
+    return typeof value === 'string' ? value : undefined
+  })
+
+  const { data } = useResourceWatch<MachineStatusSpec>(() => ({
+    skip: toValue(options)?.skip || machineId.value === undefined,
     resource: {
-      type: ClusterMachineStatusType,
       namespace: DefaultNamespace,
-      id: toValue(machineId),
+      type: MachineStatusType,
+      id: machineId.value ?? '',
     },
     runtime: Runtime.Omni,
   }))
 
-  return computed(
-    () => data.value?.metadata.labels?.[ClusterMachineStatusLabelNodeName] ?? toValue(machineId),
-  )
+  return computed(() => {
+    const value = toValue(machine)
+
+    if (typeof value === 'string') {
+      return getMachineName(data.value) || value
+    }
+
+    return getMachineName(value) ?? ''
+  })
+}
+
+function machineStatus(resource: MachineResource): MachineStatusSpec | undefined {
+  const spec = resource.spec
+
+  return 'message_status' in spec ? spec.message_status : (spec as MachineStatusSpec)
 }

--- a/frontend/src/pages/(authenticated)/machines/[machine].vue
+++ b/frontend/src/pages/(authenticated)/machines/[machine].vue
@@ -8,15 +8,12 @@ included in the LICENSE file.
 import { computed } from 'vue'
 import { RouterLink, type RouterView, useRoute } from 'vue-router'
 
-import { Runtime } from '@/api/common/omni.pb'
-import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
-import { DefaultNamespace, MachineStatusType } from '@/api/resources'
 import PageHeader from '@/components/PageHeader.vue'
 import TabButton from '@/components/Tabs/TabButton.vue'
 import TabContent from '@/components/Tabs/TabContent.vue'
 import Tabs from '@/components/Tabs/Tabs.vue'
 import { usePermissions } from '@/methods/auth'
-import { useResourceGet } from '@/methods/useResourceGet'
+import { useMachineName } from '@/methods/node'
 
 definePage({
   name: 'Machine',
@@ -59,21 +56,7 @@ const routes = computed(() => {
 
 const route = useRoute()
 
-const { data: machine } = useResourceGet<MachineStatusSpec>(() => ({
-  resource: {
-    namespace: DefaultNamespace,
-    type: MachineStatusType,
-    id: route.params.machine as string,
-  },
-  runtime: Runtime.Omni,
-}))
-
-const machineName = computed(
-  () =>
-    machine.value?.spec.network?.hostname ||
-    machine.value?.metadata.id ||
-    (route.params.machine as string),
-)
+const machineName = useMachineName(() => route.params.machine)
 
 /**
  * Some child routes do not match any tab, e.g. MachinePatchEdit

--- a/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
@@ -25,6 +25,7 @@ import ConfigPatchEditModal from '@/components/Modals/ConfigPatchEditModal.vue'
 import TSelectList from '@/components/SelectList/TSelectList.vue'
 import type { Label } from '@/methods/labels'
 import { addMachineLabels, removeMachineLabels } from '@/methods/machine'
+import { useMachineName } from '@/methods/node'
 import type { MachineSetNode } from '@/states/cluster-management'
 import { PatchID, state } from '@/states/cluster-management'
 import CreateExtensionsModal from '@/views/Clusters/components/CreateExtensionsModal.vue'
@@ -50,6 +51,8 @@ const {
   versionMismatch: string | null
   autoInstallNotice?: string | null
 }>()
+
+const machineName = useMachineName(() => item)
 
 const machineSetNode = ref<MachineSetNode>({
   patches: {},
@@ -242,7 +245,7 @@ const onSavePatchConfig = (config: string) => {
         <span class="grow truncate pr-2 font-bold">
           <WordHighlighter
             :query="searchQuery ?? ''"
-            :text-to-highlight="item?.spec?.network?.hostname ?? item?.metadata?.id"
+            :text-to-highlight="machineName"
             split-by-space
             highlight-class="bg-naturals-n14"
           />

--- a/frontend/src/views/Clusters/components/CreateExtensionsModal.vue
+++ b/frontend/src/views/Clusters/components/CreateExtensionsModal.vue
@@ -12,6 +12,7 @@ import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, MachineStatusType } from '@/api/resources'
 import TButton from '@/components/Button/TButton.vue'
 import Modal from '@/components/Modals/Modal.vue'
+import { getMachineName } from '@/methods/node'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import ExtensionsPicker from '@/views/Extensions/ExtensionsPicker.vue'
 
@@ -68,7 +69,7 @@ const updateExtensions = () => {
   >
     <template #description>
       Select the extensions to be installed on node
-      {{ machineStatus?.spec.network?.hostname ?? machine }}.
+      {{ getMachineName(machineStatus) }}.
     </template>
 
     <div class="flex flex-col gap-2">

--- a/frontend/src/views/Home/HomeRecentMachines.vue
+++ b/frontend/src/views/Home/HomeRecentMachines.vue
@@ -13,6 +13,7 @@ import Card from '@/components/Card/Card.vue'
 import CopyButton from '@/components/CopyButton/CopyButton.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
 import MachineStage from '@/components/Status/MachineStage.vue'
+import { getMachineName } from '@/methods/node'
 
 defineProps<{
   machines: Resource<MachineStatusLinkSpec>[]
@@ -51,10 +52,10 @@ defineProps<{
           :to="{ name: 'Machine', params: { machine: item.metadata.id! } }"
           class="list-item-link truncate"
         >
-          {{ item.metadata.id }}
+          {{ getMachineName(item) }}
         </RouterLink>
 
-        <CopyButton :text="item.metadata.id" />
+        <CopyButton :text="getMachineName(item)" />
       </div>
 
       <div class="flex min-w-0 justify-center">

--- a/frontend/src/views/MachineClasses/MachineMatchItem.vue
+++ b/frontend/src/views/MachineClasses/MachineMatchItem.vue
@@ -5,16 +5,16 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, toRefs } from 'vue'
 import WordHighlighter from 'vue-word-highlighter'
 
 import type { Resource } from '@/api/grpc'
 import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import TListItem from '@/components/List/TListItem.vue'
 import type { Label } from '@/methods/labels'
+import { useMachineName } from '@/methods/node'
 import ItemLabels from '@/views/ItemLabels/ItemLabels.vue'
 
-const props = defineProps<{
+const { machine } = defineProps<{
   machine: Resource<MachineStatusSpec>
   searchQuery?: string
 }>()
@@ -23,11 +23,7 @@ defineEmits<{
   filterLabels: [Label]
 }>()
 
-const { machine } = toRefs(props)
-
-const machineName = computed(() => {
-  return machine.value.spec.network?.hostname ?? machine.value.metadata.id
-})
+const machineName = useMachineName(() => machine)
 </script>
 
 <template>

--- a/frontend/src/views/Machines/MachineDetailsPanel.vue
+++ b/frontend/src/views/Machines/MachineDetailsPanel.vue
@@ -21,6 +21,7 @@ import {
   TalosSystemInformationType,
 } from '@/api/resources'
 import type { SystemInformationSpec } from '@/api/talos/hardware.pb'
+import { useMachineName } from '@/methods/node'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import MachineItemInfoCard from '@/views/Machines/MachineItemInfoCard.vue'
 import CloseButton from '@/views/Modals/CloseButton.vue'
@@ -47,9 +48,7 @@ const { data: sysInfo } = useResourceWatch<SystemInformationSpec>(() => ({
   },
 }))
 
-const machineName = computed(
-  () => machine?.spec.message_status?.network?.hostname ?? machine?.metadata.id,
-)
+const machineName = useMachineName(() => machine)
 
 const processors = computed(() =>
   machine?.spec.message_status?.hardware?.processors?.map(

--- a/frontend/src/views/Machines/MachineItem.vue
+++ b/frontend/src/views/Machines/MachineItem.vue
@@ -25,6 +25,7 @@ import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { useClusterPermissions, usePermissions } from '@/methods/auth'
 import type { Label } from '@/methods/labels'
 import { addMachineLabels, removeMachineLabels } from '@/methods/machine'
+import { getMachineName } from '@/methods/node'
 import { useDerivedMachineStage } from '@/methods/useDerivedMachineStage'
 import ItemLabels from '@/views/ItemLabels/ItemLabels.vue'
 
@@ -60,9 +61,7 @@ const { canManageKernelArgs, canReadConfigPatches } = useClusterPermissions(
 )
 
 const machineName = computed(() => {
-  return showUUID
-    ? machine.metadata.id
-    : (machine.spec.message_status?.network?.hostname ?? machine.metadata.id)
+  return showUUID ? machine.metadata.id : getMachineName(machine)
 })
 
 const clusterName = computed(() => machine.spec.message_status?.cluster)

--- a/frontend/src/views/Nodes/NodesBreadcrumbs.vue
+++ b/frontend/src/views/Nodes/NodesBreadcrumbs.vue
@@ -8,11 +8,11 @@ included in the LICENSE file.
 import { computed, ref, watchEffect } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
 import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, LabelCluster, MachineStatusType } from '@/api/resources'
 import CopyButton from '@/components/CopyButton/CopyButton.vue'
 import TSelectList from '@/components/SelectList/TSelectList.vue'
+import { getMachineName } from '@/methods/node'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 
 const { clusterId, machineId } = defineProps<{
@@ -31,7 +31,7 @@ const { data: machineStatuses } = useResourceWatch<MachineStatusSpec>(() => ({
 
 const machines = computed(() =>
   machineStatuses.value.map((machine) => ({
-    label: getDisplayNameForMachine(machine),
+    label: getMachineName(machine),
     value: machine.metadata.id!,
   })),
 )
@@ -41,10 +41,6 @@ const selectedMachine = ref<string>()
 watchEffect(() => {
   selectedMachine.value = machineId
 })
-
-function getDisplayNameForMachine(machine: Resource<MachineStatusSpec>) {
-  return machine.spec.network?.hostname || machine.metadata.id!
-}
 </script>
 
 <template>


### PR DESCRIPTION
Standardise the way we show machine names in Omni, using network.hostname with machine UUID as the fallback.

Closes #3006 