### PR TITLE
feat(frontend): update home page charts and show ongoing tasks

### DIFF
--- a/frontend/src/components/OngoingTasks/OngoingTasks.vue
+++ b/frontend/src/components/OngoingTasks/OngoingTasks.vue
@@ -8,64 +8,14 @@ included in the LICENSE file.
 import { PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka-ui'
 import { ref } from 'vue'
 
-import { Runtime } from '@/api/common/omni.pb'
-import { type Resource } from '@/api/grpc'
-import {
-  KubernetesUpgradeStatusSpecPhase,
-  type OngoingTaskSpec,
-  SecretRotationSpecComponent,
-} from '@/api/omni/specs/omni.pb'
-import { EphemeralNamespace, OngoingTaskType } from '@/api/resources'
 import TIcon from '@/components/Icon/TIcon.vue'
 import IconHeaderDropdownLoading from '@/components/icons/IconHeaderDropdownLoading.vue'
+import { useOngoingTasks } from '@/methods/ongoingTasks'
 import { formatISO } from '@/methods/time'
-import { useResourceWatch } from '@/methods/useResourceWatch'
 
-const { data } = useResourceWatch<OngoingTaskSpec>(() => ({
-  resource: {
-    namespace: EphemeralNamespace,
-    type: OngoingTaskType,
-  },
-  runtime: Runtime.Omni,
-}))
+const { data } = useOngoingTasks()
 
 const dropdownOpen = ref(false)
-
-const getPreviousVersion = (item: Resource<OngoingTaskSpec>) => {
-  if (item.spec.kubernetes_upgrade) {
-    return item.spec.kubernetes_upgrade.last_upgrade_version
-  }
-
-  if (item.spec.talos_upgrade) {
-    return item.spec.talos_upgrade.last_upgrade_version
-  }
-
-  return item.spec.machine_upgrade?.current_schematic_id
-}
-
-const getCurrentVersion = (item: Resource<OngoingTaskSpec>) => {
-  if (item.spec.kubernetes_upgrade) {
-    return item.spec.kubernetes_upgrade.current_upgrade_version
-  }
-
-  if (item.spec.talos_upgrade) {
-    return item.spec.talos_upgrade.current_upgrade_version
-  }
-
-  return item.spec.machine_upgrade?.current_schematic_id
-}
-
-const getCurrentComponent = (item: Resource<OngoingTaskSpec>) => {
-  if (item.spec.secrets_rotation) {
-    switch (item.spec.secrets_rotation.component) {
-      case SecretRotationSpecComponent.TALOS_CA:
-        return 'Talos CA'
-      default:
-        return
-    }
-  }
-  return
-}
 </script>
 
 <template>
@@ -93,7 +43,7 @@ const getCurrentComponent = (item: Resource<OngoingTaskSpec>) => {
         side="bottom"
       >
         <div
-          v-for="item in data"
+          v-for="{ item, desc } in data"
           :key="item.metadata.id"
           class="flex flex-col gap-2 border-naturals-n4 p-6 not-last:border-b"
         >
@@ -111,56 +61,37 @@ const getCurrentComponent = (item: Resource<OngoingTaskSpec>) => {
           </div>
 
           <div class="text-xs text-naturals-n9">
-            <span v-if="item.spec.destroy" class="truncate">
-              {{ item.spec.destroy.phase }}
-            </span>
-
-            <span v-else-if="item.spec.secrets_rotation" class="whitespace-nowrap">
-              Rotating {{ getCurrentComponent(item) }}
-            </span>
-
-            <div v-else class="flex items-center gap-2 text-xs">
-              <template v-if="getCurrentVersion(item)">
-                <span v-if="item.spec.kubernetes_upgrade" class="whitespace-nowrap">
-                  Upgrade Kubernetes
-                </span>
-                <span v-else-if="item.spec.machine_upgrade" class="whitespace-nowrap">
-                  Upgrade Machine
-                </span>
-                <span v-else class="whitespace-nowrap">Upgrade Talos</span>
-                <div class="flex-1" />
-                <span
-                  class="truncate rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13"
-                >
-                  {{ getPreviousVersion(item) }}
-                </span>
-                <span>⇾</span>
-                <span
-                  class="truncate rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13"
-                >
-                  {{ getCurrentVersion(item) }}
-                </span>
-              </template>
-
-              <template
-                v-else-if="
-                  (item.spec?.kubernetes_upgrade?.phase ?? item.spec?.talos_upgrade?.phase) ===
-                  KubernetesUpgradeStatusSpecPhase.Reverting
-                "
+            <div v-if="desc.fromVersion && desc.toVersion" class="flex items-center gap-2 text-xs">
+              <span class="whitespace-nowrap">{{ desc.action }}</span>
+              <div class="flex-1" />
+              <span
+                class="truncate rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13"
               >
-                <span class="whitespace-nowrap">Reverting back to</span>
-                <div class="flex-1" />
-                <span
-                  class="rounded bg-naturals-n4 px-2 text-xs font-bold whitespace-nowrap text-naturals-n13"
-                >
-                  {{
-                    (item.spec.kubernetes_upgrade ?? item.spec.talos_upgrade)?.last_upgrade_version
-                  }}
-                </span>
-              </template>
-
-              <span v-else class="whitespace-nowrap">Updating machine schematics</span>
+                {{ desc.fromVersion }}
+              </span>
+              <span>⇾</span>
+              <span
+                class="truncate rounded bg-naturals-n4 px-2 text-xs font-bold text-naturals-n13"
+              >
+                {{ desc.toVersion }}
+              </span>
             </div>
+
+            <div v-else-if="desc.revertingTo" class="flex items-center gap-2 text-xs">
+              <span class="whitespace-nowrap">Reverting back to</span>
+              <div class="flex-1" />
+              <span
+                class="rounded bg-naturals-n4 px-2 text-xs font-bold whitespace-nowrap text-naturals-n13"
+              >
+                {{ desc.revertingTo }}
+              </span>
+            </div>
+
+            <span v-else-if="desc.component" class="whitespace-nowrap">
+              {{ desc.action }} · {{ desc.component }}
+            </span>
+
+            <span v-else class="whitespace-nowrap">{{ desc.action }}</span>
           </div>
         </div>
 

--- a/frontend/src/methods/ongoingTasks.ts
+++ b/frontend/src/methods/ongoingTasks.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { computed, effectScope } from 'vue'
+
+import { Runtime } from '@/api/common/omni.pb'
+import type { Resource } from '@/api/grpc'
+import {
+  KubernetesUpgradeStatusSpecPhase,
+  type OngoingTaskSpec,
+  SecretRotationSpecComponent,
+} from '@/api/omni/specs/omni.pb'
+import { EphemeralNamespace, OngoingTaskType } from '@/api/resources'
+import { useResourceWatch } from '@/methods/useResourceWatch'
+
+type OngoingTaskKind = 'kubernetes' | 'talos' | 'machine' | 'secrets' | 'destroy' | 'unknown'
+
+/**
+ * Structured, presentation-agnostic description of an ongoing task. Both the
+ * header popover (which renders version "pills") and the home page panel (which
+ * renders an inline summary string) derive from this so the two stay in sync.
+ */
+interface OngoingTaskDescription {
+  kind: OngoingTaskKind
+  /** Short action label, e.g. "Upgrade Kubernetes", "Rotating secrets". */
+  action: string
+  /** Rotated component, when applicable (e.g. "Talos CA"). */
+  component?: string
+  /** Version being upgraded from (only when a target version is known). */
+  fromVersion?: string
+  /** Version being upgraded to. */
+  toVersion?: string
+  /** Target version when an upgrade is being reverted. */
+  revertingTo?: string
+}
+
+const taskScope = effectScope(true)
+
+const tasks = taskScope.run(() => {
+  const { data } = useResourceWatch<OngoingTaskSpec>(() => ({
+    resource: {
+      namespace: EphemeralNamespace,
+      type: OngoingTaskType,
+    },
+    runtime: Runtime.Omni,
+  }))
+
+  return data
+})!
+
+export function useOngoingTasks() {
+  return {
+    data: computed(() =>
+      tasks.value.map((item) => ({
+        item,
+        desc: describeOngoingTask(item),
+        summary: ongoingTaskSummary(item),
+      })),
+    ),
+  }
+}
+
+function secretComponentName(component?: SecretRotationSpecComponent) {
+  switch (component) {
+    case SecretRotationSpecComponent.TALOS_CA:
+      return 'Talos CA'
+    case SecretRotationSpecComponent.KUBERNETES_CA:
+      return 'Kubernetes CA'
+    default:
+      return undefined
+  }
+}
+
+const KIND_NAME = {
+  kubernetes: 'Kubernetes',
+  talos: 'Talos',
+  machine: 'Machine',
+}
+
+function getPreviousVersion({ spec }: Resource<OngoingTaskSpec>) {
+  return (
+    spec.kubernetes_upgrade?.last_upgrade_version ??
+    spec.talos_upgrade?.last_upgrade_version ??
+    spec.machine_upgrade?.current_schematic_id
+  )
+}
+
+function getCurrentVersion({ spec }: Resource<OngoingTaskSpec>) {
+  return (
+    spec.kubernetes_upgrade?.current_upgrade_version ??
+    spec.talos_upgrade?.current_upgrade_version ??
+    spec.machine_upgrade?.current_schematic_id
+  )
+}
+
+/** Maps a task's oneof payload to a structured, renderable description. */
+function describeOngoingTask(item: Resource<OngoingTaskSpec>): OngoingTaskDescription {
+  const { spec } = item
+
+  if (spec.destroy) {
+    return {
+      kind: 'destroy',
+      action: 'Destroying',
+    }
+  }
+
+  if (spec.secrets_rotation) {
+    return {
+      kind: 'secrets',
+      action: 'Rotating secrets',
+      component: secretComponentName(spec.secrets_rotation.component),
+    }
+  }
+
+  const upgrade = spec.kubernetes_upgrade ?? spec.talos_upgrade ?? spec.machine_upgrade
+  if (upgrade) {
+    const kind: OngoingTaskKind = spec.kubernetes_upgrade
+      ? 'kubernetes'
+      : spec.talos_upgrade
+        ? 'talos'
+        : 'machine'
+    const action = `Upgrade ${KIND_NAME[kind]}`
+
+    const toVersion = getCurrentVersion(item)
+    if (toVersion) {
+      return {
+        kind,
+        action,
+        fromVersion: getPreviousVersion(item),
+        toVersion,
+      }
+    }
+
+    const upgradePhase = spec.kubernetes_upgrade?.phase ?? spec.talos_upgrade?.phase
+    if (upgradePhase === KubernetesUpgradeStatusSpecPhase.Reverting) {
+      return {
+        kind,
+        action,
+        revertingTo: (spec.kubernetes_upgrade ?? spec.talos_upgrade)?.last_upgrade_version,
+      }
+    }
+
+    return {
+      kind: 'machine',
+      action: 'Updating machine schematics',
+    }
+  }
+
+  return {
+    kind: 'unknown',
+    action: 'In progress',
+  }
+}
+
+/** Single-line summary of a task, for compact/inline presentations. */
+function ongoingTaskSummary(item: Resource<OngoingTaskSpec>) {
+  const desc = describeOngoingTask(item)
+
+  if (desc.kind !== 'destroy' && desc.kind !== 'secrets' && desc.kind !== 'unknown') {
+    const name = KIND_NAME[desc.kind]
+
+    if (desc.fromVersion && desc.toVersion) {
+      return `${name} ${desc.fromVersion} → ${desc.toVersion}`
+    }
+
+    if (desc.revertingTo) {
+      return `${name} reverting to ${desc.revertingTo}`
+    }
+  }
+
+  if (desc.component) {
+    return `${desc.action} · ${desc.component}`
+  }
+
+  return desc.action
+}

--- a/frontend/src/views/Home/HomeClustersChart.stories.ts
+++ b/frontend/src/views/Home/HomeClustersChart.stories.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { createWatchStreamHandler } from '@msw/helpers.ts'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import { type ClusterStatusMetricsSpec, ClusterStatusSpecPhase } from '@/api/omni/specs/omni.pb.ts'
+import {
+  ClusterStatusMetricsID,
+  ClusterStatusMetricsType,
+  EphemeralNamespace,
+} from '@/api/resources.ts'
+
+import HomeClustersChart from './HomeClustersChart.vue'
+
+const meta: Meta = {
+  component: HomeClustersChart,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<ClusterStatusMetricsSpec>({
+          expectedOptions: {
+            namespace: EphemeralNamespace,
+            type: ClusterStatusMetricsType,
+            id: ClusterStatusMetricsID,
+          },
+          initialResources: [
+            {
+              spec: {
+                not_ready_count: 3,
+                phases: {
+                  [ClusterStatusSpecPhase.DESTROYING]: 1,
+                  [ClusterStatusSpecPhase.RUNNING]: 24,
+                  [ClusterStatusSpecPhase.SCALING_DOWN]: 2,
+                  [ClusterStatusSpecPhase.SCALING_UP]: 3,
+                },
+              },
+              metadata: {
+                namespace: EphemeralNamespace,
+                type: ClusterStatusMetricsType,
+                id: ClusterStatusMetricsID,
+              },
+            },
+          ],
+        }).handler,
+      ],
+    },
+  },
+} satisfies Story

--- a/frontend/src/views/Home/HomeClustersChart.stories.ts
+++ b/frontend/src/views/Home/HomeClustersChart.stories.ts
@@ -14,7 +14,7 @@ import {
 
 import HomeClustersChart from './HomeClustersChart.vue'
 
-const meta: Meta = {
+const meta: Meta<typeof HomeClustersChart> = {
   component: HomeClustersChart,
 }
 

--- a/frontend/src/views/Home/HomeClustersChart.vue
+++ b/frontend/src/views/Home/HomeClustersChart.vue
@@ -15,8 +15,8 @@ import {
   EphemeralNamespace,
 } from '@/api/resources'
 import Card from '@/components/Card/Card.vue'
-import RadialBar from '@/components/Charts/RadialBar.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
+import HomeStatusSegmentedBar from '@/views/Home/HomeStatusSegmentedBar.vue'
 
 const { data } = useResourceWatch<ClusterStatusMetricsSpec>({
   resource: {
@@ -27,37 +27,44 @@ const { data } = useResourceWatch<ClusterStatusMetricsSpec>({
   runtime: Runtime.Omni,
 })
 
-const counts = computed(() => {
+const items = computed(() => {
   const spec = data.value?.spec
 
   const notReadyCount = spec?.not_ready_count ?? 0
-  const destroyingCount = spec?.phases?.[ClusterStatusSpecPhase.DESTROYING] ?? 0
   const runningCount = spec?.phases?.[ClusterStatusSpecPhase.RUNNING] ?? 0
-  const scalingDownCount = spec?.phases?.[ClusterStatusSpecPhase.SCALING_DOWN] ?? 0
-  const scalingUpCount = spec?.phases?.[ClusterStatusSpecPhase.SCALING_UP] ?? 0
 
-  return {
-    healthyCount: Math.max(runningCount - notReadyCount, 0),
-    unhealthyCount: notReadyCount,
-    scalingUpCount,
-    scalingDownCount,
-    destroyingCount,
-  }
+  return [
+    {
+      label: 'Healthy',
+      value: Math.max(runningCount - notReadyCount, 0),
+      color: 'var(--color-primary-p3)',
+    },
+    { label: 'Unhealthy', value: notReadyCount, color: 'var(--color-red-r1)' },
+    {
+      label: 'Scaling Up',
+      value: spec?.phases?.[ClusterStatusSpecPhase.SCALING_UP] ?? 0,
+      color: 'var(--color-green-g1)',
+    },
+    {
+      label: 'Scaling Down',
+      value: spec?.phases?.[ClusterStatusSpecPhase.SCALING_DOWN] ?? 0,
+      color: 'var(--color-blue-b1)',
+    },
+    {
+      label: 'Destroying',
+      value: spec?.phases?.[ClusterStatusSpecPhase.DESTROYING] ?? 0,
+      color: 'var(--color-yellow-y1)',
+    },
+  ]
 })
 </script>
 
 <template>
   <Card class="p-4">
-    <RadialBar
+    <HomeStatusSegmentedBar
       title="Clusters"
-      show-hollow-total
-      :items="[
-        { label: 'Healthy', value: counts.healthyCount },
-        { label: 'Unhealthy', value: counts.unhealthyCount },
-        { label: 'Scaling Up', value: counts.scalingUpCount },
-        { label: 'Scaling Down', value: counts.scalingDownCount },
-        { label: 'Destroying', value: counts.destroyingCount },
-      ]"
+      :total="items.reduce((sum, item) => sum + item.value, 0)"
+      :bars="[{ segments: items }]"
     />
   </Card>
 </template>

--- a/frontend/src/views/Home/HomeClustersTutorialCard.stories.ts
+++ b/frontend/src/views/Home/HomeClustersTutorialCard.stories.ts
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
 import HomeClustersTutorialCard from './HomeClustersTutorialCard.vue'
 
-const meta: Meta = {
+const meta: Meta<typeof HomeClustersTutorialCard> = {
   component: HomeClustersTutorialCard,
 }
 

--- a/frontend/src/views/Home/HomeContent.stories.ts
+++ b/frontend/src/views/Home/HomeContent.stories.ts
@@ -36,7 +36,7 @@ import HomeContent from './HomeContent.vue'
 
 faker.seed(0)
 
-const meta: Meta = {
+const meta: Meta<typeof HomeContent> = {
   component: HomeContent,
 }
 

--- a/frontend/src/views/Home/HomeContent.stories.ts
+++ b/frontend/src/views/Home/HomeContent.stories.ts
@@ -31,6 +31,7 @@ import { MachineStatusEventMachineStage } from '@/api/talos/machine/machine.pb.t
 import * as HomeClustersChartStories from '@/views/Home/HomeClustersChart.stories'
 import * as HomeGeneralInformationStories from '@/views/Home/HomeGeneralInformation.stories'
 import * as HomeMachinesChartStories from '@/views/Home/HomeMachinesChart.stories'
+import * as HomeOngoingOperationsStories from '@/views/Home/HomeOngoingOperations.stories'
 
 import HomeContent from './HomeContent.vue'
 
@@ -141,6 +142,7 @@ export const Default: Story = {
         ...HomeGeneralInformationStories.Default.parameters.msw.handlers,
         ...HomeClustersChartStories.Default.parameters.msw.handlers,
         ...HomeMachinesChartStories.Default.parameters.msw.handlers,
+        ...HomeOngoingOperationsStories.Default.parameters.msw.handlers,
       ],
     },
   },

--- a/frontend/src/views/Home/HomeContent.stories.ts
+++ b/frontend/src/views/Home/HomeContent.stories.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import { createWatchStreamHandler } from '@msw/helpers.ts'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+
+import type { Resource } from '@/api/grpc.ts'
+import type { GetRequest, GetResponse } from '@/api/omni/resources/resources.pb.ts'
+import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb.ts'
+import {
+  type ClusterStatusSpec,
+  ClusterStatusSpecPhase,
+  MachineStatusSnapshotSpecPowerStage,
+} from '@/api/omni/specs/omni.pb.ts'
+import type { PermissionsSpec } from '@/api/omni/specs/virtual.pb.ts'
+import {
+  ClusterPermissionsType,
+  ClusterStatusType,
+  DefaultNamespace,
+  LabelCluster,
+  MachineStatusLinkType,
+  MetricsNamespace,
+  PermissionsID,
+  PermissionsType,
+  VirtualNamespace,
+} from '@/api/resources.ts'
+import { MachineStatusEventMachineStage } from '@/api/talos/machine/machine.pb.ts'
+import * as HomeClustersChartStories from '@/views/Home/HomeClustersChart.stories'
+import * as HomeGeneralInformationStories from '@/views/Home/HomeGeneralInformation.stories'
+import * as HomeMachinesChartStories from '@/views/Home/HomeMachinesChart.stories'
+
+import HomeContent from './HomeContent.vue'
+
+faker.seed(0)
+
+const meta: Meta = {
+  component: HomeContent,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.post<never, GetRequest, GetResponse>(
+          '/omni.resources.ResourceService/Get',
+          async ({ request }) => {
+            const { id, type, namespace } = await request.clone().json()
+
+            if (
+              id !== PermissionsID ||
+              type !== PermissionsType ||
+              namespace !== VirtualNamespace
+            ) {
+              return
+            }
+
+            return HttpResponse.json({
+              body: JSON.stringify({
+                metadata: {
+                  namespace: VirtualNamespace,
+                  type: ClusterPermissionsType,
+                  id: PermissionsID,
+                },
+                spec: {
+                  can_read_clusters: true,
+                  can_read_machines: true,
+                  can_read_join_tokens: true,
+                  can_read_audit_log: true,
+                },
+              } as Resource<PermissionsSpec>),
+            })
+          },
+        ),
+
+        createWatchStreamHandler<ClusterStatusSpec>({
+          expectedOptions: {
+            namespace: DefaultNamespace,
+            type: ClusterStatusType,
+          },
+          initialResources: faker.helpers.multiple(
+            () => ({
+              spec: {
+                phase: faker.helpers.enumValue(ClusterStatusSpecPhase),
+                ready: faker.datatype.boolean(),
+                machines: {
+                  total: faker.number.int({ min: 3, max: 50 }),
+                },
+              },
+              metadata: {
+                namespace: DefaultNamespace,
+                type: ClusterStatusType,
+                id: faker.hacker.noun(),
+              },
+            }),
+            { count: 10 },
+          ),
+        }).handler,
+
+        createWatchStreamHandler<MachineStatusLinkSpec>({
+          expectedOptions: {
+            namespace: MetricsNamespace,
+            type: MachineStatusLinkType,
+          },
+          initialResources: faker.helpers.multiple(
+            () => ({
+              spec: {
+                message_status: {
+                  network: {
+                    hostname: faker.internet.domainWord(),
+                  },
+                },
+                tearing_down: faker.datatype.boolean(),
+                snapshot: {
+                  machine_status: {
+                    stage: faker.helpers.enumValue(MachineStatusEventMachineStage),
+                  },
+                  power_stage: faker.helpers.enumValue(MachineStatusSnapshotSpecPowerStage),
+                },
+              },
+              metadata: {
+                namespace: MetricsNamespace,
+                type: MachineStatusLinkType,
+                id: faker.string.uuid(),
+                labels: {
+                  ...faker.helpers.maybe(() => ({
+                    [LabelCluster]: faker.hacker.noun(),
+                  })),
+                },
+              },
+            }),
+            { count: 50 },
+          ),
+        }).handler,
+
+        ...HomeGeneralInformationStories.Default.parameters.msw.handlers,
+        ...HomeClustersChartStories.Default.parameters.msw.handlers,
+        ...HomeMachinesChartStories.Default.parameters.msw.handlers,
+      ],
+    },
+  },
+}

--- a/frontend/src/views/Home/HomeContent.vue
+++ b/frontend/src/views/Home/HomeContent.vue
@@ -20,6 +20,7 @@ import HomeClustersChart from '@/views/Home/HomeClustersChart.vue'
 import HomeClustersTutorialCard from '@/views/Home/HomeClustersTutorialCard.vue'
 import HomeGeneralInformation from '@/views/Home/HomeGeneralInformation.vue'
 import HomeMachinesChart from '@/views/Home/HomeMachinesChart.vue'
+import HomeOngoingOperations from '@/views/Home/HomeOngoingOperations.vue'
 import HomeRecentClusters from '@/views/Home/HomeRecentClusters.vue'
 import HomeRecentMachines from '@/views/Home/HomeRecentMachines.vue'
 import WelcomeToOmniCard from '@/views/Home/WelcomeToOmniCard.vue'
@@ -80,6 +81,8 @@ const showReleaseNotes = false
             <HomeClustersChart v-if="canReadClusters" />
             <HomeMachinesChart v-if="canReadMachines" />
           </div>
+
+          <HomeOngoingOperations />
 
           <div class="flex flex-col gap-2">
             <HomeRecentClusters v-if="canReadClusters" :clusters :loading="clustersLoading" />

--- a/frontend/src/views/Home/HomeContent.vue
+++ b/frontend/src/views/Home/HomeContent.vue
@@ -76,10 +76,7 @@ const showReleaseNotes = false
             <HomeClustersTutorialCard v-else-if="!clusters.length" />
           </template>
 
-          <div
-            class="grid grid-cols-1 gap-2"
-            :class="{ 'xl:grid-cols-2': canReadClusters && canReadMachines }"
-          >
+          <div class="grid grid-cols-1 gap-2">
             <HomeClustersChart v-if="canReadClusters" />
             <HomeMachinesChart v-if="canReadMachines" />
           </div>

--- a/frontend/src/views/Home/HomeGeneralInformation.stories.ts
+++ b/frontend/src/views/Home/HomeGeneralInformation.stories.ts
@@ -32,7 +32,7 @@ faker.seed(0)
 
 const joinToken = faker.string.alphanumeric(44)
 
-const meta: Meta = {
+const meta: Meta<typeof HomeGeneralInformation> = {
   component: HomeGeneralInformation,
 }
 

--- a/frontend/src/views/Home/HomeGeneralInformation.stories.ts
+++ b/frontend/src/views/Home/HomeGeneralInformation.stories.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { faker } from '@faker-js/faker'
+import { createWatchStreamHandler } from '@msw/helpers.ts'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { FeaturesConfigSpec } from '@/api/omni/specs/omni.pb.ts'
+import type {
+  DefaultJoinTokenSpec,
+  SiderolinkAPIConfigSpec,
+} from '@/api/omni/specs/siderolink.pb.ts'
+import type { SysVersionSpec } from '@/api/omni/specs/system.pb.ts'
+import {
+  APIConfigType,
+  ConfigID,
+  DefaultJoinTokenID,
+  DefaultJoinTokenType,
+  DefaultNamespace,
+  EphemeralNamespace,
+  FeaturesConfigID,
+  FeaturesConfigType,
+  SysVersionID,
+  SysVersionType,
+} from '@/api/resources.ts'
+import * as DownloadTalosctlModalStories from '@/views/Home/components/DownloadTalosctl.stories'
+
+import HomeGeneralInformation from './HomeGeneralInformation.vue'
+
+faker.seed(0)
+
+const joinToken = faker.string.alphanumeric(44)
+
+const meta: Meta = {
+  component: HomeGeneralInformation,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<FeaturesConfigSpec>({
+          expectedOptions: {
+            type: FeaturesConfigType,
+            namespace: DefaultNamespace,
+            id: FeaturesConfigID,
+          },
+          initialResources: [
+            {
+              spec: {
+                audit_log_enabled: true,
+              },
+              metadata: {
+                type: FeaturesConfigType,
+                namespace: DefaultNamespace,
+                id: FeaturesConfigID,
+              },
+            },
+          ],
+        }).handler,
+
+        createWatchStreamHandler<SysVersionSpec>({
+          expectedOptions: {
+            type: SysVersionType,
+            namespace: EphemeralNamespace,
+            id: SysVersionID,
+          },
+          initialResources: [
+            {
+              spec: {
+                backend_version: `v${faker.system.semver()}`,
+              },
+              metadata: {
+                type: SysVersionType,
+                namespace: EphemeralNamespace,
+                id: SysVersionID,
+              },
+            },
+          ],
+        }).handler,
+
+        createWatchStreamHandler<DefaultJoinTokenSpec>({
+          expectedOptions: {
+            type: DefaultJoinTokenType,
+            namespace: DefaultNamespace,
+            id: DefaultJoinTokenID,
+          },
+          initialResources: [
+            {
+              spec: {
+                token_id: joinToken,
+              },
+              metadata: {
+                type: DefaultJoinTokenType,
+                namespace: DefaultNamespace,
+                id: DefaultJoinTokenID,
+              },
+            },
+          ],
+        }).handler,
+
+        createWatchStreamHandler<SiderolinkAPIConfigSpec>({
+          expectedOptions: {
+            type: APIConfigType,
+            namespace: DefaultNamespace,
+            id: ConfigID,
+          },
+          initialResources: [
+            {
+              spec: {
+                machine_api_advertised_url: faker.internet.url(),
+                wireguard_advertised_endpoint: `grpc://${faker.internet.ipv4({ cidrBlock: '172.20.0.0/24' })}:8090?jointoken=${joinToken}`,
+              },
+              metadata: {
+                type: APIConfigType,
+                namespace: DefaultNamespace,
+                id: ConfigID,
+              },
+            },
+          ],
+        }).handler,
+
+        ...DownloadTalosctlModalStories.Default.parameters.msw.handlers,
+      ],
+    },
+  },
+} satisfies Story

--- a/frontend/src/views/Home/HomeMachinesChart.stories.ts
+++ b/frontend/src/views/Home/HomeMachinesChart.stories.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { createWatchStreamHandler } from '@msw/helpers.ts'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { MachineStatusMetricsSpec } from '@/api/omni/specs/omni.pb.ts'
+import {
+  EphemeralNamespace,
+  MachineStatusMetricsID,
+  MachineStatusMetricsType,
+} from '@/api/resources.ts'
+
+import HomeMachinesChart from './HomeMachinesChart.vue'
+
+const meta: Meta = {
+  component: HomeMachinesChart,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<MachineStatusMetricsSpec>({
+          expectedOptions: {
+            namespace: EphemeralNamespace,
+            type: MachineStatusMetricsType,
+            id: MachineStatusMetricsID,
+          },
+          initialResources: [
+            {
+              spec: {
+                allocated_machines_count: 34,
+                connected_machines_count: 40,
+                pending_machines_count: 2,
+                registered_machines_count: 42,
+              },
+              metadata: {
+                namespace: EphemeralNamespace,
+                type: MachineStatusMetricsType,
+                id: MachineStatusMetricsID,
+              },
+            },
+          ],
+        }).handler,
+      ],
+    },
+  },
+} satisfies Story

--- a/frontend/src/views/Home/HomeMachinesChart.stories.ts
+++ b/frontend/src/views/Home/HomeMachinesChart.stories.ts
@@ -14,7 +14,7 @@ import {
 
 import HomeMachinesChart from './HomeMachinesChart.vue'
 
-const meta: Meta = {
+const meta: Meta<typeof HomeMachinesChart> = {
   component: HomeMachinesChart,
 }
 

--- a/frontend/src/views/Home/HomeMachinesChart.vue
+++ b/frontend/src/views/Home/HomeMachinesChart.vue
@@ -15,8 +15,8 @@ import {
   MachineStatusMetricsType,
 } from '@/api/resources'
 import Card from '@/components/Card/Card.vue'
-import RadialBar from '@/components/Charts/RadialBar.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
+import HomeStatusSegmentedBar from '@/views/Home/HomeStatusSegmentedBar.vue'
 
 const { data } = useResourceWatch<MachineStatusMetricsSpec>({
   resource: {
@@ -26,6 +26,14 @@ const { data } = useResourceWatch<MachineStatusMetricsSpec>({
   },
   runtime: Runtime.Omni,
 })
+
+const colors = {
+  connected: 'var(--color-primary-p3)',
+  notConnected: 'var(--color-red-r1)',
+  inCluster: 'var(--color-green-g1)',
+  freeMachine: 'var(--color-blue-b1)',
+  pending: 'var(--color-yellow-y1)',
+}
 
 const counts = computed(() => {
   const spec = data.value?.spec
@@ -44,20 +52,27 @@ const counts = computed(() => {
     freeMachineCount: Math.max(registeredCount - allocatedCount, 0),
   }
 })
+
+const connectionItems = computed(() => [
+  { label: 'Connected', value: counts.value.connectedCount, color: colors.connected },
+  { label: 'Not Connected', value: counts.value.notConnectedCount, color: colors.notConnected },
+])
+
+const allocationItems = computed(() => [
+  { label: 'In Cluster', value: counts.value.inClusterCount, color: colors.inCluster },
+  { label: 'Free Machine', value: counts.value.freeMachineCount, color: colors.freeMachine },
+  { label: 'Pending', value: counts.value.pendingCount, color: colors.pending },
+])
 </script>
 
 <template>
   <Card class="p-4">
-    <RadialBar
+    <HomeStatusSegmentedBar
       title="Machines"
-      show-hollow-total
       :total="counts.totalCount"
-      :items="[
-        { label: 'Connected', value: counts.connectedCount },
-        { label: 'Not Connected', value: counts.notConnectedCount },
-        { label: 'In Cluster', value: counts.inClusterCount },
-        { label: 'Free Machine', value: counts.freeMachineCount },
-        { label: 'Pending', value: counts.pendingCount },
+      :bars="[
+        { label: 'Connection', segments: connectionItems },
+        { label: 'Allocation', segments: allocationItems },
       ]"
     />
   </Card>

--- a/frontend/src/views/Home/HomeOngoingOperations.stories.ts
+++ b/frontend/src/views/Home/HomeOngoingOperations.stories.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { createWatchStreamHandler } from '@msw/helpers.ts'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { OngoingTaskSpec } from '@/api/omni/specs/omni.pb.ts'
+import { EphemeralNamespace, OngoingTaskType } from '@/api/resources.ts'
+
+import HomeOngoingOperations from './HomeOngoingOperations.vue'
+
+const meta: Meta<typeof HomeOngoingOperations> = {
+  component: HomeOngoingOperations,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default = {
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<OngoingTaskSpec>({
+          expectedOptions: {
+            namespace: EphemeralNamespace,
+            type: OngoingTaskType,
+          },
+          initialResources: [
+            {
+              metadata: {
+                namespace: EphemeralNamespace,
+                type: OngoingTaskType,
+                id: 'prod-east-k8s',
+                created: '2026-07-07T09:30:00Z',
+              },
+              spec: {
+                title: 'prod-east',
+                kubernetes_upgrade: {
+                  last_upgrade_version: '1.30.1',
+                  current_upgrade_version: '1.31.0',
+                },
+              },
+            },
+            {
+              metadata: {
+                namespace: EphemeralNamespace,
+                type: OngoingTaskType,
+                id: 'staging-talos',
+                created: '2026-07-07T09:42:00Z',
+              },
+              spec: {
+                title: 'staging',
+                talos_upgrade: {
+                  last_upgrade_version: 'v1.7.5',
+                  current_upgrade_version: 'v1.8.0',
+                },
+              },
+            },
+          ],
+        }).handler,
+      ],
+    },
+  },
+} satisfies Story

--- a/frontend/src/views/Home/HomeOngoingOperations.vue
+++ b/frontend/src/views/Home/HomeOngoingOperations.vue
@@ -1,0 +1,45 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import Card from '@/components/Card/Card.vue'
+import TIcon from '@/components/Icon/TIcon.vue'
+import { useOngoingTasks } from '@/methods/ongoingTasks'
+import { formatISO } from '@/methods/time'
+
+const { data } = useOngoingTasks()
+</script>
+
+<template>
+  <Card v-if="data.length" class="text-xs">
+    <header class="flex items-center justify-between gap-1 px-4 py-3">
+      <h2 class="text-sm font-medium text-naturals-n14">Ongoing Operations</h2>
+      <span class="text-naturals-n11">{{ data.length }}</span>
+    </header>
+
+    <div
+      v-for="{ item, summary } in data"
+      :key="item.metadata.id"
+      class="flex items-center gap-3 border-t border-naturals-n4 px-4 py-3"
+    >
+      <TIcon
+        icon="loading"
+        class="size-4 shrink-0 animate-spin text-primary-p3"
+        aria-hidden="true"
+      />
+
+      <span class="min-w-0 grow truncate font-medium text-naturals-n14">
+        {{ item.spec.title }}
+      </span>
+
+      <span class="min-w-0 truncate text-naturals-n11">{{ summary }}</span>
+
+      <span v-if="item.metadata.created" class="shrink-0 text-naturals-n9 tabular-nums">
+        {{ formatISO(item.metadata.created, 'HH:mm:ss') }}
+      </span>
+    </div>
+  </Card>
+</template>

--- a/frontend/src/views/Home/HomeStatusSegmentedBar.vue
+++ b/frontend/src/views/Home/HomeStatusSegmentedBar.vue
@@ -1,0 +1,87 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { useId } from 'vue'
+
+interface Segment {
+  label: string
+  value: number
+  color: string
+}
+
+interface Bar {
+  label?: string
+  segments: Segment[]
+}
+
+const { total, bars } = defineProps<{
+  title: string
+  total?: number
+  bars: Bar[]
+}>()
+
+const labelId = useId()
+
+function barTotal(bar: Bar) {
+  return bar.segments.reduce((prev, curr) => prev + curr.value, 0)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <div class="flex items-baseline justify-between gap-2">
+      <h2 :id="labelId" class="text-xl font-medium text-naturals-n14">{{ title }}</h2>
+      <span v-if="total !== undefined" class="text-sm text-naturals-n11">{{ total }} total</span>
+    </div>
+
+    <template v-for="(bar, barIndex) in bars" :key="bar.label ?? barIndex">
+      <div class="flex flex-col gap-3" :aria-labelledby="labelId">
+        <div class="flex flex-col gap-1">
+          <span v-if="bar.label" class="text-xs text-naturals-n11">{{ bar.label }}</span>
+
+          <div
+            class="flex h-2.5 w-full gap-0.5 overflow-hidden rounded-sm bg-naturals-n5"
+            role="img"
+            :aria-label="
+              bar.segments.map((segment) => `${segment.label}: ${segment.value}`).join(', ')
+            "
+          >
+            <span
+              v-for="segment in bar.segments"
+              :key="segment.label"
+              class="h-full transition-all"
+              :style="{
+                width: `${barTotal(bar) === 0 ? 0 : (segment.value / barTotal(bar)) * 100}%`,
+                backgroundColor: segment.color,
+              }"
+            />
+          </div>
+        </div>
+      </div>
+
+      <dl class="flex flex-wrap gap-x-4 gap-y-1.5">
+        <div
+          v-for="(item, index) in bar.segments"
+          :key="item.label"
+          class="flex items-center gap-2 text-xs whitespace-nowrap"
+        >
+          <span
+            aria-hidden="true"
+            class="size-2 rounded-xs"
+            :style="{ backgroundColor: item.color }"
+          />
+          <dt :id="`${labelId}-${barIndex}-dt-${index}`" class="text-naturals-n11">
+            {{ item.label }}
+          </dt>
+          <dd :aria-labelledby="`${labelId}-${barIndex}-dt-${index}`" class="text-naturals-n14">
+            {{ item.value }}
+          </dd>
+        </div>
+      </dl>
+    </template>
+  </div>
+</template>

--- a/frontend/src/views/Home/components/DownloadTalosctl.stories.ts
+++ b/frontend/src/views/Home/components/DownloadTalosctl.stories.ts
@@ -41,7 +41,7 @@ const versions = faker.helpers
   .concat(DefaultTalosVersion)
   .sort(compare)
 
-export const Default: Story = {
+export const Default = {
   parameters: {
     msw: {
       handlers: [
@@ -100,4 +100,4 @@ export const Default: Story = {
       ],
     },
   },
-}
+} satisfies Story


### PR DESCRIPTION
Replace the radial bar charts on the homepage with segmented bars which more appropriately display the information. Also splits the machine information into two separate points, connection state and allocation state.

Also added the ongoing tasks from the dropdown to the home page for better visibility, as in the dropdown it is convenient but can be missed. Added storybook stories for all home page items.

Closes #1635
Closes #1636

<img width="600" alt="image" src="https://github.com/user-attachments/assets/eef65eef-b7e1-4bbf-bf36-cee253e67847" />

