### PR TITLE
fix: dont clear sa expiration when no keys are left

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/service_account_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/service_account_status.go
@@ -34,7 +34,7 @@ const serviceAccountStatusControllerName = "ServiceAccountStatusController"
 
 // NewServiceAccountStatusController instantiates the ServiceAccountStatus controller.
 //
-//nolint:gocognit
+//nolint:gocognit,gocyclo,cyclop
 func NewServiceAccountStatusController() *ServiceAccountStatusController {
 	return qtransform.NewQController(
 		qtransform.Settings[*auth.Identity, *auth.ServiceAccountStatus]{
@@ -64,9 +64,11 @@ func NewServiceAccountStatusController() *ServiceAccountStatusController {
 				}
 
 				status.TypedSpec().Value.PublicKeys = nil
-				status.TypedSpec().Value.Expiration = nil
 
-				var expiration time.Time
+				var (
+					expiration    time.Time
+					hasRunningKey bool
+				)
 
 				for key := range publicKeyList.All() {
 					if key.Metadata().Phase() == resource.PhaseRunning {
@@ -82,6 +84,8 @@ func NewServiceAccountStatusController() *ServiceAccountStatusController {
 
 						continue
 					}
+
+					hasRunningKey = true
 
 					pgpKey := &specs.ServiceAccountStatusSpec_PgpPublicKey{
 						Id:         key.Metadata().ID(),
@@ -116,7 +120,10 @@ func NewServiceAccountStatusController() *ServiceAccountStatusController {
 				}
 
 				status.TypedSpec().Value.Role = user.TypedSpec().Value.Role
-				status.TypedSpec().Value.Expiration = timestamppb.New(expiration)
+
+				if hasRunningKey {
+					status.TypedSpec().Value.Expiration = timestamppb.New(expiration)
+				}
 
 				return nil
 			},

--- a/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/service_account_status_test.go
@@ -52,8 +52,11 @@ func (suite *ClusterServiceAccountStatusSuite) TestReconcile() {
 	user2 := auth.NewUser(infraProviderServiceAccount.TypedSpec().Value.UserId)
 	user2.TypedSpec().Value.Role = string(role.InfraProvider)
 
+	keyExpiration := time.Now().Add(time.Hour).Truncate(time.Second).UTC()
+
 	publicKey := auth.NewPublicKey("asdf")
 	publicKey.Metadata().Labels().Set(auth.LabelPublicKeyUserID, user1.Metadata().ID())
+	publicKey.TypedSpec().Value.Expiration = timestamppb.New(keyExpiration)
 	publicKey.TypedSpec().Value.Identity = &specs.Identity{
 		Email: serviceAccount.Metadata().ID(),
 	}
@@ -69,6 +72,10 @@ func (suite *ClusterServiceAccountStatusSuite) TestReconcile() {
 
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{serviceAccount.Metadata().ID()}, func(res *auth.ServiceAccountStatus, assert *assert.Assertions) {
 		assert.Equal(string(role.Admin), res.TypedSpec().Value.Role)
+
+		if assert.NotNil(res.TypedSpec().Value.Expiration) {
+			assert.Equal(keyExpiration, res.TypedSpec().Value.Expiration.AsTime())
+		}
 
 		if !assert.Len(res.TypedSpec().Value.PublicKeys, 1) {
 			return
@@ -106,6 +113,11 @@ func (suite *ClusterServiceAccountStatusSuite) TestReconcile() {
 	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{serviceAccount.Metadata().ID()}, func(res *auth.ServiceAccountStatus, assert *assert.Assertions) {
 		assert.Equal(string(role.Admin), res.TypedSpec().Value.Role)
 		assert.Len(res.TypedSpec().Value.PublicKeys, 0)
+
+		// once the last key is removed, the last-known expiration is retained rather than reset to the zero time.
+		if assert.NotNil(res.TypedSpec().Value.Expiration) {
+			assert.Equal(keyExpiration, res.TypedSpec().Value.Expiration.AsTime())
+		}
 	})
 
 	require.NoError(suite.state.Create(suite.ctx, publicKey))


### PR DESCRIPTION
Currently when all public keys are removed from a service account, the expiration gets zero'd out. When all public keys have been removed from a service account, instead leave the expiration value on the spec as is.

Closes #3128 