### PR TITLE
feat(frontend): add word wrap to monaco context menu

### DIFF
--- a/frontend/src/components/CodeEditor/CodeEditor.stories.ts
+++ b/frontend/src/components/CodeEditor/CodeEditor.stories.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import CodeEditor from './CodeEditor.vue'
+
+const meta: Meta<typeof CodeEditor> = {
+  component: CodeEditor,
+  args: {
+    class: 'h-screen',
+  },
+  argTypes: {
+    talosVersion: {
+      control: 'select',
+      options: Array(7)
+        .fill(null)
+        .map((_, index) => `1.${index + 7}`),
+    },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/components/CodeEditor/CodeEditor.vue
+++ b/frontend/src/components/CodeEditor/CodeEditor.vue
@@ -77,7 +77,13 @@ const monacoYaml = configureMonacoYaml(monaco, {
 
 const modelSchemas = new Map<string, string>()
 
-function refreshSchemas() {
+function setModelSchema(modelId: string, schema: string | null) {
+  if (typeof schema === 'string') {
+    modelSchemas.set(modelId, schema)
+  } else {
+    modelSchemas.delete(modelId)
+  }
+
   return monacoYaml.update({
     ...monacoYaml.getOptions(),
     schemas: versionedSchemas.map(({ version, settings }) => ({
@@ -120,7 +126,7 @@ monaco.editor.defineTheme(SIDERO_THEME, {
 
 <script setup lang="ts">
 import { coerce, compare, gt, lt, parse } from 'semver'
-import { computed, onWatcherCleanup, useId, useTemplateRef, watch } from 'vue'
+import { computed, onWatcherCleanup, ref, useId, useTemplateRef, watch } from 'vue'
 
 import { DefaultTalosVersion } from '@/api/resources'
 import { majorMinorVersion } from '@/methods'
@@ -175,9 +181,12 @@ const schemaVersion = computed(() => {
   return version
 })
 
+const wordWrap = ref<'on' | 'off'>('off')
+
 const editorOptions = computed<monaco.editor.IEditorOptions & monaco.editor.IGlobalEditorOptions>(
   () => ({
     theme: SIDERO_THEME,
+    wordWrap: wordWrap.value,
     fontSize: 14,
     fontFamily: styles.getPropertyValue('--font-mono'),
     automaticLayout: true,
@@ -219,6 +228,17 @@ watch(editor, (editor) => {
     ...editorOptions.value,
   })
 
+  const action = instance.addAction({
+    id: 'toggle-word-wrap',
+    label: 'Toggle Word Wrap',
+    keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
+    contextMenuGroupId: 'view',
+    contextMenuOrder: 1,
+    run() {
+      wordWrap.value = wordWrap.value === 'on' ? 'off' : 'on'
+    },
+  })
+
   function validate() {
     if (!validators?.length) return
 
@@ -248,6 +268,7 @@ watch(editor, (editor) => {
 
     contentChangeListener.dispose()
     model.dispose()
+    action.dispose()
     instance.dispose()
 
     instanceRef = undefined
@@ -257,17 +278,10 @@ watch(editor, (editor) => {
 watch(
   [schemaVersion, () => disableConfigValidation],
   ([version, disableConfigValidation]) => {
-    if (disableConfigValidation) {
-      modelSchemas.delete(modelId)
-    } else {
-      modelSchemas.set(modelId, majorMinorVersion(version.format()))
-    }
-
-    refreshSchemas()
+    setModelSchema(modelId, disableConfigValidation ? null : majorMinorVersion(version.format()))
 
     onWatcherCleanup(() => {
-      modelSchemas.delete(modelId)
-      refreshSchemas()
+      setModelSchema(modelId, null)
     })
   },
   { immediate: true },

--- a/frontend/src/components/CodeEditor/CodeEditor.vue
+++ b/frontend/src/components/CodeEditor/CodeEditor.vue
@@ -109,7 +109,7 @@ import { DefaultTalosVersion } from '@/api/resources'
 import { majorMinorVersion } from '@/methods'
 
 type Props = {
-  options?: monaco.editor.IStandaloneEditorConstructionOptions
+  options?: monaco.editor.IEditorOptions & monaco.editor.IGlobalEditorOptions
   validators?: ((
     model: monaco.editor.ITextModel,
     tokens: monaco.Token[],
@@ -158,23 +158,8 @@ const schemaVersion = computed(() => {
   return version
 })
 
-watch([editor, schemaVersion], () => {
-  if (!editor.value) {
-    return
-  }
-
-  const model = monaco.editor.createModel(
-    modelValue.value,
-    'yaml',
-    monaco.Uri.parse(
-      disableConfigValidation
-        ? `inmemory://${modelId}.yaml`
-        : `inmemory://${modelId}_${majorMinorVersion(schemaVersion.value.format())}.patch.yaml`,
-    ),
-  )
-
-  const instance = monaco.editor.create(editor.value, {
-    model,
+const editorOptions = computed<monaco.editor.IEditorOptions & monaco.editor.IGlobalEditorOptions>(
+  () => ({
     theme: SIDERO_THEME,
     fontSize: 14,
     fontFamily: styles.getPropertyValue('--font-mono'),
@@ -200,6 +185,25 @@ watch([editor, schemaVersion], () => {
       strings: true,
     },
     ...options,
+  }),
+)
+
+watch([editor, schemaVersion], ([editor, schemaVersion]) => {
+  if (!editor) return
+
+  const model = monaco.editor.createModel(
+    modelValue.value,
+    'yaml',
+    monaco.Uri.parse(
+      disableConfigValidation
+        ? `inmemory://${modelId}.yaml`
+        : `inmemory://${modelId}_${majorMinorVersion(schemaVersion.format())}.patch.yaml`,
+    ),
+  )
+
+  const instance = monaco.editor.create(editor, {
+    model,
+    ...editorOptions.value,
   })
 
   function validate() {
@@ -236,6 +240,10 @@ watch([editor, schemaVersion], () => {
     instanceRef = undefined
   })
 })
+
+// updateOptions is a partial merge, you must explicitly toggle options
+// simply deleting a key from options won't reset it to its default value
+watch(editorOptions, (options) => instanceRef?.updateOptions(options))
 </script>
 
 <template>

--- a/frontend/src/components/CodeEditor/CodeEditor.vue
+++ b/frontend/src/components/CodeEditor/CodeEditor.vue
@@ -39,7 +39,7 @@ const configSchemaMap = Object.entries(configSchemas).map(
     [path.replace(/\.\/config_(.*)\.schema\.json/, '$1').replace('_', '.'), schema] as const,
 )
 
-const schemas = configSchemaMap.map<SchemasSettings>(([version, origSchema]) => {
+const versionedSchemas = configSchemaMap.map(([version, origSchema]) => {
   const schema: typeof origSchema = JSON.parse(JSON.stringify(origSchema))
 
   for (const name in schema.$defs) {
@@ -56,21 +56,38 @@ const schemas = configSchemaMap.map<SchemasSettings>(([version, origSchema]) => 
   }
 
   return {
-    uri: schema.$id!,
-    fileMatch: [`*_${version}.patch.yaml`],
-    schema,
+    version,
+    settings: {
+      uri: schema.$id!,
+      fileMatch: [],
+      schema,
+    } satisfies SchemasSettings,
   }
 })
 
-configureMonacoYaml(monaco, {
+const monacoYaml = configureMonacoYaml(monaco, {
   hover: true,
   completion: true,
   validate: true,
   format: {
     enable: true,
   },
-  schemas,
+  schemas: [],
 })
+
+const modelSchemas = new Map<string, string>()
+
+function refreshSchemas() {
+  return monacoYaml.update({
+    ...monacoYaml.getOptions(),
+    schemas: versionedSchemas.map(({ version, settings }) => ({
+      ...settings,
+      fileMatch: [...modelSchemas]
+        .filter(([, assigned]) => assigned === version)
+        .map(([modelId]) => `*${modelId}.yaml`),
+    })),
+  })
+}
 
 // Can't use CSS variables inside monaco https://github.com/microsoft/monaco-editor/issues/2427
 const styles = getComputedStyle(document.documentElement)
@@ -188,17 +205,13 @@ const editorOptions = computed<monaco.editor.IEditorOptions & monaco.editor.IGlo
   }),
 )
 
-watch([editor, schemaVersion], ([editor, schemaVersion]) => {
+watch(editor, (editor) => {
   if (!editor) return
 
   const model = monaco.editor.createModel(
     modelValue.value,
     'yaml',
-    monaco.Uri.parse(
-      disableConfigValidation
-        ? `inmemory://${modelId}.yaml`
-        : `inmemory://${modelId}_${majorMinorVersion(schemaVersion.format())}.patch.yaml`,
-    ),
+    monaco.Uri.parse(`inmemory://${modelId}.yaml`),
   )
 
   const instance = monaco.editor.create(editor, {
@@ -240,6 +253,25 @@ watch([editor, schemaVersion], ([editor, schemaVersion]) => {
     instanceRef = undefined
   })
 })
+
+watch(
+  [schemaVersion, () => disableConfigValidation],
+  ([version, disableConfigValidation]) => {
+    if (disableConfigValidation) {
+      modelSchemas.delete(modelId)
+    } else {
+      modelSchemas.set(modelId, majorMinorVersion(version.format()))
+    }
+
+    refreshSchemas()
+
+    onWatcherCleanup(() => {
+      modelSchemas.delete(modelId)
+      refreshSchemas()
+    })
+  },
+  { immediate: true },
+)
 
 // updateOptions is a partial merge, you must explicitly toggle options
 // simply deleting a key from options won't reset it to its default value


### PR DESCRIPTION
Allow toggling word-wrapping in monaco editor through context menu or a Mod+Z shortcut (alt/cmd + z).

Added stories and made some reactivity fixes to CodeEditor also.

Closes #1645

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a8936954-66f8-4929-8e17-f963c6c2e8aa" />
