### PR TITLE
feat(frontend): dim machine stage status when machine is not healthy

### DIFF
--- a/frontend/src/components/Status/MachineStage.stories.ts
+++ b/frontend/src/components/Status/MachineStage.stories.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { Resource } from '@/api/grpc'
+import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
+import { MachineStatusSnapshotSpecPowerStage } from '@/api/omni/specs/omni.pb'
+import {
+  MachineStatusLabelConnected,
+  MachineStatusLinkType,
+  MetricsNamespace,
+} from '@/api/resources'
+import { MachineStatusEventMachineStage } from '@/api/talos/machine/machine.pb'
+
+import MachineStage from './MachineStage.vue'
+
+interface MachineOptions {
+  stage?: MachineStatusEventMachineStage
+  powerStage?: MachineStatusSnapshotSpecPowerStage
+  connected?: boolean
+}
+
+const makeMachine = ({
+  stage,
+  powerStage,
+  connected = true,
+}: MachineOptions): Resource<MachineStatusLinkSpec> => ({
+  spec: {
+    snapshot: {
+      power_stage: powerStage,
+      machine_status: stage === undefined ? undefined : { stage },
+    },
+  },
+  metadata: {
+    namespace: MetricsNamespace,
+    type: MachineStatusLinkType,
+    id: 'e5f6a7b8-0000-0000-0000-000000000000',
+    labels: connected ? { [MachineStatusLabelConnected]: '' } : {},
+  },
+})
+
+const meta: Meta<typeof MachineStage> = {
+  component: MachineStage,
+  parameters: {
+    layout: 'centered',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Running: Story = {
+  args: {
+    machine: makeMachine({ stage: MachineStatusEventMachineStage.RUNNING }),
+  },
+}
+
+export const Booting: Story = {
+  args: {
+    machine: makeMachine({ stage: MachineStatusEventMachineStage.BOOTING }),
+  },
+}
+
+export const Installing: Story = {
+  args: {
+    machine: makeMachine({ stage: MachineStatusEventMachineStage.INSTALLING }),
+  },
+}
+
+export const Upgrading: Story = {
+  args: {
+    machine: makeMachine({ stage: MachineStatusEventMachineStage.UPGRADING }),
+  },
+}
+
+export const Rebooting: Story = {
+  args: {
+    machine: makeMachine({ stage: MachineStatusEventMachineStage.REBOOTING }),
+  },
+}
+
+export const Maintenance: Story = {
+  args: {
+    machine: makeMachine({ stage: MachineStatusEventMachineStage.MAINTENANCE }),
+  },
+}
+
+export const ShuttingDown: Story = {
+  args: {
+    machine: makeMachine({ stage: MachineStatusEventMachineStage.SHUTTING_DOWN }),
+  },
+}
+
+export const Resetting: Story = {
+  args: {
+    machine: makeMachine({ stage: MachineStatusEventMachineStage.RESETTING }),
+  },
+}
+
+export const PoweredOff: Story = {
+  args: {
+    machine: makeMachine({
+      powerStage: MachineStatusSnapshotSpecPowerStage.POWER_STAGE_POWERED_OFF,
+      connected: false,
+    }),
+  },
+}
+
+export const PoweringOn: Story = {
+  args: {
+    machine: makeMachine({
+      powerStage: MachineStatusSnapshotSpecPowerStage.POWER_STAGE_POWERING_ON,
+      connected: false,
+    }),
+  },
+}
+
+export const Disconnected: Story = {
+  args: {
+    machine: makeMachine({
+      stage: MachineStatusEventMachineStage.RUNNING,
+      connected: false,
+    }),
+  },
+}

--- a/frontend/src/components/Status/MachineStage.vue
+++ b/frontend/src/components/Status/MachineStage.vue
@@ -5,8 +5,12 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import type { Resource } from '@/api/grpc'
 import type { MachineStatusLinkSpec } from '@/api/omni/specs/ephemeral.pb'
+import { MachineStatusSnapshotSpecPowerStage } from '@/api/omni/specs/omni.pb'
+import { MachineStatusLabelConnected } from '@/api/resources'
 import TIcon from '@/components/Icon/TIcon.vue'
 import { useDerivedMachineStage } from '@/methods/useDerivedMachineStage'
 import { cn } from '@/methods/utils'
@@ -16,6 +20,15 @@ const { machine } = defineProps<{
 }>()
 
 const { status } = useDerivedMachineStage(() => machine.spec.snapshot)
+
+const isConnected = computed(
+  () =>
+    machine.spec.snapshot?.power_stage ===
+      MachineStatusSnapshotSpecPowerStage.POWER_STAGE_POWERING_ON ||
+    machine.spec.snapshot?.power_stage ===
+      MachineStatusSnapshotSpecPowerStage.POWER_STAGE_POWERED_OFF ||
+    machine.metadata.labels?.[MachineStatusLabelConnected] === '',
+)
 </script>
 
 <template>
@@ -25,12 +38,12 @@ const { status } = useDerivedMachineStage(() => machine.spec.snapshot)
       cn(
         'inline-flex items-center gap-1 text-xs',
         status.class,
-        { 'opacity-50': machine.spec.tearing_down },
+        { 'brightness-50': machine.spec.tearing_down || !isConnected },
         $attrs.class,
       )
     "
   >
-    <TIcon :icon="status.icon" class="size-4" aria-hidden="true" />
+    <TIcon :icon="isConnected ? status.icon : 'unknown'" class="size-4" aria-hidden="true" />
     {{ status.name }}
   </span>
 </template>


### PR DESCRIPTION
When machine is not healthy, dim the MachineStage status like ClusterMachinePhase to indicate this. Last known status will continue to be shown.

<img width="1623" height="716" alt="image" src="https://github.com/user-attachments/assets/d021ab67-ba61-441c-8daf-bbaa47b0c3d8" />
