### PR TITLE
feat: add machine log ingestion byte-rate metric

### DIFF
--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -154,6 +154,8 @@ func Run(ctx context.Context, state *omni.State, cfg *config.Params, logger *zap
 		return fmt.Errorf("failed to set up log handler: %w", err)
 	}
 
+	prometheus.MustRegister(logHandler)
+
 	authConfig, err := auth.EnsureAuthConfigResource(ctx, state.Default(), logger, cfg.Auth)
 	if err != nil {
 		return fmt.Errorf("failed to write auth parameters to state: %w", err)

--- a/hack/compose/grafana/dashboards/omni-details.json
+++ b/hack/compose/grafana/dashboards/omni-details.json
@@ -3318,6 +3318,216 @@
       ],
       "title": "Etcd Writes",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 113
+      },
+      "id": 310,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "description": "Bytes/sec of ingested machine log messages, summed across all machines.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "Bps",
+              "unitScale": true
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 114
+          },
+          "id": 311,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(omni_machine_logs_ingested_bytes_total[$__rate_interval])",
+              "legendFormat": "Ingested",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Machine Log Ingestion: Bytes/sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "description": "Bytes/sec of machine log messages dropped by the per-machine ingestion rate limit, split by reason (rate_limit: sustained rate exceeded, oversize: a single message exceeded the configured burst).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "Bps",
+              "unitScale": true
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 114
+          },
+          "id": 312,
+          "options": {
+            "legend": {
+              "calcs": [
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "Prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (reason) (rate(omni_machine_logs_dropped_total[$__rate_interval]))",
+              "legendFormat": "{{reason}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Machine Log Rate Limit: Dropped Bytes/sec",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Machine Logs",
+      "type": "row"
     }
   ],
   "refresh": "30s",

--- a/internal/pkg/siderolink/loghandler.go
+++ b/internal/pkg/siderolink/loghandler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/siderolabs/gen/optional"
 	"go.uber.org/zap"
 
@@ -76,6 +77,12 @@ func NewLogHandler(secondaryStorageDB *sqlitexx.Pool, machineMap *MachineMap, om
 		cache:      cache,
 		logger:     logger,
 		limiter:    options.limiter,
+		ingestedBytes: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "omni",
+			Subsystem: "machine_logs",
+			Name:      "ingested_bytes_total",
+			Help:      "Total bytes of machine log messages successfully written to storage.",
+		}),
 	}
 
 	return &handler, nil
@@ -83,11 +90,24 @@ func NewLogHandler(secondaryStorageDB *sqlitexx.Pool, machineMap *MachineMap, om
 
 // LogHandler stores a map of machines to their log stores.
 type LogHandler struct {
-	omniState  state.State
-	machineMap *MachineMap
-	logger     *zap.Logger
-	cache      *MachineCache
-	limiter    *LogIngestionLimiter
+	omniState     state.State
+	machineMap    *MachineMap
+	logger        *zap.Logger
+	cache         *MachineCache
+	limiter       *LogIngestionLimiter
+	ingestedBytes prometheus.Counter
+}
+
+var _ prometheus.Collector = &LogHandler{}
+
+// Describe implements prometheus.Collector.
+func (h *LogHandler) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(h, ch)
+}
+
+// Collect implements prometheus.Collector.
+func (h *LogHandler) Collect(ch chan<- prometheus.Metric) {
+	h.ingestedBytes.Collect(ch)
 }
 
 // Start starts the LogHandler.
@@ -205,6 +225,8 @@ func (h *LogHandler) writeMessage(ctx context.Context, ip string, data []byte) e
 	if err != nil {
 		return fmt.Errorf("failed to write message to log store for machine %q: %w", id, err)
 	}
+
+	h.ingestedBytes.Add(float64(len(data)))
 
 	return nil
 }

--- a/internal/pkg/siderolink/loghandler_test.go
+++ b/internal/pkg/siderolink/loghandler_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/siderolabs/gen/optional"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
@@ -112,6 +114,61 @@ func TestLogHandler_HandleMessage(t *testing.T) {
 		line, err = reader.ReadLine(ctx)
 		require.NoError(t, err)
 		require.Equal(t, `{"hello": "world5"}`, string(line))
+	})
+}
+
+func TestLogHandler_IngestedBytesMetric(t *testing.T) {
+	storageConfig := config.LogsMachine{}
+
+	t.Run("counts bytes ingested when no limiter is configured", func(t *testing.T) {
+		machineMap := siderolink.NewMachineMap(&siderolink.MapStorage{
+			IPToMachine: map[string]siderolink.MachineID{
+				"1.2.3.4": "machine1",
+			},
+		})
+
+		st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		handler, err := siderolink.NewLogHandler(testDB(t), machineMap, st, &storageConfig, zaptest.NewLogger(t))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		msg := []byte(`{"hello": "world"}`)
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), msg)
+
+		assert.InDelta(t, float64(len(msg)), testutil.ToFloat64(handler), 0.01)
+	})
+
+	t.Run("does not count bytes rejected by the rate limiter", func(t *testing.T) {
+		machineMap := siderolink.NewMachineMap(&siderolink.MapStorage{
+			IPToMachine: map[string]siderolink.MachineID{
+				"1.2.3.4": "machine1",
+			},
+		})
+
+		st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+		// Low sustained rate with a small burst: the first message exhausts the
+		// burst, and the second is guaranteed to be rejected since refilling a
+		// single token takes a full second.
+		limiter := siderolink.NewLogIngestionLimiter(1, 10, zaptest.NewLogger(t))
+
+		handler, err := siderolink.NewLogHandler(testDB(t), machineMap, st, &storageConfig, zaptest.NewLogger(t),
+			siderolink.WithLogIngestionLimiter(limiter))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		allowed := []byte("0123456789")
+		rejected := []byte("x")
+
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), allowed)
+		handler.HandleMessage(ctx, netip.MustParseAddr("1.2.3.4"), rejected)
+
+		assert.InDelta(t, float64(len(allowed)), testutil.ToFloat64(handler), 0.01)
 	})
 }
 


### PR DESCRIPTION
Adds `omni_machine_logs_ingested_bytes_total`, a Prometheus counter on LogHandler that tracks the size of every machine log message accepted for ingestion.

Resolves: #3095
