### PR TITLE
chore: apply CA, Registry configs before install/upgrade calls

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -3529,8 +3529,13 @@ type ClusterMachineConfigStatusSpec struct {
 	// debounces such operations: the controller waits until the machine reboots and its boot
 	// ID changes before acting again.
 	PreRebootBootId string `protobuf:"bytes,11,opt,name=pre_reboot_boot_id,json=preRebootBootId,proto3" json:"pre_reboot_boot_id,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// AppliedHighPriorityConfigHash is the hash of the high-priority config documents (image factory
+	// registry auth and custom CA / trusted roots) that were last successfully applied to the machine.
+	// It is compared against the desired high-priority hash to decide whether high-priority config
+	// changes are pending and must be applied before an upgrade/install.
+	AppliedHighPriorityConfigHash string `protobuf:"bytes,12,opt,name=applied_high_priority_config_hash,json=appliedHighPriorityConfigHash,proto3" json:"applied_high_priority_config_hash,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *ClusterMachineConfigStatusSpec) Reset() {
@@ -3615,6 +3620,13 @@ func (x *ClusterMachineConfigStatusSpec) GetCompressedRedactedMachineConfig() []
 func (x *ClusterMachineConfigStatusSpec) GetPreRebootBootId() string {
 	if x != nil {
 		return x.PreRebootBootId
+	}
+	return ""
+}
+
+func (x *ClusterMachineConfigStatusSpec) GetAppliedHighPriorityConfigHash() string {
+	if x != nil {
+		return x.AppliedHighPriorityConfigHash
 	}
 	return ""
 }
@@ -11635,7 +11647,7 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\vClusterUUID\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\"4\n" +
 	"\x18ClusterConfigVersionSpec\x12\x18\n" +
-	"\aversion\x18\x01 \x01(\tR\aversion\"\xef\x03\n" +
+	"\aversion\x18\x01 \x01(\tR\aversion\"\xb9\x04\n" +
 	"\x1eClusterMachineConfigStatusSpec\x12C\n" +
 	"\x1ecluster_machine_config_version\x18\x03 \x01(\tR\x1bclusterMachineConfigVersion\x12A\n" +
 	"\x1dcluster_machine_config_sha256\x18\x05 \x01(\tR\x1aclusterMachineConfigSha256\x12*\n" +
@@ -11645,7 +11657,8 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x1fredacted_current_machine_config\x18\t \x01(\tR\x1credactedCurrentMachineConfig\x12K\n" +
 	"\"compressed_redacted_machine_config\x18\n" +
 	" \x01(\fR\x1fcompressedRedactedMachineConfig\x12+\n" +
-	"\x12pre_reboot_boot_id\x18\v \x01(\tR\x0fpreRebootBootIdJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05\"\x98\x02\n" +
+	"\x12pre_reboot_boot_id\x18\v \x01(\tR\x0fpreRebootBootId\x12H\n" +
+	"!applied_high_priority_config_hash\x18\f \x01(\tR\x1dappliedHighPriorityConfigHashJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05\"\x98\x02\n" +
 	"\x19MachinePendingUpdatesSpec\x12B\n" +
 	"\aupgrade\x18\x01 \x01(\v2(.specs.MachinePendingUpdatesSpec.UpgradeR\aupgrade\x12\x1f\n" +
 	"\vconfig_diff\x18\x02 \x01(\tR\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -624,6 +624,12 @@ message ClusterMachineConfigStatusSpec {
   // debounces such operations: the controller waits until the machine reboots and its boot
   // ID changes before acting again.
   string pre_reboot_boot_id = 11;
+
+  // AppliedHighPriorityConfigHash is the hash of the high-priority config documents (image factory
+  // registry auth and custom CA / trusted roots) that were last successfully applied to the machine.
+  // It is compared against the desired high-priority hash to decide whether high-priority config
+  // changes are pending and must be applied before an upgrade/install.
+  string applied_high_priority_config_hash = 12;
 }
 
 message MachinePendingUpdatesSpec {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -961,6 +961,7 @@ func (m *ClusterMachineConfigStatusSpec) CloneVT() *ClusterMachineConfigStatusSp
 	r.SchematicId = m.SchematicId
 	r.RedactedCurrentMachineConfig = m.RedactedCurrentMachineConfig
 	r.PreRebootBootId = m.PreRebootBootId
+	r.AppliedHighPriorityConfigHash = m.AppliedHighPriorityConfigHash
 	if rhs := m.CompressedRedactedMachineConfig; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
@@ -4622,6 +4623,9 @@ func (this *ClusterMachineConfigStatusSpec) EqualVT(that *ClusterMachineConfigSt
 		return false
 	}
 	if this.PreRebootBootId != that.PreRebootBootId {
+		return false
+	}
+	if this.AppliedHighPriorityConfigHash != that.AppliedHighPriorityConfigHash {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -10531,6 +10535,13 @@ func (m *ClusterMachineConfigStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (in
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.AppliedHighPriorityConfigHash) > 0 {
+		i -= len(m.AppliedHighPriorityConfigHash)
+		copy(dAtA[i:], m.AppliedHighPriorityConfigHash)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.AppliedHighPriorityConfigHash)))
+		i--
+		dAtA[i] = 0x62
 	}
 	if len(m.PreRebootBootId) > 0 {
 		i -= len(m.PreRebootBootId)
@@ -17858,6 +17869,10 @@ func (m *ClusterMachineConfigStatusSpec) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.PreRebootBootId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.AppliedHighPriorityConfigHash)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -27547,6 +27562,38 @@ func (m *ClusterMachineConfigStatusSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.PreRebootBootId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AppliedHighPriorityConfigHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AppliedHighPriorityConfigHash = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
@@ -7,8 +7,11 @@ package machineconfig
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -18,12 +21,17 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/gen/xerrors"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
 	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
 )
@@ -37,14 +45,24 @@ type ReconciliationContext struct {
 	clusterMachine        *omni.ClusterMachine
 	installImage          *specs.MachineConfigGenOptionsSpec_InstallImage
 
-	lastConfigError       string
-	installDisk           string
-	bootID                string
+	lastConfigError string
+	installDisk     string
+	bootID          string
+	// highPriorityHash is the hash of the high-priority config documents (image factory registry auth
+	// and custom CA / trusted roots) present in the desired config. Empty when there are none.
+	highPriorityHash      string
 	redactedMachineConfig []byte
+
+	lifecycleOp lifecycle.Op
 
 	configUpdatesAllowed bool
 	locked               bool
-	lifecycleOp          lifecycle.Op
+	// highPriorityPending is true when the desired high-priority config documents differ from the ones
+	// last applied to the machine, so they must be applied before any upgrade/install.
+	highPriorityPending bool
+	// maintenanceConfigApplied is true when the maintenance config controller has applied the config it
+	// generated (which carries the high-priority documents) for the machine's current connection.
+	maintenanceConfigApplied bool
 }
 
 // hasPendingLifecycleOperation returns true when an upgrade/install action needs to run before config can be applied.
@@ -163,6 +181,14 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 		return nil, fmt.Errorf("failed to redact secrets: %w", err)
 	}
 
+	rc.highPriorityHash, err = computeHighPriorityHash(config.Documents())
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute high-priority config hash: %w", err)
+	}
+
+	rc.highPriorityPending = rc.highPriorityHash != "" &&
+		rc.highPriorityHash != machineConfigStatus.TypedSpec().Value.AppliedHighPriorityConfigHash
+
 	if !rc.locked {
 		if rc.locked, err = checkClusterReady(ctx, r, machineConfig); err != nil {
 			return nil, err
@@ -246,10 +272,83 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 
 	rc.bootID = rc.machineStatusSnapshot.TypedSpec().Value.BootId
 
+	maintenanceConfigStatus, err := safe.ReaderGetByID[*omni.MaintenanceConfigStatus](ctx, r, machineConfig.Metadata().ID())
+	if err != nil && !state.IsNotFoundError(err) {
+		return nil, err
+	}
+
+	link, err := safe.ReaderGetByID[*siderolinkres.Link](ctx, r, machineConfig.Metadata().ID())
+	if err != nil && !state.IsNotFoundError(err) {
+		return nil, err
+	}
+
+	rc.maintenanceConfigApplied = maintenanceConfigStatus != nil && link != nil &&
+		link.TypedSpec().Value.Connected &&
+		link.TypedSpec().Value.NodePublicKey != "" &&
+		maintenanceConfigStatus.TypedSpec().Value.LastAppliedConfigHash != "" &&
+		maintenanceConfigStatus.TypedSpec().Value.PublicKeyAtLastApply != "" &&
+		maintenanceConfigStatus.TypedSpec().Value.PublicKeyAtLastApply == link.TypedSpec().Value.NodePublicKey
+
 	rc.lifecycleOp = lifecycle.DecideOp(rc.machineStatus, rc.installImage, schematicMismatch, talosVersionMismatch)
 	if rc.lifecycleOp == lifecycle.OpMaintenanceInstall && rc.installDisk == "" {
 		return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("%q install disk is not yet selected", machineConfig.Metadata().ID())
 	}
 
 	return rc, nil
+}
+
+// computeHighPriorityHash returns a stable hash of the high-priority config documents present in the
+// desired machine config: image factory registry auth (cri.RegistryAuthConfigV1Alpha1) and custom CA /
+// trusted roots (security.TrustedRootsConfigV1Alpha1). These must already be on the machine before any
+// upgrade/install can pull the installer image from a private image factory or a registry behind a
+// custom CA. It returns an empty string when there are no such documents.
+func computeHighPriorityHash(documents []talosconfig.Document) (string, error) {
+	var highPriority []talosconfig.Document
+
+	for _, doc := range documents {
+		switch doc.(type) {
+		case *cri.RegistryAuthConfigV1Alpha1, *security.TrustedRootsConfigV1Alpha1:
+			highPriority = append(highPriority, doc)
+		}
+	}
+
+	if len(highPriority) == 0 {
+		return "", nil
+	}
+
+	// Sort by kind and name so the hash is independent of the document ordering in the config.
+	slices.SortStableFunc(highPriority, func(a, b talosconfig.Document) int {
+		return strings.Compare(documentKey(a), documentKey(b))
+	})
+
+	hash := sha256.New()
+
+	for _, doc := range highPriority {
+		ctr, err := container.New(doc)
+		if err != nil {
+			return "", fmt.Errorf("failed to wrap high-priority document: %w", err)
+		}
+
+		data, err := ctr.EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
+		if err != nil {
+			return "", fmt.Errorf("failed to encode high-priority document: %w", err)
+		}
+
+		hash.Write(data)
+		hash.Write([]byte{0})
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// documentKey returns a stable sort key for a config document based on its API version, kind and
+// (optional) name.
+func documentKey(doc talosconfig.Document) string {
+	key := doc.APIVersion() + "/" + doc.Kind()
+
+	if named, ok := doc.(talosconfig.NamedDocument); ok {
+		key += "/" + named.Name()
+	}
+
+	return key
 }

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -37,6 +37,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/meta"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 	"github.com/siderolabs/omni/internal/backend/installimage"
 	"github.com/siderolabs/omni/internal/backend/kernelargs"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
@@ -163,6 +164,12 @@ func NewStatusController(lifecycleManager LifecycleManager) *StatusController {
 		qtransform.WithExtraMappedInput[*omni.UpgradeRollout](
 			mappers.MapClusterResourceToLabeledResources[*omni.ClusterMachineConfig](),
 		),
+		qtransform.WithExtraMappedInput[*omni.MaintenanceConfigStatus](
+			qtransform.MapperSameID[*omni.ClusterMachineConfig](),
+		),
+		qtransform.WithExtraMappedInput[*siderolinkres.Link](
+			qtransform.MapperSameID[*omni.ClusterMachineConfig](),
+		),
 		qtransform.WithExtraOutputs(controller.Output{
 			Type: omni.NodeForceDestroyRequestType,
 			Kind: controller.OutputShared,
@@ -280,6 +287,12 @@ func (ctrl *StatusController) reconcileRunning(
 
 	machineConfigStatus.TypedSpec().Value.ClusterMachineConfigSha256 = shaSumString
 
+	// The machine now carries the desired config (either just applied, or already in sync), so its
+	// high-priority documents are up to date. Recording the hash clears highPriorityPending; it also
+	// backfills already-configured machines on the first reconcile after this feature is deployed,
+	// without a re-apply (the whole-config sha still matches, so applyConfig above is skipped).
+	machineConfigStatus.TypedSpec().Value.AppliedHighPriorityConfigHash = rc.highPriorityHash
+
 	machineConfigStatus.TypedSpec().Value.LastConfigError = ""
 
 	if _, err = helpers.TeardownAndDestroy(ctx, r, omni.NewMachinePendingUpdates(machineConfig.Metadata().ID()).Metadata()); err != nil {
@@ -349,6 +362,8 @@ func (ctrl *StatusController) reconcileTearingDown(ctx context.Context, r contro
 //     released, so it does not pin a config rollout slot and starve machines that only need a
 //     config change. The lock is re-acquired later when the machine applies its config.
 //   - once the machine is in sync, the upgrade lock is released before the config-apply phase.
+//
+//nolint:gocognit,gocyclo,cyclop
 func (ctrl *StatusController) reconcileUpgrade(
 	ctx context.Context,
 	logger *zap.Logger,
@@ -361,26 +376,58 @@ func (ctrl *StatusController) reconcileUpgrade(
 	}
 
 	if rc.hasPendingLifecycleOperation() {
-		inSync, err := ctrl.upgrade(ctx, logger, r, rc)
-		if err != nil {
-			// Only release the config-update lock when the machine is specifically blocked
-			// waiting for a free upgrade slot. It will not apply its config until it upgrades,
-			// so holding the slot just starves machines that only need a config change. On other
-			// (transient) upgrade failures the lock is kept, so a machine still completing its
-			// config reboot is not disturbed.
-			if errors.Is(err, errAcquireUpgradeLock) {
-				if releaseErr := ctrl.releaseConfigUpdateLock(ctx, r, rc.clusterMachine); releaseErr != nil {
-					return fmt.Errorf("failed to release config update lock: %w", releaseErr)
+		switch {
+		// If high-priority config (image factory registry auth / custom CA) changes are pending on an
+		// in-cluster machine, defer the upgrade and let the config be applied first: the upgrade pulls
+		// the installer image and needs those credentials/CA to be on the machine already. We neither
+		// call ctrl.upgrade nor skip-reconcile, so the flow falls through to applyConfig below. The
+		// TalosVersion/SchematicId are not recorded because hasPendingLifecycleOperation() stays true,
+		// so the version-recording branch below is not entered. The upgrade is retried on a later
+		// reconcile, once the high-priority config is applied and no longer pending.
+		case (rc.lifecycleOp == lifecycle.OpClusterUpgrade || rc.lifecycleOp == lifecycle.OpLegacyUpgrade) && rc.highPriorityPending:
+			logger.Info("deferring upgrade until high-priority config is applied", zap.String("machine", rc.ID()))
+
+		// A machine being installed/upgraded while still in maintenance mode has its config — including any
+		// high-priority documents (image factory registry auth / custom CA) — applied by the maintenance
+		// config controller, not by this one. Block the install/upgrade until that controller has applied
+		// its config for the current connection, otherwise the installer image pull could run before the
+		// credentials/CA are on the machine.
+		//
+		// We gate every maintenance install/upgrade, not only when the rendered ClusterMachineConfig already
+		// carries high-priority documents: that rendered config lags its inputs, so right after credentials
+		// are added it can still be empty of them while the machine becomes installable. The maintenance
+		// controller applies the credentials/CA straight from their source resources (ImageFactoryAuth,
+		// machine ConfigPatches), independent of the render, so waiting on it is what actually guarantees the
+		// machine has them. This only affects Talos 1.13+ machines (older ones take the legacy upgrade path),
+		// which the maintenance controller always serves, so the gate cannot get permanently stuck.
+		case (rc.lifecycleOp == lifecycle.OpMaintenanceInstall || rc.lifecycleOp == lifecycle.OpMaintenanceUpgrade) &&
+			!rc.maintenanceConfigApplied:
+			logger.Info("waiting for maintenance config controller to apply config before install/upgrade", zap.String("machine", rc.ID()))
+
+			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for maintenance config controller to apply config: %s", rc.ID())
+
+		default:
+			inSync, err := ctrl.upgrade(ctx, logger, r, rc)
+			if err != nil {
+				// Only release the config-update lock when the machine is specifically blocked
+				// waiting for a free upgrade slot. It will not apply its config until it upgrades,
+				// so holding the slot just starves machines that only need a config change. On other
+				// (transient) upgrade failures the lock is kept, so a machine still completing its
+				// config reboot is not disturbed.
+				if errors.Is(err, errAcquireUpgradeLock) {
+					if releaseErr := ctrl.releaseConfigUpdateLock(ctx, r, rc.clusterMachine); releaseErr != nil {
+						return fmt.Errorf("failed to release config update lock: %w", releaseErr)
+					}
 				}
+
+				return err
 			}
 
-			return err
-		}
+			if !inSync {
+				logger.Info("the machine talos version is out of sync, the config is not applied", zap.String("machine", rc.ID()))
 
-		if !inSync {
-			logger.Info("the machine talos version is out of sync, the config is not applied", zap.String("machine", rc.ID()))
-
-			return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine talos version is out of sync: %s", rc.ID())
+				return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine talos version is out of sync: %s", rc.ID())
+			}
 		}
 	} else {
 		// The cached view can read None while the machine we triggered is still mid-reboot. Applying then

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -24,7 +24,10 @@ import (
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -1151,6 +1154,9 @@ func TestMachineConfigStatusController(t *testing.T) {
 					return nil
 				}))
 
+				// Open the maintenance install/upgrade gate.
+				markMaintenanceConfigApplied(ctx, t, st, id)
+
 				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
 					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
 					res.TypedSpec().Value.BootId = "boot-converged"
@@ -1543,6 +1549,9 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 					return nil
 				}))
+
+				// Open the maintenance install/upgrade gate.
+				markMaintenanceConfigApplied(ctx, t, st, id)
 
 				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
 					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
@@ -2051,6 +2060,10 @@ func setupMaintenanceMachine(
 		return nil
 	}))
 
+	// The maintenance config controller has applied its config for the current connection, so the
+	// install/upgrade gate in reconcileUpgrade is open.
+	markMaintenanceConfigApplied(ctx, t, st, id)
+
 	rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
 		res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
 		res.TypedSpec().Value.BootId = bootID
@@ -2059,6 +2072,27 @@ func setupMaintenanceMachine(
 	}))
 
 	return id
+}
+
+// markMaintenanceConfigApplied sets up a machine so the status controller's maintenance install/upgrade
+// gate is open: the machine's siderolink Link has a known public key and the MaintenanceConfigStatus
+// records an apply against that same key (see reconcileUpgrade's maintenance gate).
+func markMaintenanceConfigApplied(ctx context.Context, t *testing.T, st state.State, id string) {
+	const publicKey = "pk-applied"
+
+	rmock.Mock[*siderolink.Link](ctx, t, st, options.WithID(id), options.Modify(func(res *siderolink.Link) error {
+		res.TypedSpec().Value.Connected = true
+		res.TypedSpec().Value.NodePublicKey = publicKey
+
+		return nil
+	}))
+
+	rmock.Mock[*omni.MaintenanceConfigStatus](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MaintenanceConfigStatus) error {
+		res.TypedSpec().Value.LastAppliedConfigHash = "applied"
+		res.TypedSpec().Value.PublicKeyAtLastApply = publicKey
+
+		return nil
+	}))
 }
 
 // TestClusterLifecycleUpgrade verifies that a running (non-maintenance) Talos 1.13+ cluster machine
@@ -2129,7 +2163,7 @@ func TestClusterLifecycleUpgrade(t *testing.T) {
 
 			// Request a same-minor upgrade: both the machine and the target support the LifecycleService API,
 			// so this must take the cluster lifecycle path rather than the legacy one.
-			targetVersion := "1.13.99"
+			targetVersion := "1.13.6"
 
 			rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
 				res.TypedSpec().Value.InstallImage.TalosVersion = targetVersion
@@ -2191,7 +2225,7 @@ func TestClusterLifecycleConvergesOnLiveVersion(t *testing.T) {
 				installedSchematic = res.TypedSpec().Value.SchematicId
 			})
 
-			targetVersion := "1.13.99"
+			targetVersion := "1.13.6"
 
 			// The node already runs the target version live, even though the cached MachineStatus still
 			// reports the old one (the post-reboot lag the re-check is meant to absorb).
@@ -2305,7 +2339,7 @@ func TestClusterLifecycleHoldsUpgradeLockUntilFinalized(t *testing.T) {
 				return nil
 			}))
 
-			targetVersion := "1.13.99"
+			targetVersion := "1.13.6"
 
 			rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
 				res.TypedSpec().Value.InstallImage.TalosVersion = targetVersion
@@ -2434,7 +2468,7 @@ func TestClusterLifecycleForfeitsEtcdLeadership(t *testing.T) {
 			nodeName := "node-" + id
 			provider.SetClientset(testutils.NewFakeKubernetesClientset(nodeName))
 
-			triggerClusterUpgrade(ctx, t, st, clusterName, id, nodeName, "1.13.99")
+			triggerClusterUpgrade(ctx, t, st, clusterName, id, nodeName, "1.13.6")
 
 			// The control-plane node forfeits etcd leadership before its reboot.
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -2476,7 +2510,7 @@ func TestClusterLifecycleSkipsEtcdForfeitForLoneControlPlane(t *testing.T) {
 			nodeName := "node-" + id
 			provider.SetClientset(testutils.NewFakeKubernetesClientset(nodeName))
 
-			triggerClusterUpgrade(ctx, t, st, clusterName, id, nodeName, "1.13.99")
+			triggerClusterUpgrade(ctx, t, st, clusterName, id, nodeName, "1.13.6")
 
 			// Wait until the upgrade has run (boot ID recorded): the forfeit, if any, happens during the run.
 			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
@@ -2485,6 +2519,278 @@ func TestClusterLifecycleSkipsEtcdForfeitForLoneControlPlane(t *testing.T) {
 
 			// A lone control plane must not forfeit leadership.
 			assert.Zero(t, machineServices.Get(id).GetEtcdForfeitLeadershipCount())
+		},
+	)
+}
+
+// highPriorityConfigOption returns a Mock option that appends high-priority config documents — image
+// factory registry auth (cri.RegistryAuthConfig) and a custom CA / trusted roots
+// (security.TrustedRootsConfig) — to a machine's rendered ClusterMachineConfig, so the status
+// controller sees them as high-priority documents.
+func highPriorityConfigOption() options.MockOption {
+	return options.Modify(func(res *omni.ClusterMachineConfig) error {
+		buffer, err := res.TypedSpec().Value.GetUncompressedData()
+		if err != nil {
+			return err
+		}
+
+		defer buffer.Free()
+
+		provider, err := configloader.NewFromBytes(buffer.Data())
+		if err != nil {
+			return err
+		}
+
+		authDoc := cri.NewRegistryAuthConfigV1Alpha1("registry.example.com")
+		authDoc.RegistryUsername = "user"
+		authDoc.RegistryPassword = "pass"
+
+		caDoc := security.NewTrustedRootsConfigV1Alpha1()
+		caDoc.MetaName = "custom-ca"
+		caDoc.Certificates = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+
+		docs := append(provider.Documents(), authDoc, caDoc)
+
+		ctr, err := container.New(docs...)
+		if err != nil {
+			return err
+		}
+
+		data, err := ctr.EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
+		if err != nil {
+			return err
+		}
+
+		return res.TypedSpec().Value.SetUncompressedData(data)
+	})
+}
+
+// addHighPriorityConfig injects the high-priority documents into an already-created ClusterMachineConfig.
+func addHighPriorityConfig(ctx context.Context, t *testing.T, st state.State, id string) {
+	rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), highPriorityConfigOption())
+}
+
+// TestClusterUpgradeDeferredForHighPriorityConfig verifies that when an in-cluster machine has both a
+// pending upgrade and a pending high-priority config change (image factory registry auth / custom CA),
+// the upgrade is deferred and the config is applied first — the upgrade pulls the installer image and
+// needs those credentials/CA on the machine already.
+func TestClusterUpgradeDeferredForHighPriorityConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+	t.Cleanup(cancel)
+
+	provider := &testutils.FakeKubernetesProvider{}
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterQController(
+				machineconfig.NewStatusController(testutils.NewLifecycleManager(tc.State, provider)),
+			))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			st := tc.State
+
+			clusterName := "cluster-hp-defer"
+
+			machineServices := testutils.NewMachineServices(t, st)
+
+			_, machines := createCluster(ctx, t, st, machineServices, clusterName, 1, 0)
+			id := machines[0].Metadata().ID()
+
+			// Wait for the initial config to be applied (records the empty high-priority hash baseline).
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+
+			nodeName := "node-" + id
+			provider.SetClientset(testutils.NewFakeKubernetesClientset(nodeName))
+
+			// Make config apply require a reboot so the applied high-priority hash is never recorded and the
+			// change stays pending, keeping the upgrade deferred for the whole test.
+			machineServices.ForEach(func(m *testutils.MachineServiceMock) {
+				m.OnApplyConfig = func(_ context.Context, _ *machine.ApplyConfigurationRequest, _ state.State, _ string) (*machine.ApplyConfigurationResponse, error) {
+					//nolint:staticcheck // ApplyConfigurationRequest_REBOOT is deprecated in Talos 1.14, update the test when DefaultTalosVersion is set to 1.14
+					mode := machine.ApplyConfigurationRequest_REBOOT
+
+					return &machine.ApplyConfigurationResponse{
+						Messages: []*machine.ApplyConfiguration{{Mode: mode}},
+					}, nil
+				}
+			})
+
+			// A high-priority config change is now pending. Wait until the controller has actually observed
+			// and pushed it (an apply request carrying the high-priority docs) BEFORE requesting the upgrade.
+			// The upgrade trigger and the config change are separate resources, so if the upgrade became
+			// visible to the controller first it would run against a config with no high-priority docs yet
+			// (highPriorityPending still false). Waiting for the apply pins the doc into the controller's
+			// cache (COSI caches are monotonic), making the deferral deterministic.
+			addHighPriorityConfig(ctx, t, st, id)
+
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				requests := machineServices.Get(id).GetApplyRequests()
+				if !assert.NotEmpty(collect, requests) {
+					return
+				}
+
+				assert.Contains(collect, string(requests[len(requests)-1].GetData()), "RegistryAuthConfig")
+			}, time.Second*5, 50*time.Millisecond)
+
+			// Now request a version upgrade. The high-priority change stays pending (config apply requires a
+			// reboot, so its hash is never recorded), so the upgrade is deferred and no LifecycleService.Upgrade
+			// is issued.
+			triggerClusterUpgrade(ctx, t, st, clusterName, id, nodeName, "1.13.6")
+
+			require.Never(t, func() bool {
+				return len(machineServices.Get(id).GetLifecycleUpgradeRequests()) > 0
+			}, time.Second, 50*time.Millisecond)
+		},
+	)
+}
+
+// TestClusterUpgradeProceedsAfterHighPriorityConfigApplied verifies the deferral is temporary: once the
+// high-priority config has been applied, the upgrade is no longer pending and proceeds normally.
+func TestClusterUpgradeProceedsAfterHighPriorityConfigApplied(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+	t.Cleanup(cancel)
+
+	provider := &testutils.FakeKubernetesProvider{}
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterQController(
+				machineconfig.NewStatusController(testutils.NewLifecycleManager(tc.State, provider)),
+			))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			st := tc.State
+
+			clusterName := "cluster-hp-proceed"
+
+			machineServices := testutils.NewMachineServices(t, st)
+
+			_, machines := createCluster(ctx, t, st, machineServices, clusterName, 1, 0)
+			id := machines[0].Metadata().ID()
+
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+
+			nodeName := "node-" + id
+			provider.SetClientset(testutils.NewFakeKubernetesClientset(nodeName))
+
+			// Config apply succeeds without a reboot (mock default), so the applied high-priority hash is
+			// recorded and the change stops being pending.
+			addHighPriorityConfig(ctx, t, st, id)
+
+			triggerClusterUpgrade(ctx, t, st, clusterName, id, nodeName, "1.13.10")
+
+			// The upgrade eventually runs (boot ID recorded and a LifecycleService.Upgrade is issued), proving
+			// the deferral released once the high-priority config was applied.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.NotEmpty(res.TypedSpec().Value.PreRebootBootId)
+			})
+
+			require.NotEmpty(t, machineServices.Get(id).GetLifecycleUpgradeRequests())
+		},
+	)
+}
+
+// TestMaintenanceInstallGatedOnHighPriorityConfig verifies that a maintenance-mode machine with
+// high-priority config documents is not installed/upgraded by the status controller until the
+// maintenance config controller has applied the config it generated for the machine's current
+// connection (matched by the siderolink public key).
+func TestMaintenanceInstallGatedOnHighPriorityConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterQController(
+				machineconfig.NewStatusController(testutils.NewLifecycleManager(tc.State, nil)),
+			))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			st := tc.State
+			machineServices := testutils.NewMachineServices(t, st)
+
+			clusterName := "maint-hp-gate"
+
+			// Note: the rendered ClusterMachineConfig here does NOT carry high-priority documents. The gate
+			// must still block the install until the maintenance config controller has applied its config for
+			// the current connection — it does not rely on the rendered config (which lags its inputs), only
+			// on the maintenance controller, which applies credentials/CA straight from their source resources.
+			_, machines := createCluster(
+				ctx, t, st, machineServices, clusterName, 1, 0,
+				withMachineStatusModifier(func(res *omni.MachineStatus) error {
+					res.TypedSpec().Value.Maintenance = true
+					res.TypedSpec().Value.TalosVersion = maintenanceMachineVersion
+					res.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{} // no system disk -> install
+
+					return nil
+				}),
+			)
+			id := machines[0].Metadata().ID()
+
+			// The machine's current siderolink public key.
+			rmock.Mock[*siderolink.Link](ctx, t, st, options.WithID(id), options.Modify(func(res *siderolink.Link) error {
+				res.TypedSpec().Value.Connected = true
+				res.TypedSpec().Value.NodePublicKey = "pk-current"
+
+				return nil
+			}))
+
+			rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+				res.TypedSpec().Value.InstallImage.TalosVersion = maintenanceTargetVersion
+
+				return nil
+			}))
+
+			rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_MAINTENANCE}
+				res.TypedSpec().Value.BootId = "boot-maint-gate"
+
+				return nil
+			}))
+
+			// Fresh machine: the maintenance config controller has not applied anything yet (no
+			// MaintenanceConfigStatus), so the install is gated.
+			require.Never(t, func() bool {
+				return len(machineServices.Get(id).GetLifecycleInstallRequests()) > 0
+			}, time.Second, 50*time.Millisecond)
+
+			// The controller has applied config, but for a previous connection (the machine reconnected with a
+			// new public key, so its maintenance config is gone). The install must stay gated.
+			rmock.Mock[*omni.MaintenanceConfigStatus](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MaintenanceConfigStatus) error {
+				res.TypedSpec().Value.LastAppliedConfigHash = "maintenance-hash"
+				res.TypedSpec().Value.PublicKeyAtLastApply = "pk-stale"
+
+				return nil
+			}))
+
+			require.Never(t, func() bool {
+				return len(machineServices.Get(id).GetLifecycleInstallRequests()) > 0
+			}, time.Second, 50*time.Millisecond)
+
+			// The maintenance config controller applies its config for the current connection.
+			rmock.Mock[*omni.MaintenanceConfigStatus](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MaintenanceConfigStatus) error {
+				res.TypedSpec().Value.LastAppliedConfigHash = "maintenance-hash"
+				res.TypedSpec().Value.PublicKeyAtLastApply = "pk-current"
+
+				return nil
+			}))
+
+			// The install now proceeds.
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				assert.NotEmpty(collect, machineServices.Get(id).GetLifecycleInstallRequests())
+			}, time.Second*5, 50*time.Millisecond)
 		},
 	)
 }


### PR DESCRIPTION
Without CA and Registry Auth configs install or upgrade might fail.
High priority patches are hashed separately. If hash doesn't match, the flow upgrade -> configure is swapped for the machines which are a part of a cluster.
For not configured machines we now wait until maintenance config controller applies high priority patches.