### PR TITLE
feat: show infra provider versions in ui and cli

### DIFF
--- a/client/api/omni/specs/infra.pb.go
+++ b/client/api/omni/specs/infra.pb.go
@@ -656,6 +656,7 @@ type InfraProviderStatusSpec struct {
 	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	Description   string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	Icon          string                 `protobuf:"bytes,4,opt,name=icon,proto3" json:"icon,omitempty"`
+	Version       string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -714,6 +715,13 @@ func (x *InfraProviderStatusSpec) GetDescription() string {
 func (x *InfraProviderStatusSpec) GetIcon() string {
 	if x != nil {
 		return x.Icon
+	}
+	return ""
+}
+
+func (x *InfraProviderStatusSpec) GetVersion() string {
+	if x != nil {
+		return x.Version
 	}
 	return ""
 }
@@ -913,12 +921,13 @@ const file_omni_specs_infra_proto_rawDesc = "" +
 	"\x13POWER_STATE_UNKNOWN\x10\x00\x12\x13\n" +
 	"\x0fPOWER_STATE_OFF\x10\x01\x12\x12\n" +
 	"\x0ePOWER_STATE_ON\x10\x02\"\x13\n" +
-	"\x11InfraProviderSpec\"{\n" +
+	"\x11InfraProviderSpec\"\x95\x01\n" +
 	"\x17InfraProviderStatusSpec\x12\x16\n" +
 	"\x06schema\x18\x01 \x01(\tR\x06schema\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x12\n" +
-	"\x04icon\x18\x04 \x01(\tR\x04icon\"\x8b\x01\n" +
+	"\x04icon\x18\x04 \x01(\tR\x04icon\x12\x18\n" +
+	"\aversion\x18\x05 \x01(\tR\aversion\"\x8b\x01\n" +
 	"\x1dInfraProviderHealthStatusSpec\x12T\n" +
 	"\x18last_heartbeat_timestamp\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x16lastHeartbeatTimestamp\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\"I\n" +

--- a/client/api/omni/specs/infra.proto
+++ b/client/api/omni/specs/infra.proto
@@ -107,6 +107,7 @@ message InfraProviderStatusSpec {
   string name = 2;
   string description = 3;
   string icon = 4;
+  string version = 5;
 }
 
 message InfraProviderHealthStatusSpec {

--- a/client/api/omni/specs/infra_vtproto.pb.go
+++ b/client/api/omni/specs/infra_vtproto.pb.go
@@ -175,6 +175,7 @@ func (m *InfraProviderStatusSpec) CloneVT() *InfraProviderStatusSpec {
 	r.Name = m.Name
 	r.Description = m.Description
 	r.Icon = m.Icon
+	r.Version = m.Version
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -471,6 +472,9 @@ func (this *InfraProviderStatusSpec) EqualVT(that *InfraProviderStatusSpec) bool
 		return false
 	}
 	if this.Icon != that.Icon {
+		return false
+	}
+	if this.Version != that.Version {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -995,6 +999,13 @@ func (m *InfraProviderStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Version) > 0 {
+		i -= len(m.Version)
+		copy(dAtA[i:], m.Version)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Version)))
+		i--
+		dAtA[i] = 0x2a
+	}
 	if len(m.Icon) > 0 {
 		i -= len(m.Icon)
 		copy(dAtA[i:], m.Icon)
@@ -1349,6 +1360,10 @@ func (m *InfraProviderStatusSpec) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.Icon)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Version)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -2704,6 +2719,38 @@ func (m *InfraProviderStatusSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Icon = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Version = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -7705,6 +7705,7 @@ type InfraProviderCombinedStatusSpec struct {
 	Description   string                                  `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
 	Icon          string                                  `protobuf:"bytes,3,opt,name=icon,proto3" json:"icon,omitempty"`
 	Health        *InfraProviderCombinedStatusSpec_Health `protobuf:"bytes,4,opt,name=health,proto3" json:"health,omitempty"`
+	Version       string                                  `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7765,6 +7766,13 @@ func (x *InfraProviderCombinedStatusSpec) GetHealth() *InfraProviderCombinedStat
 		return x.Health
 	}
 	return nil
+}
+
+func (x *InfraProviderCombinedStatusSpec) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
 }
 
 type MachineConfigDiffSpec struct {
@@ -12052,12 +12060,13 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	" DiscoveryAffiliateDeleteTaskSpec\x12\x1d\n" +
 	"\n" +
 	"cluster_id\x18\x01 \x01(\tR\tclusterId\x12<\n" +
-	"\x1adiscovery_service_endpoint\x18\x02 \x01(\tR\x18discoveryServiceEndpoint\"\x92\x02\n" +
+	"\x1adiscovery_service_endpoint\x18\x02 \x01(\tR\x18discoveryServiceEndpoint\"\xac\x02\n" +
 	"\x1fInfraProviderCombinedStatusSpec\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x12\n" +
 	"\x04icon\x18\x03 \x01(\tR\x04icon\x12E\n" +
-	"\x06health\x18\x04 \x01(\v2-.specs.InfraProviderCombinedStatusSpec.HealthR\x06health\x1a^\n" +
+	"\x06health\x18\x04 \x01(\v2-.specs.InfraProviderCombinedStatusSpec.HealthR\x06health\x12\x18\n" +
+	"\aversion\x18\x05 \x01(\tR\aversion\x1a^\n" +
 	"\x06Health\x12\x1c\n" +
 	"\tconnected\x18\x01 \x01(\bR\tconnected\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12 \n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1545,6 +1545,7 @@ message InfraProviderCombinedStatusSpec {
   }
 
   Health health = 4;
+  string version = 5;
 }
 
 message MachineConfigDiffSpec {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -2886,6 +2886,7 @@ func (m *InfraProviderCombinedStatusSpec) CloneVT() *InfraProviderCombinedStatus
 	r.Description = m.Description
 	r.Icon = m.Icon
 	r.Health = m.Health.CloneVT()
+	r.Version = m.Version
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -7239,6 +7240,9 @@ func (this *InfraProviderCombinedStatusSpec) EqualVT(that *InfraProviderCombined
 		return false
 	}
 	if !this.Health.EqualVT(that.Health) {
+		return false
+	}
+	if this.Version != that.Version {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -15590,6 +15594,13 @@ func (m *InfraProviderCombinedStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (i
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Version) > 0 {
+		i -= len(m.Version)
+		copy(dAtA[i:], m.Version)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Version)))
+		i--
+		dAtA[i] = 0x2a
+	}
 	if m.Health != nil {
 		size, err := m.Health.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -19754,6 +19765,10 @@ func (m *InfraProviderCombinedStatusSpec) SizeVT() (n int) {
 	}
 	if m.Health != nil {
 		l = m.Health.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Version)
+	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -40050,6 +40065,38 @@ func (m *InfraProviderCombinedStatusSpec) UnmarshalVT(dAtA []byte) error {
 			if err := m.Health.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Version = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/client/pkg/infra/infra.go
+++ b/client/pkg/infra/infra.go
@@ -186,6 +186,7 @@ func (provider *Provider[T]) Run(ctx context.Context, logger *zap.Logger, opts .
 	providerStatus.TypedSpec().Value.Name = provider.config.Name
 	providerStatus.TypedSpec().Value.Description = provider.config.Description
 	providerStatus.TypedSpec().Value.Icon = provider.config.Icon
+	providerStatus.TypedSpec().Value.Version = options.version
 
 	err = st.Create(ctx, providerStatus)
 	if err != nil {

--- a/client/pkg/infra/options.go
+++ b/client/pkg/infra/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	imageFactory               provision.FactoryClient
 	healthCheckFunc            HealthCheckFunc
 	omniEndpoint               string
+	version                    string
 	clientOptions              []client.Option
 	concurrency                uint
 	healthCheckInterval        time.Duration
@@ -83,6 +84,13 @@ func WithHealthCheckFunc(healthCheckFunc HealthCheckFunc) Option {
 func WithHealthCheckInterval(interval time.Duration) Option {
 	return func(o *Options) {
 		o.healthCheckInterval = interval
+	}
+}
+
+// WithVersion sets the version reported by the infra provider.
+func WithVersion(version string) Option {
+	return func(o *Options) {
+		o.version = version
 	}
 }
 

--- a/client/pkg/omni/resources/infra/provider_status.go
+++ b/client/pkg/omni/resources/infra/provider_status.go
@@ -54,6 +54,10 @@ func (ProviderStatusExtension) ResourceDefinition() meta.ResourceDefinitionSpec 
 				Name:     "Description",
 				JSONPath: "{.description}",
 			},
+			{
+				Name:     "Version",
+				JSONPath: "{.version}",
+			},
 		},
 	}
 }

--- a/client/pkg/omni/resources/omni/infra_provider_combined_status.go
+++ b/client/pkg/omni/resources/omni/infra_provider_combined_status.go
@@ -54,6 +54,14 @@ func (InfraProviderCombinedStatusExtension) ResourceDefinition() meta.ResourceDe
 				Name:     "Description",
 				JSONPath: "{.description}",
 			},
+			{
+				Name:     "Version",
+				JSONPath: "{.version}",
+			},
+			{
+				Name:     "Connected",
+				JSONPath: "{.health.connected}",
+			},
 		},
 	}
 }

--- a/client/pkg/omnictl/infraprovider.go
+++ b/client/pkg/omnictl/infraprovider.go
@@ -149,14 +149,15 @@ var (
 
 				writer := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 
-				fmt.Fprintf(writer, "ID\tNAME\tDESCRIPTION\tCONNECTED\tERROR\n") //nolint:errcheck
+				fmt.Fprintf(writer, "ID\tNAME\tVERSION\tDESCRIPTION\tCONNECTED\tERROR\n") //nolint:errcheck
 
 				for ps := range infraProviders.All() {
 					fmt.Fprintf( //nolint:errcheck
 						writer,
-						"%s\t%s\t%s\t%t\t%s\n",
+						"%s\t%s\t%s\t%s\t%t\t%s\n",
 						ps.Metadata().ID(),
 						ps.TypedSpec().Value.Name,
+						ps.TypedSpec().Value.Version,
 						ps.TypedSpec().Value.Description,
 						ps.TypedSpec().Value.Health.Connected,
 						ps.TypedSpec().Value.Health.Error,

--- a/frontend/src/api/omni/specs/infra.pb.ts
+++ b/frontend/src/api/omni/specs/infra.pb.ts
@@ -78,6 +78,7 @@ export type InfraProviderStatusSpec = {
   name?: string
   description?: string
   icon?: string
+  version?: string
 }
 
 export type InfraProviderHealthStatusSpec = {

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -1043,6 +1043,7 @@ export type InfraProviderCombinedStatusSpec = {
   description?: string
   icon?: string
   health?: InfraProviderCombinedStatusSpecHealth
+  version?: string
 }
 
 export type MachineConfigDiffSpec = {

--- a/frontend/src/pages/(authenticated)/settings/infraproviders.stories.ts
+++ b/frontend/src/pages/(authenticated)/settings/infraproviders.stories.ts
@@ -37,6 +37,7 @@ export const Default: Story = {
                   .dataUri({ type: 'svg-base64' })
                   .replace('data:image/svg+xml;base64,', ''),
                 description: faker.hacker.phrase(),
+                version: `v${faker.system.semver()}`,
                 health: {
                   connected: faker.datatype.boolean(),
                   error: faker.helpers.maybe(() => faker.hacker.phrase()),

--- a/frontend/src/pages/(authenticated)/settings/infraproviders.vue
+++ b/frontend/src/pages/(authenticated)/settings/infraproviders.vue
@@ -148,7 +148,7 @@ const openRotateSecretKey = async (name: string) => {
             <div
               v-for="item in items"
               :key="item.metadata.id"
-              class="grid grid-cols-4 items-center rounded border border-naturals-n5 bg-naturals-n1 p-3"
+              class="grid grid-cols-5 items-center rounded border border-naturals-n5 bg-naturals-n1 p-3"
               :class="{ 'border-dashed': !item.spec.name }"
             >
               <div class="flex items-center gap-3">
@@ -167,6 +167,13 @@ const openRotateSecretKey = async (name: string) => {
                     ID: {{ item.metadata.id }}
                   </span>
                 </div>
+              </div>
+
+              <div
+                class="truncate text-xs text-naturals-n13"
+                :class="{ 'opacity-50': !item.spec.version }"
+              >
+                {{ item.spec.version || 'Unknown version' }}
               </div>
 
               <Tooltip :description="item.spec.health?.error" placement="top-start">

--- a/internal/backend/runtime/omni/controllers/omni/infraprovider/combined_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/infraprovider/combined_status.go
@@ -65,6 +65,7 @@ func NewCombinedStatusController(healthCheckInterval time.Duration) *CombinedSta
 					infraProviderStatus.TypedSpec().Value.Description = providerStatus.TypedSpec().Value.Description
 					infraProviderStatus.TypedSpec().Value.Icon = providerStatus.TypedSpec().Value.Icon
 					infraProviderStatus.TypedSpec().Value.Name = providerStatus.TypedSpec().Value.Name
+					infraProviderStatus.TypedSpec().Value.Version = providerStatus.TypedSpec().Value.Version
 
 					infraProviderStatus.TypedSpec().Value.Health.Initialized = true
 				}

--- a/internal/backend/runtime/omni/controllers/omni/infraprovider/combined_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/infraprovider/combined_status_test.go
@@ -83,4 +83,45 @@ func TestCombinedStatusController(t *testing.T) {
 			},
 		)
 	})
+
+	t.Run("propagatesProviderStatusFields", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*10)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{}, addControllers,
+			func(ctx context.Context, testContext testutils.TestContext) {
+				providerID := "test-provider"
+
+				rmock.Mock[*infra.Provider](
+					ctx, t, testContext.State,
+					options.WithID(providerID),
+				)
+
+				rmock.Mock[*infra.ProviderStatus](
+					ctx, t, testContext.State,
+					options.WithID(providerID),
+					options.Modify(func(res *infra.ProviderStatus) error {
+						res.TypedSpec().Value.Name = "Test Provider"
+						res.TypedSpec().Value.Description = "a test provider"
+						res.TypedSpec().Value.Version = "v1.2.3"
+
+						return nil
+					}),
+				)
+
+				rtestutils.AssertResources(
+					ctx, t, testContext.State, []string{providerID},
+					func(res *omni.InfraProviderCombinedStatus, assertions *assert.Assertions) {
+						assertions.Equal("Test Provider", res.TypedSpec().Value.Name)
+						assertions.Equal("a test provider", res.TypedSpec().Value.Description)
+						assertions.Equal("v1.2.3", res.TypedSpec().Value.Version, "provider version should be propagated to the combined status")
+						assertions.True(res.TypedSpec().Value.Health.Initialized, "provider should be initialized once the provider status is present")
+					},
+				)
+			},
+		)
+	})
 }


### PR DESCRIPTION
Show the version of an infra provider in the UI and CLI.

Closes #3150 

```
❯ ./_out/omnictl-darwin-arm64 infraprovider list
ID        NAME      VERSION          DESCRIPTION                                    CONNECTED    ERROR
talemu    Talemu    d0711a3-dirty    Emulates fake Talos nodes connected to Omni    true   
```

<img width="732" height="360" alt="image" src="https://github.com/user-attachments/assets/a64038a2-a0db-41b8-913b-1f84ef87cf7d" />
