### PR TITLE
fix: expose the machines cores and virtual state watches metrics

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_status_metrics.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_metrics.go
@@ -485,6 +485,7 @@ func (ctrl *MachineStatusMetricsController) Collect(ch chan<- prometheus.Metric)
 	ctrl.versionsMu.Unlock()
 
 	ctrl.metricNumMachines.Collect(ch)
+	ctrl.metricNumCores.Collect(ch)
 	ctrl.metricNumConnectedMachines.Collect(ch)
 	ctrl.metricNumInvalidSchematicMachines.Collect(ch)
 	ctrl.metricNumApproachingTalosVersionEndOfSupportMachines.Collect(ch)

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_metrics_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_metrics_test.go
@@ -13,6 +13,9 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/siderolabs/gen/xslices"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -187,6 +190,27 @@ func TestMachineStatusMetricsController_UnsupportedTalosVersion(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestMachineStatusMetricsController_CollectMetrics(t *testing.T) {
+	t.Parallel()
+
+	registry := prometheus.NewPedanticRegistry()
+	require.NoError(t, registry.Register(omnictrl.NewMachineStatusMetricsController(0)))
+
+	families, err := registry.Gather()
+	require.NoError(t, err)
+
+	names := xslices.Map(families, func(family *dto.MetricFamily) string { return family.GetName() })
+
+	assert.ElementsMatch(t, []string{
+		"omni_machines",
+		"omni_machines_cores",
+		"omni_connected_machines",
+		"omni_machines_invalid_schematic",
+		"omni_machines_approaching_talos_version_end_of_support",
+		"omni_machines_talos_version_end_of_support",
+	}, names)
 }
 
 func TestMachineStatusMetricsController_UnsupportedTalosVersionTeardown(t *testing.T) {

--- a/internal/backend/runtime/omni/virtual/computed.go
+++ b/internal/backend/runtime/omni/virtual/computed.go
@@ -43,11 +43,7 @@ func NewComputed(resourceType string, factory ProducerFactory, resolveID Produce
 	state := state.WrapCore(namespaced.NewState(inmem.Build))
 	scheduler := NewDedupScheduler(resourceType, state, factory, cleanupInterval, logger)
 
-	if registerMetrics {
-		prometheus.DefaultRegisterer.MustRegister(scheduler)
-	}
-
-	return &Computed{
+	computed := &Computed{
 		state:          state,
 		watchScheduler: scheduler,
 		resolveID:      resolveID,
@@ -60,6 +56,12 @@ func NewComputed(resourceType string, factory ProducerFactory, resolveID Produce
 		}),
 		logger: logger,
 	}
+
+	if registerMetrics {
+		prometheus.DefaultRegisterer.MustRegister(scheduler, computed)
+	}
+
+	return computed
 }
 
 // Run starts underlying watch scheduler.

--- a/internal/backend/runtime/omni/virtual/state_test.go
+++ b/internal/backend/runtime/omni/virtual/state_test.go
@@ -18,7 +18,10 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/siderolabs/gen/channel"
+	"github.com/siderolabs/gen/xslices"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/stripe-go/v85"
 	"go.uber.org/zap"
@@ -146,6 +149,15 @@ func TestComputed(t *testing.T) {
 
 	err = st.Watch(ctx, virtualres.NewCurrentUser().Metadata(), events)
 	require.NoError(err)
+
+	registry := prometheus.NewPedanticRegistry()
+	require.NoError(registry.Register(st))
+
+	families, err := registry.Gather()
+	require.NoError(err)
+
+	names := xslices.Map(families, func(family *dto.MetricFamily) string { return family.GetName() })
+	require.Equal([]string{"omni_virtual_state_watches"}, names)
 
 	updated := 0
 	created := 0


### PR DESCRIPTION
The gauge counting the total number of CPU cores was updated on every reconcile but never included in the collected metrics, so it did not show up on the Prometheus endpoint. The gauge tracking active virtual state watches had a similar problem, its collector was never registered. Expose both and add tests that check the exposed metrics.

Part of siderolabs/omni#3134.