### PR TITLE
feat: expose node audit skip cluster feature

### DIFF
--- a/frontend/src/pages/(authenticated)/clusters/create.vue
+++ b/frontend/src/pages/(authenticated)/clusters/create.vue
@@ -57,6 +57,7 @@ import UntaintSingleNodeModal from '@/views/Clusters/components/UntaintSingleNod
 import EmbeddedDiscoveryServiceCheckbox from '@/views/Clusters/EmbeddedDiscoveryServiceCheckbox.vue'
 import ClusterMachineItem from '@/views/Clusters/Management/ClusterMachineItem.vue'
 import MachineSets from '@/views/Clusters/Management/MachineSets.vue'
+import NodeAuditSkipCheckbox from '@/views/Clusters/NodeAuditSkipCheckbox.vue'
 import ItemLabels from '@/views/ItemLabels/ItemLabels.vue'
 import AddingMachinesTutorial from '@/views/Machines/components/AddingMachinesTutorial.vue'
 
@@ -340,6 +341,7 @@ const list = useTemplateRef('list')
           v-model="state.cluster.features.useEmbeddedDiscoveryService"
           :disabled="!isEmbeddedDiscoveryServiceAvailable"
         />
+        <NodeAuditSkipCheckbox v-model="state.cluster.features.enableNodeAuditSkip" />
         <ClusterEtcdBackupCheckbox
           :backup-status="backupStatus"
           :cluster="{

--- a/frontend/src/states/cluster-management.spec.ts
+++ b/frontend/src/states/cluster-management.spec.ts
@@ -81,6 +81,7 @@ describe('cluster-management-state', () => {
           enableWorkloadProxy: true,
           useEmbeddedDiscoveryService: true,
           encryptDisks: true,
+          enableNodeAuditSkip: true,
         },
         labels: {
           my: 'label',
@@ -157,6 +158,7 @@ describe('cluster-management-state', () => {
                 disk_encryption: true,
                 enable_workload_proxy: true,
                 use_embedded_discovery_service: true,
+                enable_node_audit_skip: true,
               },
               kubernetes_version: '1.24.0',
               talos_version: '1.5.3',

--- a/frontend/src/states/cluster-management.ts
+++ b/frontend/src/states/cluster-management.ts
@@ -121,6 +121,7 @@ export type Cluster = {
     encryptDisks?: boolean
     enableWorkloadProxy?: boolean
     useEmbeddedDiscoveryService?: boolean
+    enableNodeAuditSkip?: boolean
   }
   systemExtensions?: string[]
   etcdBackupConfig?: EtcdBackupConf
@@ -322,6 +323,13 @@ export class State {
       cluster.spec.features = {
         ...cluster.spec.features,
         disk_encryption: this.cluster.features.encryptDisks,
+      }
+    }
+
+    if (this.cluster.features.enableNodeAuditSkip) {
+      cluster.spec.features = {
+        ...cluster.spec.features,
+        enable_node_audit_skip: this.cluster.features.enableNodeAuditSkip,
       }
     }
 
@@ -706,6 +714,7 @@ export const populateExisting = async (clusterName: string) => {
       enableWorkloadProxy: cluster.spec.features?.enable_workload_proxy,
       encryptDisks: cluster.spec.features?.disk_encryption,
       useEmbeddedDiscoveryService: cluster.spec.features?.use_embedded_discovery_service,
+      enableNodeAuditSkip: cluster.spec.features?.enable_node_audit_skip,
     },
     etcdBackupConfig: {
       enabled: cluster.spec.backup_configuration?.enabled,

--- a/frontend/src/views/Clusters/NodeAuditSkipCheckbox.vue
+++ b/frontend/src/views/Clusters/NodeAuditSkipCheckbox.vue
@@ -1,0 +1,36 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import TCheckbox from '@/components/Checkbox/TCheckbox.vue'
+import Tooltip from '@/components/Tooltip/Tooltip.vue'
+
+type Props = {
+  disabled?: boolean
+}
+
+defineProps<Props>()
+
+const checked = defineModel<boolean>({ default: false })
+</script>
+
+<template>
+  <Tooltip placement="bottom">
+    <template #description>
+      <div class="flex flex-col gap-1 p-2">
+        <p>
+          Allow the omni.sidero.dev/node-audit-skip annotation on Kubernetes nodes to exempt them
+          from Omni's node audit.
+        </p>
+        <p>
+          Use this for virtual nodes (e.g. VirtualKubelet) that have no corresponding ClusterMachine
+          and would otherwise be deleted.
+        </p>
+      </div>
+    </template>
+    <TCheckbox v-model="checked" :disabled="disabled" label="Enable Node Audit Skip" />
+  </Tooltip>
+</template>

--- a/frontend/src/views/Overview/components/OverviewContent.vue
+++ b/frontend/src/views/Overview/components/OverviewContent.vue
@@ -55,6 +55,7 @@ import ClusterMachines from '@/views/ClusterMachines/ClusterMachines.vue'
 import ClusterEtcdBackupCheckbox from '@/views/Clusters/ClusterEtcdBackupCheckbox.vue'
 import ClusterWorkloadProxyingCheckbox from '@/views/Clusters/ClusterWorkloadProxyingCheckbox.vue'
 import EmbeddedDiscoveryServiceCheckbox from '@/views/Clusters/EmbeddedDiscoveryServiceCheckbox.vue'
+import NodeAuditSkipCheckbox from '@/views/Clusters/NodeAuditSkipCheckbox.vue'
 import ItemLabels from '@/views/ItemLabels/ItemLabels.vue'
 import OverviewRightPanel from '@/views/Overview/components/OverviewRightPanel/OverviewRightPanel.vue'
 
@@ -70,11 +71,13 @@ const { currentCluster } = defineProps<Props>()
 
 const enableWorkloadProxy = ref(false)
 const useEmbeddedDiscoveryService = ref(false)
+const enableNodeAuditSkip = ref(false)
 
 watchEffect(() => {
   enableWorkloadProxy.value = currentCluster.spec.features?.enable_workload_proxy || false
   useEmbeddedDiscoveryService.value =
     currentCluster.spec.features?.use_embedded_discovery_service || false
+  enableNodeAuditSkip.value = currentCluster.spec.features?.enable_node_audit_skip || false
 })
 
 const { status: backupStatus } = setupBackupStatus()
@@ -146,6 +149,15 @@ async function setClusterWorkloadProxy(value: boolean) {
 
   resource.spec.features ||= {}
   resource.spec.features.enable_workload_proxy = value
+
+  await ResourceService.Update(resource, currentCluster.metadata.version, withRuntime(Runtime.Omni))
+}
+
+async function setNodeAuditSkip(value: boolean) {
+  const resource = JSON.parse(JSON.stringify(currentCluster)) as typeof currentCluster
+
+  resource.spec.features ||= {}
+  resource.spec.features.enable_node_audit_skip = value
 
   await ResourceService.Update(resource, currentCluster.metadata.version, withRuntime(Runtime.Omni))
 }
@@ -428,6 +440,11 @@ const machineLockedForSecretRotation = computed(() => {
               :model-value="useEmbeddedDiscoveryService"
               :disabled="!canManageClusterFeatures || !isEmbeddedDiscoveryServiceAvailable"
               @update:model-value="(value) => toggleUseEmbeddedDiscoveryService(value)"
+            />
+            <NodeAuditSkipCheckbox
+              :model-value="enableNodeAuditSkip"
+              :disabled="!canManageClusterFeatures"
+              @update:model-value="(value) => setNodeAuditSkip(value)"
             />
             <ClusterEtcdBackupCheckbox
               :backup-status="backupStatus"


### PR DESCRIPTION
Surface ClusterSpec.Features.EnableNodeAuditSkip in the UI so the
cluster owner can opt in - the backend gates the node-audit-skip
annotation on this feature to prevent workloads with nodes/patch
RBAC from self-exempting.

- toggle on cluster create
- toggle on cluster overview, gated on canManageClusterFeatures

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
