### PR TITLE
feat: install same-minor maintenance machines via LifecycleService

### DIFF
--- a/client/pkg/omni/resources/omni/version_compat.go
+++ b/client/pkg/omni/resources/omni/version_compat.go
@@ -65,14 +65,14 @@ func versionCompatibleWithCluster(machineVersion semver.Version, installed bool,
 		return true, false, ""
 	}
 
-	// Same major.minor: Omni applies config and Talos installs through the normal config path.
-	if machineVersion.Major == clusterVersion.Major && machineVersion.Minor == clusterVersion.Minor {
-		return true, false, ""
-	}
-
-	// Cross-minor and not-installed: Omni can support the install only if both sides are >= 1.13.
+	// Not-installed, both sides >= 1.13: Omni installs Talos explicitly via LifecycleService, regardless of minor match.
 	if talosVersionSupportsLifecycleService(machineVersion) && talosVersionSupportsLifecycleService(clusterVersion) {
 		return true, true, ""
+	}
+
+	// Below 1.13 there is no explicit install mechanism: config-apply can only install within the same minor.
+	if machineVersion.Major == clusterVersion.Major && machineVersion.Minor == clusterVersion.Minor {
+		return true, false, ""
 	}
 
 	return false, false, "the machine running from ISO or PXE must have the same major and minor version as the cluster " +

--- a/client/pkg/omni/resources/omni/version_compat_test.go
+++ b/client/pkg/omni/resources/omni/version_compat_test.go
@@ -59,17 +59,18 @@ func TestMachineCompatibleWithCluster(t *testing.T) {
 			wantOK:  false,
 		},
 		{
-			name:    "not-installed same minor",
-			machine: mkMachine("1.13.4", false, false),
-			cluster: "1.13.4",
-			wantOK:  true,
+			name:        "not-installed same minor, both >= 1.13 (auto-install)",
+			machine:     mkMachine("1.13.4", false, false),
+			cluster:     "1.13.4",
+			wantOK:      true,
+			wantInstall: true,
 		},
 		{
 			name:        "not-installed 1.13 maintenance to 1.13.4 (auto-install)",
 			machine:     mkMachine("1.13.0", false, false),
 			cluster:     "1.13.4",
 			wantOK:      true,
-			wantInstall: false, // same minor → no auto-install needed, normal config path
+			wantInstall: true, // no system disk always installs explicitly, even within the same minor
 		},
 		{
 			name:        "not-installed 1.13 to higher 1.14 cluster (auto-install)",
@@ -83,6 +84,13 @@ func TestMachineCompatibleWithCluster(t *testing.T) {
 			machine: mkMachine("1.12.5", false, false),
 			cluster: "1.13.4",
 			wantOK:  false,
+		},
+		{
+			name:        "not-installed 1.12 same minor, below 1.13 (legacy config-apply)",
+			machine:     mkMachine("1.12.5", false, false),
+			cluster:     "1.12.6",
+			wantOK:      true,
+			wantInstall: false, // below 1.13 there is no explicit install mechanism, config-apply installs within the same minor
 		},
 		{
 			name:    "agent mode always ok",

--- a/frontend/src/methods/compat.ts
+++ b/frontend/src/methods/compat.ts
@@ -76,15 +76,17 @@ export function machineCompatibleWithCluster(
     return okResult
   }
 
+  // Not-installed, both sides >= 1.13: Omni installs Talos explicitly via LifecycleService, regardless of minor match.
+  if (supportsMaintenanceInstall(machineVersion) && supportsMaintenanceInstall(clusterVersion)) {
+    return okWithInstall(clusterVersionStr.replace(/^v/, ''))
+  }
+
+  // Below 1.13 there is no explicit install mechanism: config-apply can only install within the same minor.
   if (
     machineVersion.major === clusterVersion.major &&
     machineVersion.minor === clusterVersion.minor
   ) {
     return okResult
-  }
-
-  if (supportsMaintenanceInstall(machineVersion) && supportsMaintenanceInstall(clusterVersion)) {
-    return okWithInstall(clusterVersionStr.replace(/^v/, ''))
   }
 
   return {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -390,10 +390,10 @@ func (ctrl *StatusController) reconcileUpgrade(
 			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine to reboot before applying config: %s", rc.ID())
 		}
 
-		// LifecycleOpNone here doesn't always mean "confirmed at target": for a maintenance machine with no
-		// system disk yet, DecideLifecycleOp returns None to let the imminent config-apply perform the
-		// install itself, so the live version is still the pre-install one, not what will end up on disk.
-		// Only record it once the machine actually has Talos on disk.
+		// A machine with no system disk hasn't installed Talos yet: its live TalosVersion is still the
+		// boot media it's running from, not what will end up on disk once config-apply installs it, so
+		// only record the version once it actually has one. This can only happen for Talos < 1.13 on
+		// either end.
 		if omni.GetMachineStatusSystemDisk(rc.machineStatus) != "" {
 			// Record the version so the status reflects an already-at-target machine that ran no upgrade path.
 			rc.machineConfigStatus.TypedSpec().Value.TalosVersion = strings.TrimLeft(rc.machineStatus.TypedSpec().Value.TalosVersion, "v")

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -1421,14 +1421,14 @@ func TestMachineConfigStatusController(t *testing.T) {
 		)
 	})
 
-	// maintenanceFreshInstallDoesNotRecordPreInstallVersion verifies a fresh maintenance machine (no
-	// system disk) whose booted version shares the target's major.minor but differs in patch does not
-	// get its live pre-install version recorded as if it were confirmed installed. DecideLifecycleOp
-	// returns LifecycleOpNone here, trusting the imminent config-apply to install the exact target patch
-	// itself (see TestDecideLifecycleOp's "patch-only mismatch" case); recording the live version at this
-	// point would durably store the wrong patch and make TalosUpgradeStatusController think a real
-	// upgrade/downgrade is needed once the install actually completes.
-	t.Run("maintenanceFreshInstallDoesNotRecordPreInstallVersion", func(t *testing.T) {
+	// maintenanceSameMinorInstallUsesLifecycleService verifies a fresh maintenance machine (no system
+	// disk) whose booted version shares the target's major.minor but differs in patch still installs
+	// through an explicit LifecycleService.Install, not through config-apply: DecideLifecycleOp returns
+	// LifecycleOpMaintenanceInstall regardless of minor match (see TestDecideLifecycleOp's "patch-only
+	// mismatch" case). The pre-install live version must also not be recorded as the confirmed installed
+	// version until the install actually completes, or TalosUpgradeStatusController would think a real
+	// upgrade/downgrade is needed once it does.
+	t.Run("maintenanceSameMinorInstallUsesLifecycleService", func(t *testing.T) {
 		t.Parallel()
 
 		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
@@ -1451,7 +1451,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 				)
 
 				_, machines := createCluster(
-					ctx, t, st, machineServices, "maint-fresh-install", 1, 0,
+					ctx, t, st, machineServices, "maint-same-minor-install", 1, 0,
 					withMachineStatusModifier(func(res *omni.MachineStatus) error {
 						res.TypedSpec().Value.Maintenance = true
 						res.TypedSpec().Value.TalosVersion = machineVersion
@@ -1471,20 +1471,20 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
 					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
-					res.TypedSpec().Value.BootId = "boot-fresh-install"
+					res.TypedSpec().Value.BootId = "boot-same-minor-install"
 
 					return nil
 				}))
 
-				// Wait for config-apply to actually run, a real signal that reconcileUpgrade returned nil
-				// and let config-apply proceed, while checking that the live pre-install version was
-				// never recorded as the confirmed installed version.
+				// The install runs and the boot ID marker is recorded, a real signal that
+				// runMaintenanceLifecycle triggered LifecycleService.Install.
 				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
-					a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256, "config must still be applied via the config-apply install path")
+					a.Equal("boot-same-minor-install", res.TypedSpec().Value.PreRebootBootId)
+					a.Empty(res.TypedSpec().Value.ClusterMachineConfigSha256, "config-apply must not run until after the install completes")
 					a.Empty(res.TypedSpec().Value.TalosVersion, "the pre-install live version must not be recorded as the confirmed installed version")
 				})
 
-				assert.Empty(t, machineServices.Get(id).GetLifecycleInstallRequests(), "no explicit lifecycle install is expected for a same-minor patch-only mismatch")
+				require.Len(t, machineServices.Get(id).GetLifecycleInstallRequests(), 1, "a same-minor no-disk install must go through an explicit lifecycle install")
 				assert.Empty(t, machineServices.Get(id).GetLifecycleUpgradeRequests())
 			},
 		)

--- a/internal/backend/talos/lifecycle/decide.go
+++ b/internal/backend/talos/lifecycle/decide.go
@@ -41,16 +41,17 @@ func DecideOp(machineStatus *omni.MachineStatus, installImage *specs.MachineConf
 	// mismatch flags, so a stale status can't trigger a spurious first-reconcile upgrade.
 	if machineSupportsLifecycle && targetSupportsLifecycle {
 		if machineStatus.TypedSpec().Value.Maintenance {
-			switch {
-			case hasSystemDisk && (!machineVersion.EQ(targetVersion) || schematicDiffers(machineStatus, installImage)):
-				return OpMaintenanceUpgrade
-			case !hasSystemDisk && (machineVersion.Major != targetVersion.Major || machineVersion.Minor != targetVersion.Minor):
-				// Cross-minor without a disk: config-apply only installs within the same minor, so install explicitly.
-				return OpMaintenanceInstall
-			default:
-				// Already at target, or same-minor with no disk where config-apply installs it for us.
+			if hasSystemDisk {
+				if !machineVersion.EQ(targetVersion) || schematicDiffers(machineStatus, installImage) {
+					return OpMaintenanceUpgrade
+				}
+
 				return OpNone
 			}
+
+			// No Talos on disk: always install explicitly via LifecycleService.Install. ApplyConfig is used
+			// only to configure machines that already have Talos on disk, never to trigger an install.
+			return OpMaintenanceInstall
 		}
 
 		if hasSystemDisk {

--- a/internal/backend/talos/lifecycle/decide_test.go
+++ b/internal/backend/talos/lifecycle/decide_test.go
@@ -76,32 +76,33 @@ func TestDecideOp(t *testing.T) {
 			want:                 lifecycle.OpMaintenanceInstall,
 		},
 		{
-			name:                 "not-installed 1.13 in maintenance, patch-only mismatch → config-apply install (None)",
+			name:                 "not-installed 1.13 in maintenance, patch-only mismatch → maintenance install",
 			machine:              mkMachineStatus("1.13.0", nil, false, true),
 			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
 			image:                mkImage("1.13.4", ""),
 			talosVersionMismatch: true,
-			// same config contract (major.minor): the maintenance config apply installs the exact target version itself, no lifecycle install needed
-			want: lifecycle.OpNone,
+			// no system disk: always install explicitly via LifecycleService, even within the same major.minor
+			want: lifecycle.OpMaintenanceInstall,
 		},
 		{
-			name:     "not-installed 1.13 in maintenance at target version → config-apply install (None) despite stale mismatch flags",
+			name:     "not-installed 1.13 in maintenance at target version → maintenance install despite stale mismatch flags",
 			machine:  mkMachineStatus("1.13.4", nil, false, true),
 			snapshot: mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
 			image:    mkImage("1.13.4", ""),
-			// machineConfigStatus-based flags signal a mismatch on the first reconcile (empty status); the live machine state must win.
+			// machineConfigStatus-based flags signal a mismatch on the first reconcile (empty status); it doesn't matter
+			// here either way, since no system disk always means an explicit install regardless of version match.
 			schematicMismatch:    true,
 			talosVersionMismatch: true,
-			want:                 lifecycle.OpNone,
+			want:                 lifecycle.OpMaintenanceInstall,
 		},
 		{
-			name:                 "not-installed 1.13 in maintenance, schematic-only mismatch → config-apply install (None)",
+			name:                 "not-installed 1.13 in maintenance, schematic-only mismatch → maintenance install",
 			machine:              mkMachineStatus("1.13.4", &specs.MachineStatusSpec_Schematic{FullId: "boot-schematic"}, false, true),
 			snapshot:             mkSnapshot(machineapi.MachineStatusEvent_MAINTENANCE),
 			image:                mkImage("1.13.4", "target-schematic"),
 			schematicMismatch:    true,
 			talosVersionMismatch: true,
-			want:                 lifecycle.OpNone,
+			want:                 lifecycle.OpMaintenanceInstall,
 		},
 		{
 			name:                 "installed 1.13 in maintenance with patch-only mismatch → maintenance upgrade (exact compare)",


### PR DESCRIPTION
Omni installed same-minor maintenance machines by letting MachineService.ApplyConfig trigger the install and reboot itself. It now goes through an explicit LifecycleService.Install instead, the same path already used for cross-minor installs.
