### PR TITLE
feat(frontend): add a quickstart page for kubespan

### DIFF
--- a/frontend/e2e/qemu/clusters.spec.ts
+++ b/frontend/e2e/qemu/clusters.spec.ts
@@ -407,43 +407,7 @@ test('exposed services', async ({ page, omnictl }, testInfo) => {
   })
 })
 
-test('kubespan', async ({ page }, testInfo) => {
-  await test.step('Visit create cluster patch page', async () => {
-    await page.goto('/')
-    await page.getByRole('link', { name: 'Clusters' }).click()
-
-    await expect(page).toHaveURL('/clusters')
-    await expect(page.getByRole('heading', { name: 'Clusters', exact: true })).toBeVisible()
-
-    await page.getByRole('link', { name: clusterName, exact: true }).click()
-    await expect(page.getByRole('heading', { name: clusterName, exact: true })).toBeVisible()
-
-    await page.getByRole('main').getByRole('link', { name: 'Config Patches' }).click()
-    await page.getByRole('link', { name: 'Create Patch' }).click()
-    await expect(page.getByRole('heading', { name: 'Create Patch', exact: true })).toBeVisible()
-  })
-
-  await test.step('Add kubespan patch', async () => {
-    const kubespanPatch = await fs.readFile(
-      new URL('./kubespan_patch.yaml', import.meta.url),
-      'utf8',
-    )
-    await testInfo.attach('kubespan_patch.yaml', {
-      body: kubespanPatch,
-      contentType: 'application/yaml',
-    })
-
-    await page.evaluate((text) => navigator.clipboard.writeText(text), kubespanPatch)
-    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(kubespanPatch)
-
-    await page
-      .getByRole('textbox', { name: 'Editor content' })
-      .press(`${os.platform() === 'darwin' ? 'Meta' : 'Control'}+v`)
-    await expect(page.getByText('kind: KubeSpanConfig')).toBeVisible()
-
-    await page.getByRole('button', { name: 'Save' }).click()
-  })
-
+test('kubespan', async ({ page }) => {
   await test.step('Visit kubespan page', async () => {
     await page.goto('/')
     await page.getByRole('link', { name: 'Clusters' }).click()
@@ -453,6 +417,19 @@ test('kubespan', async ({ page }, testInfo) => {
     await page.getByRole('region', { name: 'Control Planes' }).getByRole('link').last().click()
     await expect(servicesList.getByRole('link', { name: 'etcd' })).toBeVisible()
     await page.getByRole('tab', { name: 'KubeSpan', exact: true }).click()
+  })
+
+  await test.step('Add kubespan patch', async () => {
+    await page.getByRole('button', { name: 'Enable KubeSpan' }).click()
+
+    await expect(
+      page.getByText(
+        'Wireguard encryption adds overhead to each packet that can reduce network throughput',
+      ),
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Enable KubeSpan' }).click()
+
+    await expect(page.getByText('The config patch was applied')).toBeVisible()
   })
 
   await expect

--- a/frontend/e2e/qemu/kubespan_patch.yaml
+++ b/frontend/e2e/qemu/kubespan_patch.yaml
@@ -1,7 +1,0 @@
-cluster:
-  discovery:
-    enabled: true
----
-apiVersion: v1alpha1
-kind: KubeSpanConfig
-enabled: true

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine].vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine].vue
@@ -10,15 +10,7 @@ import { RouterLink, useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { MachineStatusSpec } from '@/api/omni/specs/omni.pb'
-import {
-  DefaultNamespace,
-  LabelCluster,
-  MachineStatusType,
-  TalosConfigNamespace,
-  TalosKubespanConfigID,
-  TalosKubeSpanConfigType,
-} from '@/api/resources'
-import type { ConfigSpec } from '@/api/talos/kubespan.pb'
+import { DefaultNamespace, LabelCluster, MachineStatusType } from '@/api/resources'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
 import TabButton from '@/components/Tabs/TabButton.vue'
@@ -51,19 +43,6 @@ const { data: machine, loading: machineLoading } = useResourceWatch<MachineStatu
 const isPartOfCluster = computed(
   () => machine.value?.metadata.labels?.[LabelCluster] === clusterId.value,
 )
-
-const { data: kubeSpanConfig } = useResourceWatch<ConfigSpec>(() => ({
-  runtime: Runtime.Talos,
-  resource: {
-    namespace: TalosConfigNamespace,
-    type: TalosKubeSpanConfigType,
-    id: TalosKubespanConfigID,
-  },
-  context: {
-    cluster: clusterId.value,
-    machine: machineId.value,
-  },
-}))
 
 const routes = computed(() => {
   return [
@@ -102,7 +81,6 @@ const routes = computed(() => {
     {
       name: 'KubeSpan',
       to: { name: 'NodeKubeSpanStatus', params: { machine: machineId.value } },
-      disabled: !kubeSpanConfig.value?.spec.enabled,
     },
     {
       name: 'Disks',

--- a/frontend/src/views/KubeSpanStatus/KubeSpanStatus.stories.ts
+++ b/frontend/src/views/KubeSpanStatus/KubeSpanStatus.stories.ts
@@ -16,10 +16,13 @@ import {
   DefaultNamespace,
   LabelControlPlaneRole,
   LabelWorkerRole,
+  TalosConfigNamespace,
+  TalosKubespanConfigID,
+  TalosKubeSpanConfigType,
   TalosKubeSpanNamespace,
   TalosKubeSpanPeerStatusType,
 } from '@/api/resources.ts'
-import type { PeerStatusSpec } from '@/api/talos/kubespan.pb.ts'
+import type { ConfigSpec, PeerStatusSpec } from '@/api/talos/kubespan.pb.ts'
 
 import KubeSpanStatus from './KubeSpanStatus.vue'
 
@@ -68,6 +71,26 @@ export const Default = {
   parameters: {
     msw: {
       handlers: [
+        createWatchStreamHandler<ConfigSpec>({
+          expectedOptions: {
+            namespace: TalosConfigNamespace,
+            type: TalosKubeSpanConfigType,
+            id: TalosKubespanConfigID,
+          },
+          initialResources: [
+            {
+              spec: {
+                enabled: true,
+              },
+              metadata: {
+                namespace: TalosConfigNamespace,
+                type: TalosKubeSpanConfigType,
+                id: TalosKubespanConfigID,
+              },
+            },
+          ],
+        }).handler,
+
         createWatchStreamHandler<ClusterMachineIdentitySpec>({
           expectedOptions: {
             namespace: DefaultNamespace,

--- a/frontend/src/views/KubeSpanStatus/KubeSpanStatus.vue
+++ b/frontend/src/views/KubeSpanStatus/KubeSpanStatus.vue
@@ -16,10 +16,13 @@ import {
   ClusterMachineIdentityType,
   DefaultNamespace,
   LabelCluster,
+  TalosConfigNamespace,
+  TalosKubespanConfigID,
+  TalosKubeSpanConfigType,
   TalosKubeSpanNamespace,
   TalosKubeSpanPeerStatusType,
 } from '@/api/resources'
-import type { PeerStatusSpec } from '@/api/talos/kubespan.pb'
+import type { ConfigSpec, PeerStatusSpec } from '@/api/talos/kubespan.pb'
 import IconButton from '@/components/Button/IconButton.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
@@ -27,6 +30,7 @@ import StatsItem from '@/components/Stats/StatsItem.vue'
 import TInput from '@/components/TInput/TInput.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import KubeSpanCanvas from '@/views/KubeSpanStatus/components/KubeSpanCanvas.vue'
+import KubeSpanStatusQuickStart from '@/views/KubeSpanStatus/KubeSpanStatusQuickStart.vue'
 
 const { clusterId, machineId } = defineProps<{
   clusterId: string
@@ -36,6 +40,19 @@ const { clusterId, machineId } = defineProps<{
 const searchQuery = ref('')
 const canvasRef = useTemplateRef('canvasRef')
 const router = useRouter()
+
+const { data: kubeSpanConfig } = useResourceWatch<ConfigSpec>(() => ({
+  runtime: Runtime.Talos,
+  resource: {
+    namespace: TalosConfigNamespace,
+    type: TalosKubeSpanConfigType,
+    id: TalosKubespanConfigID,
+  },
+  context: {
+    cluster: clusterId,
+    machine: machineId,
+  },
+}))
 
 const { data: machines } = useResourceWatch<ClusterMachineIdentitySpec>(() => ({
   resource: {
@@ -97,7 +114,7 @@ function onPeerClick(peer: Resource<PeerStatusSpec>) {
 </script>
 
 <template>
-  <PageContainer class="@container flex h-full flex-col gap-4">
+  <PageContainer v-if="kubeSpanConfig?.spec.enabled" class="@container flex h-full flex-col gap-4">
     <div class="flex flex-wrap gap-6">
       <h1 class="shrink-0 text-xl font-medium text-naturals-n14">KubeSpan status</h1>
       <div class="flex flex-wrap gap-6">
@@ -224,4 +241,6 @@ function onPeerClick(peer: Resource<PeerStatusSpec>) {
       </div>
     </div>
   </PageContainer>
+
+  <KubeSpanStatusQuickStart v-else-if="kubeSpanConfig" :cluster-id="clusterId" />
 </template>

--- a/frontend/src/views/KubeSpanStatus/KubeSpanStatusQuickStart.stories.ts
+++ b/frontend/src/views/KubeSpanStatus/KubeSpanStatusQuickStart.stories.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { createWatchStreamHandler } from '@msw/helpers.ts'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+
+import type { ClusterSpec, ClusterStatusSpec } from '@/api/omni/specs/omni.pb.ts'
+import type { ClusterPermissionsSpec } from '@/api/omni/specs/virtual.pb.ts'
+import {
+  ClusterStatusType,
+  ClusterType,
+  DefaultNamespace,
+  VirtualNamespace,
+} from '@/api/resources.ts'
+
+import KubeSpanStatusQuickStart from './KubeSpanStatusQuickStart.vue'
+
+const clusterId = 'my-cluster'
+
+const clusterHandler = createWatchStreamHandler<ClusterSpec>({
+  expectedOptions: {
+    namespace: DefaultNamespace,
+    type: ClusterType,
+  },
+  initialResources: [
+    {
+      spec: { talos_version: 'v1.10.0' },
+      metadata: { namespace: DefaultNamespace, type: ClusterType, id: clusterId },
+    },
+  ],
+}).handler
+
+function clusterStatusHandler(total: number) {
+  return createWatchStreamHandler<ClusterStatusSpec>({
+    expectedOptions: {
+      namespace: DefaultNamespace,
+      type: ClusterStatusType,
+    },
+    initialResources: [
+      {
+        spec: { machines: { total } },
+        metadata: { namespace: DefaultNamespace, type: ClusterStatusType, id: clusterId },
+      },
+    ],
+  }).handler
+}
+
+function permissionsHandler(spec: ClusterPermissionsSpec) {
+  return http.post('/omni.resources.ResourceService/Get', () =>
+    HttpResponse.json({
+      body: JSON.stringify({
+        metadata: { namespace: VirtualNamespace, id: clusterId },
+        spec,
+      }),
+    }),
+  )
+}
+
+const meta: Meta<typeof KubeSpanStatusQuickStart> = {
+  component: KubeSpanStatusQuickStart,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    clusterId,
+  },
+  decorators: [
+    () => ({
+      components: { KubeSpanStatusQuickStart },
+      template: '<div class="h-screen"><story /></div>',
+    }),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof KubeSpanStatusQuickStart>
+
+export const Default = {
+  parameters: {
+    msw: {
+      handlers: [
+        permissionsHandler({ can_manage_config_patches: true }),
+        clusterHandler,
+        clusterStatusHandler(6),
+      ],
+    },
+  },
+} satisfies Story
+
+export const ReadOnly = {
+  parameters: {
+    msw: {
+      handlers: [
+        permissionsHandler({ can_manage_config_patches: false }),
+        clusterHandler,
+        clusterStatusHandler(6),
+      ],
+    },
+  },
+} satisfies Story
+
+export const LargeCluster = {
+  parameters: {
+    msw: {
+      handlers: [
+        permissionsHandler({ can_manage_config_patches: true }),
+        clusterHandler,
+        clusterStatusHandler(64),
+      ],
+    },
+  },
+} satisfies Story

--- a/frontend/src/views/KubeSpanStatus/KubeSpanStatusQuickStart.vue
+++ b/frontend/src/views/KubeSpanStatus/KubeSpanStatusQuickStart.vue
@@ -1,0 +1,275 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import { RequestError } from '@/api/fetch.pb'
+import { Code } from '@/api/google/rpc/code.pb'
+import type { Resource } from '@/api/grpc'
+import { ResourceService } from '@/api/grpc'
+import type { ClusterSpec, ClusterStatusSpec, ConfigPatchSpec } from '@/api/omni/specs/omni.pb'
+import { withRuntime } from '@/api/options'
+import {
+  ClusterStatusType,
+  ClusterType,
+  ConfigPatchName,
+  ConfigPatchType,
+  DefaultNamespace,
+  LabelCluster,
+} from '@/api/resources'
+import TButton from '@/components/Button/TButton.vue'
+import CodeBlock from '@/components/CodeBlock/CodeBlock.vue'
+import type { IconType } from '@/components/Icon/TIcon.vue'
+import TIcon from '@/components/Icon/TIcon.vue'
+import ManagedByTemplatesWarning from '@/components/ManagedByTemplatesWarning.vue'
+import ConfirmModal from '@/components/Modals/ConfirmModal.vue'
+import PageContainer from '@/components/PageContainer/PageContainer.vue'
+import TAlert from '@/components/TAlert.vue'
+import { getDocsLink } from '@/methods'
+import { useClusterPermissions } from '@/methods/auth'
+import { useResourceWatch } from '@/methods/useResourceWatch'
+import { showError, showSuccess } from '@/notification'
+
+const { clusterId } = defineProps<{
+  clusterId: string
+}>()
+
+const { canManageConfigPatches } = useClusterPermissions(() => clusterId)
+
+const { data: cluster } = useResourceWatch<ClusterSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: ClusterType,
+    id: clusterId,
+  },
+}))
+
+const talosVersion = computed(() => cluster.value?.spec.talos_version)
+
+const { data: clusterStatus } = useResourceWatch<ClusterStatusSpec>(() => ({
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: ClusterStatusType,
+    id: clusterId,
+  },
+}))
+
+// KubeSpan's WireGuard overhead scales with the number of peers; large clusters
+// are generally advised against enabling a full mesh.
+const LARGE_CLUSTER_THRESHOLD = 50
+const nodeCount = computed(() => clusterStatus.value?.spec.machines?.total ?? 0)
+const isLargeCluster = computed(() => nodeCount.value >= LARGE_CLUSTER_THRESHOLD)
+
+const features: { icon: IconType; title: string; description: string }[] = [
+  {
+    icon: 'locked',
+    title: 'Encrypted mesh',
+    description:
+      'All node-to-node traffic is encrypted with a WireGuard mesh, securing communication regardless of the underlying network.',
+  },
+  {
+    icon: 'server-network',
+    title: 'Cross-network connectivity',
+    description:
+      'Nodes spanning multiple networks — cloud, on-prem, or edge — can reach each other, even across NAT.',
+  },
+  {
+    icon: 'cloud-connection',
+    title: 'Automatic peer discovery',
+    description:
+      'Peers discover one another and manage endpoints automatically, with no manual routing or VPN setup.',
+  },
+]
+
+// The Talos machine config patch that enables KubeSpan for the whole cluster.
+// Cluster discovery must be enabled for KubeSpan to work; it is on by default,
+// but we set it explicitly to be safe.
+const kubeSpanPatch = `machine:
+  network:
+    kubespan:
+      enabled: true
+cluster:
+  discovery:
+    enabled: true
+`
+
+const confirmOpen = ref(false)
+const enabling = ref(false)
+const requested = ref(false)
+
+async function enableKubeSpan() {
+  enabling.value = true
+
+  const patch: Resource<ConfigPatchSpec> = {
+    metadata: {
+      namespace: DefaultNamespace,
+      type: ConfigPatchType,
+      id: `500-${clusterId}-kubespan`,
+      labels: {
+        [LabelCluster]: clusterId,
+      },
+      annotations: {
+        [ConfigPatchName]: 'Enable KubeSpan',
+      },
+    },
+    spec: {
+      data: kubeSpanPatch,
+    },
+  }
+
+  try {
+    await ResourceService.Create(patch, withRuntime(Runtime.Omni))
+
+    requested.value = true
+    confirmOpen.value = false
+    showSuccess(
+      'Enabling KubeSpan',
+      'The config patch was applied. Nodes may gracefully reboot before KubeSpan becomes active.',
+    )
+  } catch (e) {
+    if (e instanceof RequestError) {
+      switch (e.code) {
+        case Code.ALREADY_EXISTS:
+          requested.value = true
+          confirmOpen.value = false
+          showSuccess(
+            'Enabling KubeSpan',
+            'A KubeSpan config patch already exists for this cluster.',
+          )
+          return
+        case Code.INVALID_ARGUMENT:
+          showError('The Config is Invalid', e.message.replace('failed to validate: ', ''))
+          return
+      }
+    }
+
+    showError('Failed to Enable KubeSpan', e instanceof Error ? e.message : String(e))
+  } finally {
+    enabling.value = false
+  }
+}
+</script>
+
+<template>
+  <PageContainer class="@container flex h-full flex-col overflow-y-auto">
+    <div class="mx-auto flex flex-col items-center">
+      <div class="flex flex-col items-center gap-3 text-center">
+        <div class="flex size-14 items-center justify-center rounded-full bg-naturals-n3">
+          <TIcon icon="cloud-connection" class="size-7 text-primary-p3" />
+        </div>
+
+        <h1 class="text-xl font-medium text-naturals-n14">KubeSpan is not enabled</h1>
+
+        <p class="max-w-xl text-sm text-naturals-n11">
+          KubeSpan creates an encrypted WireGuard mesh between the nodes of this cluster, letting
+          machines on different networks discover and securely communicate with each other. It is
+          currently disabled for this cluster.
+        </p>
+
+        <a
+          :href="getDocsLink('talos', '/learn-more/kubespan', { talosVersion })"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="link-primary inline-flex items-center gap-1 text-sm"
+        >
+          Learn more about KubeSpan
+          <TIcon icon="external-link" class="size-3.5" />
+        </a>
+      </div>
+
+      <div
+        class="flex max-w-3xl flex-col gap-6 py-6 @4xl:max-w-5xl @4xl:flex-row @4xl:items-start @4xl:gap-8"
+      >
+        <div class="grid gap-3 @2xl:grid-cols-3 @4xl:flex-1 @4xl:grid-cols-1">
+          <div
+            v-for="feature in features"
+            :key="feature.title"
+            class="flex flex-col gap-2 rounded-lg bg-naturals-n2 p-4 @2xl:items-center @2xl:text-center @4xl:items-start @4xl:text-left"
+          >
+            <div class="flex items-center gap-2">
+              <TIcon :icon="feature.icon" class="size-5 text-naturals-n13" />
+              <h3 class="text-sm font-medium text-naturals-n14">{{ feature.title }}</h3>
+            </div>
+            <p class="text-xs text-naturals-n11">{{ feature.description }}</p>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-4 rounded-lg bg-naturals-n2 p-6 @4xl:flex-1">
+          <div class="flex flex-col gap-1">
+            <h2 class="text-base font-medium text-naturals-n14">Enable KubeSpan</h2>
+            <p class="text-sm text-naturals-n11">
+              This applies the following cluster-wide config patch to every node. Patches are
+              applied immediately and may result in graceful reboots.
+            </p>
+          </div>
+
+          <CodeBlock>{{ kubeSpanPatch }}</CodeBlock>
+
+          <div class="flex flex-wrap items-center gap-3">
+            <TButton
+              variant="highlighted"
+              icon="cloud-connection"
+              :disabled="!canManageConfigPatches || requested"
+              @click="confirmOpen = true"
+            >
+              {{ requested ? 'KubeSpan enabling…' : 'Enable KubeSpan' }}
+            </TButton>
+
+            <span v-if="!canManageConfigPatches" class="text-xs text-naturals-n9">
+              You do not have permission to manage config patches for this cluster.
+            </span>
+            <span v-else-if="requested" class="text-xs text-naturals-n9">
+              KubeSpan status will appear here once the configuration is applied.
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <ConfirmModal
+      v-model:open="confirmOpen"
+      title="Enable KubeSpan"
+      action-label="Enable KubeSpan"
+      :loading="enabling"
+      :disabled="!canManageConfigPatches"
+      content-class="max-w-xl"
+      @confirm="enableKubeSpan"
+    >
+      <template #description>Cluster {{ clusterId }}</template>
+
+      <ManagedByTemplatesWarning warning-style="popup" :resource="cluster" />
+
+      <p class="text-sm text-naturals-n11">
+        A cluster-wide config patch enabling KubeSpan will be created.
+        <br />
+        This applies immediately and may trigger graceful reboots of the cluster nodes.
+        <br />
+        Please confirm the action.
+      </p>
+
+      <div class="mt-3">
+        <TAlert v-if="isLargeCluster" type="warn" title="Large cluster">
+          This cluster has {{ nodeCount }} nodes. Enabling KubeSpan on clusters with
+          {{ LARGE_CLUSTER_THRESHOLD }} or more nodes is generally not recommended — the WireGuard
+          mesh overhead grows with the number of peers and can noticeably degrade network
+          performance.
+        </TAlert>
+
+        <p v-else class="flex max-w-md items-start gap-1.5 text-xs text-yellow-y1">
+          <TIcon icon="warning" class="mt-px size-3.5 shrink-0" />
+          <span>
+            Wireguard encryption adds overhead to each packet that can reduce network throughput.
+            Review the docs to decide if it fits your cluster.
+          </span>
+        </p>
+      </div>
+    </ConfirmModal>
+  </PageContainer>
+</template>


### PR DESCRIPTION
When a cluster does not have KubeSpan enabled, instead of simply disabling the tab, we will instead show a quick start page with a basic explanation, docs link, the YAML for the patch, and an "Enable KubeSpan" button to get started, which simply applies the patch. Warnings about network overhead (especially on >=50 node clusters) will be shown.

Closes #3087 

<img width="600" alt="image" src="https://github.com/user-attachments/assets/9439f7b7-735d-479c-9957-80b3ef20b15d" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1a03ff25-b6b9-4fce-a030-724cb0d9e339" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c663bc00-b54e-49c0-9cbc-4c2803d65528" />
