### PR TITLE
fix: use initial versions from input

### DIFF
--- a/client/pkg/clusterimport/input.go
+++ b/client/pkg/clusterimport/input.go
@@ -55,11 +55,11 @@ func (input *Input) initVersions(nodeName, detectedTalosVersion, detectedKuberne
 		KubernetesVersion: kubernetesVersion.String(),
 	}
 
-	if versions.InitialTalosVersion, err = input.determineInitialVersion(talosVersion, versions.InitialTalosVersion, "talos", nodeName); err != nil {
+	if versions.InitialTalosVersion, err = input.determineInitialVersion(talosVersion, input.Versions.InitialTalosVersion, "talos", nodeName); err != nil {
 		return Versions{}, err
 	}
 
-	if versions.InitialKubernetesVersion, err = input.determineInitialVersion(kubernetesVersion, versions.InitialKubernetesVersion, "kubernetes", nodeName); err != nil {
+	if versions.InitialKubernetesVersion, err = input.determineInitialVersion(kubernetesVersion, input.Versions.InitialKubernetesVersion, "kubernetes", nodeName); err != nil {
 		return Versions{}, err
 	}
 


### PR DESCRIPTION
The initial Kubernetes and Talos versions now get read from the CLI input, instead of a empty struct.

Before:

```
omnictl cluster import --talos-version v1.12.5 --kubernetes-version v1.35.2 --initial-talos-version v1.6.0 --initial-kubernetes-version v1.29.0 --dry-run --talosconfig ~/.talos/config --nodes X
discovering Talos cluster state...
importing cluster "kluster.boem" to Omni
initial talos version has not been provided, using detected version 1.12.5 from node k-ctrl-1
initial kubernetes version has not been provided, using detected version 1.35.2 from node k-ctrl-1
importing cluster "X" to Omni
importing cluster "X" with 6 nodes (1 control planes, 5 workers)
validating cluster status...
...
```

Now:

```
omnictl cluster import --talos-version v1.12.5 --kubernetes-version v1.35.2 --initial-talos-version v1.6.0 --initial-kubernetes-version v1.29.0 --dry-run --talosconfig ~/.talos/config --nodes X
discovering Talos cluster state...
importing cluster "X" to Omni
importing cluster "X" with 6 nodes (1 control planes, 5 workers)
validating cluster status...
...
```