### PR TITLE
fix: allow SAMLLabelRule to downgrade user role to None

### DIFF
--- a/internal/backend/saml/session.go
+++ b/internal/backend/saml/session.go
@@ -399,7 +399,7 @@ func MatchSAMLLabelRule(samlLabelRules []*auth.SAMLLabelRule, samlLabels map[str
 				continue
 			}
 
-			if samlRole.Compare(maxRole) == -1 {
+			if rule == nil || samlRole.Compare(maxRole) == -1 {
 				rule = labelRule
 			}
 

--- a/internal/backend/saml/session_test.go
+++ b/internal/backend/saml/session_test.go
@@ -270,3 +270,59 @@ func TestRoleCompare(t *testing.T) {
 
 	require.Equal(t, -1, role.Operator.Compare(role.Admin))
 }
+
+func TestMatchSAMLLabelRuleNone(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	noneRoleToInactive := auth.NewSAMLLabelRule("assign-none-to-inactive")
+	noneRoleToInactive.TypedSpec().Value.MatchLabels = []string{"saml.omni.sidero.dev/role/omni-none"}
+	noneRoleToInactive.TypedSpec().Value.AssignRole = string(role.None)
+	noneRoleToInactive.TypedSpec().Value.UpdateOnEachLogin = true
+
+	// None role rule should be returned (not nil)
+	matchedRule := saml.MatchSAMLLabelRule(
+		[]*auth.SAMLLabelRule{noneRoleToInactive},
+		map[string]string{
+			"saml.omni.sidero.dev/role/omni-none": "",
+		}, logger,
+	)
+
+	require.NotNil(t, matchedRule)
+	require.EqualValues(t, matchedRule.TypedSpec().Value.AssignRole, role.None)
+	require.True(t, matchedRule.TypedSpec().Value.UpdateOnEachLogin)
+}
+
+func TestMatchSAMLLabelRuleNoneWithHigherRulePresent(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	noneRule := auth.NewSAMLLabelRule("assign-none")
+	noneRule.TypedSpec().Value.MatchLabels = []string{"saml.omni.sidero.dev/role/omni-none"}
+	noneRule.TypedSpec().Value.AssignRole = string(role.None)
+
+	readerRule := auth.NewSAMLLabelRule("assign-reader")
+	readerRule.TypedSpec().Value.MatchLabels = []string{"saml.omni.sidero.dev/role/omni-reader"}
+	readerRule.TypedSpec().Value.AssignRole = string(role.Reader)
+
+	// User with only None label → returns None rule
+	matchedRule := saml.MatchSAMLLabelRule(
+		[]*auth.SAMLLabelRule{noneRule, readerRule},
+		map[string]string{
+			"saml.omni.sidero.dev/role/omni-none": "",
+		}, logger,
+	)
+
+	require.NotNil(t, matchedRule)
+	require.EqualValues(t, matchedRule.TypedSpec().Value.AssignRole, role.None)
+
+	// User with both labels → Reader wins (highest role)
+	matchedRule = saml.MatchSAMLLabelRule(
+		[]*auth.SAMLLabelRule{noneRule, readerRule},
+		map[string]string{
+			"saml.omni.sidero.dev/role/omni-none":   "",
+			"saml.omni.sidero.dev/role/omni-reader": "",
+		}, logger,
+	)
+
+	require.NotNil(t, matchedRule)
+	require.EqualValues(t, matchedRule.TypedSpec().Value.AssignRole, role.Reader)
+}


### PR DESCRIPTION
Fixes #3178

## Summary

`MatchSAMLLabelRule()` returns `nil` when the highest matched role is `None`, because `samlRole.Compare(maxRole) == -1` is never true when both values are `None` (Compare returns 0). This causes `ensureUser()` to skip reading `updateOnEachLogin` from the matched rule, preventing role downgrades to `None`.

## Fix

One-line change: `if samlRole.Compare(maxRole) == -1` → `if rule == nil || samlRole.Compare(maxRole) == -1`

This ensures the first valid match always assigns `rule` (even when role is None), preserving the existing highest-role-wins behavior for all other cases.

## Testing

- Added `TestMatchSAMLLabelRuleNone`: verifies a rule with `assignRole: None` is returned (not nil)
- Added `TestMatchSAMLLabelRuleNoneWithHigherRulePresent`: verifies None-only → returns None rule; None+Reader → Reader wins
- Existing `TestRoleInSAMLLabelRules` passes unchanged
- Live-tested on self-hosted Omni v1.9.0 with Keycloak SAML