### PR TITLE
fix: allow removing the bootstrap spec once the cluster is bootstrapped

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -4262,8 +4262,9 @@ type MachineSetSpec struct {
 	// Deprecated: Marked as deprecated in omni/specs/omni.proto.
 	MachineClass *MachineSetSpec_MachineAllocation `protobuf:"bytes,2,opt,name=machine_class,json=machineClass,proto3" json:"machine_class,omitempty"`
 	// BootstrapSpec defines the bootstrapping spec of the machine set.
-	// This field is immutable, only valid for the control plane machine set and used only once at the creation time.
+	// This field is only valid for the control plane machine set and used only once at the creation time.
 	// When set, the machine set won't be created from scratch, instead, it will be bootstrapped using the given spec.
+	// It can only be set at the creation time and cannot be changed afterwards, but it can be removed once the cluster is bootstrapped.
 	BootstrapSpec *MachineSetSpec_BootstrapSpec `protobuf:"bytes,3,opt,name=bootstrap_spec,json=bootstrapSpec,proto3" json:"bootstrap_spec,omitempty"`
 	// DeleteStrategy defines the delete strategy of the machine set.
 	DeleteStrategy MachineSetSpec_UpdateStrategy `protobuf:"varint,4,opt,name=delete_strategy,json=deleteStrategy,proto3,enum=specs.MachineSetSpec_UpdateStrategy" json:"delete_strategy,omitempty"`

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -831,8 +831,9 @@ message MachineSetSpec {
   MachineAllocation machine_class = 2 [deprecated = true];
 
   // BootstrapSpec defines the bootstrapping spec of the machine set.
-  // This field is immutable, only valid for the control plane machine set and used only once at the creation time.
+  // This field is only valid for the control plane machine set and used only once at the creation time.
   // When set, the machine set won't be created from scratch, instead, it will be bootstrapped using the given spec.
+  // It can only be set at the creation time and cannot be changed afterwards, but it can be removed once the cluster is bootstrapped.
   BootstrapSpec bootstrap_spec = 3;
 
   // DeleteStrategy defines the delete strategy of the machine set.

--- a/internal/backend/runtime/omni/validations/machine_set.go
+++ b/internal/backend/runtime/omni/validations/machine_set.go
@@ -74,12 +74,12 @@ func machineSetValidationOptions(st state.State, etcdBackupStoreFactory store.Fa
 		}
 
 		if isControlPlane && oldRes == nil { // creating a new control plane machine set
-			bootstrapStatus, err := safe.StateGetByID[*omni.ClusterBootstrapStatus](ctx, st, clusterName)
-			if err != nil && !state.IsNotFoundError(err) {
-				return fmt.Errorf("error getting cluster bootstrap status: %w", err)
+			bootstrapped, err := clusterBootstrapped(ctx, st, clusterName)
+			if err != nil {
+				return err
 			}
 
-			if bootstrapStatus != nil && bootstrapStatus.TypedSpec().Value.GetBootstrapped() {
+			if bootstrapped {
 				return errors.New("adding control plane machine set to an already bootstrapped cluster is not allowed")
 			}
 		}
@@ -222,7 +222,26 @@ func validateBootstrapSpec(ctx context.Context, st state.State, etcdBackupStoreF
 	}
 
 	if oldres != nil { // this is an update
-		if !bootstrapSpec.EqualVT(oldres.TypedSpec().Value.GetBootstrapSpec()) {
+		oldBootstrapSpec := oldres.TypedSpec().Value.GetBootstrapSpec()
+
+		if bootstrapSpec == nil && oldBootstrapSpec != nil {
+			// the bootstrap spec has no effect after the cluster is bootstrapped, so it is safe to remove it at that point.
+			// removing it earlier would silently turn a restore from a backup into a fresh cluster bootstrap.
+			clusterName, _ := res.Metadata().Labels().Get(omni.LabelCluster)
+
+			bootstrapped, err := clusterBootstrapped(ctx, st, clusterName)
+			if err != nil {
+				return err
+			}
+
+			if !bootstrapped {
+				return errors.New("bootstrap spec can only be removed after the cluster is bootstrapped")
+			}
+
+			return nil
+		}
+
+		if !bootstrapSpec.EqualVT(oldBootstrapSpec) {
 			return errors.New("bootstrap spec is immutable after creation")
 		}
 
@@ -279,6 +298,15 @@ func validateBootstrapSpec(ctx context.Context, st state.State, etcdBackupStoreF
 	}
 
 	return nil
+}
+
+func clusterBootstrapped(ctx context.Context, st state.State, clusterName resource.ID) (bool, error) {
+	bootstrapStatus, err := safe.StateGetByID[*omni.ClusterBootstrapStatus](ctx, st, clusterName)
+	if err != nil && !state.IsNotFoundError(err) {
+		return false, fmt.Errorf("error getting cluster bootstrap status: %w", err)
+	}
+
+	return bootstrapStatus != nil && bootstrapStatus.TypedSpec().Value.GetBootstrapped(), nil
 }
 
 func validateBootstrapSnapshot(snapshot string) error {

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -874,6 +874,49 @@ func TestMachineSetBootstrapSpecValidation(t *testing.T) {
 	err = st.Update(ctx, controlPlaneMachineSet)
 	assert.True(t, validated.IsValidationError(err), "expected validation error")
 	assert.ErrorContains(t, err, "bootstrap spec is immutable after creation")
+
+	// remove bootstrap spec before the cluster is bootstrapped - not allowed
+
+	controlPlaneMachineSet.TypedSpec().Value.BootstrapSpec = nil
+
+	err = st.Update(ctx, controlPlaneMachineSet)
+	assert.True(t, validated.IsValidationError(err), "expected validation error")
+	assert.ErrorContains(t, err, "bootstrap spec can only be removed after the cluster is bootstrapped")
+
+	// mark the cluster as bootstrapped
+
+	bootstrapStatus := omnires.NewClusterBootstrapStatus(clusterID)
+	bootstrapStatus.TypedSpec().Value.Bootstrapped = true
+
+	require.NoError(t, st.Create(ctx, bootstrapStatus))
+
+	// change bootstrap spec after the cluster is bootstrapped - still not allowed
+
+	controlPlaneMachineSet.TypedSpec().Value.BootstrapSpec = &specs.MachineSetSpec_BootstrapSpec{
+		ClusterUuid: clusterUUID,
+		Snapshot:    "different",
+	}
+
+	err = st.Update(ctx, controlPlaneMachineSet)
+	assert.True(t, validated.IsValidationError(err), "expected validation error")
+	assert.ErrorContains(t, err, "bootstrap spec is immutable after creation")
+
+	// remove bootstrap spec after the cluster is bootstrapped - allowed
+
+	controlPlaneMachineSet.TypedSpec().Value.BootstrapSpec = nil
+
+	assert.NoError(t, st.Update(ctx, controlPlaneMachineSet))
+
+	// add bootstrap spec back after removal - not allowed
+
+	controlPlaneMachineSet.TypedSpec().Value.BootstrapSpec = &specs.MachineSetSpec_BootstrapSpec{
+		ClusterUuid: clusterUUID,
+		Snapshot:    snapshotName,
+	}
+
+	err = st.Update(ctx, controlPlaneMachineSet)
+	assert.True(t, validated.IsValidationError(err), "expected validation error")
+	assert.ErrorContains(t, err, "bootstrap spec is immutable after creation")
 }
 
 func TestMachineSetBootstrapSnapshotValidation(t *testing.T) {


### PR DESCRIPTION
After restoring a cluster from an etcd backup with cluster templates, the bootstrap spec could never be removed from the template again, every sync without it failed validation. This forced GitOps users to carry the stale block forever.

Allow removing the bootstrap spec once the cluster is bootstrapped, it has no effect from that point on. Removing it earlier is still rejected, and setting or changing it after creation stays forbidden.