### PR TITLE
feat: allow disabling config patches

### DIFF
--- a/client/pkg/omni/resources/omni/labels.go
+++ b/client/pkg/omni/resources/omni/labels.go
@@ -49,6 +49,10 @@ const (
 	// tsgen:LabelSystemPatch
 	LabelSystemPatch = SystemLabelPrefix + "system-patch"
 
+	// LabelDisabled marks a config patch as disabled, so it is skipped when the config patches are applied to the machines.
+	// tsgen:LabelDisabled
+	LabelDisabled = SystemLabelPrefix + "disabled"
+
 	// LabelSystemManifest marks the manifest as the system manifest, so it shouldn't be editable by the user.
 	// tsgen:LabelSystemManifest
 	LabelSystemManifest = SystemLabelPrefix + "system-manifest"

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "src/components/ActionsBox/TActionsBoxItem.vue": {
-    "vue/define-props-destructuring": {
-      "count": 1
-    }
-  },
   "src/components/Animation/TAnimation.vue": {
     "vue/define-props-destructuring": {
       "count": 1

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -160,6 +160,7 @@ export const LabelMachineSet = "omni.sidero.dev/machine-set";
 export const LabelClusterMachine = "omni.sidero.dev/cluster-machine";
 export const LabelMachine = "omni.sidero.dev/machine";
 export const LabelSystemPatch = "omni.sidero.dev/system-patch";
+export const LabelDisabled = "omni.sidero.dev/disabled";
 export const LabelSystemManifest = "omni.sidero.dev/system-manifest";
 export const LabelExposedServiceAlias = "omni.sidero.dev/exposed-service-alias";
 export const LabelHasGeneratedExposedServiceAlias = "omni.sidero.dev/has-generated-exposed-service-alias";

--- a/frontend/src/components/ActionsBox/TActionsBoxItem.vue
+++ b/frontend/src/components/ActionsBox/TActionsBoxItem.vue
@@ -5,25 +5,30 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
+import { reactiveOmit } from '@vueuse/core'
 import {
   DropdownMenuItem,
   type DropdownMenuItemEmits,
   type DropdownMenuItemProps,
-  useEmitAsProps,
+  useForwardPropsEmits,
 } from 'reka-ui'
 
 import type { IconType } from '@/components/Icon/TIcon.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
 
+// eslint-disable-next-line vue/define-props-destructuring
 const props = defineProps<
   DropdownMenuItemProps & {
     icon?: IconType
     danger?: boolean
   }
 >()
+
 const emit = defineEmits<DropdownMenuItemEmits>()
 
-const emitsAsProps = useEmitAsProps(emit)
+const dropdownMenuItemProps = reactiveOmit(props, 'icon', 'danger')
+
+const forwarded = useForwardPropsEmits(dropdownMenuItemProps, emit)
 </script>
 
 <template>
@@ -34,7 +39,7 @@ const emitsAsProps = useEmitAsProps(emit)
         ? 'text-red-r1 not-data-disabled:hover:text-primary-p1'
         : 'not-data-disabled:hover:text-naturals-n12'
     "
-    v-bind="{ ...props, ...emitsAsProps }"
+    v-bind="forwarded"
   >
     <TIcon v-if="icon" class="h-4 w-4 transition-colors" :icon />
     <span class="text-xs transition-colors">

--- a/frontend/src/components/Icon/icons.ts
+++ b/frontend/src/components/Icon/icons.ts
@@ -108,6 +108,7 @@ export const icons = {
   'machines-manual': defineAsyncComponent(() => import('../icons/IconMachinesManual.vue')),
   minus: defineAsyncComponent(() => import('../icons/IconMinus.vue')),
   'no-connection': defineAsyncComponent(() => import('../icons/IconNoConnection.vue')),
+  'no-symbol': defineAsyncComponent(() => import('../icons/IconNoSymbol.vue')),
   nodes: defineAsyncComponent(() => import('../icons/IconNodes.vue')),
   'ongoing-tasks': defineAsyncComponent(() => import('../icons/IconOngoingTasks.vue')),
   overview: defineAsyncComponent(() => import('../icons/IconOverview.vue')),

--- a/frontend/src/components/Switch/Switch.stories.ts
+++ b/frontend/src/components/Switch/Switch.stories.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import Switch from './Switch.vue'
+
+const meta: Meta<typeof Switch> = {
+  component: Switch,
+  args: {
+    label: 'Label',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/components/Switch/Switch.vue
+++ b/frontend/src/components/Switch/Switch.vue
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<script setup lang="ts">
+import { SwitchRoot, SwitchThumb } from 'reka-ui'
+
+type Props = {
+  label?: string
+  disabled?: boolean
+  indeterminate?: boolean
+}
+
+const { label = '' } = defineProps<Props>()
+
+const checked = defineModel<boolean>({ default: false })
+</script>
+
+<template>
+  <label class="inline-flex cursor-pointer items-center gap-2 has-disabled:cursor-not-allowed">
+    <span
+      v-if="label || $slots.default"
+      class="grow truncate text-xs text-naturals-n11 select-none"
+    >
+      <slot>{{ label }}</slot>
+    </span>
+
+    <SwitchRoot
+      v-model="checked"
+      :disabled
+      class="inline-flex h-5 w-8 rounded-full border border-naturals-n7 bg-naturals-n4 transition-[background] disabled:cursor-not-allowed disabled:brightness-50 data-[state=checked]:border-primary-p3 data-[state=checked]:bg-primary-p3"
+    >
+      <SwitchThumb
+        class="my-auto size-3.5 translate-x-0.5 rounded-full bg-naturals-n13 text-xs transition-transform data-[state=checked]:translate-x-full"
+      />
+    </SwitchRoot>
+  </label>
+</template>

--- a/frontend/src/components/icons/IconNoSymbol.vue
+++ b/frontend/src/components/icons/IconNoSymbol.vue
@@ -1,0 +1,22 @@
+<!--
+Copyright (c) 2026 Sidero Labs, Inc.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+-->
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke-width="1.5"
+    stroke="currentColor"
+    class="size-6"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636"
+    />
+  </svg>
+</template>

--- a/frontend/src/methods/config-patch.ts
+++ b/frontend/src/methods/config-patch.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+import { Runtime } from '@/api/common/omni.pb'
+import { type Resource, ResourceService } from '@/api/grpc'
+import type { ConfigPatchSpec } from '@/api/omni/specs/omni.pb'
+import { withRuntime } from '@/api/options'
+import { ConfigPatchType, DefaultNamespace, LabelDisabled } from '@/api/resources'
+
+export function isConfigPatchDisabled(labels?: Record<string, string>) {
+  return !!labels && LabelDisabled in labels
+}
+
+export async function setConfigPatchDisabled(id: string, disabled: boolean) {
+  const patch = await ResourceService.Get<Resource<ConfigPatchSpec>>(
+    {
+      namespace: DefaultNamespace,
+      type: ConfigPatchType,
+      id,
+    },
+    withRuntime(Runtime.Omni),
+  )
+
+  patch.metadata.labels ||= {}
+
+  if (disabled) {
+    patch.metadata.labels[LabelDisabled] = ''
+  } else {
+    delete patch.metadata.labels[LabelDisabled]
+  }
+
+  await ResourceService.Update(patch, undefined, withRuntime(Runtime.Omni))
+}

--- a/frontend/src/views/Config/PatchEdit.vue
+++ b/frontend/src/views/Config/PatchEdit.vue
@@ -32,6 +32,7 @@ import {
   DefaultNamespace,
   LabelCluster,
   LabelClusterMachine,
+  LabelDisabled,
   LabelHostname,
   LabelMachine,
   LabelMachineSet,
@@ -46,9 +47,12 @@ import PageContainer from '@/components/PageContainer/PageContainer.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import TSelectList from '@/components/SelectList/TSelectList.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
+import Switch from '@/components/Switch/Switch.vue'
+import TAlert from '@/components/TAlert.vue'
 import TInput from '@/components/TInput/TInput.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { useClusterPermissions, usePermissions } from '@/methods/auth'
+import { isConfigPatchDisabled } from '@/methods/config-patch'
 import { machineSetTitle, sortMachineSetIds } from '@/methods/machineset'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError } from '@/notification'
@@ -90,6 +94,7 @@ const config = ref('')
 const weight = ref(0)
 const patchName = ref('User defined patch')
 const patchDescription = ref('')
+const patchEnabled = ref(true)
 
 enum PatchType {
   Cluster = 'Cluster',
@@ -231,6 +236,7 @@ const loadPatch = () => {
 
   if (configPatch.value?.spec?.data) {
     config.value = configPatch.value.spec.data
+    patchEnabled.value = !isConfigPatchDisabled(configPatch.value.metadata.labels)
   }
 }
 
@@ -360,6 +366,7 @@ const saveConfig = async () => {
   }
 
   currentPatch.metadata.annotations ??= {}
+  currentPatch.metadata.labels ??= {}
   currentPatch.spec.data = config.value
 
   if (patchName.value) {
@@ -372,6 +379,12 @@ const saveConfig = async () => {
     currentPatch.metadata.annotations[ConfigPatchDescription] = patchDescription.value
   } else {
     delete currentPatch.metadata.annotations[ConfigPatchDescription]
+  }
+
+  if (patchEnabled.value) {
+    delete currentPatch.metadata.labels[LabelDisabled]
+  } else {
+    currentPatch.metadata.labels[LabelDisabled] = ''
   }
 
   saving.value = true
@@ -414,6 +427,14 @@ const canManageConfigPatches = computed(() =>
     <PageContainer class="flex grow flex-col overflow-hidden">
       <PageHeader :title="title" :subtitle="subtitle" :notes="notes" />
       <ManagedByTemplatesWarning />
+      <TAlert
+        v-if="state === State.Exists && !patchEnabled"
+        class="mb-4"
+        title="Disabled"
+        type="warn"
+      >
+        This config patch is disabled and is not applied to any machines.
+      </TAlert>
       <div v-if="state === State.NotExists" class="mb-4 flex items-center gap-3">
         <TInput v-model="patchName" title="Name" />
         <TInput v-model="patchDescription" class="flex-1" title="Description" />
@@ -454,6 +475,9 @@ const canManageConfigPatches = computed(() =>
     >
       <TButton class="secondary" @click="() => $router.push(back)">Back</TButton>
       <div class="flex-1" />
+
+      <Switch v-model="patchEnabled" :disabled="!canManageConfigPatches" label="Enabled" />
+
       <TButton
         variant="highlighted"
         :disabled="!canManageConfigPatches || saving"

--- a/frontend/src/views/Config/Patches.stories.ts
+++ b/frontend/src/views/Config/Patches.stories.ts
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { createWatchStreamHandler } from '@msw/helpers'
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { http, HttpResponse } from 'msw'
+
+import type { Resource } from '@/api/grpc'
+import type { GetRequest, GetResponse } from '@/api/omni/resources/resources.pb'
+import type { ClusterMachineStatusSpec, ConfigPatchSpec } from '@/api/omni/specs/omni.pb'
+import type { ClusterPermissionsSpec, PermissionsSpec } from '@/api/omni/specs/virtual.pb'
+import {
+  ClusterMachineStatusType,
+  ClusterPermissionsType,
+  ConfigPatchDescription,
+  ConfigPatchName,
+  ConfigPatchType,
+  ControlPlanesIDSuffix,
+  DefaultNamespace,
+  DefaultWorkersIDSuffix,
+  LabelCluster,
+  LabelClusterMachine,
+  LabelDisabled,
+  LabelHostname,
+  LabelMachine,
+  LabelMachineSet,
+  PermissionsID,
+  PermissionsType,
+  VirtualNamespace,
+} from '@/api/resources'
+
+import Patches from './Patches.vue'
+
+const CLUSTER = 'talos-default'
+const MACHINE = 'e3c0d1a2-0000-0000-0000-000000000001'
+
+// Two cluster machines whose hostnames the page resolves from ClusterMachineStatus.
+const clusterMachines = [
+  { id: MACHINE, hostname: 'talos-cp-1' },
+  { id: 'a1b2c3d4-0000-0000-0000-000000000002', hostname: 'talos-worker-1' },
+]
+
+function machineStatus(id: string, hostname: string): Resource<ClusterMachineStatusSpec> {
+  return {
+    metadata: {
+      namespace: DefaultNamespace,
+      type: ClusterMachineStatusType,
+      id,
+      labels: { [LabelHostname]: hostname, [LabelCluster]: CLUSTER },
+    },
+    spec: {},
+  }
+}
+
+interface PatchInit {
+  id: string
+  name?: string
+  description?: string
+  disabled?: boolean
+  labels: Record<string, string>
+}
+
+function makePatch({
+  id,
+  name,
+  description,
+  disabled,
+  labels,
+}: PatchInit): Resource<ConfigPatchSpec> {
+  const annotations: Record<string, string> = {}
+  if (name) annotations[ConfigPatchName] = name
+  if (description) annotations[ConfigPatchDescription] = description
+
+  return {
+    metadata: {
+      namespace: DefaultNamespace,
+      type: ConfigPatchType,
+      id,
+      labels: disabled ? { ...labels, [LabelDisabled]: '' } : labels,
+      annotations: Object.keys(annotations).length ? annotations : undefined,
+    },
+    spec: {
+      data: 'machine:\n  network:\n    hostname: example\n',
+    },
+  }
+}
+
+// A set of patches that exercises every grouping the page renders: cluster-level,
+// control planes, default workers, additional workers and a specific cluster machine.
+const clusterPatches: Resource<ConfigPatchSpec>[] = [
+  makePatch({
+    id: '400-cluster-wide',
+    name: 'cluster-defaults',
+    description: 'Baseline configuration applied to every machine in the cluster',
+    labels: { [LabelCluster]: CLUSTER },
+  }),
+  makePatch({
+    id: '500-control-plane-tuning',
+    name: 'control-plane-tuning',
+    description: 'API server flags for the control plane',
+    labels: { [LabelCluster]: CLUSTER, [LabelMachineSet]: `${CLUSTER}-${ControlPlanesIDSuffix}` },
+  }),
+  makePatch({
+    id: '500-worker-kubelet',
+    name: 'worker-kubelet',
+    description: 'Kubelet extra args for the default worker set',
+    labels: { [LabelCluster]: CLUSTER, [LabelMachineSet]: `${CLUSTER}-${DefaultWorkersIDSuffix}` },
+  }),
+  makePatch({
+    id: '500-gpu-drivers',
+    name: 'gpu-drivers',
+    description: 'System extensions for the GPU worker pool',
+    disabled: true,
+    labels: { [LabelCluster]: CLUSTER, [LabelMachineSet]: `${CLUSTER}-gpu` },
+  }),
+  makePatch({
+    id: '500-cp-1-hostname',
+    name: 'cp-1-hostname',
+    description: 'Per-machine override for the first control plane node',
+    labels: { [LabelCluster]: CLUSTER, [LabelClusterMachine]: clusterMachines[0].id },
+  }),
+  makePatch({
+    id: '999-no-metadata',
+    labels: { [LabelCluster]: CLUSTER },
+  }),
+]
+
+function clusterPatchesHandler(patches = clusterPatches) {
+  return createWatchStreamHandler<ConfigPatchSpec>({
+    expectedOptions: { namespace: DefaultNamespace, type: ConfigPatchType },
+    initialResources: patches,
+  }).handler
+}
+
+const machineStatusesHandler = createWatchStreamHandler<ClusterMachineStatusSpec>({
+  expectedOptions: { namespace: DefaultNamespace, type: ClusterMachineStatusType },
+  initialResources: clusterMachines.map((m) => machineStatus(m.id, m.hostname)),
+}).handler
+
+// Answers the ClusterPermissions Get for the cluster-scoped page.
+function clusterPermissionsHandler(canManage: boolean) {
+  return http.post<never, GetRequest, GetResponse>(
+    '/omni.resources.ResourceService/Get',
+    async ({ request }) => {
+      const { type, namespace } = await request.clone().json()
+
+      if (type !== ClusterPermissionsType || namespace !== VirtualNamespace) return
+
+      return HttpResponse.json({
+        body: JSON.stringify({
+          metadata: { namespace: VirtualNamespace, type: ClusterPermissionsType, id: CLUSTER },
+          spec: {
+            can_read_config_patches: true,
+            can_manage_config_patches: canManage,
+          },
+        } satisfies Resource<ClusterPermissionsSpec>),
+      })
+    },
+  )
+}
+
+// Answers the Permissions Get for the machine-scoped page.
+function machinePermissionsHandler(canManage: boolean) {
+  return http.post<never, GetRequest, GetResponse>(
+    '/omni.resources.ResourceService/Get',
+    async ({ request }) => {
+      const { type, namespace } = await request.clone().json()
+
+      if (type !== PermissionsType || namespace !== VirtualNamespace) return
+
+      return HttpResponse.json({
+        body: JSON.stringify({
+          metadata: { namespace: VirtualNamespace, type: PermissionsType, id: PermissionsID },
+          spec: {
+            can_read_machine_config_patches: true,
+            can_manage_machine_config_patches: canManage,
+          },
+        } satisfies Resource<PermissionsSpec>),
+      })
+    },
+  )
+}
+
+const meta: Meta<typeof Patches> = {
+  component: Patches,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    () => ({
+      template: '<div class="h-screen bg-naturals-n0 p-8"><story /></div>',
+    }),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** Cluster-scoped view with patches spread across every group and full manage permissions. */
+export const Cluster: Story = {
+  args: { cluster: CLUSTER },
+  parameters: {
+    msw: {
+      handlers: [clusterPatchesHandler(), machineStatusesHandler, clusterPermissionsHandler(true)],
+    },
+  },
+}
+
+/** Same data, but the user cannot manage patches — create, toggle and delete are disabled. */
+export const ClusterReadOnly: Story = {
+  args: { cluster: CLUSTER },
+  parameters: {
+    msw: {
+      handlers: [clusterPatchesHandler(), machineStatusesHandler, clusterPermissionsHandler(false)],
+    },
+  },
+}
+
+/** Machine-scoped view: patches attached to a single machine. */
+export const Machine: Story = {
+  args: { machine: MACHINE },
+  parameters: {
+    msw: {
+      handlers: [
+        clusterPatchesHandler([
+          makePatch({
+            id: '500-machine-network',
+            name: 'machine-network',
+            description: 'Static network configuration for this machine',
+            labels: { [LabelMachine]: MACHINE },
+          }),
+          makePatch({
+            id: '500-machine-disabled',
+            name: 'experimental',
+            description: 'A disabled experimental patch',
+            disabled: true,
+            labels: { [LabelMachine]: MACHINE },
+          }),
+        ]),
+        machineStatusesHandler,
+        machinePermissionsHandler(true),
+      ],
+    },
+  },
+}
+
+/** No patches associated — renders the empty-state alert. */
+export const Empty: Story = {
+  args: { cluster: CLUSTER },
+  parameters: {
+    msw: {
+      handlers: [
+        clusterPatchesHandler([]),
+        machineStatusesHandler,
+        clusterPermissionsHandler(true),
+      ],
+    },
+  },
+}
+
+/** Watches never bootstrap — the loading spinner stays visible. */
+export const Loading: Story = {
+  args: { cluster: CLUSTER },
+  parameters: {
+    msw: {
+      handlers: [
+        createWatchStreamHandler<ConfigPatchSpec>({
+          skipBootstrap: true,
+          expectedOptions: { namespace: DefaultNamespace, type: ConfigPatchType },
+        }).handler,
+        createWatchStreamHandler<ClusterMachineStatusSpec>({
+          skipBootstrap: true,
+          expectedOptions: { namespace: DefaultNamespace, type: ClusterMachineStatusType },
+        }).handler,
+        clusterPermissionsHandler(true),
+      ],
+    },
+  },
+}

--- a/frontend/src/views/Config/Patches.vue
+++ b/frontend/src/views/Config/Patches.vue
@@ -28,14 +28,18 @@ import {
   LabelMachineSet,
   LabelSystemPatch,
 } from '@/api/resources'
-import IconButton from '@/components/Button/IconButton.vue'
+import TActionsBox from '@/components/ActionsBox/TActionsBox.vue'
+import TActionsBoxItem from '@/components/ActionsBox/TActionsBoxItem.vue'
 import TButton from '@/components/Button/TButton.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
 import ManagedByTemplatesWarning from '@/components/ManagedByTemplatesWarning.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
+import TStatus from '@/components/Status/TStatus.vue'
 import TAlert from '@/components/TAlert.vue'
 import TInput from '@/components/TInput/TInput.vue'
+import { TCommonStatuses } from '@/constants'
 import { useClusterPermissions, usePermissions } from '@/methods/auth'
+import { isConfigPatchDisabled, setConfigPatchDisabled } from '@/methods/config-patch'
 import {
   controlPlaneTitle,
   defaultWorkersTitle,
@@ -43,6 +47,7 @@ import {
   workersTitlePrefix,
 } from '@/methods/machineset'
 import { useResourceWatch } from '@/methods/useResourceWatch'
+import { showError } from '@/notification'
 import ConfigPatchDestroyModal from '@/views/Config/components/ConfigPatchDestroyModal.vue'
 
 const { machine, cluster } = defineProps<{
@@ -114,6 +119,7 @@ interface RouteItem {
   route: RouteLocationRaw
   id: string
   description?: string
+  disabled: boolean
 }
 
 const patchTypeCluster = 'Cluster'
@@ -182,6 +188,7 @@ const routes = computed(() => {
       route: getRouteForPatch(item.metadata.id),
       id: item.metadata.id!,
       description: item.metadata.annotations?.[ConfigPatchDescription],
+      disabled: isConfigPatchDisabled(item.metadata.labels),
     }
 
     const labels = item.metadata.labels || {}
@@ -249,6 +256,23 @@ const canManageConfigPatches = computed(() => {
 
   return false
 })
+
+const togglingPatchId = ref<string>()
+
+const toggleDisabled = async (item: RouteItem) => {
+  togglingPatchId.value = item.id
+
+  try {
+    await setConfigPatchDisabled(item.id, !item.disabled)
+  } catch (e) {
+    showError(
+      `Failed to ${item.disabled ? 'Enable' : 'Disable'} The Config Patch`,
+      e instanceof Error ? e.message : String(e),
+    )
+  } finally {
+    togglingPatchId.value = undefined
+  }
+}
 </script>
 
 <template>
@@ -280,58 +304,78 @@ const canManageConfigPatches = computed(() => {
               : `on the account`
         }}
       </TAlert>
-      <Disclosure v-for="group in routes" v-else :key="group.name" as="div" :default-open="true">
+      <Disclosure
+        v-for="group in routes"
+        v-else
+        :key="group.name"
+        as="div"
+        :default-open="true"
+        class="[--actions-col:--spacing(6)]"
+      >
         <template #default="{ open }">
-          <DisclosureButton as="div" class="disclosure">
+          <DisclosureButton
+            as="div"
+            class="grid cursor-pointer grid-cols-[repeat(4,1fr)_var(--actions-col)] gap-4 bg-naturals-n1 px-4 py-3 text-xs font-bold text-naturals-n11 transition-colors duration-200 select-none hover:text-naturals-n14"
+          >
+            <WordHighlighter
+              :text-to-highlight="group.name"
+              :query="filter"
+              highlight-class="bg-naturals-n14"
+            />
+
+            <div>ID</div>
+            <div class="col-span-2">Description</div>
+
             <TIcon
               icon="arrow-up"
-              class="absolute top-0 right-4 bottom-0 m-auto h-4 w-4"
+              class="size-4 justify-self-center"
               :class="{ 'rotate-180': open }"
             />
-            <div class="grid grid-cols-4">
-              <WordHighlighter
-                :text-to-highlight="group.name"
-                :query="filter"
-                highlight-class="bg-naturals-n14"
-              />
-              <div>ID</div>
-              <div class="col-span-2">Description</div>
-            </div>
           </DisclosureButton>
+
           <DisclosurePanel>
             <div
               v-for="item in group.items"
               :key="item.name"
-              class="relative my-2 grid w-full cursor-pointer grid-cols-4 items-center gap-2 px-4 py-2 text-xs transition-colors duration-200 hover:bg-naturals-n3 hover:text-naturals-n12"
+              class="my-1 grid w-full cursor-pointer grid-cols-[repeat(4,1fr)_var(--actions-col)] items-center gap-2 px-4 py-2 text-xs transition-colors duration-200 select-none hover:bg-naturals-n3 hover:text-naturals-n12"
+              :class="{ 'opacity-50': item.disabled }"
               @click="() => $router.push(item.route)"
             >
-              <IconButton
-                :disabled="!canManageConfigPatches"
-                icon="delete"
-                class="absolute top-0 right-3 bottom-0 m-auto"
-                @click.stop="
-                  () => {
-                    configPatchDestroyModalOpen = true
-                    configPatchDestroyModalPatchId = item.id
-                  }
-                "
-              />
-              <div class="pointer-events-none flex items-center gap-4">
-                <DocumentIcon class="h-4 w-4" />
+              <div class="flex min-w-0 items-center gap-4">
+                <DocumentIcon class="size-4 shrink-0" />
+
                 <WordHighlighter
                   :text-to-highlight="item.name"
                   :query="filter"
                   highlight-class="bg-naturals-n14"
+                  class="truncate"
                 />
+
+                <TStatus v-if="item.disabled" :title="TCommonStatuses.DISABLED" />
               </div>
+
               <WordHighlighter
                 :text-to-highlight="item.id"
                 :query="filter"
-                highlight-class="pointer-events-none bg-naturals-n14"
+                highlight-class="bg-naturals-n14"
               />
-              <div class="pointer-events-none col-span-2 truncate">
+
+              <div class="col-span-2 truncate">
                 {{ item.description }}
               </div>
+
+              <TActionsBox aria-label="patch actions">
+                <TActionsBoxItem
+                  :icon="item.disabled ? 'check-in-circle-classic' : 'no-symbol'"
+                  @select="toggleDisabled(item)"
+                >
+                  {{ item.disabled ? 'Enable' : 'Disable' }}
+                </TActionsBoxItem>
+
+                <TActionsBoxItem danger icon="delete" @select="toggleDisabled(item)">
+                  Delete
+                </TActionsBoxItem>
+              </TActionsBox>
             </div>
           </DisclosurePanel>
         </template>
@@ -345,11 +389,3 @@ const canManageConfigPatches = computed(() => {
     />
   </div>
 </template>
-
-<style scoped>
-@reference "../../index.css";
-
-.disclosure {
-  @apply relative cursor-pointer bg-naturals-n1 px-4 py-3 text-xs font-bold text-naturals-n11 transition-colors duration-200 select-none hover:text-naturals-n14;
-}
-</style>

--- a/internal/backend/runtime/omni/controllers/omni/internal/layeredresource/layeredresource.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/layeredresource/layeredresource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller/generic"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/xslices"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -27,7 +28,7 @@ type Helper[T generic.ResourceWithRD] struct {
 
 // NewHelper creates a new helper for managing layered resources.
 func NewHelper[T generic.ResourceWithRD](ctx context.Context, r controller.Reader) (*Helper[T], error) {
-	allResources, err := safe.ReaderListAll[T](ctx, r)
+	allResources, err := safe.ReaderListAll[T](ctx, r, state.WithLabelQuery(resource.LabelExists(omni.LabelDisabled, resource.NotMatches)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/runtime/omni/controllers/omni/internal/layeredresource/layeredresource_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/layeredresource/layeredresource_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package layeredresource_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/gen/xslices"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/layeredresource"
+)
+
+func TestHelperGetSkipsDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	const (
+		clusterName    = "c1"
+		machineSetName = "ms1"
+		machineID      = "m1"
+	)
+
+	clusterMachine := omni.NewClusterMachine(machineID)
+	clusterMachine.Metadata().Labels().Set(omni.LabelCluster, clusterName)
+	clusterMachine.Metadata().Labels().Set(omni.LabelMachineSet, machineSetName)
+
+	machineSet := omni.NewMachineSet(machineSetName)
+
+	// cluster-level patch that should be applied
+	enabled := omni.NewConfigPatch("cluster-enabled")
+	enabled.Metadata().Labels().Set(omni.LabelCluster, clusterName)
+
+	// cluster-level patch that is disabled and must be skipped
+	disabled := omni.NewConfigPatch("cluster-disabled")
+	disabled.Metadata().Labels().Set(omni.LabelCluster, clusterName)
+	disabled.Metadata().Labels().Set(omni.LabelDisabled, "")
+
+	// machine-level patch that should be applied
+	machineLevel := omni.NewConfigPatch("machine-enabled")
+	machineLevel.Metadata().Labels().Set(omni.LabelCluster, clusterName)
+	machineLevel.Metadata().Labels().Set(omni.LabelMachine, machineID)
+
+	// machine-level patch that is disabled and must be skipped
+	machineLevelDisabled := omni.NewConfigPatch("machine-disabled")
+	machineLevelDisabled.Metadata().Labels().Set(omni.LabelCluster, clusterName)
+	machineLevelDisabled.Metadata().Labels().Set(omni.LabelMachine, machineID)
+	machineLevelDisabled.Metadata().Labels().Set(omni.LabelDisabled, "")
+
+	for _, res := range []resource.Resource{enabled, disabled, machineLevel, machineLevelDisabled} {
+		require.NoError(t, st.Create(ctx, res))
+	}
+
+	helper, err := layeredresource.NewHelper[*omni.ConfigPatch](ctx, st)
+	require.NoError(t, err)
+
+	patches, err := helper.Get(clusterMachine, machineSet)
+	require.NoError(t, err)
+
+	ids := xslices.Map(patches, func(p *omni.ConfigPatch) string { return p.Metadata().ID() })
+
+	require.ElementsMatch(t, []string{"cluster-enabled", "machine-enabled"}, ids)
+}

--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_status.go
@@ -333,7 +333,10 @@ func (helper *maintenanceConfigStatusControllerHelper) transform(ctx context.Con
 
 // getMachinePatches collects the running machine-level config patches for the machine, ordered by ID (lower ID = lower priority).
 func getMachinePatches(ctx context.Context, r controller.Reader, machineID resource.ID) ([]string, error) {
-	list, err := safe.ReaderListAll[*omni.ConfigPatch](ctx, r, state.WithLabelQuery(resource.LabelEqual(omni.LabelMachine, machineID)))
+	list, err := safe.ReaderListAll[*omni.ConfigPatch](ctx, r, state.WithLabelQuery(
+		resource.LabelEqual(omni.LabelMachine, machineID),
+		resource.LabelExists(omni.LabelDisabled, resource.NotMatches),
+	))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow disabling config patches for a machine, which keeps it around as a resource but prevents it from ever getting applied.

Closes #3144

https://github.com/user-attachments/assets/675ce1f5-f249-4cc2-88cc-2a41a958588f
