### PR TITLE
feat: do not pre-pull the kube-proxy image on Kubernetes upgrades

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch.go
@@ -157,5 +157,6 @@ func patchKubeProxy(vc *config.VersionContract, version string) (Patcher, error)
 		return Patcher{}, fmt.Errorf("failed to build kube-proxy patch: %w", err)
 	}
 
-	return Patcher{Patch: data, UsedImages: []string{img}}, nil
+	// UsedImages is deliberately left empty so the kube-proxy image is not pre-pulled.
+	return Patcher{Patch: data}, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/upgrade_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/upgrade_test.go
@@ -40,7 +40,6 @@ func TestUpgradePath(t *testing.T) {
 		if controlPlane {
 			images = append(
 				images,
-				fmt.Sprintf("%s:v%s", constants.KubeProxyImage, desiredVersion),
 				fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, desiredVersion),
 				fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, desiredVersion),
 				fmt.Sprintf("%s:v%s", constants.KubernetesControllerManagerImage, desiredVersion),


### PR DESCRIPTION
Clusters that use a kube-proxy replacement like Cilium turn kube-proxy off, but kubernetes upgrades still pre-pulled it and wasted bandwidth. Drop the kube-proxy image from the pre-pull list.

Resolves: #3136
