### PR TITLE
fix: correct boot ID and Talos version tracking for maintenance installs

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/task/snapshot/snapshot.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/snapshot/snapshot.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/channel"
@@ -33,6 +34,9 @@ const (
 	bootIDProbeInterval = 30 * time.Second
 	// bootIDCheckTimeout is how long the collect task waits for the machine bootID to be available.
 	bootIDCheckTimeout = 5 * time.Second
+	// minTalosVersionForRead is the earliest Talos version whose MachineService implements the Read RPC;
+	// older machines always return Unimplemented for it, so boot ID collection is skipped below it.
+	minTalosVersionForRead = "1.13"
 )
 
 // InfoChan is a channel for sending machine info from tasks back to the controller.
@@ -107,7 +111,19 @@ func (spec CollectTaskSpec) RunTask(ctx context.Context, logger *zap.Logger, not
 		return nil
 	}
 
-	bootID := spec.readBootID(ctx, client, logger)
+	var (
+		bootID         string
+		bootIDTickerCh <-chan time.Time
+	)
+
+	if spec.talosSupportsBootID(ctx, client, logger) {
+		bootID = spec.readBootID(ctx, client, logger)
+
+		bootIDTicker := time.NewTicker(bootIDProbeInterval)
+		defer bootIDTicker.Stop()
+
+		bootIDTickerCh = bootIDTicker.C
+	}
 
 	watchCh := make(chan state.Event)
 
@@ -115,16 +131,13 @@ func (spec CollectTaskSpec) RunTask(ctx context.Context, logger *zap.Logger, not
 		return err
 	}
 
-	bootIDTicker := time.NewTicker(bootIDProbeInterval)
-	defer bootIDTicker.Stop()
-
 	for {
 		var event state.Event
 
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-bootIDTicker.C:
+		case <-bootIDTickerCh:
 			currentBootID := spec.readBootID(ctx, client, logger)
 			if bootID != currentBootID {
 				return fmt.Errorf("boot id changed, restarting the task (old: %s, new: %s)", bootID, currentBootID)
@@ -157,6 +170,36 @@ func (spec CollectTaskSpec) RunTask(ctx context.Context, logger *zap.Logger, not
 			}
 		}
 	}
+}
+
+// talosSupportsBootID reports whether the connected machine's Talos version implements the Read RPC used
+// to fetch boot_id. Older machines always return Unimplemented for it, so callers should skip the attempt
+// entirely rather than pay the RPC round trip (and its timeout) on every probe.
+func (spec CollectTaskSpec) talosSupportsBootID(ctx context.Context, c *client.Client, logger *zap.Logger) bool {
+	ctx, cancel := context.WithTimeout(ctx, bootIDCheckTimeout)
+	defer cancel()
+
+	versionResp, err := c.Version(ctx)
+	if err != nil {
+		logger.Debug("failed to read talos version for boot id support check", zap.Error(err))
+
+		return false
+	}
+
+	minVersion := semver.MustParse(minTalosVersionForRead + ".0")
+
+	for _, msg := range versionResp.GetMessages() {
+		version, err := semver.ParseTolerant(msg.GetVersion().GetTag())
+		if err != nil {
+			continue
+		}
+
+		if version.GTE(minVersion) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // readBootID reads the machine's kernel boot identifier from the node. It is best-effort: on certain scenarios boot_id might not be available, instead of failing with error it returns "".

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_snapshot.go
@@ -84,15 +84,15 @@ func (ctrl *MachineStatusSnapshotController) Settings() controller.QSettings {
 				case <-ctx.Done():
 					return nil
 				case resource := <-ctrl.siderolinkCh:
-					if err := ctrl.reconcileSnapshot(ctx, r, resource); err != nil {
+					if err := ctrl.reconcileSnapshot(ctx, r, resource, false); err != nil {
 						return err
 					}
 				case resource := <-ctrl.notifyCh:
-					if err := ctrl.reconcileSnapshot(ctx, r, resource); err != nil {
+					if err := ctrl.reconcileSnapshot(ctx, r, resource, true); err != nil {
 						return err
 					}
 				case resource := <-ctrl.powerStageCh:
-					if err := ctrl.reconcileSnapshot(ctx, r, resource); err != nil {
+					if err := ctrl.reconcileSnapshot(ctx, r, resource, false); err != nil {
 						return err
 					}
 				}
@@ -224,7 +224,7 @@ func (ctrl *MachineStatusSnapshotController) handleDisconnectedMachinePowerOff(c
 	poweredOffSnapshot := omni.NewMachineStatusSnapshot(machineID)
 	poweredOffSnapshot.TypedSpec().Value.PowerStage = specs.MachineStatusSnapshotSpec_POWER_STAGE_POWERED_OFF
 
-	return ctrl.reconcileSnapshot(ctx, r, poweredOffSnapshot)
+	return ctrl.reconcileSnapshot(ctx, r, poweredOffSnapshot, false)
 }
 
 func (ctrl *MachineStatusSnapshotController) reconcileTearingDown(ctx context.Context, r controller.QRuntime, logger *zap.Logger, machine *omni.Machine) error {
@@ -244,7 +244,7 @@ func (ctrl *MachineStatusSnapshotController) reconcileTearingDown(ctx context.Co
 	return r.RemoveFinalizer(ctx, machine.Metadata(), ctrl.Name())
 }
 
-func (ctrl *MachineStatusSnapshotController) reconcileSnapshot(ctx context.Context, r controller.QRuntime, snapshot *omni.MachineStatusSnapshot) error {
+func (ctrl *MachineStatusSnapshotController) reconcileSnapshot(ctx context.Context, r controller.QRuntime, snapshot *omni.MachineStatusSnapshot, fromCollectTask bool) error {
 	machine, err := safe.ReaderGetByID[*omni.Machine](ctx, r, snapshot.Metadata().ID())
 	if err != nil {
 		if state.IsNotFoundError(err) {
@@ -263,7 +263,11 @@ func (ctrl *MachineStatusSnapshotController) reconcileSnapshot(ctx context.Conte
 			m.TypedSpec().Value.MachineStatus = snapshot.TypedSpec().Value.MachineStatus
 		}
 
-		if snapshot.TypedSpec().Value.BootId != "" { // only the collect task reads the boot ID; preserve the existing value for siderolink/power snapshots
+		// Only the collect task reads the boot ID, so it is the sole authority on the field: apply its
+		// value even when empty (e.g. the connected Talos version doesn't support reading it, such as
+		// after a downgrade), otherwise a stale boot ID from before the downgrade would stick forever.
+		// Siderolink/power-stage snapshots never carry a boot ID, so they must never touch it.
+		if fromCollectTask {
 			m.TypedSpec().Value.BootId = snapshot.TypedSpec().Value.BootId
 		}
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -392,13 +392,19 @@ func (ctrl *ClusterMachineConfigStatusController) reconcileUpgrade(
 			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine to reboot before applying config: %s", rc.ID())
 		}
 
-		// Record the version so the status reflects an already-at-target machine that ran no upgrade path.
-		rc.machineConfigStatus.TypedSpec().Value.TalosVersion = strings.TrimLeft(rc.machineStatus.TypedSpec().Value.TalosVersion, "v")
+		// LifecycleOpNone here doesn't always mean "confirmed at target": for a maintenance machine with no
+		// system disk yet, DecideLifecycleOp returns None to let the imminent config-apply perform the
+		// install itself, so the live version is still the pre-install one, not what will end up on disk.
+		// Only record it once the machine actually has Talos on disk.
+		if omni.GetMachineStatusSystemDisk(rc.machineStatus) != "" {
+			// Record the version so the status reflects an already-at-target machine that ran no upgrade path.
+			rc.machineConfigStatus.TypedSpec().Value.TalosVersion = strings.TrimLeft(rc.machineStatus.TypedSpec().Value.TalosVersion, "v")
 
-		if rc.machineStatus.TypedSpec().Value.GetSchematic().GetInvalid() {
-			rc.machineConfigStatus.TypedSpec().Value.SchematicId = ""
-		} else {
-			rc.machineConfigStatus.TypedSpec().Value.SchematicId = rc.installImage.SchematicId
+			if rc.machineStatus.TypedSpec().Value.GetSchematic().GetInvalid() {
+				rc.machineConfigStatus.TypedSpec().Value.SchematicId = ""
+			} else {
+				rc.machineConfigStatus.TypedSpec().Value.SchematicId = rc.installImage.SchematicId
+			}
 		}
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -1420,6 +1420,75 @@ func TestMachineConfigStatusController(t *testing.T) {
 			},
 		)
 	})
+
+	// maintenanceFreshInstallDoesNotRecordPreInstallVersion verifies a fresh maintenance machine (no
+	// system disk) whose booted version shares the target's major.minor but differs in patch does not
+	// get its live pre-install version recorded as if it were confirmed installed. DecideLifecycleOp
+	// returns LifecycleOpNone here, trusting the imminent config-apply to install the exact target patch
+	// itself (see TestDecideLifecycleOp's "patch-only mismatch" case); recording the live version at this
+	// point would durably store the wrong patch and make TalosUpgradeStatusController think a real
+	// upgrade/downgrade is needed once the install actually completes.
+	t.Run("maintenanceFreshInstallDoesNotRecordPreInstallVersion", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(
+					machineconfig.NewClusterMachineConfigStatusController(imageFactoryHost, "ghcr.io/siderolabs/installer", testutils.NewLifecycleManager(tc.State, nil)),
+				))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				const (
+					machineVersion = "1.13.0"
+					targetVersion  = "1.13.4" // same major.minor as machineVersion, different patch
+				)
+
+				_, machines := createCluster(
+					ctx, t, st, machineServices, "maint-fresh-install", 1, 0,
+					withMachineStatusModifier(func(res *omni.MachineStatus) error {
+						res.TypedSpec().Value.Maintenance = true
+						res.TypedSpec().Value.TalosVersion = machineVersion
+						res.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{} // no system disk yet
+
+						return nil
+					}),
+				)
+
+				id := machines[0].Metadata().ID()
+
+				rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+					res.TypedSpec().Value.InstallImage.TalosVersion = targetVersion
+
+					return nil
+				}))
+
+				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
+					res.TypedSpec().Value.BootId = "boot-fresh-install"
+
+					return nil
+				}))
+
+				// Wait for config-apply to actually run, a real signal that reconcileUpgrade returned nil
+				// and let config-apply proceed, while checking that the live pre-install version was
+				// never recorded as the confirmed installed version.
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+					a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256, "config must still be applied via the config-apply install path")
+					a.Empty(res.TypedSpec().Value.TalosVersion, "the pre-install live version must not be recorded as the confirmed installed version")
+				})
+
+				assert.Empty(t, machineServices.Get(id).GetLifecycleInstallRequests(), "no explicit lifecycle install is expected for a same-minor patch-only mismatch")
+				assert.Empty(t, machineServices.Get(id).GetLifecycleUpgradeRequests())
+			},
+		)
+	})
 }
 
 // createClusterOption customizes the resources spawned by createCluster.


### PR DESCRIPTION
The maintenance-mode Talos install/upgrade lifecycle recorded machine state before it was actually confirmed. A fresh same-minor install could get its pre-install Talos version written as the confirmed one, and TalosUpgradeStatusController would later read that and report a bogus downgrade.

A machine downgraded below 1.13 kept a stale boot ID forever because the snapshot merge couldn't tell the collect task's own empty value apart from a source that never carries one. This also skips the boot_id Read RPC on Talos versions that never implement it, instead of retrying a call with certain error every 30 seconds.