### PR TITLE
feat(frontend): handle machine services errors gracefully

### DIFF
--- a/frontend/src/api/grpc.ts
+++ b/frontend/src/api/grpc.ts
@@ -127,7 +127,12 @@ export class Stream<R, T> {
           return
         }
 
-        console.error('watch failed', e)
+        const watchTarget =
+          params && typeof params === 'object' && 'namespace' in params && 'type' in params
+            ? `${params.namespace}/${params.type}`
+            : (String(method).match(/`\/(.*?)`/)?.[1] ?? 'Unknown service')
+
+        console.error(`Watch failed for "${watchTarget}"\n\n${e.message}`)
 
         const err = e instanceof Error ? e : new Error(String(e))
 

--- a/frontend/src/methods/useMachineServices.ts
+++ b/frontend/src/methods/useMachineServices.ts
@@ -2,15 +2,17 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
+import { refThrottled } from '@vueuse/core'
 import { type MaybeRefOrGetter, ref, toValue, watchEffect } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
+import { RequestError } from '@/api/fetch.pb'
+import { Code } from '@/api/google/rpc/code.pb'
 import { subscribe } from '@/api/grpc'
 import type { RuntimeContext } from '@/api/options'
 import { withAbortController, withContext, withRuntime } from '@/api/options'
 import { MachineService, type ServiceEvent } from '@/api/talos/machine/machine.pb'
 import { TCommonStatuses } from '@/constants'
-import { showError } from '@/notification'
 
 interface Service {
   name?: string
@@ -20,15 +22,30 @@ interface Service {
 }
 
 export function useMachineServices(context: MaybeRefOrGetter<RuntimeContext>) {
-  const services = ref<Service[]>([])
+  const data = ref<Service[]>([])
+  const loading = ref(true)
+  const err = ref<Error>()
+  const errCode = ref<Code>()
+
   const serviceListVersion = ref(0)
+  const serviceListVersionDebounced = refThrottled(serviceListVersion, 1000)
+
+  let retryCount = 0
+  let retryTimer: number | undefined
 
   watchEffect(async (onCleanup) => {
     // To track for forced updates
-    void serviceListVersion.value
+    void serviceListVersionDebounced.value
 
     const abortController = new AbortController()
-    onCleanup(() => abortController.abort())
+    onCleanup(() => {
+      abortController.abort()
+      clearTimeout(retryTimer)
+    })
+
+    loading.value = true
+    err.value = undefined
+    errCode.value = undefined
 
     try {
       const { messages = [] } = await MachineService.ServiceList(
@@ -38,7 +55,7 @@ export function useMachineServices(context: MaybeRefOrGetter<RuntimeContext>) {
         withAbortController(abortController),
       )
 
-      services.value = messages.flatMap(({ services = [] }) =>
+      data.value = messages.flatMap(({ services = [] }) =>
         services.map((service) => ({
           name: service.id,
           state: service.state,
@@ -50,10 +67,20 @@ export function useMachineServices(context: MaybeRefOrGetter<RuntimeContext>) {
           events: service.events?.events,
         })),
       )
+
+      retryCount = 0
     } catch (e) {
       if (abortController.signal.aborted) return
 
-      showError('Error', e instanceof Error ? e.message : String(e))
+      err.value = e instanceof Error ? e : new Error(JSON.stringify(e))
+      errCode.value = e instanceof RequestError ? e.code : undefined
+
+      // Retry with backoff
+      const backoff = Math.min(2 ** retryCount * 500, 10_000)
+      retryCount++
+      retryTimer = setTimeout(() => serviceListVersion.value++, backoff)
+    } finally {
+      loading.value = false
     }
   })
 
@@ -76,5 +103,5 @@ export function useMachineServices(context: MaybeRefOrGetter<RuntimeContext>) {
     onCleanup(() => stream.shutdown())
   })
 
-  return { services }
+  return { data, loading, err, errCode }
 }

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/index.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/index.vue
@@ -12,6 +12,7 @@ import { computed, ref, useId } from 'vue'
 import { useRoute } from 'vue-router'
 
 import { Runtime } from '@/api/common/omni.pb'
+import { Code } from '@/api/google/rpc/code.pb'
 import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
 import type { ClusterMachineStatusSpec } from '@/api/omni/specs/omni.pb'
 import { ConfigApplyStatus } from '@/api/omni/specs/omni.pb'
@@ -42,7 +43,6 @@ import TStatus from '@/components/Status/TStatus.vue'
 import Tag from '@/components/Tag/Tag.vue'
 import TAlert from '@/components/TAlert.vue'
 import { TCommonStatuses } from '@/constants'
-import { getContext } from '@/context'
 import { getStatus } from '@/methods'
 import { addMachineLabels, removeMachineLabels } from '@/methods/machine'
 import { useMachineServices } from '@/methods/useMachineServices'
@@ -56,9 +56,12 @@ import NodeServiceEvents from '@/views/Nodes/NodeServiceEvents.vue'
 definePage({ name: 'NodeOverview' })
 
 const route = useRoute()
-const context = computed(() => getContext(route))
+const context = computed(() => ({
+  cluster: route.params.cluster,
+  node: route.params.machine,
+}))
 
-const { services } = useMachineServices(context)
+const { data: services, err: servicesErr, errCode: servicesErrCode } = useMachineServices(context)
 
 const configApplyStatusToConfigApplyStatusName = (status?: ConfigApplyStatus): string => {
   switch (status) {
@@ -376,7 +379,8 @@ const servicesSectionHeadingId = useId()
         <li class="overview-table-name">Running</li>
         <li class="overview-table-name">Health</li>
       </ul>
-      <TGroupAnimation>
+
+      <TGroupAnimation v-if="services.length">
         <TListItem v-for="service in services" :key="service.name">
           <template #default>
             <div class="grid grid-cols-4 p-1">
@@ -407,6 +411,11 @@ const servicesSectionHeadingId = useId()
           </template>
         </TListItem>
       </TGroupAnimation>
+
+      <div v-else-if="servicesErr" class="flex items-center justify-center py-8 text-sm">
+        <span v-if="servicesErrCode === Code.UNAVAILABLE">Talos API is not ready yet</span>
+        <span v-else class="text-red-r1">{{ servicesErr }}</span>
+      </div>
     </section>
   </PageContainer>
 </template>

--- a/frontend/src/views/Home/HomeStatusSegmentedBar.vue
+++ b/frontend/src/views/Home/HomeStatusSegmentedBar.vue
@@ -51,7 +51,7 @@ function barTotal(bar: Bar) {
             "
           >
             <span
-              v-for="segment in bar.segments"
+              v-for="segment in bar.segments.filter((s) => s.value > 0)"
               :key="segment.label"
               class="h-full transition-all"
               :style="{

--- a/frontend/src/views/Machines/MachineLogsContainer.vue
+++ b/frontend/src/views/Machines/MachineLogsContainer.vue
@@ -43,7 +43,7 @@ const CONTROLLER_RUNTIME = 'controller-runtime' // service with logs that isn't 
 // 'machine' check to continue support for /logs/machine but it is equivalent to /logs
 const isMachineLogs = computed(() => !service || service === MACHINE_LOGS)
 
-const { services } = useMachineServices(context)
+const { data: services } = useMachineServices(context)
 
 const servicesSelectValues = computed(() => [
   MACHINE_LOGS,


### PR DESCRIPTION
When querying machine services, show errors inline in the page instead of as a toast. If its a talos unavailable error, show it as "Talos API not ready" - otherwise, show the error message in red. Also add throttling with retry and backoff logic.

<img width="486" height="190" alt="image" src="https://github.com/user-attachments/assets/4a37ff7c-7e49-4e6e-b80d-8784fca4af15" />

As a side task, improved the "watch failed" console errors a bit.
<img width="558" height="239" alt="image" src="https://github.com/user-attachments/assets/d8402e03-9efa-43cd-90a4-677b64f6d447" />

Also fixed a small issue with home page charts rendering 0 length segments