### PR TITLE
fix: update kube-service-exposer to v0.4.0

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster/data/kube-service-exposer-manifest.tmpl.yaml
+++ b/internal/backend/runtime/omni/controllers/omni/cluster/data/kube-service-exposer-manifest.tmpl.yaml
@@ -47,7 +47,7 @@ spec:
         - operator: Exists
       containers:
         - name: omni-kube-service-exposer
-          image: ghcr.io/siderolabs/kube-service-exposer:v0.3.0
+          image: ghcr.io/siderolabs/kube-service-exposer:v0.4.0
           args:
             - --debug=false
             - --annotation-key={{ .AnnotationKey }}


### PR DESCRIPTION
The new version disables its metrics server by default, so it no longer listens on the workload cluster node addresses.

Related to siderolabs/kube-service-exposer#22.