### PR TITLE
feat: build version aware Kubernetes component patches for upgrades

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/kubernetes.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/kubernetes.go
@@ -6,6 +6,8 @@
 // Package kubernetes provides helpers for controller Kubernetes operations.
 package kubernetes
 
+import "github.com/siderolabs/talos/pkg/machinery/config"
+
 // Component is an enumeration of Kubernetes components.
 type Component string
 
@@ -25,16 +27,26 @@ var AllControlPlaneComponents = []Component{
 }
 
 // Patch returns a patcher for a specific component.
-func (c Component) Patch(version string) Patcher {
+func (c Component) Patch(vc *config.VersionContract, version string) (Patcher, error) {
 	switch c {
 	case APIServer:
-		return MultiPatcher(patchAPIServer(version), patchKubeProxy(version))
+		apiServerPatch, err := patchAPIServer(vc, version)
+		if err != nil {
+			return Patcher{}, err
+		}
+
+		kubeProxyPatch, err := patchKubeProxy(vc, version)
+		if err != nil {
+			return Patcher{}, err
+		}
+
+		return MultiPatcher(apiServerPatch, kubeProxyPatch)
 	case ControllerManager:
-		return patchControllerManager(version)
+		return patchControllerManager(vc, version)
 	case Scheduler:
-		return patchScheduler(version)
+		return patchScheduler(vc, version)
 	case Kubelet:
-		return patchKubelet(version)
+		return patchKubelet(vc, version)
 	default:
 		panic("unknown component")
 	}

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/kubernetes_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/kubernetes_test.go
@@ -13,8 +13,9 @@ import (
 	"testing"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	"github.com/siderolabs/talos/pkg/machinery/config/container"
-	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -40,37 +41,57 @@ func TestComponentPatch(t *testing.T) {
 		assert.Equal(t, v, strings.TrimLeft(tag, "v"))
 	}
 
-	for i := range 10 {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	componentVersionAssertion := map[kubernetes.Component]func(*testing.T, config.Provider, string){
+		kubernetes.APIServer: func(t *testing.T, cfg config.Provider, v string) {
+			assertVersion(t, v, cfg.K8sAPIServerConfig().Image())
+			assertVersion(t, v, cfg.K8sProxyConfig().Image())
+		},
+		kubernetes.ControllerManager: func(t *testing.T, cfg config.Provider, v string) {
+			assertVersion(t, v, cfg.K8sControllerManagerConfig().Image())
+		},
+		kubernetes.Scheduler: func(t *testing.T, cfg config.Provider, v string) {
+			assertVersion(t, v, cfg.K8sSchedulerConfig().Image())
+		},
+		kubernetes.Kubelet: func(t *testing.T, cfg config.Provider, v string) {
+			assertVersion(t, v, cfg.Machine().Kubelet().Image())
+		},
+	}
+
+	for _, vc := range []*config.VersionContract{config.TalosVersion1_13, config.TalosVersion1_14} {
+		t.Run(vc.String(), func(t *testing.T) {
 			t.Parallel()
 
-			components := append(slices.Clone(kubernetes.AllControlPlaneComponents), kubernetes.Kubelet)
-			rand.Shuffle(len(components), func(i, j int) {
-				components[i], components[j] = components[j], components[i]
-			})
+			for i := range 10 {
+				t.Run(strconv.Itoa(i), func(t *testing.T) {
+					t.Parallel()
 
-			v1alpha1Cfg := &v1alpha1.Config{}
-			cfg := container.NewV1Alpha1(v1alpha1Cfg)
+					components := append(slices.Clone(kubernetes.AllControlPlaneComponents), kubernetes.Kubelet)
+					rand.Shuffle(len(components), func(i, j int) {
+						components[i], components[j] = components[j], components[i]
+					})
 
-			componentVersionAssertion := map[kubernetes.Component]func(*testing.T, config.Provider, string){
-				kubernetes.APIServer: func(t *testing.T, cfg config.Provider, v string) {
-					assertVersion(t, v, cfg.K8sAPIServerConfig().Image())
-					assertVersion(t, v, cfg.K8sProxyConfig().Image())
-				},
-				kubernetes.ControllerManager: func(t *testing.T, cfg config.Provider, v string) {
-					assertVersion(t, v, cfg.K8sControllerManagerConfig().Image())
-				},
-				kubernetes.Scheduler: func(t *testing.T, cfg config.Provider, v string) {
-					assertVersion(t, v, cfg.K8sSchedulerConfig().Image())
-				},
-				kubernetes.Kubelet: func(t *testing.T, cfg config.Provider, v string) {
-					assertVersion(t, v, cfg.Machine().Kubelet().Image())
-				},
-			}
+					in, err := generate.NewInput("component-patch-test", "https://127.0.0.1/", "1.34.0", generate.WithVersionContract(vc))
+					require.NoError(t, err)
 
-			for _, component := range components {
-				component.Patch("1.2.3").Apply(v1alpha1Cfg)
-				componentVersionAssertion[component](t, cfg, "1.2.3")
+					cfg, err := in.Config(machine.TypeControlPlane)
+					require.NoError(t, err)
+
+					for _, component := range components {
+						patcher, err := component.Patch(vc, "1.2.3")
+						require.NoError(t, err)
+
+						patch, err := configpatcher.LoadPatch(patcher.Patch)
+						require.NoError(t, err)
+
+						patched, err := configpatcher.Apply(configpatcher.WithConfig(cfg), []configpatcher.Patch{patch})
+						require.NoError(t, err)
+
+						cfg, err = patched.Config()
+						require.NoError(t, err)
+
+						componentVersionAssertion[component](t, cfg, "1.2.3")
+					}
+				})
 			}
 		})
 	}

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch.go
@@ -6,10 +6,14 @@
 package kubernetes
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/siderolabs/gen/xslices"
-	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate/stdpatches"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 )
 
@@ -41,134 +45,117 @@ func (p UpgradeStep) Less(other UpgradeStep) bool {
 	return p.Component.Less(other.Component)
 }
 
-// Patcher returns the instructions to patch v1alpha1.Config to upgrade a specific component.
+// Patcher holds a machine config patch that upgrades a specific component.
 // It also returns the list of images used by it.
 type Patcher struct {
-	Apply      func(*v1alpha1.Config)
+	Patch      []byte
 	UsedImages []string
 }
 
 // MultiPatcher combines several patches.
-func MultiPatcher(patchers ...Patcher) Patcher {
+func MultiPatcher(patchers ...Patcher) (Patcher, error) {
+	if len(patchers) == 0 {
+		return Patcher{}, fmt.Errorf("at least one patcher is required")
+	}
+
+	merged := patchers[0].Patch
+
+	for _, p := range patchers[1:] {
+		var err error
+
+		merged, err = MergePatch(merged, p.Patch)
+		if err != nil {
+			return Patcher{}, err
+		}
+	}
+
 	return Patcher{
-		Apply: func(config *v1alpha1.Config) {
-			for _, patcher := range patchers {
-				patcher.Apply(config)
-			}
-		},
+		Patch: merged,
 		UsedImages: xslices.FlatMap(patchers, func(p Patcher) []string {
 			return p.UsedImages
 		}),
-	}
+	}, nil
 }
 
-func patchKubelet(version string) Patcher {
+// MergePatch merges a new patch into an existing patch.
+func MergePatch(existing, newPatch []byte) ([]byte, error) {
+	if len(bytes.TrimSpace(existing)) == 0 {
+		return newPatch, nil
+	}
+
+	if len(bytes.TrimSpace(newPatch)) == 0 {
+		return existing, nil
+	}
+
+	base, err := configloader.NewFromBytes(existing)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse existing patch: %w", err)
+	}
+
+	patch, err := configpatcher.LoadPatch(newPatch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse new patch: %w", err)
+	}
+
+	merged, err := configpatcher.Apply(configpatcher.WithConfig(base), []configpatcher.Patch{patch})
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge patch: %w", err)
+	}
+
+	return merged.Bytes()
+}
+
+func patchKubelet(vc *config.VersionContract, version string) (Patcher, error) {
 	img := fmt.Sprintf("%s:v%s", constants.KubeletImage, version)
 
-	return Patcher{
-		Apply: func(config *v1alpha1.Config) {
-			if config.MachineConfig == nil {
-				config.MachineConfig = &v1alpha1.MachineConfig{}
-			}
-
-			if config.MachineConfig.MachineKubelet == nil {
-				config.MachineConfig.MachineKubelet = &v1alpha1.KubeletConfig{}
-			}
-
-			config.MachineConfig.MachineKubelet.KubeletImage = img
-		},
-		UsedImages: []string{img},
+	data, err := stdpatches.WithKubeletImage(vc, img)
+	if err != nil {
+		return Patcher{}, fmt.Errorf("failed to build kubelet patch: %w", err)
 	}
+
+	return Patcher{Patch: data, UsedImages: []string{img}}, nil
 }
 
-// The inline API server config fields are deprecated in favor of separate config documents, but Omni still
-// relies on the inline form, so the deprecation is suppressed here.
-//
-//nolint:staticcheck
-func patchAPIServer(version string) Patcher {
+func patchAPIServer(vc *config.VersionContract, version string) (Patcher, error) {
 	img := fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, version)
 
-	return Patcher{
-		Apply: func(config *v1alpha1.Config) {
-			if config.ClusterConfig == nil {
-				config.ClusterConfig = &v1alpha1.ClusterConfig{}
-			}
-
-			if config.ClusterConfig.APIServerConfig == nil {
-				config.ClusterConfig.APIServerConfig = &v1alpha1.APIServerConfig{}
-			}
-
-			config.ClusterConfig.APIServerConfig.ContainerImage = img
-		},
-		UsedImages: []string{img},
+	data, err := stdpatches.WithKubeAPIServerImage(vc, img)
+	if err != nil {
+		return Patcher{}, fmt.Errorf("failed to build kube-apiserver patch: %w", err)
 	}
+
+	return Patcher{Patch: data, UsedImages: []string{img}}, nil
 }
 
-// The inline controller manager config fields are deprecated in favor of separate config documents, but Omni still
-// relies on the inline form, so the deprecation is suppressed here.
-//
-//nolint:staticcheck
-func patchControllerManager(version string) Patcher {
+func patchControllerManager(vc *config.VersionContract, version string) (Patcher, error) {
 	img := fmt.Sprintf("%s:v%s", constants.KubernetesControllerManagerImage, version)
 
-	return Patcher{
-		Apply: func(config *v1alpha1.Config) {
-			if config.ClusterConfig == nil {
-				config.ClusterConfig = &v1alpha1.ClusterConfig{}
-			}
-
-			if config.ClusterConfig.ControllerManagerConfig == nil {
-				config.ClusterConfig.ControllerManagerConfig = &v1alpha1.ControllerManagerConfig{}
-			}
-
-			config.ClusterConfig.ControllerManagerConfig.ContainerImage = img
-		},
-		UsedImages: []string{img},
+	data, err := stdpatches.WithKubeControllerManagerImage(vc, img)
+	if err != nil {
+		return Patcher{}, fmt.Errorf("failed to build kube-controller-manager patch: %w", err)
 	}
+
+	return Patcher{Patch: data, UsedImages: []string{img}}, nil
 }
 
-// The inline scheduler config fields are deprecated in favor of separate config documents, but Omni still relies on
-// the inline form, so the deprecation is suppressed here.
-//
-//nolint:staticcheck
-func patchScheduler(version string) Patcher {
+func patchScheduler(vc *config.VersionContract, version string) (Patcher, error) {
 	img := fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, version)
 
-	return Patcher{
-		Apply: func(config *v1alpha1.Config) {
-			if config.ClusterConfig == nil {
-				config.ClusterConfig = &v1alpha1.ClusterConfig{}
-			}
-
-			if config.ClusterConfig.SchedulerConfig == nil {
-				config.ClusterConfig.SchedulerConfig = &v1alpha1.SchedulerConfig{}
-			}
-
-			config.ClusterConfig.SchedulerConfig.ContainerImage = img
-		},
-		UsedImages: []string{img},
+	data, err := stdpatches.WithKubeSchedulerImage(vc, img)
+	if err != nil {
+		return Patcher{}, fmt.Errorf("failed to build kube-scheduler patch: %w", err)
 	}
+
+	return Patcher{Patch: data, UsedImages: []string{img}}, nil
 }
 
-// The inline kube-proxy config fields are deprecated in favor of separate config documents, but Omni still relies on
-// the inline form, so the deprecation is suppressed here.
-//
-//nolint:staticcheck
-func patchKubeProxy(version string) Patcher {
+func patchKubeProxy(vc *config.VersionContract, version string) (Patcher, error) {
 	img := fmt.Sprintf("%s:v%s", constants.KubeProxyImage, version)
 
-	return Patcher{
-		Apply: func(config *v1alpha1.Config) {
-			if config.ClusterConfig == nil {
-				config.ClusterConfig = &v1alpha1.ClusterConfig{}
-			}
-
-			if config.ClusterConfig.ProxyConfig == nil {
-				config.ClusterConfig.ProxyConfig = &v1alpha1.ProxyConfig{}
-			}
-
-			config.ClusterConfig.ProxyConfig.ContainerImage = img
-		},
-		UsedImages: []string{img},
+	data, err := stdpatches.WithKubeProxyImage(vc, img)
+	if err != nil {
+		return Patcher{}, fmt.Errorf("failed to build kube-proxy patch: %w", err)
 	}
+
+	return Patcher{Patch: data, UsedImages: []string{img}}, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package kubernetes_test
+
+import (
+	"testing"
+
+	"github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/configpatcher"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate"
+	"github.com/siderolabs/talos/pkg/machinery/config/machine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/image"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/kubernetes"
+)
+
+// TestMergePatch verifies that patches for several components accumulate into a single machine patch.
+func TestMergePatch(t *testing.T) {
+	t.Parallel()
+
+	for _, vc := range []*config.VersionContract{config.TalosVersion1_13, config.TalosVersion1_14} {
+		t.Run(vc.String(), func(t *testing.T) {
+			t.Parallel()
+
+			var accumulated []byte
+
+			for _, component := range []kubernetes.Component{
+				kubernetes.APIServer,
+				kubernetes.ControllerManager,
+				kubernetes.Scheduler,
+				kubernetes.Kubelet,
+			} {
+				patch, err := component.Patch(vc, "1.2.3")
+				require.NoError(t, err)
+
+				accumulated, err = kubernetes.MergePatch(accumulated, patch.Patch)
+				require.NoError(t, err)
+			}
+
+			// reapplying a component's patch should replace its contribution, not duplicate it.
+			newAPIServerPatch, err := kubernetes.APIServer.Patch(vc, "1.2.4")
+			require.NoError(t, err)
+
+			accumulated, err = kubernetes.MergePatch(accumulated, newAPIServerPatch.Patch)
+			require.NoError(t, err)
+
+			in, err := generate.NewInput("merge-patch-test", "https://127.0.0.1/", "1.34.0", generate.WithVersionContract(vc))
+			require.NoError(t, err)
+
+			cfg, err := in.Config(machine.TypeControlPlane)
+			require.NoError(t, err)
+
+			patch, err := configpatcher.LoadPatch(accumulated)
+			require.NoError(t, err)
+
+			patched, err := configpatcher.Apply(configpatcher.WithConfig(cfg), []configpatcher.Patch{patch})
+			require.NoError(t, err)
+
+			patchedCfg, err := patched.Config()
+			require.NoError(t, err)
+
+			assertTag := func(t *testing.T, expected, ref string) {
+				t.Helper()
+
+				tag, err := image.GetTag(ref)
+
+				require.NoError(t, err)
+				assert.Equal(t, expected, tag)
+			}
+
+			assertTag(t, "v1.2.4", patchedCfg.K8sAPIServerConfig().Image())
+			assertTag(t, "v1.2.4", patchedCfg.K8sProxyConfig().Image())
+			assertTag(t, "v1.2.3", patchedCfg.K8sControllerManagerConfig().Image())
+			assertTag(t, "v1.2.3", patchedCfg.K8sSchedulerConfig().Image())
+			assertTag(t, "v1.2.3", patchedCfg.Machine().Kubelet().Image())
+		})
+	}
+}
+
+// TestMergePatchIdempotent verifies that merging an already-applied patch again reproduces byte-identical output.
+func TestMergePatchIdempotent(t *testing.T) {
+	t.Parallel()
+
+	for _, vc := range []*config.VersionContract{config.TalosVersion1_13, config.TalosVersion1_14} {
+		t.Run(vc.String(), func(t *testing.T) {
+			t.Parallel()
+
+			patch, err := kubernetes.APIServer.Patch(vc, "1.2.3")
+			require.NoError(t, err)
+
+			// first reconcile: no patch stored yet on the ConfigPatch resource.
+			firstMerge, err := kubernetes.MergePatch(nil, patch.Patch)
+			require.NoError(t, err)
+
+			// second reconcile: the desired version hasn't changed, so the same component patch is merged again on
+			// top of the result of the first reconcile.
+			secondMerge, err := kubernetes.MergePatch(firstMerge, patch.Patch)
+			require.NoError(t, err)
+
+			assert.Equal(t, firstMerge, secondMerge)
+		})
+	}
+}
+
+// TestMultiPatcherNoPatchers verifies that MultiPatcher rejects an empty patcher list instead of panicking.
+func TestMultiPatcherNoPatchers(t *testing.T) {
+	t.Parallel()
+
+	_, err := kubernetes.MultiPatcher()
+	require.Error(t, err)
+}
+
+// TestMergePatchEmptyNewPatch verifies that merging an empty new patch is a no-op that returns the existing patch
+// unchanged, rather than failing to parse the empty input.
+func TestMergePatchEmptyNewPatch(t *testing.T) {
+	t.Parallel()
+
+	existing, err := kubernetes.APIServer.Patch(config.TalosVersion1_14, "1.2.3")
+	require.NoError(t, err)
+
+	merged, err := kubernetes.MergePatch(existing.Patch, nil)
+	require.NoError(t, err)
+	assert.Equal(t, existing.Patch, merged)
+
+	merged, err = kubernetes.MergePatch(existing.Patch, []byte("   \n"))
+	require.NoError(t, err)
+	assert.Equal(t, existing.Patch, merged)
+}

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/upgrade.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/upgrade.go
@@ -13,6 +13,7 @@ import (
 	"github.com/siderolabs/gen/maps"
 	"github.com/siderolabs/gen/pair"
 	"github.com/siderolabs/gen/xslices"
+	"github.com/siderolabs/talos/pkg/machinery/config"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
@@ -56,7 +57,11 @@ func (path *UpgradePath) BlockedNodes() []string {
 // CalculateUpgradePath calculates the upgrade path for the cluster.
 //
 //nolint:gocyclo,cyclop,gocognit
-func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *omni.KubernetesStatus, desiredVersion string) *UpgradePath {
+func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *omni.KubernetesStatus, desiredVersion string, vc *config.VersionContract) (*UpgradePath, error) {
+	if vc == nil {
+		return nil, fmt.Errorf("version contract must not be nil")
+	}
+
 	upgradePath := &UpgradePath{
 		ClusterID: kubernetesStatus.Metadata().ID(),
 	}
@@ -75,11 +80,14 @@ func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *om
 		}
 	}
 
-	appPatch := func(nodename string, component Component, pending bool) {
+	appPatch := func(nodename string, component Component, pending bool) error {
 		machineID, ok := nodenameToMachineMap.ControlPlanes[nodename]
 
 		if ok && component.Valid() {
-			patch := component.Patch(desiredVersion)
+			patch, err := component.Patch(vc, desiredVersion)
+			if err != nil {
+				return fmt.Errorf("failed to build patch for node %q component %q: %w", nodename, component, err)
+			}
 
 			addImagesToNode(nodename, patch.UsedImages)
 
@@ -93,19 +101,24 @@ func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *om
 				})
 			}
 		}
+
+		return nil
 	}
 
-	kubeletPatch := func(nodename string, pending bool) {
+	kubeletPatch := func(nodename string, pending bool) error {
 		machineID, ok := nodenameToMachineMap.ControlPlanes[nodename]
 		if !ok {
 			machineID, ok = nodenameToMachineMap.Workers[nodename]
 		}
 
 		if !ok {
-			return
+			return nil
 		}
 
-		patch := Kubelet.Patch(desiredVersion)
+		patch, err := Kubelet.Patch(vc, desiredVersion)
+		if err != nil {
+			return fmt.Errorf("failed to build kubelet patch for node %q: %w", nodename, err)
+		}
 
 		addImagesToNode(nodename, patch.UsedImages)
 
@@ -120,6 +133,8 @@ func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *om
 				Blocked:     locked, // Upgrade step is blocked from progressing because the machine is locked
 			})
 		}
+
+		return nil
 	}
 
 	unreadyApps := map[pair.Pair[string, Component]]struct{}{}
@@ -136,7 +151,9 @@ func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *om
 				delete(unreadyApps, pair.MakePair(controlPlane.Nodename, Component(app.App)))
 			}
 
-			appPatch(controlPlane.Nodename, Component(app.App), app.Version != desiredVersion)
+			if err := appPatch(controlPlane.Nodename, Component(app.App), app.Version != desiredVersion); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -147,7 +164,9 @@ func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *om
 			delete(unreadyNodes, nodeInfo.Nodename)
 		}
 
-		kubeletPatch(nodeInfo.Nodename, nodeInfo.KubeletVersion != desiredVersion)
+		if err := kubeletPatch(nodeInfo.Nodename, nodeInfo.KubeletVersion != desiredVersion); err != nil {
+			return nil, err
+		}
 	}
 
 	switch {
@@ -170,12 +189,16 @@ func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *om
 
 	// try appending patches for not ready apps, as they might not show up, but still require patching
 	for notReadyApp := range unreadyApps {
-		appPatch(notReadyApp.F1, notReadyApp.F2, true)
+		if err := appPatch(notReadyApp.F1, notReadyApp.F2, true); err != nil {
+			return nil, err
+		}
 	}
 
 	// try appending patches for not ready nodes, as they might not show up, but still require patching
 	for notReadyNode := range unreadyNodes {
-		kubeletPatch(notReadyNode, true)
+		if err := kubeletPatch(notReadyNode, true); err != nil {
+			return nil, err
+		}
 	}
 
 	slices.SortFunc(upgradePath.Steps, func(a, b UpgradeStep) int {
@@ -199,5 +222,5 @@ func CalculateUpgradePath(nodenameToMachineMap *MachineMap, kubernetesStatus *om
 		upgradePath.AllNodesToRequiredImages[node] = requiredImages
 	}
 
-	return upgradePath
+	return upgradePath, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/upgrade_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/upgrade_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -647,7 +648,8 @@ func TestUpgradePath(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			upgradePath := kubernetes.CalculateUpgradePath(test.machineMap, test.kubernetesStatus, test.desiredVersion)
+			upgradePath, err := kubernetes.CalculateUpgradePath(test.machineMap, test.kubernetesStatus, test.desiredVersion, config.TalosVersion1_14)
+			require.NoError(t, err)
 			assert.Equal(t, test.expected.AllComponentsReady, upgradePath.AllComponentsReady)
 			assert.Equal(t, test.expected.NotReadyStatus, upgradePath.NotReadyStatus)
 			assert.Equal(t, test.expected.BlockedNodes(), upgradePath.BlockedNodes())

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_upgrade_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_upgrade_status.go
@@ -6,9 +6,9 @@
 package omni
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
@@ -16,9 +16,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/xerrors"
-	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/siderolabs/talos/pkg/machinery/config"
 	"go.uber.org/zap"
-	"go.yaml.in/yaml/v4"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -111,8 +110,25 @@ func NewKubernetesUpgradeStatusController() *KubernetesUpgradeStatusController {
 					return fmt.Errorf("failed to build nodename to machine map: %w", err)
 				}
 
+				clusterConfigVersion, err := safe.ReaderGet[*omni.ClusterConfigVersion](ctx, r, omni.NewClusterConfigVersion(cluster.Metadata().ID()).Metadata())
+				if err != nil {
+					if state.IsNotFoundError(err) {
+						return xerrors.NewTagged[qtransform.SkipReconcileTag](err)
+					}
+
+					return err
+				}
+
+				vc, err := config.ParseContractFromVersion(clusterConfigVersion.TypedSpec().Value.Version)
+				if err != nil {
+					return fmt.Errorf("failed to parse version contract: %w", err)
+				}
+
 				// check if all Kubernetes components are ready
-				upgradePath := kubernetes.CalculateUpgradePath(nodenameToMachineMap, kubernetesStatus, cluster.TypedSpec().Value.KubernetesVersion)
+				upgradePath, err := kubernetes.CalculateUpgradePath(nodenameToMachineMap, kubernetesStatus, cluster.TypedSpec().Value.KubernetesVersion, vc)
+				if err != nil {
+					return fmt.Errorf("failed to calculate upgrade path: %w", err)
+				}
 
 				upgradeStatus.Metadata().Labels().Set(omni.LabelCluster, cluster.Metadata().ID())
 
@@ -248,6 +264,9 @@ func NewKubernetesUpgradeStatusController() *KubernetesUpgradeStatusController {
 		qtransform.WithExtraMappedInput[*omni.ClusterStatus](
 			qtransform.MapperSameID[*omni.Cluster](),
 		),
+		qtransform.WithExtraMappedInput[*omni.ClusterConfigVersion](
+			qtransform.MapperSameID[*omni.Cluster](),
+		),
 		qtransform.WithExtraMappedInput[*omni.KubernetesStatus](
 			qtransform.MapperSameID[*omni.Cluster](),
 		),
@@ -343,8 +362,6 @@ func applyUpgradePatches(ctx context.Context, r controller.Writer, cluster *omni
 		if err := safe.WriterModify(ctx, r,
 			omni.NewConfigPatch(fmt.Sprintf("900-cm-%s-kubernetes-upgrade", patch.MachineID)),
 			func(configPatch *omni.ConfigPatch) error {
-				var cfg v1alpha1.Config
-
 				buffer, err := configPatch.TypedSpec().Value.GetUncompressedData()
 				if err != nil {
 					return err
@@ -352,20 +369,13 @@ func applyUpgradePatches(ctx context.Context, r controller.Writer, cluster *omni
 
 				defer buffer.Free()
 
-				patchData := buffer.Data()
-
-				if len(patchData) > 0 {
-					if err = yaml.Unmarshal(patchData, &cfg); err != nil {
-						return err
-					}
+				merged, err := kubernetes.MergePatch(buffer.Data(), patch.Patch.Patch)
+				if err != nil {
+					return fmt.Errorf("failed to merge kubernetes upgrade patch: %w", err)
 				}
 
-				oldCfg := cfg.DeepCopy()
-
-				patch.Patch.Apply(&cfg)
-
 				// patch is already applied, skip it
-				if reflect.DeepEqual(oldCfg, cfg) {
+				if bytes.Equal(buffer.Data(), merged) {
 					return nil
 				}
 
@@ -373,12 +383,7 @@ func applyUpgradePatches(ctx context.Context, r controller.Writer, cluster *omni
 				configPatch.Metadata().Labels().Set(omni.LabelClusterMachine, patch.MachineID)
 				configPatch.Metadata().Labels().Set(omni.LabelSystemPatch, "")
 
-				data, err := yaml.Marshal(cfg)
-				if err != nil {
-					return err
-				}
-
-				if err = configPatch.TypedSpec().Value.SetUncompressedData(data); err != nil {
+				if err = configPatch.TypedSpec().Value.SetUncompressedData(merged); err != nil {
 					return err
 				}
 


### PR DESCRIPTION
Talos v1.14 drops the inline v1alpha1 fields Omni used to set kube-apiserver, kube-scheduler, kube-controller-manager and kube-proxy images, so component patchers now build version-contract-aware YAML patches through the talos machinery's `stdpatches` helpers. `CalculateUpgradePath` takes the cluster's parsed `VersionContract` so it produces the right patch shape for <1.14 and  >= 1.14 clusters.

Resolves: #3026
