### PR TITLE
feat(frontend): hide pxe boot option for enterprise

### DIFF
--- a/frontend/src/components/SideBar/TSideBar.vue
+++ b/frontend/src/components/SideBar/TSideBar.vue
@@ -37,7 +37,7 @@ import TSidebarList from '@/components/SideBar/TSideBarList.vue'
 import UserInfo from '@/components/UserInfo/UserInfo.vue'
 import { setupBackupStatus } from '@/methods'
 import { useClusterPermissions, usePermissions } from '@/methods/auth'
-import { useFeatures } from '@/methods/features'
+import { useFeatures, useIsEnterprise } from '@/methods/features'
 import { useIdentity } from '@/methods/identity'
 import { useResourceGet } from '@/methods/useResourceGet'
 import { useResourceWatch } from '@/methods/useResourceWatch'
@@ -48,6 +48,7 @@ const { avatar, fullname, identity } = useIdentity()
 
 const { data: featuresConfig } = useFeatures()
 const { canManageBackupStore, canManageUsers, canReadClusters, canReadMachines } = usePermissions()
+const isEnterpriseFactory = useIsEnterprise()
 
 const currentCluster = computed(() =>
   'cluster' in route.params ? route.params.cluster : undefined,
@@ -345,7 +346,7 @@ const clusterItems = computed(() => {
   ]
 
   if (
-    featuresConfig.value?.spec.is_enterprise_image_factory &&
+    isEnterpriseFactory.value &&
     cluster.value?.spec.talos_version &&
     gte(cluster.value.spec.talos_version, '1.13.0')
   ) {

--- a/frontend/src/methods/features.ts
+++ b/frontend/src/methods/features.ts
@@ -2,7 +2,7 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
-import { effectScope } from 'vue'
+import { computed, effectScope } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
 import type { FeaturesConfigSpec } from '@/api/omni/specs/omni.pb'
@@ -15,6 +15,12 @@ export function useFeatures() {
   features ||= initFeatures()
 
   return features
+}
+
+export function useIsEnterprise() {
+  const { data } = useFeatures()
+
+  return computed(() => data.value?.spec.is_enterprise_image_factory ?? false)
 }
 
 function initFeatures() {

--- a/frontend/src/views/ClusterSecurity/ClusterSecurity.vue
+++ b/frontend/src/views/ClusterSecurity/ClusterSecurity.vue
@@ -31,7 +31,7 @@ import TSpinner from '@/components/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { getDocsLink } from '@/methods'
-import { useFeatures } from '@/methods/features'
+import { useIsEnterprise } from '@/methods/features'
 import { useResourceList } from '@/methods/useResourceList'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import SeverityBadges from '@/views/ClusterSecurity/components/SeverityBadges.vue'
@@ -47,8 +47,7 @@ import ScanDetailsModal from '@/views/InstallationMedia/vulnerabilities/ScanDeta
 
 const { clusterId } = defineProps<{ clusterId: string }>()
 
-const { data: features } = useFeatures()
-const isEnterpriseFactory = computed(() => !!features.value?.spec.is_enterprise_image_factory)
+const isEnterpriseFactory = useIsEnterprise()
 
 const { data: clusterStatus, loading: statusLoading } = useResourceWatch<ClusterStatusSpec>(() => ({
   runtime: Runtime.Omni,

--- a/frontend/src/views/InstallationMedia/Confirmation.vue
+++ b/frontend/src/views/InstallationMedia/Confirmation.vue
@@ -31,7 +31,7 @@ import TSpinner from '@/components/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { getDocsLink, majorMinorVersion } from '@/methods'
-import { useFeatures } from '@/methods/features'
+import { useFeatures, useIsEnterprise } from '@/methods/features'
 import { useImageFactoryAuth, withImageFactoryAuth } from '@/methods/useImageFactoryAuth'
 import { useResourceGet } from '@/methods/useResourceGet'
 import { useTalosctlDownloads } from '@/methods/useTalosctlDownloads'
@@ -63,7 +63,7 @@ const talosctlAvailable = computed(() => quirks.value?.spec.supports_factory_tal
 
 const { data: features } = useFeatures()
 const imageFactoryBaseURL = computed(() => features.value?.spec.image_factory_base_url)
-const isEnterpriseFactory = computed(() => features.value?.spec.is_enterprise_image_factory)
+const isEnterpriseFactory = useIsEnterprise()
 
 const imageFactoryAuth = useImageFactoryAuth()
 
@@ -118,9 +118,9 @@ const secureBootSuffix = computed(() => {
 // true if the platform supports boot methods other than disk-image.
 const notOnlyDiskImage = computed(
   () =>
-    selectedPlatform.value?.spec.boot_methods?.some(
-      (m) => m !== PlatformConfigSpecBootMethod.DISK_IMAGE,
-    ) ?? false,
+    selectedPlatform.value?.spec.boot_methods
+      ?.filter((m) => !isEnterpriseFactory.value || m !== PlatformConfigSpecBootMethod.PXE)
+      .some((m) => m !== PlatformConfigSpecBootMethod.DISK_IMAGE) ?? false,
 )
 
 const preset = computed(() => formStateToPreset(formState.value))
@@ -320,23 +320,25 @@ const VEXBaseURL = computed(() =>
       />
     </template>
 
-    <h3 class="text-sm text-naturals-n14">PXE Boot with booter</h3>
-    <p>
-      To easily PXE boot bare-metal machines using
-      <a
-        class="link-primary"
-        href="https://github.com/siderolabs/booter"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        booter
-      </a>
-      with this schematic, run the following command on a host in the same subnet:
-    </p>
-    <CodeBlock
-      :button-attrs="{ 'aria-label': 'Copy PXE booter docker run command' }"
-      :code="`docker run --rm --network host ghcr.io/siderolabs/booter:v0.3.0 --talos-version=v${resolvedTalosVersion} --schematic-id=${schematic.id}`"
-    />
+    <template v-if="!isEnterpriseFactory">
+      <h3 class="text-sm text-naturals-n14">PXE Boot with booter</h3>
+      <p>
+        To easily PXE boot bare-metal machines using
+        <a
+          class="link-primary"
+          href="https://github.com/siderolabs/booter"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          booter
+        </a>
+        with this schematic, run the following command on a host in the same subnet:
+      </p>
+      <CodeBlock
+        :button-attrs="{ 'aria-label': 'Copy PXE booter docker run command' }"
+        :code="`docker run --rm --network host ghcr.io/siderolabs/booter:v0.3.0 --talos-version=v${resolvedTalosVersion} --schematic-id=${schematic.id}`"
+      />
+    </template>
 
     <h3 class="text-sm text-naturals-n14">Documentation</h3>
     <ul class="ml-2 flex list-inside list-disc flex-col gap-2 text-primary-p3">

--- a/frontend/src/views/InstallationMedia/usePresetDownloadLinks.ts
+++ b/frontend/src/views/InstallationMedia/usePresetDownloadLinks.ts
@@ -18,7 +18,7 @@ import {
   VirtualNamespace,
 } from '@/api/resources'
 import { getDocsLink } from '@/methods'
-import { useFeatures } from '@/methods/features'
+import { useFeatures, useIsEnterprise } from '@/methods/features'
 import { useImageFactoryAuth, withImageFactoryAuth } from '@/methods/useImageFactoryAuth'
 import { useResourceGet } from '@/methods/useResourceGet'
 
@@ -30,6 +30,7 @@ export function usePresetDownloadLinks(
 
   const { data: features } = useFeatures()
   const auth = useImageFactoryAuth()
+  const isEnterpriseFactory = useIsEnterprise()
 
   const { data: selectedCloudProvider } = useResourceGet<PlatformConfigSpec>(() => ({
     skip: !toValue(presetRef).cloud,
@@ -131,22 +132,78 @@ export function usePresetDownloadLinks(
       }
     }
 
-    return selectedPlatform.value.spec.boot_methods.flatMap<DownloadLink>((bootMethod) => {
-      switch (bootMethod) {
-        case PlatformConfigSpecBootMethod.DISK_IMAGE: {
-          if (!platformDiskImagePath.value) return []
+    return selectedPlatform.value.spec.boot_methods
+      .filter((m) => !isEnterpriseFactory.value || m !== PlatformConfigSpecBootMethod.PXE)
+      .flatMap<DownloadLink>((bootMethod) => {
+        switch (bootMethod) {
+          case PlatformConfigSpecBootMethod.DISK_IMAGE: {
+            if (!platformDiskImagePath.value) return []
 
-          if (preset.secure_boot) {
+            if (preset.secure_boot) {
+              return {
+                label: 'SecureBoot Disk Image',
+                link: platformDiskImagePath.value,
+                withChecksums: true,
+                documentation: isMetal.value
+                  ? {
+                      label: 'SecureBoot documentation',
+                      link: getDocsLink(
+                        'talos',
+                        '/platform-specific-installations/bare-metal-platforms/secureboot',
+                        { talosVersion: preset.talos_version },
+                      ),
+                    }
+                  : undefined,
+              }
+            }
+
+            if (isMetal.value && qcow2DiskImagePath.value) {
+              return [
+                {
+                  label: 'Disk Image (raw)',
+                  link: platformDiskImagePath.value,
+                  withChecksums: true,
+                },
+                {
+                  label: 'Disk Image (qcow2)',
+                  link: qcow2DiskImagePath.value,
+                  withChecksums: true,
+                },
+              ]
+            }
+
+            return { label: 'Disk Image', link: platformDiskImagePath.value, withChecksums: true }
+          }
+
+          case PlatformConfigSpecBootMethod.ISO: {
+            if (!isoPath.value) return []
+
+            if (preset.secure_boot) {
+              return {
+                label: 'SecureBoot ISO',
+                link: isoPath.value,
+                withChecksums: true,
+                documentation: {
+                  label: 'SecureBoot documentation',
+                  link: getDocsLink(
+                    'talos',
+                    '/platform-specific-installations/bare-metal-platforms/secureboot',
+                    { talosVersion: preset.talos_version },
+                  ),
+                },
+              }
+            }
+
             return {
-              label: 'SecureBoot Disk Image',
-              link: platformDiskImagePath.value,
+              label: 'ISO',
+              link: isoPath.value,
               withChecksums: true,
               documentation: isMetal.value
                 ? {
-                    label: 'SecureBoot documentation',
+                    label: 'ISO documentation',
                     link: getDocsLink(
                       'talos',
-                      '/platform-specific-installations/bare-metal-platforms/secureboot',
+                      '/platform-specific-installations/bare-metal-platforms/iso',
                       { talosVersion: preset.talos_version },
                     ),
                   }
@@ -154,75 +211,29 @@ export function usePresetDownloadLinks(
             }
           }
 
-          if (isMetal.value && qcow2DiskImagePath.value) {
-            return [
-              { label: 'Disk Image (raw)', link: platformDiskImagePath.value, withChecksums: true },
-              { label: 'Disk Image (qcow2)', link: qcow2DiskImagePath.value, withChecksums: true },
-            ]
-          }
+          case PlatformConfigSpecBootMethod.PXE: {
+            if (!pxeBootURL.value) return []
 
-          return { label: 'Disk Image', link: platformDiskImagePath.value, withChecksums: true }
-        }
-
-        case PlatformConfigSpecBootMethod.ISO: {
-          if (!isoPath.value) return []
-
-          if (preset.secure_boot) {
             return {
-              label: 'SecureBoot ISO',
-              link: isoPath.value,
-              withChecksums: true,
-              documentation: {
-                label: 'SecureBoot documentation',
-                link: getDocsLink(
-                  'talos',
-                  '/platform-specific-installations/bare-metal-platforms/secureboot',
-                  { talosVersion: preset.talos_version },
-                ),
-              },
+              label: preset.secure_boot ? 'SecureBoot PXE (iPXE script)' : 'PXE boot (iPXE script)',
+              link: pxeBootURL.value,
+              copyOnly: true,
+              documentation: isMetal.value
+                ? {
+                    label: 'PXE documentation',
+                    link: getDocsLink(
+                      'talos',
+                      '/platform-specific-installations/bare-metal-platforms/pxe',
+                      { talosVersion: preset.talos_version },
+                    ),
+                  }
+                : undefined,
             }
           }
-
-          return {
-            label: 'ISO',
-            link: isoPath.value,
-            withChecksums: true,
-            documentation: isMetal.value
-              ? {
-                  label: 'ISO documentation',
-                  link: getDocsLink(
-                    'talos',
-                    '/platform-specific-installations/bare-metal-platforms/iso',
-                    { talosVersion: preset.talos_version },
-                  ),
-                }
-              : undefined,
-          }
         }
 
-        case PlatformConfigSpecBootMethod.PXE: {
-          if (!pxeBootURL.value) return []
-
-          return {
-            label: preset.secure_boot ? 'SecureBoot PXE (iPXE script)' : 'PXE boot (iPXE script)',
-            link: pxeBootURL.value,
-            copyOnly: true,
-            documentation: isMetal.value
-              ? {
-                  label: 'PXE documentation',
-                  link: getDocsLink(
-                    'talos',
-                    '/platform-specific-installations/bare-metal-platforms/pxe',
-                    { talosVersion: preset.talos_version },
-                  ),
-                }
-              : undefined,
-          }
-        }
-      }
-
-      return []
-    })
+        return []
+      })
   })
 
   return { links }

--- a/frontend/src/views/Machines/components/AddingMachinesTutorial.vue
+++ b/frontend/src/views/Machines/components/AddingMachinesTutorial.vue
@@ -17,7 +17,10 @@ import {
 import TButton from '@/components/Button/TButton.vue'
 import CodeBlock from '@/components/CodeBlock/CodeBlock.vue'
 import { getDocsLink } from '@/methods'
+import { useIsEnterprise } from '@/methods/features'
 import { useResourceWatch } from '@/methods/useResourceWatch'
+
+const isEnterpriseFactory = useIsEnterprise()
 
 const isDismissed = useLocalStorage('_add_first_machine_tutorial_dismissed', false)
 
@@ -68,8 +71,10 @@ const pxeBootCode =
         <p>AWS</p>
         <CodeBlock :code="awsCode"></CodeBlock>
 
-        <p>PXE boot</p>
-        <CodeBlock :code="pxeBootCode"></CodeBlock>
+        <template v-if="!isEnterpriseFactory">
+          <p>PXE boot</p>
+          <CodeBlock :code="pxeBootCode"></CodeBlock>
+        </template>
 
         <p>Download ISO</p>
         <CodeBlock code="omnictl download iso --arch amd64"></CodeBlock>


### PR DESCRIPTION
For Enterprise clients, hide PXE boot as an option in the UI as it is generally an unencrypted option that they are unlikely to use anyway.

Closes #3137