### PR TITLE
fix(frontend): remove power icon from machines page

### DIFF
--- a/frontend/src/components/Status/MachineStage.vue
+++ b/frontend/src/components/Status/MachineStage.vue
@@ -8,37 +8,29 @@ included in the LICENSE file.
 import type { Resource } from '@/api/grpc'
 import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
 import TIcon from '@/components/Icon/TIcon.vue'
-import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { useDerivedMachineStage } from '@/methods/useDerivedMachineStage'
+import { cn } from '@/methods/utils'
 
-defineOptions({ inheritAttrs: false })
-
-const { machine, iconOnly } = defineProps<{
+const { machine } = defineProps<{
   machine: Resource<MachineStatusLinkSpec>
-  iconOnly?: boolean
 }>()
 
 const { status } = useDerivedMachineStage(() => machine.spec.snapshot)
 </script>
 
 <template>
-  <Tooltip
+  <span
     v-if="status"
-    :disabled="!iconOnly"
-    :description="status.name"
-    :class="{ 'opacity-50': machine.spec.tearing_down }"
+    :class="
+      cn(
+        'inline-flex items-center gap-1 text-xs',
+        status.class,
+        { 'opacity-50': machine.spec.tearing_down },
+        $attrs.class,
+      )
+    "
   >
-    <div class="flex items-center gap-1" v-bind="$attrs" :class="status.class">
-      <!-- Wrapper to prevent tooltip bounce when icon is animated e.g. loading -->
-      <span class="size-4 shrink-0">
-        <TIcon
-          :icon="status.icon"
-          class="size-full"
-          :aria-label="`status: ${status.name.toLowerCase()}`"
-        />
-      </span>
-
-      <span v-if="!iconOnly" class="text-xs">{{ status.name }}</span>
-    </div>
-  </Tooltip>
+    <TIcon :icon="status.icon" class="size-4" aria-hidden="true" />
+    {{ status.name }}
+  </span>
 </template>

--- a/frontend/src/views/Machines/MachineItem.vue
+++ b/frontend/src/views/Machines/MachineItem.vue
@@ -13,7 +13,6 @@ import WordHighlighter from 'vue-word-highlighter'
 
 import type { Resource } from '@/api/grpc'
 import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
-import { MachineStatusSpecPowerState } from '@/api/omni/specs/omni.pb'
 import { LabelCluster, MachineStatusLabelInstalled } from '@/api/resources'
 import TActionsBox from '@/components/ActionsBox/TActionsBox.vue'
 import TActionsBoxItem from '@/components/ActionsBox/TActionsBoxItem.vue'
@@ -161,36 +160,10 @@ const canUseLifecycleUpgrade = computed(() => {
         </h2>
 
         <Tooltip :description="showUUID ? 'Copy machine UUID' : 'Copy machine name'">
-          <CopyButton :text="machineName" />
+          <CopyButton :text="machineName" class="shrink-0" />
         </Tooltip>
 
-        <Tooltip
-          v-if="
-            machine.spec.message_status?.power_state === MachineStatusSpecPowerState.POWER_STATE_ON
-          "
-          description="Powered on"
-        >
-          <TIcon
-            icon="power"
-            class="size-4 shrink-0 text-green-g1"
-            aria-label="machine powered on"
-          />
-        </Tooltip>
-
-        <Tooltip
-          v-if="
-            machine.spec.message_status?.power_state === MachineStatusSpecPowerState.POWER_STATE_OFF
-          "
-          description="Powered off"
-        >
-          <TIcon
-            icon="power-off"
-            class="size-4 shrink-0 text-red-r1"
-            aria-label="machine powered off"
-          />
-        </Tooltip>
-
-        <MachineStage :machine icon-only />
+        <MachineStage :machine />
 
         <div class="grow" />
 


### PR DESCRIPTION
Remove the dedicated power icon from the Machines list, as powered off and powering on state are covered already by the MachineStage component. Powered on is not, but is implicit. Given the extra space, we can drop the tooltip and show the text directly.

Closes #3100 