### PR TITLE
feat: send initial instance user to signup page

### DIFF
--- a/client/api/omni/specs/auth.pb.go
+++ b/client/api/omni/specs/auth.pb.go
@@ -75,14 +75,15 @@ func (PublicKeySpec_Type) EnumDescriptor() ([]byte, []int) {
 
 // AuthConfigSpec describes the authentication configuration.
 type AuthConfigSpec struct {
-	state         protoimpl.MessageState   `protogen:"open.v1"`
-	Auth0         *AuthConfigSpec_Auth0    `protobuf:"bytes,1,opt,name=auth0,proto3" json:"auth0,omitempty"`
-	Webauthn      *AuthConfigSpec_Webauthn `protobuf:"bytes,2,opt,name=webauthn,proto3" json:"webauthn,omitempty"`
-	Suspended     bool                     `protobuf:"varint,3,opt,name=suspended,proto3" json:"suspended,omitempty"`
-	Saml          *AuthConfigSpec_SAML     `protobuf:"bytes,4,opt,name=saml,proto3" json:"saml,omitempty"`
-	Oidc          *AuthConfigSpec_OIDC     `protobuf:"bytes,5,opt,name=oidc,proto3" json:"oidc,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState   `protogen:"open.v1"`
+	Auth0          *AuthConfigSpec_Auth0    `protobuf:"bytes,1,opt,name=auth0,proto3" json:"auth0,omitempty"`
+	Webauthn       *AuthConfigSpec_Webauthn `protobuf:"bytes,2,opt,name=webauthn,proto3" json:"webauthn,omitempty"`
+	Suspended      bool                     `protobuf:"varint,3,opt,name=suspended,proto3" json:"suspended,omitempty"`
+	Saml           *AuthConfigSpec_SAML     `protobuf:"bytes,4,opt,name=saml,proto3" json:"saml,omitempty"`
+	Oidc           *AuthConfigSpec_OIDC     `protobuf:"bytes,5,opt,name=oidc,proto3" json:"oidc,omitempty"`
+	HasInitialUser bool                     `protobuf:"varint,6,opt,name=has_initial_user,json=hasInitialUser,proto3" json:"has_initial_user,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *AuthConfigSpec) Reset() {
@@ -148,6 +149,13 @@ func (x *AuthConfigSpec) GetOidc() *AuthConfigSpec_OIDC {
 		return x.Oidc
 	}
 	return nil
+}
+
+func (x *AuthConfigSpec) GetHasInitialUser() bool {
+	if x != nil {
+		return x.HasInitialUser
+	}
+	return false
 }
 
 // SAMLAssertionSpec describes SAML assertion.
@@ -1894,13 +1902,14 @@ var File_omni_specs_auth_proto protoreflect.FileDescriptor
 
 const file_omni_specs_auth_proto_rawDesc = "" +
 	"\n" +
-	"\x15omni/specs/auth.proto\x12\x05specs\x1a\x1btalos/machine/machine.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf8\a\n" +
+	"\x15omni/specs/auth.proto\x12\x05specs\x1a\x1btalos/machine/machine.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa2\b\n" +
 	"\x0eAuthConfigSpec\x121\n" +
 	"\x05auth0\x18\x01 \x01(\v2\x1b.specs.AuthConfigSpec.Auth0R\x05auth0\x12:\n" +
 	"\bwebauthn\x18\x02 \x01(\v2\x1e.specs.AuthConfigSpec.WebauthnR\bwebauthn\x12\x1c\n" +
 	"\tsuspended\x18\x03 \x01(\bR\tsuspended\x12.\n" +
 	"\x04saml\x18\x04 \x01(\v2\x1a.specs.AuthConfigSpec.SAMLR\x04saml\x12.\n" +
-	"\x04oidc\x18\x05 \x01(\v2\x1a.specs.AuthConfigSpec.OIDCR\x04oidc\x1ax\n" +
+	"\x04oidc\x18\x05 \x01(\v2\x1a.specs.AuthConfigSpec.OIDCR\x04oidc\x12(\n" +
+	"\x10has_initial_user\x18\x06 \x01(\bR\x0ehasInitialUser\x1ax\n" +
 	"\x05Auth0\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x16\n" +
 	"\x06domain\x18\x02 \x01(\tR\x06domain\x12\x1b\n" +

--- a/client/api/omni/specs/auth.proto
+++ b/client/api/omni/specs/auth.proto
@@ -46,6 +46,7 @@ message AuthConfigSpec {
   bool suspended = 3;
   SAML saml = 4;
   OIDC oidc = 5;
+  bool has_initial_user = 6;
 }
 
 // SAMLAssertionSpec describes SAML assertion.

--- a/client/api/omni/specs/auth_vtproto.pb.go
+++ b/client/api/omni/specs/auth_vtproto.pb.go
@@ -129,6 +129,7 @@ func (m *AuthConfigSpec) CloneVT() *AuthConfigSpec {
 	r.Suspended = m.Suspended
 	r.Saml = m.Saml.CloneVT()
 	r.Oidc = m.Oidc.CloneVT()
+	r.HasInitialUser = m.HasInitialUser
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -863,6 +864,9 @@ func (this *AuthConfigSpec) EqualVT(that *AuthConfigSpec) bool {
 		return false
 	}
 	if !this.Oidc.EqualVT(that.Oidc) {
+		return false
+	}
+	if this.HasInitialUser != that.HasInitialUser {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1959,6 +1963,16 @@ func (m *AuthConfigSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.HasInitialUser {
+		i--
+		if m.HasInitialUser {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
 	}
 	if m.Oidc != nil {
 		size, err := m.Oidc.MarshalToSizedBufferVT(dAtA[:i])
@@ -3569,6 +3583,9 @@ func (m *AuthConfigSpec) SizeVT() (n int) {
 	if m.Oidc != nil {
 		l = m.Oidc.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.HasInitialUser {
+		n += 2
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5181,6 +5198,26 @@ func (m *AuthConfigSpec) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HasInitialUser", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.HasInitialUser = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/frontend/e2e/auth_fixtures.ts
+++ b/frontend/e2e/auth_fixtures.ts
@@ -23,8 +23,14 @@ const test = base.extend<AuthFixtures>({
       // Sometimes auth0 page load is flaky
       await expect(async () => {
         await page.goto('/')
-        await expect(page.getByRole('textbox', { name: 'Email address' })).toBeVisible()
+        await page.getByRole('heading', { name: 'Welcome' }).waitFor()
       }, 'Navigate to auth0 login page').toPass()
+
+      // Switch to login page, if we are sent to signup page (first user login gets signup)
+      if (await page.getByText('Already have an account?').isVisible()) {
+        await page.getByRole('link', { name: 'Log in' }).click()
+        await page.getByText("Don't have an account?").isVisible()
+      }
 
       await page.getByRole('textbox', { name: 'Email address' }).fill(process.env.AUTH_USERNAME)
       await page.getByRole('textbox', { name: 'Password' }).fill(process.env.AUTH_PASSWORD)

--- a/frontend/e2e/eula/accept-eula.spec.ts
+++ b/frontend/e2e/eula/accept-eula.spec.ts
@@ -16,5 +16,5 @@ test('accept EULA', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Accept' }).click()
 
-  await expect(page.getByText(/Log in to [\w\s]+ to continue to [\w\s]+./)).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible()
 })

--- a/frontend/src/api/omni/specs/auth.pb.ts
+++ b/frontend/src/api/omni/specs/auth.pb.ts
@@ -47,6 +47,7 @@ export type AuthConfigSpec = {
   suspended?: boolean
   saml?: AuthConfigSpecSAML
   oidc?: AuthConfigSpecOIDC
+  has_initial_user?: boolean
 }
 
 export type SAMLAssertionSpec = {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -78,6 +78,13 @@ async function setupApp() {
   if (authConfig.spec.auth0?.enabled) {
     authType.value = AuthType.Auth0
 
+    const searchParams = new URLSearchParams(window.location.search)
+    const signupDisabled =
+      searchParams.get('error') === 'invalid_request' &&
+      searchParams.get('error_description') === 'signup is disabled'
+
+    const requestSignup = !authConfig.spec.has_initial_user && !signupDisabled
+
     app.use(
       createAuth0({
         domain: authConfig.spec.auth0.domain!,
@@ -85,6 +92,7 @@ async function setupApp() {
         authorizationParams: {
           redirect_uri: window.location.origin,
           max_age: millisecondsToSeconds(milliseconds({ minutes: 2 })),
+          screen_hint: requestSignup ? 'signup' : 'login',
         },
         useFormData: !!authConfig.spec.auth0.useFormData,
       }),

--- a/frontend/src/methods/useMachineServices.ts
+++ b/frontend/src/methods/useMachineServices.ts
@@ -10,6 +10,7 @@ import type { RuntimeContext } from '@/api/options'
 import { withAbortController, withContext, withRuntime } from '@/api/options'
 import { MachineService, type ServiceEvent } from '@/api/talos/machine/machine.pb'
 import { TCommonStatuses } from '@/constants'
+import { showError } from '@/notification'
 
 interface Service {
   name?: string
@@ -29,25 +30,31 @@ export function useMachineServices(context: MaybeRefOrGetter<RuntimeContext>) {
     const abortController = new AbortController()
     onCleanup(() => abortController.abort())
 
-    const { messages = [] } = await MachineService.ServiceList(
-      {},
-      withRuntime(Runtime.Talos),
-      withContext(toValue(context)),
-      withAbortController(abortController),
-    )
+    try {
+      const { messages = [] } = await MachineService.ServiceList(
+        {},
+        withRuntime(Runtime.Talos),
+        withContext(toValue(context)),
+        withAbortController(abortController),
+      )
 
-    services.value = messages.flatMap(({ services = [] }) =>
-      services.map((service) => ({
-        name: service.id,
-        state: service.state,
-        status: service.health?.unknown
-          ? TCommonStatuses.HEALTH_UNKNOWN
-          : service.health?.healthy
-            ? TCommonStatuses.HEALTHY
-            : TCommonStatuses.UNHEALTHY,
-        events: service.events?.events,
-      })),
-    )
+      services.value = messages.flatMap(({ services = [] }) =>
+        services.map((service) => ({
+          name: service.id,
+          state: service.state,
+          status: service.health?.unknown
+            ? TCommonStatuses.HEALTH_UNKNOWN
+            : service.health?.healthy
+              ? TCommonStatuses.HEALTHY
+              : TCommonStatuses.UNHEALTHY,
+          events: service.events?.events,
+        })),
+      )
+    } catch (e) {
+      if (abortController.signal.aborted) return
+
+      showError('Error', e instanceof Error ? e.message : String(e))
+    }
   })
 
   watchEffect((onCleanup) => {

--- a/internal/backend/grpc/auth.go
+++ b/internal/backend/grpc/auth.go
@@ -346,6 +346,10 @@ func (s *authServer) ConfirmPublicKey(ctx context.Context, request *authpb.Confi
 		zap.String("role", pubKey.TypedSpec().Value.GetRole()),
 	)
 
+	if err = auth.SetHasInitialUser(ctx, s.state); err != nil {
+		return nil, err
+	}
+
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		values := md.Get(workloadproxy.PublicKeyIDSignatureBase64Cookie)

--- a/internal/backend/runtime/omni/migration/manager.go
+++ b/internal/backend/runtime/omni/migration/manager.go
@@ -305,6 +305,10 @@ func NewManager(state state.State, logger *zap.Logger) *Manager {
 				callback: dropSchematicResource,
 				name:     "dropSchematicResource",
 			},
+			{
+				callback: setInitialUserFlagForExistingInstances,
+				name:     "setInitialUserFlagForExistingInstances",
+			},
 		},
 	}
 }

--- a/internal/backend/runtime/omni/migration/migration_test.go
+++ b/internal/backend/runtime/omni/migration/migration_test.go
@@ -407,6 +407,52 @@ func (suite *MigrationSuite) TestCreateIdentityLastActiveForExistingIdentities()
 	suite.Assert().Nil(saLastActive.TypedSpec().Value.LastActive, "new IdentityLastActive should have no timestamp")
 }
 
+func (suite *MigrationSuite) TestSetInitialUserFlagFromExistingKey() {
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Second)
+	defer cancel()
+
+	// Any existing public key means the instance has been used, so the flag is back-filled.
+	key := authres.NewPublicKey("some-key")
+	key.Metadata().Labels().Set(authres.LabelPublicKeyUserID, "user-1")
+	suite.Require().NoError(suite.state.Create(ctx, key))
+
+	suite.Require().NoError(suite.state.Create(ctx, authres.NewAuthConfig()))
+
+	_, err := suite.manager.Run(ctx, migration.WithFilter(filterWith("setInitialUserFlagForExistingInstances")))
+	suite.Require().NoError(err)
+
+	authConfig, err := safe.ReaderGetByID[*authres.Config](ctx, suite.state, authres.ConfigID)
+	suite.Require().NoError(err)
+	suite.Assert().True(authConfig.TypedSpec().Value.GetHasInitialUser(), "existing public key must back-fill the flag")
+}
+
+func (suite *MigrationSuite) TestSetInitialUserFlagNoKeys() {
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Second)
+	defer cancel()
+
+	// An instance with a config but no public keys keeps the flag false.
+	suite.Require().NoError(suite.state.Create(ctx, authres.NewAuthConfig()))
+
+	_, err := suite.manager.Run(ctx, migration.WithFilter(filterWith("setInitialUserFlagForExistingInstances")))
+	suite.Require().NoError(err)
+
+	authConfig, err := safe.ReaderGetByID[*authres.Config](ctx, suite.state, authres.ConfigID)
+	suite.Require().NoError(err)
+	suite.Assert().False(authConfig.TypedSpec().Value.GetHasInitialUser(), "no public keys means no initial user")
+}
+
+func (suite *MigrationSuite) TestSetInitialUserFlagNoConfig() {
+	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Second)
+	defer cancel()
+
+	// A fresh instance has no auth config yet: the migration is a no-op and must not fail.
+	_, err := suite.manager.Run(ctx, migration.WithFilter(filterWith("setInitialUserFlagForExistingInstances")))
+	suite.Require().NoError(err)
+
+	_, err = safe.ReaderGetByID[*authres.Config](ctx, suite.state, authres.ConfigID)
+	suite.Assert().True(state.IsNotFoundError(err), "migration must not create the auth config on a fresh instance")
+}
+
 func (suite *MigrationSuite) TestDropRedactedMachineConfigFinalizersFromClusterMachineConfigs() {
 	ctx, cancel := context.WithTimeout(suite.T().Context(), 10*time.Second)
 	defer cancel()

--- a/internal/backend/runtime/omni/migration/migrations.go
+++ b/internal/backend/runtime/omni/migration/migrations.go
@@ -402,6 +402,34 @@ func dropWorkloadProxyConfigPatches(ctx context.Context, st state.State, _ *zap.
 	return nil
 }
 
+func setInitialUserFlagForExistingInstances(ctx context.Context, st state.State, logger *zap.Logger, _ migrationContext) error {
+	authConfig, err := safe.ReaderGetByID[*authres.Config](ctx, st, authres.ConfigID)
+	if state.IsNotFoundError(err) {
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+
+	publicKeys, err := safe.ReaderListAll[*authres.PublicKey](ctx, st)
+	if err != nil {
+		return err
+	}
+
+	if _, err = safe.StateUpdateWithConflicts(ctx, st, authConfig.Metadata(), func(res *authres.Config) error {
+		res.TypedSpec().Value.HasInitialUser = publicKeys.Len() > 0
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	logger.Info("back-filled HasInitialUser flag from existing public keys")
+
+	return nil
+}
+
 func makeMachineRequestsOwnerEmpty(ctx context.Context, st state.State, _ *zap.Logger, _ migrationContext) error {
 	machineRequests, err := safe.ReaderListAll[*infra.MachineRequest](ctx, st)
 	if err != nil {

--- a/internal/pkg/auth/config.go
+++ b/internal/pkg/auth/config.go
@@ -124,6 +124,20 @@ func EnsureAuthConfigResource(ctx context.Context, st state.State, logger *zap.L
 	return authConfig, nil
 }
 
+// SetHasInitialUser flips the HasInitialUser flag on the auth Config resource to true.
+func SetHasInitialUser(ctx context.Context, st state.State) error {
+	_, err := safe.StateUpdateWithConflicts(ctx, st, auth.NewAuthConfig().Metadata(), func(res *auth.Config) error {
+		res.TypedSpec().Value.HasInitialUser = true
+
+		return nil
+	})
+	if err != nil && !state.IsNotFoundError(err) {
+		return err
+	}
+
+	return nil
+}
+
 func validateParams(authParams config.Auth) error {
 	samlEnabled := authParams.Saml.GetEnabled()
 	auth0Enabled := authParams.Auth0.GetEnabled()

--- a/internal/pkg/auth/config_test.go
+++ b/internal/pkg/auth/config_test.go
@@ -8,6 +8,7 @@ package auth_test
 import (
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
@@ -17,6 +18,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/logging"
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/config"
@@ -203,4 +205,37 @@ func TestEnsureAuthConfigResource(t *testing.T) {
 			assert.True(t, proto.Equal(authConfig.TypedSpec().Value, tt.expected), "expected %v, got %v", tt.expected, authConfig.TypedSpec().Value)
 		})
 	}
+}
+
+func auth0Config() config.Auth {
+	var c config.Auth
+
+	c.Auth0.SetEnabled(true)
+	c.Auth0.SetClientID("client-id")
+	c.Auth0.SetDomain("domain")
+
+	return c
+}
+
+func TestMarkUsersLoggedIn(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := zaptest.NewLogger(t).With(logging.Component("auth"))
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	authConfig, err := auth.EnsureAuthConfigResource(ctx, st, logger, auth0Config())
+	require.NoError(t, err)
+	require.False(t, authConfig.TypedSpec().Value.GetHasInitialUser())
+
+	require.NoError(t, auth.SetHasInitialUser(ctx, st))
+
+	authConfig, err = safe.StateGet[*authres.Config](ctx, st, authres.NewAuthConfig().Metadata())
+	require.NoError(t, err)
+	assert.True(t, authConfig.TypedSpec().Value.GetHasInitialUser())
+
+	authConfig, err = auth.EnsureAuthConfigResource(ctx, st, logger, auth0Config())
+	require.NoError(t, err)
+	assert.True(t, authConfig.TypedSpec().Value.GetHasInitialUser())
 }


### PR DESCRIPTION
Currently we always send users to the login page. With this change, the very first user of any instance will always be sent instead to the sign up page. We can't do it on a per-user basis as until we reach auth0 and the user attempts to login, we do not know who is attempting the login.

Closes #2061