### PR TITLE
feat(frontend): persist search and filters as query strings

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -116,11 +116,6 @@
       "count": 1
     }
   },
-  "src/views/ItemLabels/LabelsInput.vue": {
-    "vue/custom-event-name-casing": {
-      "count": 5
-    }
-  },
   "src/views/MachineClasses/MachineTemplate.vue": {
     "vue/custom-event-name-casing": {
       "count": 6

--- a/frontend/src/components/Labels/Labels.vue
+++ b/frontend/src/components/Labels/Labels.vue
@@ -48,7 +48,7 @@ const addLabel = async () => {
   }
 }
 
-const removeLabel = async (key: string) => {
+const removeLabel = (key: string) => {
   addingLabel.value = false
 
   currentLabel.value = ''
@@ -73,7 +73,7 @@ const removeLabel = async (key: string) => {
         labelClass: label.labelClass,
         removable: label.canRemove,
       }"
-      :remove-label="removeLabel"
+      @remove="removeLabel"
     />
     <TInput
       v-if="addingLabel"

--- a/frontend/src/components/Labels/Labels.vue
+++ b/frontend/src/components/Labels/Labels.vue
@@ -73,7 +73,7 @@ const removeLabel = (key: string) => {
         labelClass: label.labelClass,
         removable: label.canRemove,
       }"
-      @remove="removeLabel"
+      @remove-label="removeLabel(key)"
     />
     <TInput
       v-if="addingLabel"

--- a/frontend/src/components/List/TList.vue
+++ b/frontend/src/components/List/TList.vue
@@ -6,6 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts" generic="T = unknown">
 import { useLocalStorage } from '@vueuse/core'
+import { useRouteQuery } from '@vueuse/router'
 import { computed, ref, watch } from 'vue'
 
 import TIcon from '@/components/Icon/TIcon.vue'
@@ -70,11 +71,11 @@ const filterOptionsVariants = computed(() => {
   })
 })
 
-const filterValueInternal = ref('')
+const filterValueInternal = useRouteQuery('q', '')
 const currentPage = ref(1)
 const selectedItemsPerPage = useLocalStorage('itemsPerPage', 10)
-const selectedSortOption = ref<string | undefined>(sortOptionsVariants?.value?.[0])
-const selectedFilterOption = ref<string | undefined>(filterOptionsVariants.value?.[0])
+const selectedSortOption = useRouteQuery('sort', sortOptionsVariants?.value?.[0])
+const selectedFilterOption = useRouteQuery('filter', filterOptionsVariants.value?.[0])
 const sidePanelOpen = ref(false)
 const sidePanelSelectedItemId = ref<string>()
 
@@ -288,15 +289,10 @@ const openPage = (page: number | string) => {
 
               <TSelectList
                 v-if="itemsPerPage?.length > 1 && pagination"
+                v-model="selectedItemsPerPage"
                 title="Items per Page"
-                :default-value="selectedItemsPerPage"
                 :values="itemsPerPage"
-                @checked-value="
-                  (value: number) => {
-                    selectedItemsPerPage = value
-                    currentPage = 1
-                  }
-                "
+                @checked-value="currentPage = 1"
               />
             </div>
           </div>

--- a/frontend/src/components/Modals/JoinTokenCreate.vue
+++ b/frontend/src/components/Modals/JoinTokenCreate.vue
@@ -63,7 +63,7 @@ const handleCreate = async () => {
     @confirm="handleCreate"
   >
     <div class="flex flex-col gap-2">
-      <TInput v-model="name" title="Name" class="h-full flex-1" :on-clear="() => (name = '')" />
+      <TInput v-model="name" title="Name" class="h-full flex-1" clearable />
 
       <div class="flex items-center gap-1 text-xs">
         Lifetime:

--- a/frontend/src/components/TInput/TInput.stories.ts
+++ b/frontend/src/components/TInput/TInput.stories.ts
@@ -24,6 +24,7 @@ const meta: Meta<typeof TInput> = {
     secondary: false,
     focus: false,
     compact: false,
+    clearable: true,
     onClear: fn(),
     'onUpdate:modelValue': fn(),
   },

--- a/frontend/src/components/TInput/TInput.vue
+++ b/frontend/src/components/TInput/TInput.vue
@@ -23,8 +23,8 @@ interface Props {
   min?: number
   disabled?: boolean
   required?: boolean
+  clearable?: boolean
   step?: number
-  onClear?: () => void
 }
 
 const {
@@ -36,11 +36,11 @@ const {
   max = undefined,
   min = undefined,
   step = 1,
-  onClear = undefined,
 } = defineProps<Props>()
 
 const emit = defineEmits<{
   blur: []
+  clear: []
 }>()
 
 defineExpose({
@@ -62,7 +62,7 @@ const inputRef = useTemplateRef('input')
 
 const clearInput = () => {
   updateValue('')
-  onClear?.()
+  emit('clear')
 }
 
 const blurHandler = () => {
@@ -137,7 +137,7 @@ onMounted(() => focus && inputRef.value?.focus())
       </div>
 
       <TIcon
-        v-else-if="modelValue !== '' || onClear"
+        v-else-if="modelValue !== '' || clearable"
         role="button"
         aria-label="clear"
         class="size-4 fill-current text-naturals-n8 transition-colors peer-focus:text-naturals-n14"

--- a/frontend/src/methods/labels.ts
+++ b/frontend/src/methods/labels.ts
@@ -3,6 +3,8 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 
+import { useRouteQuery } from '@vueuse/router'
+
 import {
   InfraProviderLabelPrefix,
   LabelCluster,
@@ -82,12 +84,35 @@ const labelClasses: Record<string, string> = {
 
 export const getLabelClass = (labelKey: string) => labelClasses[labelKey]
 
+export function useLabelRouteQuery() {
+  return useRouteQuery<string, Label[]>('labels', '', {
+    transform: {
+      get(val) {
+        if (!val) return []
+
+        try {
+          const parsed = JSON.parse(window.atob(val))
+
+          return Array.isArray(parsed) ? parsed : []
+        } catch {
+          return []
+        }
+      },
+      set(val) {
+        if (!val.length) return ''
+
+        return window.btoa(JSON.stringify(val))
+      },
+    },
+  })
+}
+
 export const addLabel = (dest: Label[], label: Label) => {
   if (dest.find((l) => l.value === label.value && l.key === label.key)) {
-    return
+    return dest
   }
 
-  dest.push({
+  return dest.concat({
     ...label,
     id: !label.value ? `has label: ${label.id}` : label.id,
   })

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/config-diffs.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/config-diffs.vue
@@ -5,8 +5,9 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useRouteQuery } from '@vueuse/router'
 import { compareAsc, compareDesc, parseISO } from 'date-fns'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -37,7 +38,7 @@ const { data: configDiffs, loading: diffsLoading } = useResourceWatch<MachineCon
   }),
 )
 
-const sortOrder = ref<'asc' | 'desc'>('desc')
+const sortOrder = useRouteQuery<'asc' | 'desc'>('sort', 'desc')
 
 const sortOptions = [
   { label: 'Creation Time ⬇', value: 'desc' as const },

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/pods.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/pods.vue
@@ -5,8 +5,9 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useRouteQuery } from '@vueuse/router'
 import type { PodSpec as V1PodSpec, PodStatus as V1PodStatus } from 'kubernetes-types/core/v1'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -25,8 +26,8 @@ import TPodsItem from '@/views/Pods/TPodsItem.vue'
 definePage({ name: 'Pods' })
 
 const route = useRoute()
-const filterOption = ref(TPodsViewFilterOptions.ALL)
-const searchOption = ref('')
+const filterOption = useRouteQuery('filter', TPodsViewFilterOptions.ALL)
+const searchOption = useRouteQuery('q', '')
 
 const filterOptions = Object.values(TPodsViewFilterOptions)
 
@@ -90,12 +91,7 @@ const filteredItems = computed(() =>
     <div v-else class="pt-2">
       <div class="mb-3 flex gap-4">
         <TInput v-model="searchOption" icon="search" placeholder="Search..." class="w-full" />
-        <TSelectList
-          title="Phase"
-          :default-value="TPodsViewFilterOptions.ALL"
-          :values="filterOptions"
-          @checked-value="filterOption = $event"
-        />
+        <TSelectList v-model="filterOption" title="Phase" :values="filterOptions" />
       </div>
 
       <ul class="mb-1 flex rounded bg-naturals-n2 px-8 py-2.5 text-xs text-naturals-n13">

--- a/frontend/src/pages/(authenticated)/clusters/index.vue
+++ b/frontend/src/pages/(authenticated)/clusters/index.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { ref } from 'vue'
+import { useRouteQuery } from '@vueuse/router'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { ClusterStatusMetricsSpec, ClusterStatusSpec } from '@/api/omni/specs/omni.pb'
@@ -26,8 +26,7 @@ import StatsItem from '@/components/Stats/StatsItem.vue'
 import TAlert from '@/components/TAlert.vue'
 import { getDocsLink } from '@/methods'
 import { usePermissions } from '@/methods/auth'
-import type { Label } from '@/methods/labels'
-import { addLabel, selectors } from '@/methods/labels'
+import { addLabel, selectors, useLabelRouteQuery } from '@/methods/labels'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import ClusterItem from '@/views/Clusters/ClusterItem.vue'
 import LabelsInput from '@/views/ItemLabels/LabelsInput.vue'
@@ -45,8 +44,8 @@ const { data } = useResourceWatch<ClusterStatusMetricsSpec>({
   runtime: Runtime.Omni,
 })
 
-const filterValue = ref('')
-const filterLabels = ref<Label[]>([])
+const filterLabels = useLabelRouteQuery()
+const filterValue = useRouteQuery('q', '')
 
 const sortOptions = [
   { id: 'id', desc: 'ID ⬆' },
@@ -153,7 +152,7 @@ const filterOptions = [
               :default-open="index === 0"
               :search-query="searchQuery"
               :item="item"
-              @filter-labels="(label) => addLabel(filterLabels, label)"
+              @filter-labels="(label) => (filterLabels = addLabel(filterLabels, label))"
             />
           </ul>
         </div>

--- a/frontend/src/pages/(authenticated)/settings/audit-logs.vue
+++ b/frontend/src/pages/(authenticated)/settings/audit-logs.vue
@@ -65,7 +65,7 @@ const dateRange = shallowRef<DateRange>({
   end: today(getLocalTimeZone()).add({ days: 1 }),
 })
 
-const searchInput = useRouteQuery('search', '')
+const searchInput = useRouteQuery('q', '')
 const search = refDebounced(searchInput, 500)
 
 const orderByField = useRouteQuery(

--- a/frontend/src/pages/(authenticated)/settings/infraproviders.vue
+++ b/frontend/src/pages/(authenticated)/settings/infraproviders.vue
@@ -32,8 +32,6 @@ import TStatus from '@/components/Status/TStatus.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { TCommonStatuses } from '@/constants'
 import { usePermissions } from '@/methods/auth'
-import type { Label } from '@/methods/labels'
-import { selectors } from '@/methods/labels'
 import InfraProviderDeleteModal from '@/views/InfraProviders/components/InfraProviderDeleteModal.vue'
 import InfraProviderSetupModal from '@/views/InfraProviders/components/InfraProviderSetupModal.vue'
 import ServiceAccountCreateModal from '@/views/Users/components/ServiceAccountCreateModal.vue'
@@ -77,8 +75,6 @@ const getStatus = (item: Resource<InfraProviderCombinedStatusSpec>) => {
 
   return TCommonStatuses.HEALTHY
 }
-
-const filterLabels = ref<Label[]>([])
 
 const openRotateSecretKey = async (name: string) => {
   const saName = `${name}@${InfraProviderServiceAccountDomain}`
@@ -139,7 +135,6 @@ const openRotateSecretKey = async (name: string) => {
             namespace: EphemeralNamespace,
             type: InfraProviderCombinedStatusType,
           },
-          selectors: selectors(filterLabels),
           sortByField: 'created',
         }"
         search

--- a/frontend/src/views/Clusters/ClusterItem.vue
+++ b/frontend/src/views/Clusters/ClusterItem.vue
@@ -194,7 +194,7 @@ const clusterDestroyDialogOpen = ref(false)
           :resource="item"
           :add-label-func="addClusterLabels"
           :remove-label-func="removeClusterLabels"
-          @filter-label="(label) => $emit('filterLabels', label)"
+          @select-label="(label) => $emit('filterLabels', label)"
         />
       </div>
 

--- a/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
@@ -323,7 +323,7 @@ const onSavePatchConfig = (config: string) => {
         :resource="item"
         :add-label-func="addMachineLabels"
         :remove-label-func="removeMachineLabels"
-        @filter-label="(label) => $emit('filterLabel', label)"
+        @select-label="(label) => $emit('filterLabel', label)"
       />
     </template>
 

--- a/frontend/src/views/Config/Patches.vue
+++ b/frontend/src/views/Config/Patches.vue
@@ -7,6 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/vue'
 import { DocumentIcon } from '@heroicons/vue/24/solid'
+import { useRouteQuery } from '@vueuse/router'
 import { v4 as uuidv4 } from 'uuid'
 import { computed, ref } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
@@ -49,7 +50,7 @@ const { machine, cluster } = defineProps<{
   machine?: string
 }>()
 
-const filter = ref('')
+const filter = useRouteQuery('q', '')
 const configPatchDestroyModalOpen = ref(false)
 const configPatchDestroyModalPatchId = ref<string>()
 

--- a/frontend/src/views/ItemLabels/ItemLabel.vue
+++ b/frontend/src/views/ItemLabels/ItemLabel.vue
@@ -21,8 +21,8 @@ interface Props extends /* @vue-ignore */ ButtonHTMLAttributes {
 const { label } = defineProps<Props>()
 
 defineEmits<{
-  filterLabel: [label: Label]
-  remove: [key: string]
+  selectLabel: []
+  removeLabel: []
 }>()
 
 const description = computed(() => {
@@ -40,7 +40,7 @@ const description = computed(() => {
       class="inline-flex items-center gap-1"
       :class="['resource-label', label.labelClass, small ? 'max-w-50' : 'max-w-75']"
       v-bind="$attrs"
-      @click.stop="$emit('filterLabel', label)"
+      @click.stop="$emit('selectLabel')"
     >
       <TIcon v-if="label.icon" :icon="label.icon" class="-ml-1 size-3.5 shrink-0" />
       <span class="truncate">
@@ -50,7 +50,7 @@ const description = computed(() => {
         v-if="label.removable"
         icon="close"
         class="-mr-1 size-3 shrink-0 cursor-pointer rounded-full transition-all hover:bg-naturals-n14 hover:text-naturals-n1"
-        @click.stop="$emit('remove', label.key)"
+        @click.stop="$emit('removeLabel')"
       />
     </button>
   </Tooltip>

--- a/frontend/src/views/ItemLabels/ItemLabel.vue
+++ b/frontend/src/views/ItemLabels/ItemLabel.vue
@@ -5,20 +5,24 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed } from 'vue'
+import { type ButtonHTMLAttributes, computed } from 'vue'
 
 import TIcon from '@/components/Icon/TIcon.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import type { Label } from '@/methods/labels'
 
-const { label } = defineProps<{
+defineOptions({ inheritAttrs: false })
+
+interface Props extends /* @vue-ignore */ ButtonHTMLAttributes {
   label: Label
   small?: boolean
-  removeLabel?: (key: string) => Promise<void>
-}>()
+}
+
+const { label } = defineProps<Props>()
 
 defineEmits<{
-  filterLabel: [Label]
+  filterLabel: [label: Label]
+  remove: [key: string]
 }>()
 
 const description = computed(() => {
@@ -35,6 +39,7 @@ const description = computed(() => {
     <button
       class="inline-flex items-center gap-1"
       :class="['resource-label', label.labelClass, small ? 'max-w-50' : 'max-w-75']"
+      v-bind="$attrs"
       @click.stop="$emit('filterLabel', label)"
     >
       <TIcon v-if="label.icon" :icon="label.icon" class="-ml-1 size-3.5 shrink-0" />
@@ -42,10 +47,10 @@ const description = computed(() => {
         {{ label.value ? `${label.id}:${label.value}` : label.id }}
       </span>
       <TIcon
-        v-if="label.removable && removeLabel"
+        v-if="label.removable"
         icon="close"
         class="-mr-1 size-3 shrink-0 cursor-pointer rounded-full transition-all hover:bg-naturals-n14 hover:text-naturals-n1"
-        @click.stop="() => removeLabel?.(label.key)"
+        @click.stop="$emit('remove', label.key)"
       />
     </button>
   </Tooltip>

--- a/frontend/src/views/ItemLabels/ItemLabels.vue
+++ b/frontend/src/views/ItemLabels/ItemLabels.vue
@@ -131,8 +131,8 @@ const destroyUserLabel = async (key: string) => {
     <ItemLabel
       v-for="label in labels"
       :key="label.key"
-      :label="label"
-      :remove-label="removeLabelFunc ? destroyUserLabel : undefined"
+      :label="{ ...label, removable: label.removable && !!removeLabelFunc }"
+      @remove="removeLabelFunc ? destroyUserLabel : undefined"
       @filter-label="(label) => $emit('filterLabel', label)"
     />
     <TInput

--- a/frontend/src/views/ItemLabels/ItemLabels.vue
+++ b/frontend/src/views/ItemLabels/ItemLabels.vue
@@ -24,7 +24,7 @@ const { resource, addLabelFunc, removeLabelFunc } = defineProps<{
 }>()
 
 defineEmits<{
-  filterLabel: [Label]
+  selectLabel: [label: Label]
 }>()
 
 const labelOrder = {
@@ -132,8 +132,8 @@ const destroyUserLabel = async (key: string) => {
       v-for="label in labels"
       :key="label.key"
       :label="{ ...label, removable: label.removable && !!removeLabelFunc }"
-      @remove="removeLabelFunc ? destroyUserLabel : undefined"
-      @filter-label="(label) => $emit('filterLabel', label)"
+      @remove-label="removeLabelFunc ? destroyUserLabel(label.key) : undefined"
+      @select-label="$emit('selectLabel', label)"
     />
     <TInput
       v-if="addingLabel"

--- a/frontend/src/views/ItemLabels/LabelsInput.vue
+++ b/frontend/src/views/ItemLabels/LabelsInput.vue
@@ -242,18 +242,7 @@ watch(
           class="-mx-1 -my-2 rounded-md border p-0.5 transition-all"
           :class="selectedLabel === index ? 'border-white' : 'border-transparent'"
         >
-          <ItemLabel
-            small
-            :label="{
-              ...label,
-              removable: true,
-            }"
-            :remove-label="
-              async () => {
-                removeLabel(index)
-              }
-            "
-          />
+          <ItemLabel small :label="{ ...label, removable: true }" @remove="removeLabel(index)" />
         </div>
       </template>
     </TInput>
@@ -268,7 +257,7 @@ watch(
         :class="{ 'bg-naturals-n4': index === selectedSuggestion }"
         @click="autoComplete(index)"
       >
-        <ItemLabel :label="suggestion" class="pointer-events-none" />
+        <ItemLabel :label="{ ...suggestion, removable: false }" class="pointer-events-none" />
       </div>
     </div>
   </div>

--- a/frontend/src/views/ItemLabels/LabelsInput.vue
+++ b/frontend/src/views/ItemLabels/LabelsInput.vue
@@ -229,12 +229,9 @@ watch(
       class="h-full flex-1 flex-wrap text-xs"
       icon="search"
       :model-value="filterValue"
-      :on-clear="
-        () => {
-          $emit('update:filter-labels', [])
-        }
-      "
       :placeholder
+      clearable
+      @clear="$emit('update:filter-labels', [])"
       @update:model-value="(value) => $emit('update:filter-value', value)"
       @click="showCompletions = true"
     >

--- a/frontend/src/views/ItemLabels/LabelsInput.vue
+++ b/frontend/src/views/ItemLabels/LabelsInput.vue
@@ -6,14 +6,14 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { vOnClickOutside } from '@vueuse/components'
-import { ref, useTemplateRef, watch } from 'vue'
+import { computed, ref, useTemplateRef, watch } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
-import type { Resource } from '@/api/grpc'
-import { ResourceService } from '@/api/grpc'
-import { withAbortController, withRuntime } from '@/api/options'
+import type { GetRequest } from '@/api/omni/resources/resources.pb'
+import type { LabelsCompletionSpec } from '@/api/omni/specs/virtual.pb'
 import TInput from '@/components/TInput/TInput.vue'
 import { getLabelFromID as createLabel } from '@/methods/labels'
+import { useResourceGet } from '@/methods/useResourceGet'
 
 import ItemLabel from './ItemLabel.vue'
 
@@ -24,32 +24,57 @@ type Label = {
   labelClass?: string
 }
 
-const { completionsResource, filterValue, filterLabels } = defineProps<{
-  completionsResource: {
-    id: string
-    namespace: string
-    type: string
-  }
-  filterValue: string
-  filterLabels: Label[]
-  placeholder?: string
+const { completionsResource } = defineProps<{
+  completionsResource: GetRequest
 }>()
+
+const filterValue = defineModel<string>('filterValue', { required: true })
+const filterLabels = defineModel<Label[]>('filterLabels', { required: true })
 
 const showCompletions = ref(false)
-
-const emit = defineEmits<{
-  'update:filter-value': [string | undefined]
-  'update:filter-labels': [Label[]]
-}>()
 
 const input = useTemplateRef('input')
 const selectedSuggestion = ref(0)
 const selectedLabel = ref<number>()
 
-const matchedLabelsCompletion = ref<Label[]>([])
+const { data: completion, loadData } = useResourceGet<LabelsCompletionSpec>(() => ({
+  skip: true,
+  runtime: Runtime.Omni,
+  resource: completionsResource,
+}))
 
-let labelsCompletions: { key: string; value: string }[] = []
-let matchValue = ''
+const labelsCompletions = computed(() => {
+  const completionEntries = Object.entries(completion.value?.spec.items ?? {})
+
+  return completionEntries.flatMap(([key, { items = [] }]) => {
+    const uniqItems = [...new Set(['', ...items])]
+
+    return uniqItems.map((value) => ({ key, value }))
+  })
+})
+
+// we always do completion for the last space separated word
+const matchValue = computed(() => filterValue.value.split(' ').at(-1))
+
+const matchedLabelsCompletion = computed(() => {
+  if (!matchValue.value) return []
+
+  const [key, value] = matchValue.value.split(':') as [string, string | undefined]
+
+  return labelsCompletions.value
+    .filter((item) =>
+      value === undefined
+        ? item.key.includes(key) || item.value.includes(key)
+        : item.key.includes(key) && item.value.includes(value),
+    )
+    .map((item) => {
+      const label = createLabel(item.key, item.value)
+
+      label.id = item.value === '' ? `has label: ${label.id}` : label.id
+
+      return label
+    })
+})
 
 const autoComplete = (index: number) => {
   const label = matchedLabelsCompletion.value[index]
@@ -58,129 +83,42 @@ const autoComplete = (index: number) => {
     return
   }
 
-  emit('update:filter-value', filterValue.replace(new RegExp(`${matchValue}$`), ''))
+  if (matchValue.value && filterValue.value.endsWith(matchValue.value)) {
+    filterValue.value = filterValue.value.slice(0, -matchValue.value.length)
+  }
 
   addLabel(label)
 }
 
 const addLabel = (label: Label) => {
-  if (filterLabels.find((l) => l.value === label.value && l.key === label.key)) {
+  if (filterLabels.value.some((l) => l.value === label.value && l.key === label.key)) {
     return
   }
 
-  emit('update:filter-labels', filterLabels.concat([label]))
+  filterLabels.value = filterLabels.value.concat(label)
 }
 
 const removeLabel = (index: number) => {
-  const copyArray = [...filterLabels]
-
-  copyArray.splice(index, 1)
-
-  emit('update:filter-labels', copyArray)
+  filterLabels.value = filterLabels.value.toSpliced(index, 1)
 }
 
 let abortController: AbortController | null
 
-watch(
-  () => filterValue,
-  async (val, old) => {
+watch(filterValue, async (val, old, onCleanup) => {
+  onCleanup(() => {
     selectedSuggestion.value = 0
     selectedLabel.value = undefined
+    abortController?.abort({ reason: 'input changed' })
+  })
 
-    if (abortController) {
-      abortController.abort({ reason: 'input changed' })
-    }
+  if (old === '' || abortController) {
+    abortController = new AbortController()
 
-    if (old === '' || abortController) {
-      abortController = new AbortController()
+    await loadData(abortController)
 
-      try {
-        const completion: Resource<{
-          items: Record<
-            string,
-            {
-              items: string[]
-            }
-          >
-        }> = await ResourceService.Get(
-          completionsResource,
-          withRuntime(Runtime.Omni),
-          withAbortController(abortController),
-        )
-
-        abortController = null
-
-        labelsCompletions = []
-
-        const addLabel = (l: { key: string; value: string }) => {
-          if (labelsCompletions.find((item) => item.key === l.key && item.value === l.value)) {
-            return
-          }
-
-          labelsCompletions.push(l)
-        }
-
-        for (const key in completion.spec.items) {
-          let hasEmptyValue = false
-
-          for (const value of completion.spec.items[key].items!) {
-            addLabel({
-              key: key,
-              value: value,
-            })
-
-            if (!value) {
-              hasEmptyValue = true
-            }
-          }
-
-          if (!hasEmptyValue) {
-            addLabel({
-              key: key,
-              value: '',
-            })
-          }
-        }
-      } catch (e) {
-        if (e.reason !== 'input changed') {
-          throw e
-        }
-      }
-    }
-
-    // we always do completion for the last space separated word
-    const parts = val.split(' ')
-
-    matchValue = parts[parts.length - 1]
-
-    const keyAndValue = matchValue.split(':')
-
-    if (matchValue === '') {
-      matchedLabelsCompletion.value = []
-
-      return
-    }
-
-    const matcher = (item: { key: string; value: string }) => {
-      const key = keyAndValue[0]
-      const value = keyAndValue[1]
-
-      if (value === undefined) {
-        return item.key.includes(key) || item.value.includes(key)
-      }
-
-      return item.key.includes(key) && item.value.includes(value)
-    }
-
-    matchedLabelsCompletion.value = labelsCompletions.filter(matcher).map((item) => {
-      const label = createLabel(item.key, item.value)
-
-      label.id = item.value === '' ? `has label: ${label.id}` : label.id
-
-      return label
-    })
-  },
-)
+    abortController = null
+  }
+})
 </script>
 
 <template>
@@ -225,14 +163,13 @@ watch(
   >
     <TInput
       ref="input"
+      v-model="filterValue"
       v-on-click-outside="() => (showCompletions = false)"
       class="h-full flex-1 flex-wrap text-xs"
       icon="search"
-      :model-value="filterValue"
-      :placeholder
       clearable
-      @clear="$emit('update:filter-labels', [])"
-      @update:model-value="(value) => $emit('update:filter-value', value)"
+      placeholder="Search ..."
+      @clear="filterLabels = []"
       @click="showCompletions = true"
     >
       <template #labels>

--- a/frontend/src/views/ItemLabels/LabelsInput.vue
+++ b/frontend/src/views/ItemLabels/LabelsInput.vue
@@ -179,7 +179,11 @@ watch(filterValue, async (val, old, onCleanup) => {
           class="-mx-1 -my-2 rounded-md border p-0.5 transition-all"
           :class="selectedLabel === index ? 'border-white' : 'border-transparent'"
         >
-          <ItemLabel small :label="{ ...label, removable: true }" @remove="removeLabel(index)" />
+          <ItemLabel
+            small
+            :label="{ ...label, removable: true }"
+            @remove-label="removeLabel(index)"
+          />
         </div>
       </template>
     </TInput>

--- a/frontend/src/views/KubeSpanStatus/KubeSpanStatus.vue
+++ b/frontend/src/views/KubeSpanStatus/KubeSpanStatus.vue
@@ -5,8 +5,9 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useRouteQuery } from '@vueuse/router'
 import prettyBytes from 'pretty-bytes'
-import { computed, ref, useTemplateRef } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -37,7 +38,7 @@ const { clusterId, machineId } = defineProps<{
   machineId: string
 }>()
 
-const searchQuery = ref('')
+const searchQuery = useRouteQuery('q', '')
 const canvasRef = useTemplateRef('canvasRef')
 const router = useRouter()
 

--- a/frontend/src/views/MachineClasses/MachineMatchItem.vue
+++ b/frontend/src/views/MachineClasses/MachineMatchItem.vue
@@ -42,7 +42,7 @@ const machineName = useMachineName(() => machine)
               highlight-class="bg-naturals-n14"
             />
           </RouterLink>
-          <ItemLabels :resource="machine" @filter-label="(label) => $emit('filterLabels', label)" />
+          <ItemLabels :resource="machine" @select-label="(label) => $emit('filterLabels', label)" />
         </div>
         <div class="w-8 flex-initial">
           <div class="flex justify-end" />

--- a/frontend/src/views/Machines/MachineExtensions.vue
+++ b/frontend/src/views/Machines/MachineExtensions.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useRouteQuery } from '@vueuse/router'
 import { computed, ref } from 'vue'
 import WordHighlighter from 'vue-word-highlighter'
 
@@ -55,7 +56,7 @@ const { data: machineExtensionsStatus, loading: machineExtensionsStatusWatchLoad
   }))
 
 const updateExtensionsModalOpen = ref(false)
-const searchString = ref('')
+const searchString = useRouteQuery('q', '')
 
 const ready = computed(() => {
   return !machineExtensionsStatusWatchLoading.value

--- a/frontend/src/views/Machines/MachineItem.vue
+++ b/frontend/src/views/Machines/MachineItem.vue
@@ -300,7 +300,7 @@ const canUseLifecycleUpgrade = computed(() => {
         :resource="machine"
         :add-label-func="machine.spec.tearing_down ? undefined : addMachineLabels"
         :remove-label-func="removeMachineLabels"
-        @filter-label="(label) => $emit('filterLabels', label)"
+        @select-label="(label) => $emit('filterLabels', label)"
       />
     </div>
   </div>

--- a/frontend/src/views/Machines/MachineLogsContainer.vue
+++ b/frontend/src/views/Machines/MachineLogsContainer.vue
@@ -5,6 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { useRouteQuery } from '@vueuse/router'
 import { DateTime } from 'luxon'
 import { computed, ref, watchEffect } from 'vue'
 
@@ -29,7 +30,7 @@ const { clusterId, machineId, service } = defineProps<{
   service?: string
 }>()
 
-const searchInput = ref('')
+const searchInput = useRouteQuery('q', '')
 const logs = ref<LogLine[]>([])
 const context = computed(() => ({
   cluster: clusterId,

--- a/frontend/src/views/Machines/Machines.vue
+++ b/frontend/src/views/Machines/Machines.vue
@@ -270,7 +270,6 @@ function updateSelected(machine: Resource<MachineStatusLinkSpec>, v?: boolean) {
             namespace: VirtualNamespace,
           }"
           class="w-full"
-          placeholder="Search ..."
         />
       </template>
 

--- a/frontend/src/views/Machines/Machines.vue
+++ b/frontend/src/views/Machines/Machines.vue
@@ -6,6 +6,7 @@ included in the LICENSE file.
 -->
 <script setup lang="ts">
 import { useLocalStorage } from '@vueuse/core'
+import { useRouteQuery } from '@vueuse/router'
 import { computed, ref } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -36,8 +37,7 @@ import PageHeader from '@/components/PageHeader.vue'
 import StatsItem from '@/components/Stats/StatsItem.vue'
 import TAlert from '@/components/TAlert.vue'
 import { getDocsLink } from '@/methods'
-import type { Label } from '@/methods/labels'
-import { addLabel, selectors as labelsToSelectors } from '@/methods/labels'
+import { addLabel, selectors as labelsToSelectors, useLabelRouteQuery } from '@/methods/labels'
 import { MachineFilterOption } from '@/methods/machine'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import LabelsInput from '@/views/ItemLabels/LabelsInput.vue'
@@ -124,8 +124,8 @@ const sortOptions = [
   { id: 'last_alive', desc: 'Last Active Time ⬇' },
 ]
 
-const filterLabels = ref<Label[]>([])
-const filterValue = ref('')
+const filterLabels = useLabelRouteQuery()
+const filterValue = useRouteQuery('q', '')
 
 const docsLink = getDocsLink('omni', '/explanation/infrastructure-providers')
 const openDocs = () => window.open(docsLink, '_blank')?.focus()
@@ -310,7 +310,7 @@ function updateSelected(machine: Resource<MachineStatusLinkSpec>, v?: boolean) {
           :show-u-u-i-d="showUUID === 'uuid'"
           @update:selected="(v) => updateSelected(item, v)"
           @open-panel="openPanel(item.metadata.id ?? '')"
-          @filter-labels="(label) => addLabel(filterLabels, label)"
+          @filter-labels="(label) => (filterLabels = addLabel(filterLabels, label))"
           @open-maintenance-update="
             (machine) => {
               maintenaceUpdateModalMachine = machine


### PR DESCRIPTION
When searching/filtering/sorting in Omni, we will now persist the fields in the URL bar as query strings. For the labels part (e.g. from cluster/machine lists) it required a bit of refactoring first. Refactors are separated into their own commits.

Closes #2492 