### PR TITLE
test: run browser e2e tests off the host network

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,6 +2,7 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
+import dns from 'node:dns/promises'
 import path from 'node:path'
 
 import { defineConfig, devices } from '@playwright/test'
@@ -12,6 +13,33 @@ import dotenv from 'dotenv'
  * https://github.com/motdotla/dotenv
  */
 dotenv.config({ quiet: true })
+
+/**
+ * Chromium resolves any *.localhost hostname to loopback without consulting the OS resolver,
+ * so when the tests run in a container that reaches Omni through an --add-host mapping of
+ * such a hostname, the mapping never takes effect in the browser. Repeat it through
+ * Chromium's own resolver rules, using the address the OS resolver returns. The rule
+ * wildcard spans multiple labels, so *.omni.localhost also covers workload proxy hostnames
+ * like nginx-my-instance.proxy-us.omni.localhost.
+ */
+async function chromiumArgs(): Promise<string[]> {
+  const host = process.env.BASE_URL ? new URL(process.env.BASE_URL).hostname : undefined
+  if (!host?.endsWith('.localhost')) return []
+
+  let address: string
+  try {
+    ;({ address } = await dns.lookup(host))
+  } catch {
+    return []
+  }
+
+  if (['127.0.0.1', '::1'].includes(address)) return []
+
+  const parentDomain = host.split('.').slice(1).join('.')
+  const target = address.includes(':') ? `[${address}]` : address
+
+  return [`--host-resolver-rules=MAP *.${parentDomain} ${target}`]
+}
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -25,6 +53,7 @@ export default defineConfig({
   reporter: process.env.CI ? [['html'], ['list'], ['github']] : [['html'], ['list']],
   use: {
     baseURL: process.env.BASE_URL,
+    launchOptions: { args: await chromiumArgs() },
     permissions: ['clipboard-read', 'clipboard-write'],
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -70,7 +70,9 @@ if [[ "${AUTH_PROVIDER}" == "auth0" ]]; then
 else
   export AUTH_USERNAME="test-user@siderolabs.com"
   export AUTH_PASSWORD="test-password-1234"
-  export DEX_ISSUER="http://127.0.0.1:5556/dex"
+  # Use the omni hostname (resolving to 127.0.0.1 on the host) rather than 127.0.0.1,
+  # so the e2e test container can reach Dex through its --add-host host-gateway mapping.
+  export DEX_ISSUER="http://my-instance.omni.localhost:5556/dex"
   export DEX_OIDC_CLIENT_ID="omni"
   export DEX_OIDC_CLIENT_SECRET="omni-oidc-secret"
   export AUTH_PROVIDER_CONFIG="  oidc:

--- a/hack/test/e2e-auth0.sh
+++ b/hack/test/e2e-auth0.sh
@@ -46,6 +46,11 @@ SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
 
 # Run the e2e test.
 # the e2e tests are in a submodule and need to be executed in a container with playwright dependencies
+#
+# Keep this container off the host network. Machine provisioning adds and removes host
+# network interfaces, and Chromium aborts every in-flight request (including the resource
+# watch streams feeding the UI) with ERR_NETWORK_CHANGED when it sees an interface change
+# in its own network namespace, so on the host network the UI tests randomly flake.
 cd frontend/
 docker buildx build --load . -t e2etest
 docker run --rm \
@@ -55,7 +60,7 @@ docker run --rm \
   -e BASE_URL="$BASE_URL" \
   -e PROJECT="auth0" \
   -v "${TEST_OUTPUTS_DIR}/e2e/playwright-report:/tmp/test/playwright-report" \
-  --network=host \
+  --add-host=my-instance.omni.localhost:host-gateway \
   e2etest
 
 # No cleanup here, as it runs in the CI as a container in a pod.

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -81,6 +81,11 @@ SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
 
 # Run the e2e test.
 # the e2e tests are in a submodule and need to be executed in a container with playwright dependencies
+#
+# Keep this container off the host network. Machine provisioning adds and removes host
+# network interfaces, and Chromium aborts every in-flight request (including the resource
+# watch streams feeding the UI) with ERR_NETWORK_CHANGED when it sees an interface change
+# in its own network namespace, so on the host network the UI tests randomly flake.
 cd frontend/
 docker buildx build --load . -t e2etest
 docker run --rm \
@@ -91,7 +96,7 @@ docker run --rm \
   -e PROJECT="qemu" \
   -v "${TEST_OUTPUTS_DIR}/e2e/playwright-report:/tmp/test/playwright-report" \
   -v "${TEST_OUTPUTS_DIR}/e2e/support-bundles:/tmp/test/test-results/support-bundles/" \
-  --network=host \
+  --add-host=my-instance.omni.localhost:host-gateway \
   e2etest
 
 # No cleanup here, as it runs in the CI as a container in a pod.

--- a/hack/test/e2e-talemu.sh
+++ b/hack/test/e2e-talemu.sh
@@ -62,6 +62,11 @@ SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
 
 # Run the e2e test.
 # the e2e tests are in a submodule and need to be executed in a container with playwright dependencies
+#
+# Keep this container off the host network. Machine provisioning adds and removes host
+# network interfaces, and Chromium aborts every in-flight request (including the resource
+# watch streams feeding the UI) with ERR_NETWORK_CHANGED when it sees an interface change
+# in its own network namespace, so on the host network the UI tests randomly flake.
 cd frontend/
 docker buildx build --load . -t e2etest
 docker run --rm \
@@ -71,7 +76,7 @@ docker run --rm \
   -e BASE_URL="$BASE_URL" \
   -e PROJECT="talemu" \
   -v "${TEST_OUTPUTS_DIR}/e2e/playwright-report:/tmp/test/playwright-report" \
-  --network=host \
+  --add-host=my-instance.omni.localhost:host-gateway \
   e2etest
 
 # No cleanup here, as it runs in the CI as a container in a pod.

--- a/hack/test/integration-qemu.sh
+++ b/hack/test/integration-qemu.sh
@@ -132,6 +132,7 @@ if [[ -n "$ANOTHER_OMNI_VERSION" && -n "$INTEGRATION_PREPARE_TEST_ARGS" ]]; then
     -e SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
     -e SSL_CERT_DIR=hack/certs:/etc/ssl/certs \
     --network host \
+    --add-host=my-instance.omni.localhost:127.0.0.1 \
     "ghcr.io/siderolabs/omni-integration-test:${ANOTHER_OMNI_VERSION}" \
     --omni.talos-version="${TALOS_VERSION}" \
     --omni.stable-talos-version="${STABLE_TALOS_VERSION}" \


### PR DESCRIPTION
The e2e jobs ran the browser container on the host network, while machine provisioning constantly adds and removes network interfaces on that same host. Chromium treats every interface change as a network change and aborts all in-flight requests, including the streams that feed the UI, so pages intermittently showed stale or missing data and the tests flaked, most often on the cluster create and scale flows.

Run the browser container in its own network namespace instead, reaching Omni and Dex through a host gateway mapping. The OIDC issuer now uses the same hostname as the Omni endpoint so the login flow also works from outside the host network namespace.