### PR TITLE
fix: ignore not-found errors when deleting an infra provider

### DIFF
--- a/client/pkg/omnictl/infraprovider.go
+++ b/client/pkg/omnictl/infraprovider.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/go-api-signature/pkg/serviceaccount"
 	"github.com/spf13/cobra"
 
@@ -176,8 +177,7 @@ var (
 			name := args[0]
 
 			return access.WithClient(func(ctx context.Context, client *client.Client, _ access.ServerInfo) error {
-				err := client.Omni().State().TeardownAndDestroy(ctx, infra.NewProvider(name).Metadata())
-				if err != nil {
+				if err := client.Omni().State().TeardownAndDestroy(ctx, infra.NewProvider(name).Metadata()); err != nil && !state.IsNotFoundError(err) {
 					return fmt.Errorf("failed to delete infra provider: %w", err)
 				}
 


### PR DESCRIPTION
Omni registers a destroy controller for every user-managed resource type, so once TeardownAndDestroy clears the provider's finalizers, that controller can race in and destroy the resource before the client-side call gets to issue its own Destroy. The client then sees a not-found error even though the provider was removed successfully, so it should be treated as success rather than surfaced to the user.