### PR TITLE
feat: support following the audit log over the management API

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -1766,17 +1766,36 @@ func (x *GetSupportBundleResponse) GetBundleData() []byte {
 
 // specifies start and end time (inclusive range) in <year>-<month>-<day> format. We pass time as string to avoid timezone issues.
 type ReadAuditLogRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	StartTime     string                 `protobuf:"bytes,1,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
-	EndTime       string                 `protobuf:"bytes,2,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
-	OrderByField  AuditLogOrderByField   `protobuf:"varint,3,opt,name=order_by_field,json=orderByField,proto3,enum=management.AuditLogOrderByField" json:"order_by_field,omitempty"`
-	OrderByDir    AuditLogOrderByDir     `protobuf:"varint,4,opt,name=order_by_dir,json=orderByDir,proto3,enum=management.AuditLogOrderByDir" json:"order_by_dir,omitempty"`
-	Search        string                 `protobuf:"bytes,5,opt,name=search,proto3" json:"search,omitempty"`
-	EventType     AuditLogEventType      `protobuf:"varint,6,opt,name=event_type,json=eventType,proto3,enum=management.AuditLogEventType" json:"event_type,omitempty"`
-	ResourceType  string                 `protobuf:"bytes,7,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
-	ResourceId    string                 `protobuf:"bytes,8,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
-	ClusterId     string                 `protobuf:"bytes,9,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
-	Actor         string                 `protobuf:"bytes,10,opt,name=actor,proto3" json:"actor,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	StartTime    string                 `protobuf:"bytes,1,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	EndTime      string                 `protobuf:"bytes,2,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
+	OrderByField AuditLogOrderByField   `protobuf:"varint,3,opt,name=order_by_field,json=orderByField,proto3,enum=management.AuditLogOrderByField" json:"order_by_field,omitempty"`
+	OrderByDir   AuditLogOrderByDir     `protobuf:"varint,4,opt,name=order_by_dir,json=orderByDir,proto3,enum=management.AuditLogOrderByDir" json:"order_by_dir,omitempty"`
+	Search       string                 `protobuf:"bytes,5,opt,name=search,proto3" json:"search,omitempty"`
+	EventType    AuditLogEventType      `protobuf:"varint,6,opt,name=event_type,json=eventType,proto3,enum=management.AuditLogEventType" json:"event_type,omitempty"`
+	ResourceType string                 `protobuf:"bytes,7,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
+	ResourceId   string                 `protobuf:"bytes,8,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	ClusterId    string                 `protobuf:"bytes,9,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	Actor        string                 `protobuf:"bytes,10,opt,name=actor,proto3" json:"actor,omitempty"`
+	// Follow keeps the stream open after the backlog is drained, delivering new events as they are written.
+	//
+	// Events are delivered in insertion order. No ordering, search, filter or time-range fields may be
+	// combined with follow, except StartTsMs. The server acknowledges follow support with an initial
+	// response carrying an empty audit_log, and ends the stream cleanly after a bounded duration:
+	// reconnect to keep following.
+	Follow bool `protobuf:"varint,11,opt,name=follow,proto3" json:"follow,omitempty"`
+	// StartTsMs is the inclusive start position in Unix milliseconds, matched against the event timestamps.
+	//
+	// Zero means unset. When set, it takes precedence over StartTime. When unset in follow mode, the
+	// stream starts at the current tail, delivering only events written after the stream was established.
+	// To read everything retained, pass 1.
+	StartTsMs int64 `protobuf:"varint,12,opt,name=start_ts_ms,json=startTsMs,proto3" json:"start_ts_ms,omitempty"`
+	// FromId is the inclusive follow start position by event id, as delivered in the follow responses.
+	//
+	// Zero means unset. When set, it takes precedence over the timestamp fields, and the resume is
+	// exact. Only usable with follow, and only with ids obtained from the same server: following an
+	// id position the server no longer knows fails the stream.
+	FromId        int64 `protobuf:"varint,13,opt,name=from_id,json=fromId,proto3" json:"from_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1881,9 +1900,36 @@ func (x *ReadAuditLogRequest) GetActor() string {
 	return ""
 }
 
+func (x *ReadAuditLogRequest) GetFollow() bool {
+	if x != nil {
+		return x.Follow
+	}
+	return false
+}
+
+func (x *ReadAuditLogRequest) GetStartTsMs() int64 {
+	if x != nil {
+		return x.StartTsMs
+	}
+	return 0
+}
+
+func (x *ReadAuditLogRequest) GetFromId() int64 {
+	if x != nil {
+		return x.FromId
+	}
+	return 0
+}
+
 type ReadAuditLogResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	AuditLog      []byte                 `protobuf:"bytes,1,opt,name=audit_log,json=auditLog,proto3" json:"audit_log,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	AuditLog []byte                 `protobuf:"bytes,1,opt,name=audit_log,json=auditLog,proto3" json:"audit_log,omitempty"`
+	// Id is the id of the event in AuditLog, populated on follow streams. Following from FromId set to
+	// an id plus one resumes exactly after that event.
+	//
+	// Every follow stream starts with an acknowledgment response carrying an empty AuditLog, whose id is
+	// the resolved start position: the id just before the first event the stream will deliver.
+	Id            int64 `protobuf:"varint,2,opt,name=id,proto3" json:"id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1923,6 +1969,13 @@ func (x *ReadAuditLogResponse) GetAuditLog() []byte {
 		return x.AuditLog
 	}
 	return nil
+}
+
+func (x *ReadAuditLogResponse) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
 }
 
 type ValidateJsonSchemaRequest struct {
@@ -3516,7 +3569,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12\x14\n" +
 	"\x05state\x18\x03 \x01(\tR\x05state\x12\x14\n" +
 	"\x05total\x18\x04 \x01(\x05R\x05total\x12\x14\n" +
-	"\x05value\x18\x05 \x01(\x05R\x05value\"\xaa\x03\n" +
+	"\x05value\x18\x05 \x01(\x05R\x05value\"\xfb\x03\n" +
 	"\x13ReadAuditLogRequest\x12\x1d\n" +
 	"\n" +
 	"start_time\x18\x01 \x01(\tR\tstartTime\x12\x19\n" +
@@ -3533,9 +3586,13 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\n" +
 	"cluster_id\x18\t \x01(\tR\tclusterId\x12\x14\n" +
 	"\x05actor\x18\n" +
-	" \x01(\tR\x05actor\"3\n" +
+	" \x01(\tR\x05actor\x12\x16\n" +
+	"\x06follow\x18\v \x01(\bR\x06follow\x12\x1e\n" +
+	"\vstart_ts_ms\x18\f \x01(\x03R\tstartTsMs\x12\x17\n" +
+	"\afrom_id\x18\r \x01(\x03R\x06fromId\"C\n" +
 	"\x14ReadAuditLogResponse\x12\x1b\n" +
-	"\taudit_log\x18\x01 \x01(\fR\bauditLog\"G\n" +
+	"\taudit_log\x18\x01 \x01(\fR\bauditLog\x12\x0e\n" +
+	"\x02id\x18\x02 \x01(\x03R\x02id\"G\n" +
 	"\x19ValidateJsonSchemaRequest\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\tR\x04data\x12\x16\n" +
 	"\x06schema\x18\x02 \x01(\tR\x06schema\"\x86\x02\n" +

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -244,10 +244,35 @@ message ReadAuditLogRequest {
   string resource_id = 8;
   string cluster_id = 9;
   string actor = 10;
+  // Follow keeps the stream open after the backlog is drained, delivering new events as they are written.
+  //
+  // Events are delivered in insertion order. No ordering, search, filter or time-range fields may be
+  // combined with follow, except StartTsMs. The server acknowledges follow support with an initial
+  // response carrying an empty audit_log, and ends the stream cleanly after a bounded duration:
+  // reconnect to keep following.
+  bool follow = 11;
+  // StartTsMs is the inclusive start position in Unix milliseconds, matched against the event timestamps.
+  //
+  // Zero means unset. When set, it takes precedence over StartTime. When unset in follow mode, the
+  // stream starts at the current tail, delivering only events written after the stream was established.
+  // To read everything retained, pass 1.
+  int64 start_ts_ms = 12;
+  // FromId is the inclusive follow start position by event id, as delivered in the follow responses.
+  //
+  // Zero means unset. When set, it takes precedence over the timestamp fields, and the resume is
+  // exact. Only usable with follow, and only with ids obtained from the same server: following an
+  // id position the server no longer knows fails the stream.
+  int64 from_id = 13;
 }
 
 message ReadAuditLogResponse {
   bytes audit_log = 1;
+  // Id is the id of the event in AuditLog, populated on follow streams. Following from FromId set to
+  // an id plus one resumes exactly after that event.
+  //
+  // Every follow stream starts with an acknowledgment response carrying an empty AuditLog, whose id is
+  // the resolved start position: the id just before the first event the stream will deliver.
+  int64 id = 2;
 }
 
 message ValidateJsonSchemaRequest {

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -601,6 +601,9 @@ func (m *ReadAuditLogRequest) CloneVT() *ReadAuditLogRequest {
 	r.ResourceId = m.ResourceId
 	r.ClusterId = m.ClusterId
 	r.Actor = m.Actor
+	r.Follow = m.Follow
+	r.StartTsMs = m.StartTsMs
+	r.FromId = m.FromId
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -617,6 +620,7 @@ func (m *ReadAuditLogResponse) CloneVT() *ReadAuditLogResponse {
 		return (*ReadAuditLogResponse)(nil)
 	}
 	r := new(ReadAuditLogResponse)
+	r.Id = m.Id
 	if rhs := m.AuditLog; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
@@ -1833,6 +1837,15 @@ func (this *ReadAuditLogRequest) EqualVT(that *ReadAuditLogRequest) bool {
 	if this.Actor != that.Actor {
 		return false
 	}
+	if this.Follow != that.Follow {
+		return false
+	}
+	if this.StartTsMs != that.StartTsMs {
+		return false
+	}
+	if this.FromId != that.FromId {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -1850,6 +1863,9 @@ func (this *ReadAuditLogResponse) EqualVT(that *ReadAuditLogResponse) bool {
 		return false
 	}
 	if string(this.AuditLog) != string(that.AuditLog) {
+		return false
+	}
+	if this.Id != that.Id {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -3942,6 +3958,26 @@ func (m *ReadAuditLogRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.FromId != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FromId))
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.StartTsMs != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.StartTsMs))
+		i--
+		dAtA[i] = 0x60
+	}
+	if m.Follow {
+		i--
+		if m.Follow {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x58
+	}
 	if len(m.Actor) > 0 {
 		i -= len(m.Actor)
 		copy(dAtA[i:], m.Actor)
@@ -4038,6 +4074,11 @@ func (m *ReadAuditLogResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Id != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Id))
+		i--
+		dAtA[i] = 0x10
 	}
 	if len(m.AuditLog) > 0 {
 		i -= len(m.AuditLog)
@@ -5744,6 +5785,15 @@ func (m *ReadAuditLogRequest) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.Follow {
+		n += 2
+	}
+	if m.StartTsMs != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.StartTsMs))
+	}
+	if m.FromId != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.FromId))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -5757,6 +5807,9 @@ func (m *ReadAuditLogResponse) SizeVT() (n int) {
 	l = len(m.AuditLog)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Id != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Id))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -10161,6 +10214,64 @@ func (m *ReadAuditLogRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Actor = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Follow", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Follow = bool(v != 0)
+		case 12:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StartTsMs", wireType)
+			}
+			m.StartTsMs = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StartTsMs |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FromId", wireType)
+			}
+			m.FromId = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.FromId |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10246,6 +10357,25 @@ func (m *ReadAuditLogResponse) UnmarshalVT(dAtA []byte) error {
 				m.AuditLog = []byte{}
 			}
 			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			m.Id = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Id |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/client/management/export_test.go
+++ b/client/pkg/client/management/export_test.go
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package management
+
+import (
+	"time"
+
+	"github.com/siderolabs/omni/client/api/omni/management"
+)
+
+// NewTestClient builds a client from the given raw service client, for tests, reconnecting
+// follow streams without a real-time floor.
+func NewTestClient(conn management.ManagementServiceClient) *Client {
+	return &Client{conn: conn, followReconnectFloor: time.Millisecond}
+}

--- a/client/pkg/client/management/follow_test.go
+++ b/client/pkg/client/management/follow_test.go
@@ -1,0 +1,275 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package management_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/client/api/omni/management"
+	managementcli "github.com/siderolabs/omni/client/pkg/client/management"
+)
+
+// scriptedStream scripts one follow stream: the responses it serves, and the error it ends
+// with afterwards (nil is a clean end, the way the server ends a stream at its lifetime bound).
+type scriptedStream struct {
+	err       error
+	responses []*management.ReadAuditLogResponse
+}
+
+// ack builds the event-less acknowledgment response carrying the resolved start position.
+func ack(pos int64) *management.ReadAuditLogResponse {
+	return &management.ReadAuditLogResponse{Id: pos}
+}
+
+func event(id int64, payload string) *management.ReadAuditLogResponse {
+	return &management.ReadAuditLogResponse{AuditLog: []byte(payload + "\n"), Id: id}
+}
+
+// startPosition is the follow position of one connection attempt: the id to resume from, and
+// the timestamp field it fell back to when no id was known yet.
+type startPosition struct {
+	fromID    int64
+	startTsMs int64
+}
+
+// received is one response yielded by the follow iterator: the acknowledgments carry an empty
+// payload, the events a newline-terminated one.
+type received struct {
+	payload string
+	id      int64
+}
+
+func ackReceived(pos int64) received {
+	return received{id: pos}
+}
+
+func eventReceived(id int64, payload string) received {
+	return received{id: id, payload: payload + "\n"}
+}
+
+// fakeServiceClient serves one scripted stream per connection attempt and records the start
+// position and the context of each attempt.
+type fakeServiceClient struct {
+	management.ManagementServiceClient
+
+	t           *testing.T
+	streams     []scriptedStream
+	requests    []startPosition
+	requestCtxs []context.Context
+}
+
+func (c *fakeServiceClient) ReadAuditLog(
+	ctx context.Context, req *management.ReadAuditLogRequest, _ ...grpc.CallOption,
+) (grpc.ServerStreamingClient[management.ReadAuditLogResponse], error) {
+	require.True(c.t, req.Follow, "every request must be a follow request")
+	require.Less(c.t, len(c.requests), len(c.streams), "more connection attempts than scripted streams")
+
+	c.requests = append(c.requests, startPosition{fromID: req.FromId, startTsMs: req.StartTsMs})
+	c.requestCtxs = append(c.requestCtxs, ctx)
+
+	stream := c.streams[len(c.requests)-1]
+
+	return &fakeStream{responses: stream.responses, err: stream.err}, nil
+}
+
+type fakeStream struct {
+	grpc.ClientStream
+
+	err       error
+	responses []*management.ReadAuditLogResponse
+}
+
+func (s *fakeStream) Recv() (*management.ReadAuditLogResponse, error) {
+	if len(s.responses) == 0 {
+		if s.err != nil {
+			return nil, s.err
+		}
+
+		return nil, io.EOF
+	}
+
+	resp := s.responses[0]
+	s.responses = s.responses[1:]
+
+	return resp, nil
+}
+
+// collectFollow drains the follow iterator, returning everything it yields, acknowledgments
+// included, along with the terminal error.
+func collectFollow(ctx context.Context, t *testing.T, cli *fakeServiceClient, req *management.ReadAuditLogRequest) ([]received, error) {
+	t.Helper()
+
+	var results []received
+
+	for resp, err := range managementcli.NewTestClient(cli).FollowAuditLog(ctx, req) {
+		if err != nil {
+			return results, err
+		}
+
+		results = append(results, received{id: resp.Id, payload: string(resp.AuditLog)})
+	}
+
+	return results, nil
+}
+
+var errStream = status.Error(codes.Unavailable, "stream failure")
+
+func TestFollowAuditLogReconnectsOnCleanEnd(t *testing.T) {
+	cli := &fakeServiceClient{
+		t: t,
+		streams: []scriptedStream{
+			// backlog, then the server ends the stream at its lifetime bound
+			{responses: []*management.ReadAuditLogResponse{ack(0), event(1, "a"), event(2, "b")}},
+			// the resume is exact: nothing is repeated, nothing is skipped
+			{responses: []*management.ReadAuditLogResponse{ack(2), event(3, "c")}},
+			{err: errStream},
+		},
+	}
+
+	results, err := collectFollow(t.Context(), t, cli, &management.ReadAuditLogRequest{})
+	require.ErrorIs(t, err, errStream, "a non-clean error terminates the iteration")
+
+	assert.Equal(t, []received{
+		ackReceived(0), eventReceived(1, "a"), eventReceived(2, "b"),
+		ackReceived(2), eventReceived(3, "c"),
+	}, results, "every event exactly once, with the acknowledgments yielded as position-only responses")
+	assert.Equal(t, []startPosition{{}, {fromID: 3}, {fromID: 4}}, cli.requests,
+		"each reconnect resumes exactly after the last delivered event")
+}
+
+func TestFollowAuditLogAckEstablishesRecoveryBaseline(t *testing.T) {
+	cli := &fakeServiceClient{
+		t: t,
+		streams: []scriptedStream{
+			// the stream fails right after the acknowledgment, before any event: the yielded
+			// acknowledgment is what lets the consumer persist the resolved position and
+			// resume exactly, e.g. picking up an event committed during the failure
+			{responses: []*management.ReadAuditLogResponse{ack(40)}, err: errStream},
+		},
+	}
+
+	results, err := collectFollow(t.Context(), t, cli, &management.ReadAuditLogRequest{})
+	require.ErrorIs(t, err, errStream)
+
+	assert.Equal(t, []received{ackReceived(40)}, results,
+		"the consumer observes the resolved position even when no event was delivered")
+}
+
+func TestFollowAuditLogAckOnlyLeaseResumesFromAck(t *testing.T) {
+	cli := &fakeServiceClient{
+		t: t,
+		streams: []scriptedStream{
+			// the stream ends cleanly before any event: the position resolved by the
+			// acknowledgment is the resume baseline, so nothing written during the gap is skipped
+			{responses: []*management.ReadAuditLogResponse{ack(7)}},
+			{responses: []*management.ReadAuditLogResponse{ack(7), event(8, "a")}},
+			{err: errStream},
+		},
+	}
+
+	results, err := collectFollow(t.Context(), t, cli, &management.ReadAuditLogRequest{})
+	require.ErrorIs(t, err, errStream)
+
+	assert.Equal(t, []received{ackReceived(7), ackReceived(7), eventReceived(8, "a")}, results)
+	assert.Equal(t, []startPosition{{}, {fromID: 8}, {fromID: 9}}, cli.requests)
+}
+
+func TestFollowAuditLogTimestampStartBecomesIDResume(t *testing.T) {
+	cli := &fakeServiceClient{
+		t: t,
+		streams: []scriptedStream{
+			// the first attempt positions by timestamp, and the acknowledgment converts the
+			// position into an id: the timestamp is out of the picture from then on
+			{responses: []*management.ReadAuditLogResponse{ack(41)}},
+			{responses: []*management.ReadAuditLogResponse{ack(41), event(42, "a")}},
+			{err: errStream},
+		},
+	}
+
+	results, err := collectFollow(t.Context(), t, cli, &management.ReadAuditLogRequest{StartTsMs: 7500})
+	require.ErrorIs(t, err, errStream)
+
+	assert.Equal(t, []received{ackReceived(41), ackReceived(41), eventReceived(42, "a")}, results)
+	assert.Equal(t, []startPosition{{startTsMs: 7500}, {fromID: 42}, {fromID: 43}}, cli.requests,
+		"the timestamp is only sent before the first acknowledgment")
+}
+
+func TestFollowAuditLogRejectsOldServer(t *testing.T) {
+	for name, streams := range map[string][]scriptedStream{
+		// an old server ignores the follow flag and serves a bounded read: events with no
+		// acknowledgment first, or, on an empty backlog, a clean end with no message at all
+		"event without ack":             {{responses: []*management.ReadAuditLogResponse{event(1, "a")}}},
+		"clean end without any message": {{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cli := &fakeServiceClient{t: t, streams: streams}
+
+			results, err := collectFollow(t.Context(), t, cli, &management.ReadAuditLogRequest{})
+			require.ErrorIs(t, err, managementcli.ErrAuditLogFollowUnsupported)
+			assert.Empty(t, results, "nothing must be yielded on an unsupported server")
+		})
+	}
+}
+
+func TestFollowAuditLogRejectsMalformedEvent(t *testing.T) {
+	cli := &fakeServiceClient{
+		t: t,
+		streams: []scriptedStream{
+			// an event without an id has no usable resume position
+			{responses: []*management.ReadAuditLogResponse{ack(0), event(1, "a"), {AuditLog: []byte("x\n")}}},
+		},
+	}
+
+	results, err := collectFollow(t.Context(), t, cli, &management.ReadAuditLogRequest{})
+	require.ErrorContains(t, err, "malformed")
+	assert.Equal(t, []received{ackReceived(0), eventReceived(1, "a")}, results)
+}
+
+func TestFollowAuditLogEarlyStopTearsDownStream(t *testing.T) {
+	cli := &fakeServiceClient{
+		t: t,
+		streams: []scriptedStream{
+			{responses: []*management.ReadAuditLogResponse{ack(0), event(1, "a"), event(2, "b")}},
+		},
+	}
+
+	// the consumer stops after the first event: the stream context must be canceled, so the
+	// abandoned stream does not linger on the server until its lease ends
+	for resp, err := range managementcli.NewTestClient(cli).FollowAuditLog(t.Context(), &management.ReadAuditLogRequest{}) {
+		require.NoError(t, err)
+
+		if len(resp.AuditLog) != 0 {
+			break
+		}
+	}
+
+	require.Len(t, cli.requestCtxs, 1)
+	require.ErrorIs(t, cli.requestCtxs[0].Err(), context.Canceled, "stopping the iteration must cancel the stream context")
+}
+
+func TestFollowAuditLogStopsOnCanceledContext(t *testing.T) {
+	cli := &fakeServiceClient{
+		t: t,
+		streams: []scriptedStream{
+			{responses: []*management.ReadAuditLogResponse{ack(0), event(1, "a")}},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// the canceled context surfaces as the terminal error instead of reconnecting forever
+	results, err := collectFollow(ctx, t, cli, &management.ReadAuditLogRequest{})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, []received{ackReceived(0), eventReceived(1, "a")}, results)
+}

--- a/client/pkg/client/management/management.go
+++ b/client/pkg/client/management/management.go
@@ -87,12 +87,15 @@ func WithOIDCCacheIsolation(value bool) KubeconfigOption {
 // Client for Management API .
 type Client struct {
 	conn management.ManagementServiceClient
+
+	followReconnectFloor time.Duration
 }
 
 // NewClient builds a client out of gRPC connection.
 func NewClient(conn *grpc.ClientConn) *Client {
 	return &Client{
-		conn: management.NewManagementServiceClient(conn),
+		conn:                 management.NewManagementServiceClient(conn),
+		followReconnectFloor: auditLogFollowReconnectFloor,
 	}
 }
 
@@ -284,6 +287,9 @@ func (client *Client) GetSupportBundle(ctx context.Context, cluster string, prog
 }
 
 // ReadAuditLog reads the audit log from the backend.
+//
+// To follow the audit log continuously, use [Client.FollowAuditLog], which also handles the
+// follow protocol details of the raw request.
 func (client *Client) ReadAuditLog(ctx context.Context, req *management.ReadAuditLogRequest) iter.Seq2[*management.ReadAuditLogResponse, error] {
 	return func(yield func(*management.ReadAuditLogResponse, error) bool) {
 		streamingResponse, err := client.conn.ReadAuditLog(ctx, req)
@@ -310,6 +316,115 @@ func (client *Client) ReadAuditLog(ctx context.Context, req *management.ReadAudi
 			}
 		}
 	}
+}
+
+// ErrAuditLogFollowUnsupported means the server does not implement following the audit log.
+var ErrAuditLogFollowUnsupported = errors.New("the server does not support following the audit log")
+
+// auditLogFollowReconnectFloor is the minimum wait before re-establishing a cleanly ended
+// follow stream, guarding against hammering a server that ends streams unusually fast.
+const auditLogFollowReconnectFloor = 500 * time.Millisecond
+
+// FollowAuditLog streams the audit log endlessly: the backlog from the requested start
+// position first, then new events as they are written. The start position is either an id
+// on FromId (exact, as delivered in previous follow responses, plus one), or an inclusive
+// Unix millisecond timestamp on StartTsMs, where zero means the current tail and one means
+// everything the server still retains. The follow flag is set by this method, and the
+// remaining request fields are passed through as given: the server rejects the ones that
+// cannot be combined with following, such as filters.
+//
+// The server bounds the lifetime of every follow stream, and this iterator reconnects
+// transparently when a stream ends cleanly, resuming exactly after the last delivered event.
+//
+// Every stream starts with an event-less acknowledgment carrying the resolved start position
+// as its id. The acknowledgments are yielded like the events, with an empty audit log
+// payload: a consumer persisting its position for exact recovery should persist their ids
+// too, so that a failure before the first event does not lose the resolved position.
+//
+// Any error ends the iteration: the caller decides the retry policy and resumes by calling
+// again with FromId set to the id of the last response it processed, plus one. Following a
+// server without follow support yields [ErrAuditLogFollowUnsupported].
+func (client *Client) FollowAuditLog(ctx context.Context, req *management.ReadAuditLogRequest) iter.Seq2[*management.ReadAuditLogResponse, error] {
+	return func(yield func(*management.ReadAuditLogResponse, error) bool) {
+		req = req.CloneVT()
+		req.Follow = true
+
+		for {
+			if !client.followAuditLogOnce(ctx, req, yield) {
+				return
+			}
+
+			// a clean end after a valid acknowledgment is the server ending the stream at
+			// its lifetime bound: reconnect and resume
+			select {
+			case <-ctx.Done():
+				yield(nil, ctx.Err())
+
+				return
+			case <-time.After(client.followReconnectFloor):
+			}
+		}
+	}
+}
+
+// followAuditLogOnce consumes a single follow stream, yielding its events and advancing the
+// start position on the request for the next stream. It reports whether following should
+// continue, which it should not when the stream failed, the server turned out not to support
+// following, or the consumer stopped the iteration.
+func (client *Client) followAuditLogOnce(
+	ctx context.Context, req *management.ReadAuditLogRequest, yield func(*management.ReadAuditLogResponse, error) bool,
+) bool {
+	// each attempt gets its own canceled-on-return context, so that a consumer stopping the
+	// iteration mid-stream tears the stream down instead of leaving it open until its lease ends
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	gotAck := false
+
+	for resp, err := range client.ReadAuditLog(ctx, req) {
+		if err != nil {
+			yield(nil, err)
+
+			return false
+		}
+
+		// every follow stream starts with an event-less acknowledgment: an event as the
+		// first message means the server served a bounded read, ignoring the follow flag
+		if !gotAck {
+			if len(resp.AuditLog) != 0 {
+				yield(nil, ErrAuditLogFollowUnsupported)
+
+				return false
+			}
+
+			gotAck = true
+
+			// the position is an exact id from here on: drop the timestamp so that the
+			// reconnect requests stay unambiguous
+			req.StartTsMs = 0
+		} else if len(resp.AuditLog) == 0 || resp.Id <= 0 {
+			yield(nil, errors.New("malformed audit log follow event"))
+
+			return false
+		}
+
+		// The acknowledgment is yielded like the events, so that the consumer can persist
+		// the resolved start position before any event arrives. The resume position only
+		// advances after the consumer accepts the response.
+		if !yield(resp, nil) {
+			return false
+		}
+
+		req.FromId = resp.Id + 1
+	}
+
+	if !gotAck {
+		yield(nil, ErrAuditLogFollowUnsupported)
+
+		return false
+	}
+
+	return true
 }
 
 // MaintenanceLifecycle installs Talos to disk or upgrades the existing on-disk Talos on a machine running in maintenance mode.

--- a/client/pkg/omnictl/audit-log.go
+++ b/client/pkg/omnictl/audit-log.go
@@ -6,11 +6,14 @@ package omnictl
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"iter"
 	"maps"
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -28,6 +31,8 @@ var auditLogFlags struct {
 	resourceID   string
 	clusterID    string
 	actor        string
+	since        time.Duration
+	follow       bool
 }
 
 // auditLog represents audit-log command.
@@ -40,10 +45,26 @@ var auditLog = &cobra.Command{
 		start := safeGet(arg, 0)
 		end := safeGet(arg, 1)
 
+		var startTsMs int64
+
+		if auditLogFlags.since < 0 {
+			return errors.New("--since must be positive")
+		}
+
+		if auditLogFlags.since > 0 {
+			if start != "" {
+				return errors.New("--since cannot be combined with the start argument")
+			}
+
+			startTsMs = time.Now().Add(-auditLogFlags.since).UnixMilli()
+		}
+
 		return access.WithClient(func(ctx context.Context, client *client.Client, _ access.ServerInfo) error {
-			for resp, err := range client.Management().ReadAuditLog(ctx, &management.ReadAuditLogRequest{
+			// the fields that cannot be combined with --follow are rejected by the server
+			req := &management.ReadAuditLogRequest{
 				StartTime:    start,
 				EndTime:      end,
+				StartTsMs:    startTsMs,
 				Search:       auditLogFlags.search,
 				EventType:    auditLogFlags.eventType.value,
 				OrderByField: auditLogFlags.orderByField.value,
@@ -52,13 +73,27 @@ var auditLog = &cobra.Command{
 				ResourceId:   auditLogFlags.resourceID,
 				ClusterId:    auditLogFlags.clusterID,
 				Actor:        auditLogFlags.actor,
-			}) {
+			}
+
+			var events iter.Seq2[*management.ReadAuditLogResponse, error]
+
+			if auditLogFlags.follow {
+				events = client.Management().FollowAuditLog(ctx, req)
+			} else {
+				events = client.Management().ReadAuditLog(ctx, req)
+			}
+
+			for resp, err := range events {
 				if err != nil {
+					// interrupting the command is not an error, e.g. ctrl-c on a followed stream
+					if ctx.Err() != nil {
+						return nil
+					}
+
 					return err
 				}
 
-				_, err := os.Stdout.Write(resp.AuditLog)
-				if err != nil {
+				if _, err := os.Stdout.Write(resp.AuditLog); err != nil {
 					return err
 				}
 			}
@@ -152,6 +187,14 @@ func init() {
 	auditLog.Flags().StringVar(&auditLogFlags.resourceID, "resource-id", "", "filter events by resource ID")
 	auditLog.Flags().StringVar(&auditLogFlags.clusterID, "cluster-id", "", "filter events by cluster ID")
 	auditLog.Flags().StringVar(&auditLogFlags.actor, "actor", "", "filter events by actor email")
+	auditLog.Flags().BoolVarP(&auditLogFlags.follow, "follow", "f", false,
+		"stream new events as they are written, starting at the current tail unless --since is given. "+
+			"Cannot be combined with filters. The stream is re-established transparently whenever the "+
+			"server ends it cleanly, while errors terminate the command.")
+	auditLog.Flags().DurationVar(&auditLogFlags.since, "since", 0,
+		"start from the given duration ago, e.g. 2h. More precise than the date-only start argument, "+
+			"and the only way to include history in follow mode. A duration reaching past the "+
+			"retention period returns everything still retained.")
 
 	RootCmd.AddCommand(auditLog)
 }

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -237,10 +237,14 @@ export type ReadAuditLogRequest = {
   resource_id?: string
   cluster_id?: string
   actor?: string
+  follow?: boolean
+  start_ts_ms?: string
+  from_id?: string
 }
 
 export type ReadAuditLogResponse = {
   audit_log?: Uint8Array
+  id?: string
 }
 
 export type ValidateJsonSchemaRequest = {

--- a/internal/backend/grpc/export_test.go
+++ b/internal/backend/grpc/export_test.go
@@ -6,6 +6,8 @@
 package grpc
 
 import (
+	"time"
+
 	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
@@ -16,6 +18,9 @@ import (
 )
 
 type ManagementServer = managementServer
+
+// AuditLogFollowBatchSize is exported for testing.
+const AuditLogFollowBatchSize = auditLogFollowBatchSize
 
 type AuthServer = authServer
 
@@ -34,6 +39,8 @@ func NewManagementServer(st state.State, imageFactoryClient *imagefactory.Client
 		kubernetesRuntime:   kubernetesRuntime,
 		talosconfigProvider: talosconfigProvider,
 		lifecycleManager:    lifecycle.NewManager(logger, "test-factory", "ghcr.io/siderolabs/installer", nil, nil),
+
+		auditLogFollowLease: auditLogFollowDefaultLease,
 	}
 
 	for _, opt := range opts {
@@ -41,6 +48,14 @@ func NewManagementServer(st state.State, imageFactoryClient *imagefactory.Client
 	}
 
 	return server
+}
+
+// WithAuditLogFollowLease configures the stream lease of audit log follow streams on a test
+// management server.
+func WithAuditLogFollowLease(lease time.Duration) ManagementServerOption {
+	return func(server *ManagementServer) {
+		server.auditLogFollowLease = lease
+	}
 }
 
 // WithTalosRuntime configures the Talos runtime on a test management server.

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -117,8 +117,20 @@ func newManagementServer(cfg *config.Params, omniState state.State, jwtSigningKe
 		talosRuntime:          talosRuntime,
 		talosconfigProvider:   talosconfigProvider,
 		lifecycleManager:      lifecycleManager,
+
+		auditLogFollowLease: auditLogFollowDefaultLease,
 	}
 }
+
+const (
+	// auditLogFollowDefaultLease bounds the lifetime of a single follow stream, forcing the
+	// client to reconnect and re-authenticate to keep following.
+	auditLogFollowDefaultLease = time.Hour
+
+	// auditLogFollowBatchSize is the number of events a follow stream reads from the store
+	// per batch.
+	auditLogFollowBatchSize = 512
+)
 
 // managementServer implements omni management service.
 type managementServer struct {
@@ -136,6 +148,8 @@ type managementServer struct {
 	management.UnimplementedManagementServiceServer
 	omniState      state.State
 	omniconfigDest string
+
+	auditLogFollowLease time.Duration
 }
 
 func (s *managementServer) register(server grpc.ServiceRegistrar) {
@@ -547,6 +561,18 @@ func (s *managementServer) ReadAuditLog(req *management.ReadAuditLogRequest, srv
 		return err
 	}
 
+	if req.GetStartTsMs() < 0 {
+		return status.Error(codes.InvalidArgument, "start_ts_ms cannot be negative")
+	}
+
+	if req.GetFromId() < 0 {
+		return status.Error(codes.InvalidArgument, "from_id cannot be negative")
+	}
+
+	if req.GetFollow() {
+		return s.followAuditLog(req, srv)
+	}
+
 	now := time.Now()
 
 	filters := auditlog.ReadFilters{
@@ -568,6 +594,14 @@ func (s *managementServer) ReadAuditLog(req *management.ReadAuditLogRequest, srv
 	filters.End, err = parseTime(req.GetEndTime(), now)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid end time: %v", err)
+	}
+
+	if req.GetFromId() != 0 {
+		return status.Error(codes.InvalidArgument, "from_id requires follow")
+	}
+
+	if startTsMs := req.GetStartTsMs(); startTsMs > 0 {
+		filters.Start = time.UnixMilli(startTsMs)
 	}
 
 	if err = s.auditor.AuditAuditLogAccess(ctx, filters); err != nil {
@@ -598,6 +632,135 @@ func (s *managementServer) ReadAuditLog(req *management.ReadAuditLogRequest, srv
 	}
 
 	return closeFn()
+}
+
+// followAuditLog streams the audit log: the backlog from the requested start position first,
+// then new events as they are written, until the stream lease expires. A client keeps
+// following by reconnecting and resuming from the id of the last received event.
+func (s *managementServer) followAuditLog(req *management.ReadAuditLogRequest, srv grpc.ServerStreamingServer[management.ReadAuditLogResponse]) error {
+	ctx := srv.Context()
+
+	if err := validateAuditLogFollowRequest(req); err != nil {
+		return err
+	}
+
+	if err := s.auditor.AuditAuditLogFollow(ctx, req.GetFromId(), req.GetStartTsMs()); err != nil {
+		return fmt.Errorf("failed to audit the audit log access: %w", err)
+	}
+
+	var pos int64
+
+	if fromID := req.GetFromId(); fromID > 0 {
+		// an id position resumes exactly where a previous stream left off
+		pos = fromID - 1
+	} else {
+		var err error
+
+		// a timestamp start needs resolving into an id position, a zero one means the tail
+		if pos, err = s.auditor.FollowStart(ctx, req.GetStartTsMs()); err != nil {
+			// the acknowledgment is deliberately not sent yet: a stream that cannot even
+			// resolve its start position fails without ever looking like a working follow
+			return err
+		}
+	}
+
+	// Acknowledge the follow mode with an event-less response before any events. A server
+	// unaware of the follow flag can never produce one, so receiving it as the first message
+	// is how the client knows the stream will actually follow instead of ending at the
+	// backlog. It carries the resolved start position, the exact resume baseline for a
+	// client whose stream ends before delivering any event.
+	if err := srv.Send(&management.ReadAuditLogResponse{Id: pos}); err != nil {
+		return err
+	}
+
+	// The stream is bounded: it ends cleanly when the lease expires, and the client is
+	// expected to reconnect and continue from the position it reached. Reconnecting re-runs
+	// authentication and authorization, which are otherwise checked only at stream start,
+	// so an identity that has been revoked, expired or downgraded stops being served within
+	// the lease duration.
+	lease := time.NewTimer(s.auditLogFollowLease)
+	defer lease.Stop()
+
+	// Written events wake the stream through the subscription instead of a poll. Subscribing
+	// before the first scan means no event can slip through: one written after a scan leaves
+	// a wakeup behind, and the wait after that scan returns immediately.
+	wakeCh, unsubscribe := s.auditor.FollowSubscribe()
+	defer unsubscribe()
+
+	for {
+		entries, err := s.auditor.FollowBatch(ctx, pos, auditLogFollowBatchSize)
+		if err != nil {
+			// The position points beyond every stored event, which cleanup cannot cause (it
+			// spares the newest event) but a database restored from a backup can. There is
+			// no safe automatic recovery from an id position, so the stream fails and the
+			// operator decides how to recover.
+			if errors.Is(err, auditlog.ErrFollowPositionLost) {
+				return status.Error(codes.FailedPrecondition, "the follow position no longer exists")
+			}
+
+			return err
+		}
+
+		for _, entry := range entries {
+			if err = srv.Send(&management.ReadAuditLogResponse{AuditLog: entry.Payload, Id: entry.ID}); err != nil {
+				return err
+			}
+
+			// Honor the lease during long drains, not only while idle. The bound is soft: a
+			// send blocked on a client that stopped reading is only interrupted by the
+			// transport, so such a stream can overrun the lease and receives at most one
+			// more event once the client resumes reading.
+			select {
+			case <-lease.C:
+				return nil
+			default:
+			}
+		}
+
+		if len(entries) > 0 {
+			pos = entries[len(entries)-1].ID
+		}
+
+		if int64(len(entries)) == auditLogFollowBatchSize {
+			continue // keep draining the backlog
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-lease.C:
+			return nil
+		case <-wakeCh:
+		}
+	}
+}
+
+// validateAuditLogFollowRequest rejects the request fields that make no sense combined with
+// follow: a followed log is always whole, in insertion order and without an end.
+func validateAuditLogFollowRequest(req *management.ReadAuditLogRequest) error {
+	incompatible := []struct {
+		name string
+		set  bool
+	}{
+		{"start_time", req.GetStartTime() != ""},
+		{"end_time", req.GetEndTime() != ""},
+		{"order_by_field", req.GetOrderByField() != management.AuditLogOrderByField_AUDIT_LOG_ORDER_BY_FIELD_UNSPECIFIED},
+		{"order_by_dir", req.GetOrderByDir() != management.AuditLogOrderByDir_AUDIT_LOG_ORDER_BY_DIR_UNSPECIFIED},
+		{"search", req.GetSearch() != ""},
+		{"event_type", req.GetEventType() != management.AuditLogEventType_AUDIT_LOG_EVENT_TYPE_UNSPECIFIED},
+		{"resource_type", req.GetResourceType() != ""},
+		{"resource_id", req.GetResourceId() != ""},
+		{"cluster_id", req.GetClusterId() != ""},
+		{"actor", req.GetActor() != ""},
+	}
+
+	for _, field := range incompatible {
+		if field.set {
+			return status.Errorf(codes.InvalidArgument, "%s cannot be combined with follow", field.name)
+		}
+	}
+
+	return nil
 }
 
 // MaintenanceUpgrade performs a maintenance upgrade on a specified machine.
@@ -1313,8 +1476,12 @@ func generateDest(apiurl string) (string, error) {
 // AuditLogger is an interface for reading the audit log and logging access events.
 type AuditLogger interface {
 	Reader(ctx context.Context, filters auditlog.ReadFilters) (auditlog.Reader, error)
+	FollowStart(ctx context.Context, startTsMs int64) (int64, error)
+	FollowBatch(ctx context.Context, afterID int64, limit int64) ([]auditlog.Entry, error)
+	FollowSubscribe() (<-chan struct{}, func())
 	AuditTalosAccess(ctx context.Context, fullMethodName, clusterID, nodeID string) error
 	AuditAuditLogAccess(ctx context.Context, filters auditlog.ReadFilters) error
+	AuditAuditLogFollow(ctx context.Context, fromID, startTsMs int64) error
 }
 
 func auditLogOrderByField(f management.AuditLogOrderByField) auditlog.OrderByField {

--- a/internal/backend/grpc/management_auditlog_e2e_test.go
+++ b/internal/backend/grpc/management_auditlog_e2e_test.go
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package grpc_test
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/siderolabs/omni/client/api/omni/management"
+	"github.com/siderolabs/omni/client/pkg/access/role"
+	managementcli "github.com/siderolabs/omni/client/pkg/client/management"
+	grpcomni "github.com/siderolabs/omni/internal/backend/grpc"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+// TestFollowAuditLogEndToEnd exercises the whole follow stack together, the real SQLite
+// store behind the real handler served over a real gRPC connection to the real client
+// library, across the situations a long-running follower meets: lease expiries, the log
+// being wiped by cleanup, and the server going away mid-stream.
+func TestFollowAuditLogEndToEnd(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	store := newE2EStore(ctx, t)
+
+	var (
+		listener    atomic.Pointer[bufconn.Listener]
+		numStreams  atomic.Int64
+		grpcServers []*grpc.Server
+	)
+
+	startServer := func() *grpc.Server {
+		server := grpcomni.NewManagementServer(nil, nil, zaptest.NewLogger(t), false, nil, nil,
+			grpcomni.WithAuditLogger(&e2eAuditor{store}),
+			grpcomni.WithAuditLogFollowLease(e2eLease))
+
+		grpcServer := grpc.NewServer(grpc.StreamInterceptor(
+			func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+				numStreams.Add(1)
+
+				return handler(srv, &authStream{
+					ServerStream: ss,
+					ctx:          managementPowerTestContext(ss.Context(), "admin@example.com", role.Admin),
+				})
+			},
+		))
+
+		management.RegisterManagementServiceServer(grpcServer, server)
+
+		lis := bufconn.Listen(1024 * 1024)
+		listener.Store(lis)
+
+		go grpcServer.Serve(lis) //nolint:errcheck
+
+		grpcServers = append(grpcServers, grpcServer)
+
+		return grpcServer
+	}
+
+	firstServer := startServer()
+
+	t.Cleanup(func() {
+		for _, srv := range grpcServers {
+			srv.Stop()
+		}
+	})
+
+	conn, err := grpc.NewClient("passthrough:///audit-log-e2e",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(dialCtx context.Context, _ string) (net.Conn, error) {
+			return listener.Load().DialContext(dialCtx)
+		}))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	cli := managementcli.NewClient(conn)
+
+	// phase 1: the backlog is delivered, and events written while the stream keeps cycling
+	// through lease expiries and transparent reconnects keep arriving
+	writeE2EEvents(ctx, t, store, 1, 5)
+
+	follower := startFollower(ctx, t, cli, &management.ReadAuditLogRequest{StartTsMs: 1})
+
+	follower.requireEvents(t, idRange(1, 5))
+
+	require.Eventually(t, func() bool {
+		return numStreams.Load() >= 2
+	}, 10*time.Second, 10*time.Millisecond, "at least one lease expiry must force a reconnect")
+
+	writeE2EEvents(ctx, t, store, 6, 10)
+	follower.requireEvents(t, idRange(6, 10))
+
+	// phase 2: cleanup covering every event spares the newest one, so the storage ids keep
+	// increasing and the follower keeps receiving events without a reconnect
+	require.NoError(t, store.Remove(ctx, time.UnixMilli(0), time.UnixMilli(baseE2ETsMs+10)))
+
+	writeE2EEvents(ctx, t, store, 11, 11)
+	follower.requireEvents(t, idRange(11, 11))
+
+	// phase 3: the server goes away mid-stream, the iterator surfaces the error to the
+	// caller, and re-invoking with the id of the last received event plus one resumes
+	// exactly, the way the exporter retries after a failure
+	firstServer.Stop()
+
+	streamErr := follower.requireError(t)
+	require.NotErrorIs(t, streamErr, managementcli.ErrAuditLogFollowUnsupported)
+
+	startServer()
+
+	writeE2EEvents(ctx, t, store, 12, 12)
+
+	resumed := startFollower(ctx, t, cli, &management.ReadAuditLogRequest{FromId: 12})
+	resumed.requireEvents(t, idRange(12, 12))
+}
+
+// TestFollowAuditLogWakesOnWrite proves the write notification over the whole stack. The
+// lease is minutes away, so nothing but the wakeup can deliver a live event before the
+// receive helper gives up: with a broken notification this test fails, while the lease
+// reconnects of [TestFollowAuditLogEndToEnd] would mask it there by rediscovering the
+// events on every fresh stream.
+func TestFollowAuditLogWakesOnWrite(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	store := newE2EStore(ctx, t)
+
+	server := grpcomni.NewManagementServer(nil, nil, zaptest.NewLogger(t), false, nil, nil,
+		grpcomni.WithAuditLogger(&e2eAuditor{store}),
+		grpcomni.WithAuditLogFollowLease(10*time.Minute))
+
+	grpcServer := grpc.NewServer(grpc.StreamInterceptor(
+		func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			return handler(srv, &authStream{
+				ServerStream: ss,
+				ctx:          managementPowerTestContext(ss.Context(), "admin@example.com", role.Admin),
+			})
+		},
+	))
+
+	management.RegisterManagementServiceServer(grpcServer, server)
+
+	lis := bufconn.Listen(1024 * 1024)
+
+	go grpcServer.Serve(lis) //nolint:errcheck
+
+	t.Cleanup(grpcServer.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///audit-log-notify",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(dialCtx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(dialCtx)
+		}))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	follower := startFollower(ctx, t, managementcli.NewClient(conn), &management.ReadAuditLogRequest{StartTsMs: 1})
+
+	// the first event can race the initial scan of the stream, so receiving it proves
+	// nothing yet: it pins the stream past its backlog, parked waiting for a wakeup
+	writeE2EEvents(ctx, t, store, 1, 1)
+	follower.requireEvents(t, idRange(1, 1))
+
+	// this is the load-bearing write: the stream is parked, and only the wakeup can
+	// deliver the event before the receive helper times out
+	writeE2EEvents(ctx, t, store, 2, 2)
+	follower.requireEvents(t, idRange(2, 2))
+}
+
+// baseE2ETsMs keeps the synthetic event timestamps positive and distinct.
+const baseE2ETsMs = 1_000_000
+
+// e2eLease is long enough for the wipe-recovery timing assertion to tell lost-position
+// detection apart from a lease expiry, and short enough to cycle a few times in the test.
+const e2eLease = 3 * time.Second
+
+// idRange returns the expected event ids: the events are written sequentially, so their ids
+// match their ordinals, and cleanup never makes the ids restart.
+func idRange(from, to int64) []int64 {
+	result := make([]int64, 0, to-from+1)
+
+	for i := from; i <= to; i++ {
+		result = append(result, i)
+	}
+
+	return result
+}
+
+func writeE2EEvents(ctx context.Context, t *testing.T, store *auditlogsqlite.Store, from, to int64) {
+	t.Helper()
+
+	for i := from; i <= to; i++ {
+		require.NoError(t, store.Write(ctx, auditlog.Event{
+			Type:       "create",
+			TimeMillis: baseE2ETsMs + i,
+		}))
+	}
+}
+
+func newE2EStore(ctx context.Context, t *testing.T) *auditlogsqlite.Store {
+	t.Helper()
+
+	conf := config.Default().Storage.Sqlite
+	conf.SetPath(filepath.Join(t.TempDir(), "audit.db"))
+
+	db, err := sqlite.OpenDB(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	store, err := auditlogsqlite.NewStore(ctx, db, 30*time.Second, 0, 0, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	return store
+}
+
+// e2eAuditor serves follow reads from a real store, with the access-event methods stubbed out
+// so that the followed stream carries only the events the test writes.
+type e2eAuditor struct {
+	*auditlogsqlite.Store
+}
+
+func (a *e2eAuditor) AuditTalosAccess(context.Context, string, string, string) error { return nil }
+
+func (a *e2eAuditor) AuditAuditLogAccess(context.Context, auditlog.ReadFilters) error { return nil }
+
+func (a *e2eAuditor) AuditAuditLogFollow(context.Context, int64, int64) error { return nil }
+
+// authStream overrides the stream context with one carrying admin authentication, standing in
+// for the signature interceptor of the full server.
+type authStream struct {
+	grpc.ServerStream
+
+	ctx context.Context //nolint:containedctx
+}
+
+func (s *authStream) Context() context.Context {
+	return s.ctx
+}
+
+// e2eFollower consumes a follow iterator on a goroutine, handing out the received event ids
+// and the terminal error.
+type e2eFollower struct {
+	idCh  chan int64
+	errCh chan error
+}
+
+func startFollower(ctx context.Context, t *testing.T, cli *managementcli.Client, req *management.ReadAuditLogRequest) *e2eFollower {
+	t.Helper()
+
+	follower := &e2eFollower{
+		idCh:  make(chan int64, 1024),
+		errCh: make(chan error, 1),
+	}
+
+	followCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	go func() {
+		for resp, err := range cli.FollowAuditLog(followCtx, req) {
+			if err != nil {
+				follower.errCh <- err
+
+				return
+			}
+
+			// skip the yielded acknowledgments, the test tracks the events
+			if len(resp.AuditLog) == 0 {
+				continue
+			}
+
+			follower.idCh <- resp.Id
+		}
+	}()
+
+	return follower
+}
+
+// requireEvents waits until every expected event id has been received, in order, asserting
+// the exact-resume contract: no duplicates and nothing unexpected, even across reconnects.
+func (f *e2eFollower) requireEvents(t *testing.T, expected []int64) {
+	t.Helper()
+
+	for _, want := range expected {
+		select {
+		case id := <-f.idCh:
+			require.Equal(t, want, id, "events must arrive exactly once, in order")
+		case err := <-f.errCh:
+			require.NoError(t, err, "the stream failed while waiting for event %d", want)
+		case <-time.After(30 * time.Second):
+			require.Failf(t, "timed out", "waiting for event %d", want)
+		}
+	}
+}
+
+// requireError waits for the follow iterator to surface a terminal error.
+func (f *e2eFollower) requireError(t *testing.T) error {
+	t.Helper()
+
+	select {
+	case err := <-f.errCh:
+		require.Error(t, err)
+
+		return err
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "timed out waiting for the stream error")
+
+		return nil
+	}
+}

--- a/internal/backend/grpc/management_auditlog_test.go
+++ b/internal/backend/grpc/management_auditlog_test.go
@@ -9,9 +9,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
@@ -73,17 +76,291 @@ func TestReadAuditLogRequiresAdmin(t *testing.T) {
 	require.False(t, auditor.readerCalled)
 }
 
-func newAuditLogTestServer(t *testing.T, auditor *auditLogAccessAuditor) *grpcomni.ManagementServer {
-	t.Helper()
+func TestFollowAuditLogRejectsIncompatibleFields(t *testing.T) {
+	for _, testCase := range []struct {
+		req  *management.ReadAuditLogRequest
+		name string
+	}{
+		{name: "start_time", req: &management.ReadAuditLogRequest{StartTime: "2026-01-01"}},
+		{name: "end_time", req: &management.ReadAuditLogRequest{EndTime: "2026-01-31"}},
+		{name: "order_by_field", req: &management.ReadAuditLogRequest{OrderByField: management.AuditLogOrderByField_AUDIT_LOG_ORDER_BY_FIELD_ACTOR}},
+		{name: "order_by_dir", req: &management.ReadAuditLogRequest{OrderByDir: management.AuditLogOrderByDir_AUDIT_LOG_ORDER_BY_DIR_DESC}},
+		{name: "search", req: &management.ReadAuditLogRequest{Search: "something"}},
+		{name: "event_type", req: &management.ReadAuditLogRequest{EventType: management.AuditLogEventType_AUDIT_LOG_EVENT_TYPE_CREATE}},
+		{name: "resource_type", req: &management.ReadAuditLogRequest{ResourceType: "some.resource"}},
+		{name: "resource_id", req: &management.ReadAuditLogRequest{ResourceId: "some-id"}},
+		{name: "cluster_id", req: &management.ReadAuditLogRequest{ClusterId: "some-cluster"}},
+		{name: "actor", req: &management.ReadAuditLogRequest{Actor: "someone@example.com"}},
+		{name: "start_ts_ms", req: &management.ReadAuditLogRequest{StartTsMs: -1}},
+		{name: "from_id", req: &management.ReadAuditLogRequest{FromId: -1}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			auditor := &auditLogAccessAuditor{}
+			server := newAuditLogTestServer(t, auditor)
+			stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "admin@example.com", role.Admin)}
 
-	return grpcomni.NewManagementServer(nil, nil, zaptest.NewLogger(t), false, nil, nil, grpcomni.WithAuditLogger(auditor))
+			testCase.req.Follow = true
+
+			err := server.ReadAuditLog(testCase.req, stream)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+			require.ErrorContains(t, err, testCase.name)
+
+			require.False(t, auditor.followAudited)
+			require.Empty(t, stream.numResponses())
+		})
+	}
 }
 
+func TestFollowAuditLogRequiresAdmin(t *testing.T) {
+	auditor := &auditLogAccessAuditor{}
+	server := newAuditLogTestServer(t, auditor)
+
+	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "user@example.com", role.Operator)}
+
+	err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true}, stream)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+	require.Empty(t, stream.numResponses())
+}
+
+func TestFollowAuditLogFailsClosedOnAuditError(t *testing.T) {
+	auditor := &auditLogAccessAuditor{accessErr: errors.New("audit write failure")}
+	server := newAuditLogTestServer(t, auditor)
+
+	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "admin@example.com", role.Admin)}
+
+	err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true}, stream)
+	require.ErrorContains(t, err, "audit write failure")
+
+	require.Empty(t, stream.numResponses(), "nothing must be sent when the access audit write fails")
+}
+
+func TestFollowAuditLogAcknowledgesAndEndsOnLease(t *testing.T) {
+	auditor := &auditLogAccessAuditor{}
+	server := newAuditLogTestServer(t, auditor, grpcomni.WithAuditLogFollowLease(100*time.Millisecond))
+
+	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "admin@example.com", role.Admin)}
+
+	err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true, StartTsMs: 12345}, stream)
+	require.NoError(t, err, "lease expiry must end the stream cleanly")
+
+	require.True(t, auditor.followAudited)
+	require.Equal(t, int64(12345), auditor.followStartTsMs)
+
+	responses := stream.snapshotResponses()
+	require.Len(t, responses, 1)
+	require.Empty(t, responses[0].AuditLog, "the first response must be the event-less acknowledgment")
+	require.Zero(t, responses[0].Id, "the acknowledgment carries the resolved start position")
+}
+
+func TestFollowAuditLogDeliversBacklogAndLiveEvents(t *testing.T) {
+	auditor := &auditLogAccessAuditor{
+		followStartPos: 1, // skip the first entry, as a follow resuming after it would
+		followEntries: []auditlog.Entry{
+			{ID: 1, Payload: []byte(`{"event_ts":100}` + "\n")},
+			{ID: 2, Payload: []byte(`{"event_ts":200}` + "\n")},
+			{ID: 3, Payload: []byte(`{"event_ts":300}` + "\n")},
+		},
+	}
+	server := newAuditLogTestServer(t, auditor, grpcomni.WithAuditLogFollowLease(time.Minute))
+
+	ctx, cancel := context.WithCancel(managementPowerTestContext(t.Context(), "admin@example.com", role.Admin))
+	t.Cleanup(cancel)
+
+	stream := &auditLogStream{ctx: ctx}
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true}, stream)
+	}()
+
+	// the acknowledgment and the backlog after the start position
+	requireResponses(ctx, t, stream, 3)
+
+	// an event written while the stream is live wakes it through the subscription
+	auditor.appendFollowEntries(auditlog.Entry{ID: 4, Payload: []byte(`{"event_ts":400}` + "\n")})
+
+	requireResponses(ctx, t, stream, 4)
+
+	cancel()
+
+	require.ErrorIs(t, <-errCh, context.Canceled)
+
+	responses := stream.snapshotResponses()
+	require.Empty(t, responses[0].AuditLog)
+
+	payloads := make([]string, 0, len(responses)-1)
+	ids := make([]int64, 0, len(responses)-1)
+
+	for _, resp := range responses[1:] {
+		payloads = append(payloads, string(resp.AuditLog))
+		ids = append(ids, resp.Id)
+	}
+
+	require.Equal(t, []string{
+		`{"event_ts":200}` + "\n",
+		`{"event_ts":300}` + "\n",
+		`{"event_ts":400}` + "\n",
+	}, payloads)
+	require.Equal(t, []int64{2, 3, 4}, ids)
+}
+
+func TestFollowAuditLogPaginatesBatches(t *testing.T) {
+	// one entry beyond the server batch size, so the backlog takes a full batch plus one
+	const numEntries = grpcomni.AuditLogFollowBatchSize + 1
+
+	entries := make([]auditlog.Entry, 0, numEntries)
+	for i := range numEntries {
+		entries = append(entries, auditlog.Entry{ID: int64(i + 1), Payload: []byte("{}\n")})
+	}
+
+	auditor := &auditLogAccessAuditor{followEntries: entries}
+	server := newAuditLogTestServer(t, auditor, grpcomni.WithAuditLogFollowLease(time.Minute))
+
+	ctx, cancel := context.WithCancel(managementPowerTestContext(t.Context(), "admin@example.com", role.Admin))
+	t.Cleanup(cancel)
+
+	stream := &auditLogStream{ctx: ctx}
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true, StartTsMs: 1}, stream)
+	}()
+
+	requireResponses(ctx, t, stream, numEntries+1)
+
+	cancel()
+
+	require.ErrorIs(t, <-errCh, context.Canceled)
+
+	responses := stream.snapshotResponses()
+	for i, resp := range responses[1:] {
+		require.Equal(t, int64(i+1), resp.Id)
+	}
+}
+
+func TestFollowAuditLogFailsWithoutAckOnStartError(t *testing.T) {
+	auditor := &auditLogAccessAuditor{followStartErr: errors.New("audit log is disabled")}
+	server := newAuditLogTestServer(t, auditor, grpcomni.WithAuditLogFollowLease(time.Minute))
+
+	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "admin@example.com", role.Admin)}
+
+	// a stream that cannot resolve its start position fails before the acknowledgment,
+	// so it never looks like a working follow to the client
+	err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true}, stream)
+	require.ErrorContains(t, err, "audit log is disabled")
+	require.Empty(t, stream.numResponses())
+}
+
+func TestFollowAuditLogFailsOnLostPosition(t *testing.T) {
+	auditor := &auditLogAccessAuditor{followBatchErr: auditlog.ErrFollowPositionLost}
+	server := newAuditLogTestServer(t, auditor, grpcomni.WithAuditLogFollowLease(time.Minute))
+
+	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "admin@example.com", role.Admin)}
+
+	// a lost position means the database was replaced underneath the id the client resumes
+	// from: there is no safe automatic recovery, so the stream fails for the operator
+	err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true, FromId: 100}, stream)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestFollowAuditLogResumesFromID(t *testing.T) {
+	auditor := &auditLogAccessAuditor{
+		followEntries: []auditlog.Entry{
+			{ID: 1, Payload: []byte(`{"event_ts":100}` + "\n")},
+			{ID: 2, Payload: []byte(`{"event_ts":200}` + "\n")},
+			{ID: 3, Payload: []byte(`{"event_ts":300}` + "\n")},
+		},
+	}
+	server := newAuditLogTestServer(t, auditor, grpcomni.WithAuditLogFollowLease(200*time.Millisecond))
+
+	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "admin@example.com", role.Admin)}
+
+	// an id position resumes exactly: no timestamp resolution is involved
+	err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true, FromId: 3}, stream)
+	require.NoError(t, err)
+
+	require.False(t, auditor.followStartCalled, "an id position must not be re-resolved")
+
+	responses := stream.snapshotResponses()
+	require.Len(t, responses, 2)
+	require.Empty(t, responses[0].AuditLog)
+	require.Equal(t, int64(2), responses[0].Id, "the acknowledgment carries the resolved position")
+	require.Equal(t, int64(3), responses[1].Id)
+}
+
+func TestFollowAuditLogSendFailure(t *testing.T) {
+	auditor := &auditLogAccessAuditor{}
+	server := newAuditLogTestServer(t, auditor, grpcomni.WithAuditLogFollowLease(time.Minute))
+
+	stream := &auditLogStream{
+		ctx:     managementPowerTestContext(t.Context(), "admin@example.com", role.Admin),
+		sendErr: errors.New("send failure"),
+	}
+
+	err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true}, stream)
+	require.ErrorContains(t, err, "send failure")
+}
+
+// requireResponses waits until the stream has sent at least n responses.
+func requireResponses(ctx context.Context, t *testing.T, stream *auditLogStream, n int) {
+	t.Helper()
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.GreaterOrEqual(collect, stream.numResponses(), n)
+	}, 10*time.Second, time.Millisecond, "expected %d responses, got %d (ctx err: %v)", n, stream.numResponses(), ctx.Err())
+}
+
+func newAuditLogTestServer(t *testing.T, auditor *auditLogAccessAuditor, opts ...grpcomni.ManagementServerOption) *grpcomni.ManagementServer {
+	t.Helper()
+
+	return grpcomni.NewManagementServer(nil, nil, zaptest.NewLogger(t), false, nil, nil,
+		append([]grpcomni.ManagementServerOption{grpcomni.WithAuditLogger(auditor)}, opts...)...)
+}
+
+//nolint:govet // field grouping is preferred over alignment here
 type auditLogAccessAuditor struct {
-	accessErr     error
-	accessFilters *auditlog.ReadFilters
-	events        [][]byte
-	readerCalled  bool
+	accessErr         error
+	followStartErr    error
+	followBatchErr    error
+	accessFilters     *auditlog.ReadFilters
+	events            [][]byte
+	followStartPos    int64
+	followFromID      int64
+	followStartTsMs   int64
+	readerCalled      bool
+	followAudited     bool
+	followStartCalled bool
+
+	mu            sync.Mutex
+	followEntries []auditlog.Entry
+	followWakeCh  chan struct{}
+}
+
+// appendFollowEntries adds live events to the fake store while a follow stream is running,
+// waking the subscribed follower like the real store does after a write.
+func (a *auditLogAccessAuditor) appendFollowEntries(entries ...auditlog.Entry) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.followEntries = append(a.followEntries, entries...)
+
+	if a.followWakeCh != nil {
+		select {
+		case a.followWakeCh <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (a *auditLogAccessAuditor) FollowSubscribe() (<-chan struct{}, func()) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.followWakeCh = make(chan struct{}, 1)
+
+	return a.followWakeCh, func() {}
 }
 
 func (a *auditLogAccessAuditor) Reader(context.Context, auditlog.ReadFilters) (auditlog.Reader, error) {
@@ -100,6 +377,39 @@ func (a *auditLogAccessAuditor) AuditAuditLogAccess(_ context.Context, filters a
 	a.accessFilters = &filters
 
 	return a.accessErr
+}
+
+func (a *auditLogAccessAuditor) AuditAuditLogFollow(_ context.Context, fromID, startTsMs int64) error {
+	a.followAudited = true
+	a.followFromID = fromID
+	a.followStartTsMs = startTsMs
+
+	return a.accessErr
+}
+
+func (a *auditLogAccessAuditor) FollowStart(context.Context, int64) (int64, error) {
+	a.followStartCalled = true
+
+	return a.followStartPos, a.followStartErr
+}
+
+func (a *auditLogAccessAuditor) FollowBatch(_ context.Context, afterID int64, limit int64) ([]auditlog.Entry, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.followBatchErr != nil {
+		return nil, a.followBatchErr
+	}
+
+	var entries []auditlog.Entry
+
+	for _, entry := range a.followEntries {
+		if entry.ID > afterID && int64(len(entries)) < limit {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
 }
 
 type sliceAuditLogReader struct {
@@ -121,11 +431,16 @@ func (r *sliceAuditLogReader) Close() error {
 	return nil
 }
 
+//nolint:govet // field grouping is preferred over alignment here
 type auditLogStream struct {
 	grpc.ServerStream
 
-	ctx  context.Context //nolint:containedctx
-	sent [][]byte
+	ctx     context.Context //nolint:containedctx
+	sent    [][]byte
+	sendErr error
+
+	mu        sync.Mutex
+	responses []*management.ReadAuditLogResponse
 }
 
 func (s *auditLogStream) Context() context.Context {
@@ -133,7 +448,31 @@ func (s *auditLogStream) Context() context.Context {
 }
 
 func (s *auditLogStream) Send(resp *management.ReadAuditLogResponse) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.sent = append(s.sent, resp.AuditLog)
+	s.responses = append(s.responses, resp)
 
 	return nil
+}
+
+// numResponses returns the number of responses sent so far.
+func (s *auditLogStream) numResponses() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return len(s.responses)
+}
+
+// snapshotResponses returns a copy of the responses sent so far.
+func (s *auditLogStream) snapshotResponses() []*management.ReadAuditLogResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return slices.Clone(s.responses)
 }

--- a/internal/backend/grpc/management_power_test.go
+++ b/internal/backend/grpc/management_power_test.go
@@ -141,6 +141,22 @@ func (c *capturingAuditLogger) AuditAuditLogAccess(context.Context, auditlog.Rea
 	return nil
 }
 
+func (c *capturingAuditLogger) AuditAuditLogFollow(context.Context, int64, int64) error {
+	return nil
+}
+
+func (c *capturingAuditLogger) FollowStart(context.Context, int64) (int64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (c *capturingAuditLogger) FollowBatch(context.Context, int64, int64) ([]auditlog.Entry, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *capturingAuditLogger) FollowSubscribe() (<-chan struct{}, func()) {
+	return nil, func() {}
+}
+
 func (c *capturingAuditLogger) AuditTalosAccess(ctx context.Context, fullMethodName, clusterID, nodeID string) error {
 	c.ctx = captureContext(ctx)
 	c.fullMethod = fullMethodName

--- a/internal/backend/runtime/omni/audit/audit.go
+++ b/internal/backend/runtime/omni/audit/audit.go
@@ -31,6 +31,9 @@ type Logger interface {
 	Write(ctx context.Context, event auditlog.Event) error
 	Remove(ctx context.Context, start, end time.Time) error
 	Reader(ctx context.Context, filters auditlog.ReadFilters) (auditlog.Reader, error)
+	FollowStart(ctx context.Context, startTsMs int64) (int64, error)
+	FollowBatch(ctx context.Context, afterID int64, limit int64) ([]auditlog.Entry, error)
+	FollowSubscribe() (<-chan struct{}, func())
 }
 
 // LogOption configures optional Log behavior.
@@ -111,6 +114,21 @@ func (l *Log) Reader(ctx context.Context, filters auditlog.ReadFilters) (auditlo
 	return l.auditLogger.Reader(ctx, filters)
 }
 
+// FollowStart resolves the initial follow position for the given inclusive start timestamp.
+func (l *Log) FollowStart(ctx context.Context, startTsMs int64) (int64, error) {
+	return l.auditLogger.FollowStart(ctx, startTsMs)
+}
+
+// FollowBatch reads one batch of events after the given position.
+func (l *Log) FollowBatch(ctx context.Context, afterID int64, limit int64) ([]auditlog.Entry, error) {
+	return l.auditLogger.FollowBatch(ctx, afterID, limit)
+}
+
+// FollowSubscribe registers a wakeup channel signaled after every audit event write.
+func (l *Log) FollowSubscribe() (<-chan struct{}, func()) {
+	return l.auditLogger.FollowSubscribe()
+}
+
 // LogCreate logs the resource creation if there is a hook for this type.
 func (l *Log) LogCreate(r resource.Resource) CreateHook {
 	l.mu.RLock()
@@ -180,16 +198,8 @@ func (l *Log) AuditTalosAccess(ctx context.Context, fullMethodName string, clust
 
 // AuditAuditLogAccess logs the audit log access event.
 func (l *Log) AuditAuditLogAccess(ctx context.Context, filters auditlog.ReadFilters) error {
-	data := extractData(ctx, options{
-		userAgent:     internalAgent,
-		newDataIfNone: true,
-	})
-	if data == nil {
-		return nil
-	}
-
 	// the query bounds have millisecond precision, format the logged range accordingly
-	data.AuditLogAccess = &auditlog.AuditLogAccess{
+	return l.auditAuditLogAccess(ctx, &auditlog.AuditLogAccess{
 		Start:        filters.Start.Truncate(time.Millisecond).Format(time.RFC3339Nano),
 		End:          filters.End.Truncate(time.Millisecond).Format(time.RFC3339Nano),
 		Search:       filters.Search,
@@ -198,7 +208,36 @@ func (l *Log) AuditAuditLogAccess(ctx context.Context, filters auditlog.ReadFilt
 		ResourceID:   filters.ResourceID,
 		ClusterID:    filters.ClusterID,
 		Actor:        filters.Actor,
+	})
+}
+
+// AuditAuditLogFollow logs the audit log access event for a follow stream, recording the
+// mechanism that actually positions the stream: the exact id when given, the timestamp
+// otherwise.
+func (l *Log) AuditAuditLogFollow(ctx context.Context, fromID, startTsMs int64) error {
+	access := &auditlog.AuditLogAccess{Follow: true}
+
+	switch {
+	case fromID > 0:
+		access.FromID = fromID
+	case startTsMs > 0:
+		access.Start = time.UnixMilli(startTsMs).Format(time.RFC3339Nano)
 	}
+
+	return l.auditAuditLogAccess(ctx, access)
+}
+
+// auditAuditLogAccess writes the audit log access event with the given access description.
+func (l *Log) auditAuditLogAccess(ctx context.Context, access *auditlog.AuditLogAccess) error {
+	data := extractData(ctx, options{
+		userAgent:     internalAgent,
+		newDataIfNone: true,
+	})
+	if data == nil {
+		return nil
+	}
+
+	data.AuditLogAccess = access
 
 	return l.auditLogger.Write(ctx, auditlog.Event{
 		Type:       auditlog.EventTypeAuditLogAccess.SQLString(),

--- a/internal/backend/runtime/omni/audit/auditlog/auditlog.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlog.go
@@ -7,6 +7,7 @@
 package auditlog
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -17,6 +18,18 @@ type Reader interface {
 	io.Closer
 	Read() ([]byte, error)
 }
+
+// Entry is a single audit log event read for streaming: the marshaled, newline-terminated
+// payload and the storage id.
+type Entry struct {
+	Payload []byte
+	ID      int64
+}
+
+// ErrFollowPositionLost means the position a follower reads from points beyond every stored
+// event. Cleanup cannot cause this, it always spares the newest event so ids keep increasing,
+// but a database replaced underneath, e.g. restored from a backup, can.
+var ErrFollowPositionLost = errors.New("the follow position no longer exists")
 
 // EventType represents the type of audit log event.
 type EventType int

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite.go
@@ -14,7 +14,9 @@ import (
 	"io"
 	"iter"
 	"math/rand/v2"
+	"slices"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -87,9 +89,14 @@ func WithCleanupCallback(cb func(int)) Option {
 
 // Store is the SQLite-backed audit log store.
 type Store struct {
-	db                 *sqlitexx.Pool
-	logger             *zap.Logger
-	onCleanup          func(int)
+	db        *sqlitexx.Pool
+	logger    *zap.Logger
+	onCleanup func(int)
+
+	// subscribers holds the follower wakeup channels, guarded by subscribersMu.
+	subscribers   []chan struct{}
+	subscribersMu sync.Mutex
+
 	timeout            time.Duration
 	maxSize            uint64
 	cleanupProbability float64
@@ -160,7 +167,7 @@ func NewStore(ctx context.Context, db *sqlitexx.Pool, timeout time.Duration, max
 }
 
 func (s *Store) Write(ctx context.Context, event auditlog.Event) error {
-	query := fmt.Sprintf(`INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s) VALUES 
+	query := fmt.Sprintf(`INSERT INTO %s (%s, %s, %s, %s, %s, %s, %s) VALUES
 	($event_type, $resource_type, $event_ts_ms, $event_data, $actor_email, $resource_id, $cluster_id)`,
 		TableName, eventTypeColumn, resourceTypeColumn, eventTSMillisColumn, eventDataColumn,
 		actorEmailColumn, resourceIDColumn, clusterIDColumn)
@@ -212,6 +219,10 @@ func (s *Store) Write(ctx context.Context, event auditlog.Event) error {
 		return fmt.Errorf("failed to write audit log event: %w", err)
 	}
 
+	// waking the followers before the opportunistic cleanup is safe: cleanup spares the
+	// newest event, so it can never remove the one just announced
+	s.notifySubscribers()
+
 	if s.maxSize > 0 && rand.Float64() < s.cleanupProbability {
 		if err := s.removeBySize(conn); err != nil {
 			s.logger.Warn("failed to cleanup audit logs by size", zap.Error(err))
@@ -224,11 +235,15 @@ func (s *Store) Write(ctx context.Context, event auditlog.Event) error {
 // Remove deletes audit log events in the given time range in batches of removeBatchSize.
 // Batching keeps each autocommit DELETE small, releasing the SQLite write lock between
 // statements so other writers sharing the same database are not blocked for long.
+//
+// The event with the highest id is never deleted, no matter the range: without it, SQLite
+// would reuse its id for the next event, and the ids serve as the positions of the follow
+// streams, which reused ids would silently corrupt.
 func (s *Store) Remove(ctx context.Context, start, end time.Time) error {
 	// DELETE ... LIMIT is not supported (requires SQLITE_ENABLE_UPDATE_DELETE_LIMIT), so we use a subquery to select the IDs to delete.
 	query := fmt.Sprintf(
-		`DELETE FROM %s WHERE %s IN (SELECT %s FROM %s WHERE %s >= $start AND %s <= $end LIMIT $limit)`,
-		TableName, idColumn, idColumn, TableName, eventTSMillisColumn, eventTSMillisColumn,
+		`DELETE FROM %s WHERE %s IN (SELECT %s FROM %s WHERE %s >= $start AND %s <= $end AND %s < (SELECT MAX(%s) FROM %s) LIMIT $limit)`,
+		TableName, idColumn, idColumn, TableName, eventTSMillisColumn, eventTSMillisColumn, idColumn, idColumn, TableName,
 	)
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
@@ -343,6 +358,12 @@ func (s *Store) removeBySize(conn *zombiesqlite.Conn) error {
 	// below it. This lets SQLite use the primary key index directly.
 	cutoffID := minID + rowsToDelete - 1
 
+	// The event with the highest id is never deleted: without it, SQLite would reuse its id
+	// for the next event, corrupting the follow stream positions the ids serve as.
+	if cutoffID >= maxID {
+		cutoffID = maxID - 1
+	}
+
 	deleteQuery := fmt.Sprintf(`DELETE FROM %s WHERE %s <= $cutoff_id`, TableName, idColumn)
 
 	q, err = sqlitexx.NewQuery(conn, deleteQuery)
@@ -453,6 +474,176 @@ func (s *Store) Reader(ctx context.Context, filters auditlog.ReadFilters) (audit
 	}, nil
 }
 
+// FollowStart resolves the initial follow position for the given inclusive start timestamp:
+// the position just below the first event at or after it, so that following from the returned
+// position delivers that event first. A zero start, or a start beyond every stored event,
+// resolves to the current tail exactly, delivering only events written afterwards.
+//
+// The timestamp resolution is best-effort under non-monotonic clocks: the ids follow the
+// insertion order, and an event written under a stepped-back clock can carry a timestamp
+// below its predecessors. Exactness is what the id positions are for.
+func (s *Store) FollowStart(ctx context.Context, startTsMs int64) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	conn, err := s.db.Take(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to take connection from pool: %w", err)
+	}
+
+	defer s.db.Put(conn)
+
+	// A single statement resolves each case in one consistent snapshot: events committed
+	// afterwards have higher ids than anything it observed, so the following FollowBatch
+	// calls pick them up and nothing can fall between the lookup and the returned position.
+	query := fmt.Sprintf("SELECT COALESCE(MAX(%s), 0) AS pos FROM %s", idColumn, TableName)
+	if startTsMs > 0 {
+		query = fmt.Sprintf(`SELECT COALESCE(
+			(SELECT MIN(%s) - 1 FROM %s WHERE %s >= $start),
+			(SELECT COALESCE(MAX(%s), 0) FROM %s)
+		) AS pos`,
+			idColumn, TableName, eventTSMillisColumn, idColumn, TableName)
+	}
+
+	q, err := sqlitexx.NewQuery(conn, query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare sqlite statement: %w", err)
+	}
+
+	if startTsMs > 0 {
+		q = q.BindInt64("$start", startTsMs)
+	}
+
+	var pos int64
+
+	if err = q.QueryRow(func(stmt *zombiesqlite.Stmt) error {
+		pos = stmt.GetInt64("pos")
+
+		return nil
+	}); err != nil {
+		return 0, fmt.Errorf("failed to resolve the follow start position: %w", err)
+	}
+
+	return pos, nil
+}
+
+// FollowSubscribe registers a wakeup channel signaled after every write, for a follower to
+// wait on between [Store.FollowBatch] calls instead of polling. The channel is buffered to
+// one, so a wakeup arriving while the follower is busy is kept, never lost: subscribing
+// before a scan therefore guarantees that no event written after that scan goes unnoticed.
+// The returned function unsubscribes and must be called when the follower is done.
+func (s *Store) FollowSubscribe() (<-chan struct{}, func()) {
+	ch := make(chan struct{}, 1)
+
+	s.subscribersMu.Lock()
+	s.subscribers = append(s.subscribers, ch)
+	s.subscribersMu.Unlock()
+
+	return ch, func() {
+		s.subscribersMu.Lock()
+		defer s.subscribersMu.Unlock()
+
+		s.subscribers = slices.DeleteFunc(s.subscribers, func(c chan struct{}) bool { return c == ch })
+	}
+}
+
+// notifySubscribers wakes every follower after a write, without blocking on the ones that
+// are already woken.
+func (s *Store) notifySubscribers() {
+	s.subscribersMu.Lock()
+	defer s.subscribersMu.Unlock()
+
+	for _, ch := range s.subscribers {
+		select {
+		case ch <- struct{}{}:
+		default: // the channel already holds a wakeup
+		}
+	}
+}
+
+// FollowBatch reads up to limit events with ids above afterID, oldest first. The events are
+// fully materialized, holding a database connection only for the read itself. Receiving
+// fewer events than the limit means the log is exhausted for now: the caller waits before
+// the next call, keeping its position at the last event it received.
+//
+// When the position no longer exists because every event at or above it was cleaned up and
+// the storage ids restarted below it, FollowBatch returns [auditlog.ErrFollowPositionLost]:
+// without this, a follower would wait blindly for the restarted ids to catch up.
+func (s *Store) FollowBatch(ctx context.Context, afterID int64, limit int64) ([]auditlog.Entry, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	conn, err := s.db.Take(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to take connection from pool: %w", err)
+	}
+
+	defer s.db.Put(conn)
+
+	query := fmt.Sprintf(`SELECT %s, %s, %s, %s, %s, %s FROM %s WHERE %s > $after_id ORDER BY %s ASC LIMIT $limit`,
+		idColumn, eventTypeColumn, resourceTypeColumn, resourceIDColumn, eventTSMillisColumn, eventDataColumn,
+		TableName, idColumn, idColumn)
+
+	q, err := sqlitexx.NewQuery(conn, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare sqlite statement: %w", err)
+	}
+
+	var entries []auditlog.Entry
+
+	for stmt, iterErr := range q.
+		BindInt64("$after_id", afterID).
+		BindInt64("$limit", limit).
+		QueryIter() {
+		if iterErr != nil {
+			return nil, fmt.Errorf("failed to read audit log event: %w", iterErr)
+		}
+
+		payload, marshalErr := marshalEventRow(stmt)
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+
+		entries = append(entries, auditlog.Entry{
+			ID:      stmt.GetInt64(idColumn),
+			Payload: payload,
+		})
+	}
+
+	if len(entries) == 0 && afterID > 0 {
+		maxID, maxErr := readMaxID(conn)
+		if maxErr != nil {
+			return nil, maxErr
+		}
+
+		if maxID < afterID {
+			return nil, auditlog.ErrFollowPositionLost
+		}
+	}
+
+	return entries, nil
+}
+
+// readMaxID returns the highest id in the audit log table, zero when the table is empty.
+func readMaxID(conn *zombiesqlite.Conn) (int64, error) {
+	q, err := sqlitexx.NewQuery(conn, fmt.Sprintf("SELECT COALESCE(MAX(%s), 0) AS max_id FROM %s", idColumn, TableName))
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare sqlite statement: %w", err)
+	}
+
+	var maxID int64
+
+	if err = q.QueryRow(func(stmt *zombiesqlite.Stmt) error {
+		maxID = stmt.GetInt64("max_id")
+
+		return nil
+	}); err != nil {
+		return 0, fmt.Errorf("failed to read the max audit log event id: %w", err)
+	}
+
+	return maxID, nil
+}
+
 func (s *Store) HasData(ctx context.Context) (bool, error) {
 	query := fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", TableName)
 
@@ -517,6 +708,12 @@ func (l *logReader) Read() ([]byte, error) {
 		return nil, io.EOF
 	}
 
+	return marshalEventRow(result)
+}
+
+// marshalEventRow marshals the audit log event in the current statement row into its
+// newline-terminated JSON payload.
+func marshalEventRow(result *zombiesqlite.Stmt) ([]byte, error) {
 	var dataJSON []byte
 
 	var event rawEvent

--- a/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
+++ b/internal/backend/runtime/omni/audit/auditlog/auditlogsqlite/auditlogsqlite_test.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
 	zombiesqlite "zombiezen.com/go/sqlite"
 	"zombiezen.com/go/sqlite/sqlitex"
 
@@ -859,4 +860,358 @@ func readAllEvents(t *testing.T, rdr auditlog.Reader) []auditlog.Event {
 
 		events = append(events, evt)
 	}
+}
+
+func TestFollowStartPositions(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t, zaptest.NewLogger(t))
+
+	// empty table: every start resolves to the zero tail
+	pos, err := store.FollowStart(ctx, 123)
+	require.NoError(t, err)
+	assert.Zero(t, pos)
+
+	writeEventAt(ctx, t, store, 100)
+	writeEventAt(ctx, t, store, 200)
+	writeEventAt(ctx, t, store, 300)
+
+	for _, testCase := range []struct {
+		name        string
+		startTsMs   int64
+		expectedPos int64
+	}{
+		{name: "zero starts at the tail exactly", startTsMs: 0, expectedPos: 3},
+		{name: "before all events starts at the beginning", startTsMs: 1, expectedPos: 0},
+		{name: "exact match is inclusive", startTsMs: 200, expectedPos: 1},
+		{name: "between events starts at the next one", startTsMs: 250, expectedPos: 2},
+		{name: "after all events starts at the tail", startTsMs: 400, expectedPos: 3},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			startPos, startErr := store.FollowStart(ctx, testCase.startTsMs)
+			require.NoError(t, startErr)
+			assert.Equal(t, testCase.expectedPos, startPos)
+		})
+	}
+}
+
+func TestFollowBatchPagination(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t, zaptest.NewLogger(t))
+
+	for i := range 5 {
+		writeEventAt(ctx, t, store, int64(100*(i+1)))
+	}
+
+	entries, err := store.FollowBatch(ctx, 0, 2)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, int64(1), entries[0].ID)
+	assert.Equal(t, int64(2), entries[1].ID)
+
+	// payloads are newline-terminated JSON events
+	var event auditlog.Event
+
+	require.NoError(t, json.Unmarshal(entries[0].Payload, &event))
+	assert.Equal(t, int64(100), event.TimeMillis)
+	assert.Equal(t, byte('\n'), entries[0].Payload[len(entries[0].Payload)-1])
+
+	entries, err = store.FollowBatch(ctx, 2, 2)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, int64(3), entries[0].ID)
+	assert.Equal(t, int64(4), entries[1].ID)
+
+	// a short batch means the log is exhausted for now
+	entries, err = store.FollowBatch(ctx, 4, 2)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(5), entries[0].ID)
+
+	entries, err = store.FollowBatch(ctx, 5, 2)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestCleanupSparesNewestEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t, zaptest.NewLogger(t))
+
+	writeEventAt(ctx, t, store, 100) // id 1
+	writeEventAt(ctx, t, store, 200) // id 2
+
+	// a removal spanning every event spares the one with the highest id: SQLite would
+	// otherwise hand out its id again, corrupting the follow positions
+	require.NoError(t, store.Remove(ctx, time.UnixMilli(0), time.UnixMilli(250)))
+
+	entries, err := store.FollowBatch(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(2), entries[0].ID, "the newest event survives a full-range removal")
+
+	writeEventAt(ctx, t, store, 300)
+
+	// ids keep increasing across the cleanup, so a follower position stays exact
+	entries, err = store.FollowBatch(ctx, 2, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(3), entries[0].ID)
+
+	// an exhausted but existing position is not lost, it just has nothing new
+	entries, err = store.FollowBatch(ctx, 3, 10)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestRemoveBySizeSparesNewestEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	// a tiny size budget with certain cleanup: every write triggers a size cleanup that
+	// wants to delete far more rows than exist
+	store, _ := setupStoreWithOpts(ctx, t, zaptest.NewLogger(t), 1, 1.0)
+
+	writeEventAt(ctx, t, store, 100) // id 1
+	writeEventAt(ctx, t, store, 200) // id 2, its write deletes everything the clamp allows
+
+	entries, err := store.FollowBatch(ctx, 0, 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "the newest event must survive the size cleanup")
+	assert.Equal(t, int64(2), entries[len(entries)-1].ID)
+
+	// ids keep increasing across the cleanup, so a follower position stays exact
+	writeEventAt(ctx, t, store, 300)
+
+	entries, err = store.FollowBatch(ctx, 2, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(3), entries[0].ID)
+}
+
+func TestFollowPositionLost(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t, zaptest.NewLogger(t))
+
+	writeEventAt(ctx, t, store, 100) // id 1
+
+	// a position beyond every stored event cannot happen through cleanup (the newest event
+	// survives it), only through the database being replaced, e.g. restored from a backup:
+	// reading from it reports the position as lost instead of waiting blindly
+	_, err := store.FollowBatch(ctx, 5, 10)
+	require.ErrorIs(t, err, auditlog.ErrFollowPositionLost)
+}
+
+func TestFollowSinglePoolConnection(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	path := filepath.Join(t.TempDir(), "test.db")
+
+	conf := config.Default().Storage.Sqlite
+	conf.SetPath(path)
+	conf.SetPoolSize(1)
+
+	db, err := sqlite.OpenDB(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	store, err := auditlogsqlite.NewStore(ctx, db, 30*time.Second, 0, 0, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	// every operation must release the single connection, otherwise the next call deadlocks
+	writeEventAt(ctx, t, store, 100)
+
+	pos, err := store.FollowStart(ctx, 1)
+	require.NoError(t, err)
+	assert.Zero(t, pos)
+
+	entries, err := store.FollowBatch(ctx, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	writeEventAt(ctx, t, store, 200)
+
+	entries, err = store.FollowBatch(ctx, 1, 10)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}
+
+func TestFollowCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t, zaptest.NewLogger(t))
+
+	writeEventAt(ctx, t, store, 100)
+
+	canceledCtx, cancelNow := context.WithCancel(ctx)
+	cancelNow()
+
+	_, err := store.FollowStart(canceledCtx, 1)
+	require.Error(t, err)
+
+	_, err = store.FollowBatch(canceledCtx, 0, 10)
+	require.Error(t, err)
+}
+
+func TestFollowConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t, zaptest.NewLogger(t))
+
+	const numEvents = 200
+
+	var eg errgroup.Group
+
+	eg.Go(func() error {
+		for i := range numEvents {
+			if err := store.Write(ctx, auditlog.Event{Type: "create", TimeMillis: int64(i + 1)}); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	// follow the way the server does: read batches, advance to the watermark on a short batch,
+	// and verify that no id is ever skipped
+	eg.Go(func() error {
+		var (
+			pos      int64
+			received []int64
+		)
+
+		for len(received) < numEvents {
+			if ctx.Err() != nil {
+				return fmt.Errorf("timed out after receiving %d events", len(received))
+			}
+
+			entries, err := store.FollowBatch(ctx, pos, 16)
+			if err != nil {
+				return err
+			}
+
+			for _, entry := range entries {
+				received = append(received, entry.ID)
+			}
+
+			if len(entries) > 0 {
+				pos = entries[len(entries)-1].ID
+			}
+		}
+
+		for i, id := range received {
+			if id != int64(i+1) {
+				return fmt.Errorf("received id %d at position %d", id, i)
+			}
+		}
+
+		return nil
+	})
+
+	require.NoError(t, eg.Wait())
+}
+
+func TestFollowSubscribeWakesOnWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	store, _ := setupStore(ctx, t, zaptest.NewLogger(t))
+
+	wakeCh, unsubscribe := store.FollowSubscribe()
+	defer unsubscribe()
+
+	otherWakeCh, otherUnsubscribe := store.FollowSubscribe()
+	defer otherUnsubscribe()
+
+	select {
+	case <-wakeCh:
+		t.Fatal("no wakeup must arrive before a write")
+	default:
+	}
+
+	writeEventAt(ctx, t, store, 100)
+
+	select {
+	case <-wakeCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for the write wakeup")
+	}
+
+	// every subscriber gets its own wakeup
+	select {
+	case <-otherWakeCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for the write wakeup of the second subscriber")
+	}
+
+	entries, err := store.FollowBatch(ctx, 0, 16)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	// writes arriving while the follower is busy collapse into one pending wakeup
+	writeEventAt(ctx, t, store, 200)
+	writeEventAt(ctx, t, store, 300)
+
+	select {
+	case <-wakeCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for the write wakeup")
+	}
+
+	entries, err = store.FollowBatch(ctx, entries[len(entries)-1].ID, 16)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "one wakeup is enough, the scan picks up everything written")
+
+	unsubscribe()
+
+	writeEventAt(ctx, t, store, 400)
+
+	select {
+	case <-wakeCh:
+		t.Fatal("no wakeup must arrive after unsubscribing")
+	default:
+	}
+}
+
+func writeEventAt(ctx context.Context, t *testing.T, store *auditlogsqlite.Store, tsMillis int64) {
+	t.Helper()
+
+	event := auditlog.MakeEvent("create", "test.resource", "test-id", &auditlog.Data{
+		Session: auditlog.Session{UserID: "user-1"},
+	})
+	event.TimeMillis = tsMillis
+
+	require.NoError(t, store.Write(ctx, event))
 }

--- a/internal/backend/runtime/omni/audit/auditlog/data.go
+++ b/internal/backend/runtime/omni/audit/auditlog/data.go
@@ -147,6 +147,8 @@ type AuditLogAccess struct {
 	ResourceID   string `json:"resource_id,omitempty"`
 	ClusterID    string `json:"cluster_id,omitempty"`
 	Actor        string `json:"actor,omitempty"`
+	FromID       int64  `json:"from_id,omitempty"`
+	Follow       bool   `json:"follow,omitempty"`
 }
 
 // K8SAccess struct contains information about the access to the Kubernetes cluster.

--- a/internal/backend/runtime/omni/audit/logger.go
+++ b/internal/backend/runtime/omni/audit/logger.go
@@ -48,8 +48,25 @@ func (n *nopLogger) Reader(context.Context, auditlog.ReadFilters) (auditlog.Read
 	return &nopReader{}, nil
 }
 
+func (n *nopLogger) FollowStart(context.Context, int64) (int64, error) {
+	return 0, fmt.Errorf("audit logs are disabled")
+}
+
+func (n *nopLogger) FollowBatch(context.Context, int64, int64) ([]auditlog.Entry, error) {
+	return nil, fmt.Errorf("audit logs are disabled")
+}
+
+// FollowSubscribe returns a nil channel: nothing is ever written, so there is nothing to
+// wake up for, and following fails before it ever waits, at the start position resolution
+// or at the first batch read of an id resume.
+func (n *nopLogger) FollowSubscribe() (<-chan struct{}, func()) {
+	return nil, func() {}
+}
+
 type nopReader struct{}
 
 func (n *nopReader) Close() error { return nil }
 
-func (n *nopReader) Read() ([]byte, error) { return nil, fmt.Errorf("audit logs are disabled") }
+func (n *nopReader) Read() ([]byte, error) {
+	return nil, fmt.Errorf("audit logs are disabled")
+}

--- a/internal/backend/runtime/omni/state.go
+++ b/internal/backend/runtime/omni/state.go
@@ -388,6 +388,34 @@ func (w *AuditWrap) Reader(ctx context.Context, filters auditlog.ReadFilters) (a
 	return w.log.Reader(ctx, filters)
 }
 
+// FollowStart resolves the initial follow position for the given inclusive start timestamp.
+func (w *AuditWrap) FollowStart(ctx context.Context, startTsMs int64) (int64, error) {
+	if w.log == nil {
+		return 0, errors.New("audit log is disabled")
+	}
+
+	return w.log.FollowStart(ctx, startTsMs)
+}
+
+// FollowBatch reads one batch of events after the given position.
+func (w *AuditWrap) FollowBatch(ctx context.Context, afterID int64, limit int64) ([]auditlog.Entry, error) {
+	if w.log == nil {
+		return nil, errors.New("audit log is disabled")
+	}
+
+	return w.log.FollowBatch(ctx, afterID, limit)
+}
+
+// FollowSubscribe registers a wakeup channel signaled after every audit event write. With
+// the audit log disabled it returns a nil channel: following fails before ever waiting.
+func (w *AuditWrap) FollowSubscribe() (<-chan struct{}, func()) {
+	if w.log == nil {
+		return nil, func() {}
+	}
+
+	return w.log.FollowSubscribe()
+}
+
 // RunCleanup runs wrapped [audit.Log.RunCleanup] if the audit log is enabled. Otherwise, blocks until context is
 // canceled.
 func (w *AuditWrap) RunCleanup(ctx context.Context) error {
@@ -425,6 +453,16 @@ func (w *AuditWrap) AuditAuditLogAccess(ctx context.Context, filters auditlog.Re
 	}
 
 	return w.log.AuditAuditLogAccess(ctx, filters)
+}
+
+// AuditAuditLogFollow logs an audit log access event for a follow stream. It does nothing if
+// the audit log is disabled.
+func (w *AuditWrap) AuditAuditLogFollow(ctx context.Context, fromID, startTsMs int64) error {
+	if w.log == nil {
+		return nil
+	}
+
+	return w.log.AuditAuditLogFollow(ctx, fromID, startTsMs)
 }
 
 // WrapState wraps the state with audit logging. It does nothing if the audit log is disabled.


### PR DESCRIPTION
The audit log read API gains a follow mode: after serving the backlog, the stream stays open and delivers new events as they are written, in insertion order. The request accepts a millisecond-precision start position for resuming from where a previous stream left off, and each response carries the event timestamp, so a client can track its position without parsing the payloads.

A follow stream starts with an event-less acknowledgment response, letting a client tell a server that honors the follow mode apart from an older one that would serve a bounded read and stop. Streams end cleanly after a bounded duration, and reconnecting re-runs authentication and authorization, so an identity that has been revoked or downgraded stops being served promptly. Follow access is recorded in the audit log like any other audit log access.

Follow reads are served in bounded batches that do not hold a database connection while the stream is blocked on a slow client.

omnictl audit-log gains a --follow flag to tail the log live.

Part of siderolabs/omni#2985.