### PR TITLE
fix: honor current machine set update limits

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 )
 
 // LifecycleOp identifies which upgrade/install path the controller should follow for a given machine.
@@ -237,7 +238,8 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 		return nil, errors.New("failed to get machine set name from the machine config resource")
 	}
 
-	machineSetConfigStatus, err := safe.ReaderGetByID[*omni.MachineSetConfigStatus](ctx, r, machineSetName)
+	// A stale allow value could apply a config while updates are blocked.
+	machineSetConfigStatus, err := safe.ReaderGetByID[*omni.MachineSetConfigStatus](ctx, uncached.Reader(r), machineSetName)
 	if err != nil && !state.IsNotFoundError(err) {
 		return nil, err
 	}

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -1360,7 +1360,8 @@ func (ctrl *ClusterMachineConfigStatusController) acquireConfigUpdateLock(ctx co
 		return errors.New("failed to get machine set name from the cluster machine")
 	}
 
-	machineSetConfigStatus, err := safe.ReaderGetByID[*omni.MachineSetConfigStatus](ctx, r, machineSetName)
+	// A stale strategy could exceed the configured update parallelism.
+	machineSetConfigStatus, err := safe.ReaderGetByID[*omni.MachineSetConfigStatus](ctx, uncached.Reader(r), machineSetName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The controller cache can lag machine set activity and rollout changes. This could start a configuration update while updates are blocked or use outdated rollout parallelism, and it made the config-updates-blocked controller test flaky.

Read the current machine set status before applying configuration or claiming an update slot.