### PR TITLE
fix: verify maintenance install/upgrade against the live machine

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -59,7 +59,6 @@ const (
 
 // LifecycleManager owns the node-side install/upgrade work. The controller decides timing.
 type LifecycleManager interface {
-	CheckAlive(ctx context.Context, machineID string) error
 	GetForMachine(ctx context.Context, machineID string) (*talos.Client, error)
 	Run(ctx context.Context, op lifecycle.Operation, opts ...lifecycle.Option) error
 	FinalizeReboot(ctx context.Context, opts ...lifecycle.Option) error
@@ -566,8 +565,14 @@ func (ctrl *StatusController) runMaintenanceLifecycle(
 	}
 
 	// Wait if we already triggered the install/upgrade and the node hasn't rebooted yet.
-	if preRebootBootID := rc.machineConfigStatus.TypedSpec().Value.PreRebootBootId; preRebootBootID != "" && rc.bootID == preRebootBootID {
-		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine to reboot after %s: %s", operationName, machineID)
+	if preRebootBootID := rc.machineConfigStatus.TypedSpec().Value.PreRebootBootId; preRebootBootID != "" {
+		if rc.bootID == preRebootBootID {
+			return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine to reboot after %s: %s", operationName, machineID)
+		}
+
+		if omni.GetMachineStatusSystemDisk(rc.machineStatus) == "" {
+			return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine status to get valid system disk after %s: %s", operationName, machineID)
+		}
 	}
 
 	if stage := rc.machineStatusSnapshot.TypedSpec().Value.GetMachineStatus().GetStage(); stage != machineapi.MachineStatusEvent_MAINTENANCE {
@@ -577,13 +582,21 @@ func (ctrl *StatusController) runMaintenanceLifecycle(
 	probeCtx, probeCancel := context.WithTimeout(ctx, lifecycle.LivenessProbeTimeout)
 	defer probeCancel()
 
-	if err := ctrl.lifecycleManager.CheckAlive(probeCtx, machineID); err != nil {
-		logger.Info("liveness probe before "+operationName+" failed, will retry", zap.String("machine", machineID), zap.Error(err))
+	installed, err := ctrl.checkInstalledImage(probeCtx, rc)
+	if err != nil {
+		logger.Info("version check before "+operationName+" failed, will retry", zap.String("machine", machineID), zap.Error(err))
 
 		return false, controller.NewRequeueInterval(lifecycle.RetryInterval)
 	}
 
-	if err := ctrl.acquireUpgradeLock(ctx, r, rc); err != nil {
+	if installed.atTarget && omni.GetMachineStatusSystemDisk(rc.machineStatus) != "" {
+		rc.machineConfigStatus.TypedSpec().Value.TalosVersion = installed.version
+		rc.machineConfigStatus.TypedSpec().Value.SchematicId = installed.schematic
+
+		return true, nil
+	}
+
+	if err = ctrl.acquireUpgradeLock(ctx, r, rc); err != nil {
 		return false, err
 	}
 
@@ -607,7 +620,7 @@ func (ctrl *StatusController) runMaintenanceLifecycle(
 		zap.String("version", operation.Version),
 		zap.String("disk", operation.Disk))
 
-	err := ctrl.lifecycleManager.Run(ctx, operation, lifecycle.WithProgress(func(msg string) {
+	err = ctrl.lifecycleManager.Run(ctx, operation, lifecycle.WithProgress(func(msg string) {
 		logger.Debug(operationName+" progress", zap.String("machine", machineID), zap.String("message", msg))
 	}))
 
@@ -654,6 +667,11 @@ func (ctrl *StatusController) runClusterLifecycle(
 		return false, fmt.Errorf("cluster machine %q has no cluster label", machineID)
 	}
 
+	// Wait if we already triggered the upgrade and the node hasn't rebooted yet.
+	if preRebootBootID := rc.machineConfigStatus.TypedSpec().Value.PreRebootBootId; preRebootBootID != "" && preRebootBootID == rc.bootID {
+		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine to reboot after upgrade: %s", machineID)
+	}
+
 	installed, err := ctrl.checkInstalledImage(ctx, rc)
 	if err != nil {
 		logger.Info("version check before upgrade failed, will retry", zap.String("machine", machineID), zap.Error(err))
@@ -666,11 +684,6 @@ func (ctrl *StatusController) runClusterLifecycle(
 		rc.machineConfigStatus.TypedSpec().Value.SchematicId = installed.schematic
 
 		return true, nil
-	}
-
-	// Wait if we already triggered the upgrade and the node hasn't rebooted yet.
-	if preRebootBootID := rc.machineConfigStatus.TypedSpec().Value.PreRebootBootId; preRebootBootID != "" && preRebootBootID == rc.bootID {
-		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine to reboot after upgrade: %s", machineID)
 	}
 
 	nodeName, err := ctrl.getNodeName(ctx, r, machineID)

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -1098,6 +1098,80 @@ func TestMachineConfigStatusController(t *testing.T) {
 		)
 	})
 
+	// maintenanceUpgradeConvergesOnLiveVersion verifies that after a maintenance upgrade reboots, a cached
+	// MachineStatus still reporting the pre-upgrade version (the post-reboot lag) does not cause a second
+	// upgrade: the controller reads the live version, sees the machine already at the target, and converges
+	// on it. Without the live re-check the stale version mismatch would re-run the upgrade and reboot the
+	// machine again. The schematic is marked invalid so the re-check turns purely on the version, isolating
+	// the version lag.
+	t.Run("maintenanceUpgradeConvergesOnLiveVersion", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(
+					machineconfig.NewStatusController(testutils.NewLifecycleManager(tc.State, nil)),
+				))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				// The machine has Talos on disk and is booted in maintenance, but its cached MachineStatus
+				// still lags at the pre-upgrade version. An invalid schematic keeps the re-check version-only.
+				_, machines := createCluster(
+					ctx, t, st, machineServices, "maint-upgrade-converged", 1, 0,
+					withMachineStatusModifier(func(res *omni.MachineStatus) error {
+						res.TypedSpec().Value.Maintenance = true
+						res.TypedSpec().Value.TalosVersion = maintenanceMachineVersion
+						res.TypedSpec().Value.Schematic.Invalid = true
+
+						return nil
+					}),
+				)
+
+				id := machines[0].Metadata().ID()
+
+				// Set the live version before the trigger resources below, so the controller cannot fire an
+				// upgrade before it can observe the machine is already at the target. The node reports the
+				// target version even though the cached MachineStatus still reports the old one.
+				machineServices.Get(id).SetVersionHandler(func(context.Context, *emptypb.Empty) (*machine.VersionResponse, error) {
+					return &machine.VersionResponse{
+						Messages: []*machine.Version{{Version: &machine.VersionInfo{Tag: "v" + maintenanceTargetVersion}}},
+					}, nil
+				})
+
+				rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+					res.TypedSpec().Value.InstallImage.TalosVersion = maintenanceTargetVersion
+
+					return nil
+				}))
+
+				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
+					res.TypedSpec().Value.BootId = "boot-converged"
+
+					return nil
+				}))
+
+				// The config status converges to the live version with the reboot marker left empty. Had the
+				// controller re-triggered instead, it would have recorded the boot ID and never stamped the
+				// target version here, so this pair of positive checks rules out a spurious upgrade.
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+					a.Equal(maintenanceTargetVersion, res.TypedSpec().Value.TalosVersion)
+					a.Empty(res.TypedSpec().Value.PreRebootBootId)
+				})
+
+				assert.Empty(t, machineServices.Get(id).GetLifecycleUpgradeRequests(), "a machine already at the target must not be upgraded again")
+				assert.Empty(t, machineServices.Get(id).GetLifecycleInstallRequests())
+			},
+		)
+	})
+
 	// maintenanceLifecycleError verifies a failed operation surfaces the error in LastConfigError
 	// (returning a raw error would make qtransform drop the output write) and does not record the boot
 	// ID, so the operation is retried.

--- a/internal/backend/talos/lifecycle/manager.go
+++ b/internal/backend/talos/lifecycle/manager.go
@@ -175,20 +175,6 @@ func (m *Manager) GetForMachine(ctx context.Context, machineID string) (*talos.C
 	return m.talosClientFactory.GetForMachine(ctx, machineID)
 }
 
-// CheckAlive does a quick Version call on the machine's Talos client, so callers can fail fast instead of committing the full operation to an unresponsive machine.
-func (m *Manager) CheckAlive(ctx context.Context, machineID string) error {
-	talosClient, err := m.GetForMachine(ctx, machineID)
-	if err != nil {
-		return err
-	}
-
-	if _, err = talosClient.Version(ctx); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Run performs the install or upgrade synchronously, returning when the machine has been rebooted into the target Talos or on error.
 // Returns ErrAlreadyInFlight if another operation holds this machine.
 func (m *Manager) Run(ctx context.Context, op Operation, opts ...Option) error {


### PR DESCRIPTION
The maintenance install/upgrade path trusted the cached MachineStatus once it saw a reboot, so during the window where the status still lagged behind the node it could re-run the operation. A re-run install got rejected as AlreadyExists and fell back to a spurious upgrade and reboot, and a re-run upgrade ran a second time. The controller now reads the live version before acting and waits for the status to report the installed disk before deciding, the same way the cluster path already does.