### PR TITLE
fix: don't treat unset S3 endpoint as an empty override

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/s3store.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcdbackup/store/s3store.go
@@ -199,7 +199,7 @@ func S3ClientFromResource(ctx context.Context, s3Conf *omni.EtcdBackupS3Conf) (*
 
 	client := s3.NewFromConfig(loadedCfg, func(o *s3.Options) {
 		o.UsePathStyle = true
-		o.BaseEndpoint = aws.String(baseEndpoint)
+		o.BaseEndpoint = resolveBaseEndpoint(baseEndpoint)
 		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
 		o.DisableLogOutputChecksumValidationSkipped = true
 	})
@@ -210,6 +210,19 @@ func S3ClientFromResource(ctx context.Context, s3Conf *omni.EtcdBackupS3Conf) (*
 	}
 
 	return client, bucket, nil
+}
+
+// resolveBaseEndpoint returns the S3 base endpoint override for the given endpoint string, or nil
+// to fall back to the SDK's default endpoint resolution.
+//
+// The AWS SDK treats a non-nil BaseEndpoint of "" as an explicit (invalid) endpoint override, so
+// an unset endpoint must resolve to a nil pointer rather than aws.String("").
+func resolveBaseEndpoint(endpoint string) *string {
+	if endpoint == "" {
+		return nil
+	}
+
+	return aws.String(endpoint)
 }
 
 // Description returns a description of the store.


### PR DESCRIPTION
When the S3 endpoint field was left unset, Omni still passed an empty string to the AWS SDK as a literal endpoint override, and the SDK rejected it as an invalid URI. Configuring S3 backup storage against real AWS S3, as opposed to a custom endpoint like MinIO, always failed as a result. resolveBaseEndpoint now returns nil when no endpoint is configured, so the SDK falls back to its normal endpoint resolution.