### PR TITLE
feat: add Auditor role for reading the audit log

### DIFF
--- a/client/pkg/access/role/role.go
+++ b/client/pkg/access/role/role.go
@@ -7,6 +7,7 @@ package role
 
 import (
 	"fmt"
+	"slices"
 )
 
 // Role represents a user role.
@@ -28,6 +29,14 @@ const (
 	// tsgen:RoleReader
 	Reader Role = "Reader"
 
+	// Auditor is a role that has read-only capability, plus the capability to read the audit log.
+	//
+	// Reading the audit log is restricted to this role and Admin, so it is checked by exact role match
+	// rather than by the ordering below.
+	//
+	// tsgen:RoleAuditor
+	Auditor Role = "Auditor"
+
 	// Operator is a role that has read/write capability.
 	//
 	// tsgen:RoleOperator
@@ -39,7 +48,18 @@ const (
 	Admin Role = "Admin"
 )
 
-var roles = []Role{None, InfraProvider, Reader, Operator, Admin}
+var roles = []Role{None, InfraProvider, Reader, Auditor, Operator, Admin}
+
+// AuditLogRoles are the roles allowed to read the audit log.
+//
+// Operator outranks Auditor in the ordering above yet is deliberately absent, so audit log access is
+// checked by exact role rather than by rank. This is the single source of that policy.
+var AuditLogRoles = []Role{Auditor, Admin}
+
+// CanReadAuditLog reports whether the role is allowed to read the audit log.
+func CanReadAuditLog(r Role) bool {
+	return slices.Contains(AuditLogRoles, r)
+}
 
 var indexes = func() map[Role]int {
 	result := make(map[Role]int, len(roles))
@@ -117,6 +137,11 @@ func (r Role) Compare(another Role) int {
 }
 
 // Min returns the least capable role from the given roles.
+//
+// Audit log access is not a point on the ordering: Auditor sits below Operator, yet only Auditor and Admin
+// may read it. Capping by rank alone would therefore grant audit log access to a combination where no input
+// had it, for example an Operator holding a key registered as Auditor. The result keeps audit log access
+// only when every input has it, and falls back to Reader otherwise.
 func Min(first Role, role ...Role) (Role, error) {
 	result := first
 
@@ -125,16 +150,24 @@ func Min(first Role, role ...Role) (Role, error) {
 		return "", fmt.Errorf("unknown first role in min check: %q", first)
 	}
 
+	canReadAuditLog := CanReadAuditLog(first)
+
 	for i, currentRole := range role {
 		currentIndex, currentIndexOk := indexes[currentRole]
 		if !currentIndexOk {
 			return "", fmt.Errorf("unknown role in min check at index %d: %q", i, currentRole)
 		}
 
+		canReadAuditLog = canReadAuditLog && CanReadAuditLog(currentRole)
+
 		if currentIndex < resultIndex {
 			result = currentRole
 			resultIndex = currentIndex
 		}
+	}
+
+	if result == Auditor && !canReadAuditLog {
+		return Reader, nil
 	}
 
 	return result, nil

--- a/client/pkg/access/role/role_test.go
+++ b/client/pkg/access/role/role_test.go
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package role_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/access/role"
+)
+
+var all = []role.Role{role.None, role.InfraProvider, role.Reader, role.Auditor, role.Operator, role.Admin}
+
+func TestParse(t *testing.T) {
+	for _, r := range all {
+		parsed, err := role.Parse(string(r))
+		require.NoError(t, err)
+		assert.Equal(t, r, parsed)
+	}
+
+	_, err := role.Parse("Nonexistent")
+	assert.Error(t, err)
+
+	_, err = role.Parse("")
+	assert.Error(t, err)
+}
+
+// TestCheckMatrix pins the full ordering, so that inserting or reordering a role cannot silently change
+// who satisfies what.
+func TestCheckMatrix(t *testing.T) {
+	// expected[actor][required] reports whether actor satisfies required.
+	expected := map[role.Role]map[role.Role]bool{
+		role.None:          {role.None: true, role.InfraProvider: false, role.Reader: false, role.Auditor: false, role.Operator: false, role.Admin: false},
+		role.InfraProvider: {role.None: true, role.InfraProvider: true, role.Reader: false, role.Auditor: false, role.Operator: false, role.Admin: false},
+		role.Reader:        {role.None: true, role.InfraProvider: true, role.Reader: true, role.Auditor: false, role.Operator: false, role.Admin: false},
+		role.Auditor:       {role.None: true, role.InfraProvider: true, role.Reader: true, role.Auditor: true, role.Operator: false, role.Admin: false},
+		role.Operator:      {role.None: true, role.InfraProvider: true, role.Reader: true, role.Auditor: true, role.Operator: true, role.Admin: false},
+		role.Admin:         {role.None: true, role.InfraProvider: true, role.Reader: true, role.Auditor: true, role.Operator: true, role.Admin: true},
+	}
+
+	for _, actor := range all {
+		for _, required := range all {
+			assert.Equal(t, expected[actor][required], actor.Check(required) == nil,
+				"actor %q checking %q", actor, required)
+		}
+	}
+}
+
+// TestAuditorIsNotWriter is the regression that keeps an Auditor away from write access, and with it away
+// from the OIDC system:masters group, which is granted on a successful Check(Operator).
+func TestAuditorIsNotWriter(t *testing.T) {
+	assert.NoError(t, role.Auditor.Check(role.Reader), "Auditor must retain read access")
+	assert.Error(t, role.Auditor.Check(role.Operator), "Auditor must not satisfy Operator")
+	assert.Error(t, role.Auditor.Check(role.Admin), "Auditor must not satisfy Admin")
+}
+
+// TestOperatorOutranksAuditor documents why audit log access cannot be a threshold check. Operator sits
+// above Auditor in the ordering, so a Check-based gate would hand the audit log to every Operator. The
+// audit log is therefore gated by exact role at its call sites.
+func TestOperatorOutranksAuditor(t *testing.T) {
+	assert.NoError(t, role.Operator.Check(role.Auditor))
+	assert.NoError(t, role.Admin.Check(role.Auditor))
+}
+
+func TestCanReadAuditLog(t *testing.T) {
+	for _, r := range all {
+		want := r == role.Auditor || r == role.Admin
+		assert.Equal(t, want, role.CanReadAuditLog(r), "CanReadAuditLog(%q)", r)
+	}
+
+	assert.False(t, role.CanReadAuditLog(role.Operator),
+		"Operator outranks Auditor but must never read the audit log")
+}
+
+// TestMinDoesNotSynthesizeAuditAccess is the regression for a privilege inversion. Auditor sits below
+// Operator, so capping by rank alone made Min(Operator, Auditor) return Auditor. An Operator could then
+// register a public key as Auditor, or keep an old Auditor key after being changed to Operator, and read
+// the audit log with an effective role neither input legitimately held.
+func TestMinDoesNotSynthesizeAuditAccess(t *testing.T) {
+	for _, other := range []role.Role{role.None, role.InfraProvider, role.Reader, role.Operator} {
+		got, err := role.Min(role.Auditor, other)
+		require.NoError(t, err)
+		assert.False(t, role.CanReadAuditLog(got),
+			"Min(Auditor, %q) = %q must not be able to read the audit log", other, got)
+
+		got, err = role.Min(other, role.Auditor)
+		require.NoError(t, err)
+		assert.False(t, role.CanReadAuditLog(got),
+			"Min(%q, Auditor) = %q must not be able to read the audit log", other, got)
+	}
+
+	// audit access survives only when every input has it.
+	for _, pair := range [][2]role.Role{{role.Auditor, role.Auditor}, {role.Auditor, role.Admin}, {role.Admin, role.Auditor}} {
+		got, err := role.Min(pair[0], pair[1])
+		require.NoError(t, err)
+		assert.Equal(t, role.Auditor, got, "Min(%q, %q)", pair[0], pair[1])
+	}
+}
+
+// TestPrevious pins the ordering as seen by Previous, which the integration auth matrix uses to derive
+// its "insufficient role" cases. Inserting Auditor moves Operator's predecessor from Reader to Auditor,
+// and both are equally valid negative cases because neither satisfies Operator.
+func TestPrevious(t *testing.T) {
+	for _, tt := range []struct {
+		in, want role.Role
+	}{
+		{role.InfraProvider, role.None},
+		{role.Reader, role.InfraProvider},
+		{role.Auditor, role.Reader},
+		{role.Operator, role.Auditor},
+		{role.Admin, role.Operator},
+	} {
+		got, err := tt.in.Previous()
+		require.NoError(t, err)
+		assert.Equal(t, tt.want, got, "Previous(%q)", tt.in)
+	}
+
+	_, err := role.None.Previous()
+	assert.Error(t, err, "the lowest role has no predecessor")
+}
+
+func TestMinMax(t *testing.T) {
+	for _, tt := range []struct {
+		a, b, min, max role.Role
+	}{
+		{role.Reader, role.Admin, role.Reader, role.Admin},
+		{role.Auditor, role.Admin, role.Auditor, role.Admin},
+		{role.Auditor, role.Reader, role.Reader, role.Auditor},
+		// not Auditor: mixing with a role that cannot read the audit log drops that access.
+		{role.Auditor, role.Operator, role.Reader, role.Operator},
+		{role.None, role.Auditor, role.None, role.Auditor},
+	} {
+		minRole, err := role.Min(tt.a, tt.b)
+		require.NoError(t, err)
+		assert.Equal(t, tt.min, minRole, "Min(%q, %q)", tt.a, tt.b)
+
+		maxRole, err := role.Max(tt.a, tt.b)
+		require.NoError(t, err)
+		assert.Equal(t, tt.max, maxRole, "Max(%q, %q)", tt.a, tt.b)
+	}
+}

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -72,6 +72,7 @@ export const InfraProviderServiceAccountDomain = "infra-provider.serviceaccount.
 export const RoleNone = "None";
 export const RoleInfraProvider = "InfraProvider";
 export const RoleReader = "Reader";
+export const RoleAuditor = "Auditor";
 export const RoleOperator = "Operator";
 export const RoleAdmin = "Admin";
 export const DefaultNamespace = "default";

--- a/frontend/src/components/SideBar/TSideBar.vue
+++ b/frontend/src/components/SideBar/TSideBar.vue
@@ -47,7 +47,8 @@ const route = useRoute()
 const { avatar, fullname, identity } = useIdentity()
 
 const { data: featuresConfig } = useFeatures()
-const { canManageBackupStore, canManageUsers, canReadClusters, canReadMachines } = usePermissions()
+const { canManageBackupStore, canManageUsers, canReadAuditLog, canReadClusters, canReadMachines } =
+  usePermissions()
 const isEnterpriseFactory = useIsEnterprise()
 
 const currentCluster = computed(() =>
@@ -268,8 +269,13 @@ const rootItems = computed(() => {
     result.push(item)
   }
 
-  if (canManageUsers.value || (backupStatus.value.configurable && canManageBackupStore.value)) {
-    const subItems: SideBarItem[] = [
+  const canManageSettings =
+    canManageUsers.value || (backupStatus.value.configurable && canManageBackupStore.value)
+
+  const settingsItems: SideBarItem[] = []
+
+  if (canManageSettings) {
+    settingsItems.push(
       {
         name: 'Users',
         route: getRoute('Users', '/settings/users'),
@@ -290,29 +296,33 @@ const rootItems = computed(() => {
         route: getRoute('Backups', '/settings/backups'),
         icon: 'rollback',
       },
-    ]
+    )
+  }
 
-    if (featuresConfig.value?.spec.audit_log_enabled) {
-      subItems.push({
-        name: 'Audit Logs',
-        route: getRoute('AuditLogs', '/settings/audit-logs'),
-        icon: 'document',
-      })
-    }
+  if (featuresConfig.value?.spec.audit_log_enabled && canReadAuditLog.value) {
+    settingsItems.push({
+      name: 'Audit Logs',
+      route: getRoute('AuditLogs', '/settings/audit-logs'),
+      icon: 'document',
+    })
+  }
 
-    if (featuresConfig.value?.spec.stripe_settings?.enabled) {
-      subItems.push({
-        name: 'Billing',
-        route: 'https://billing.stripe.com/p/login/8wMcOC8z51GgdPi144',
-        regularLink: true,
-        icon: 'dashboard',
-      })
-    }
+  if (canManageSettings && featuresConfig.value?.spec.stripe_settings?.enabled) {
+    settingsItems.push({
+      name: 'Billing',
+      route: 'https://billing.stripe.com/p/login/8wMcOC8z51GgdPi144',
+      regularLink: true,
+      icon: 'dashboard',
+    })
+  }
 
+  // an Auditor on an instance with the audit log disabled qualifies for the group but gets no items
+  // in it, and a group with no sub items renders as an inert row.
+  if (settingsItems.length > 0) {
     result.push({
       name: 'Settings',
       icon: 'settings',
-      subItems,
+      subItems: settingsItems,
     })
   }
 

--- a/frontend/src/views/Users/components/RoleEditModal.vue
+++ b/frontend/src/views/Users/components/RoleEditModal.vue
@@ -13,6 +13,7 @@ import type { UserSpec } from '@/api/omni/specs/auth.pb'
 import {
   DefaultNamespace,
   RoleAdmin,
+  RoleAuditor,
   RoleNone,
   RoleOperator,
   RoleReader,
@@ -34,7 +35,7 @@ const open = defineModel<boolean>('open', { default: false })
 
 const { canManageUsers } = usePermissions()
 
-const roles = [RoleNone, RoleReader, RoleOperator, RoleAdmin]
+const roles = [RoleNone, RoleReader, RoleAuditor, RoleOperator, RoleAdmin]
 
 const role = ref<string>()
 const isEditing = ref(false)

--- a/frontend/src/views/Users/components/ServiceAccountCreateModal.vue
+++ b/frontend/src/views/Users/components/ServiceAccountCreateModal.vue
@@ -7,7 +7,7 @@ included in the LICENSE file.
 <script setup lang="ts">
 import { ref, watchEffect } from 'vue'
 
-import { RoleAdmin, RoleNone, RoleOperator, RoleReader } from '@/api/resources'
+import { RoleAdmin, RoleAuditor, RoleNone, RoleOperator, RoleReader } from '@/api/resources'
 import Modal from '@/components/Modals/Modal.vue'
 import TSelectList from '@/components/SelectList/TSelectList.vue'
 import TInput from '@/components/TInput/TInput.vue'
@@ -26,7 +26,7 @@ const open = defineModel<boolean>('open', { default: false })
 
 const { canManageUsers } = usePermissions()
 
-const roles = [RoleNone, RoleReader, RoleOperator, RoleAdmin]
+const roles = [RoleNone, RoleReader, RoleAuditor, RoleOperator, RoleAdmin]
 
 const isCreating = ref(false)
 const name = ref('')

--- a/frontend/src/views/Users/components/UserCreateModal.vue
+++ b/frontend/src/views/Users/components/UserCreateModal.vue
@@ -8,7 +8,7 @@ included in the LICENSE file.
 import { ref, watchEffect } from 'vue'
 
 import { ManagementService } from '@/api/omni/management/management.pb'
-import { RoleAdmin, RoleNone, RoleOperator, RoleReader } from '@/api/resources'
+import { RoleAdmin, RoleAuditor, RoleNone, RoleOperator, RoleReader } from '@/api/resources'
 import Modal from '@/components/Modals/Modal.vue'
 import TSelectList from '@/components/SelectList/TSelectList.vue'
 import TInput from '@/components/TInput/TInput.vue'
@@ -20,7 +20,7 @@ const open = defineModel<boolean>('open', { default: false })
 
 const { canManageUsers } = usePermissions()
 
-const roles = [RoleNone, RoleReader, RoleOperator, RoleAdmin]
+const roles = [RoleNone, RoleReader, RoleAuditor, RoleOperator, RoleAdmin]
 
 const identity = ref('')
 const role = ref(RoleReader)

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -557,7 +557,8 @@ func (s *managementServer) KubernetesUpgradePreChecks(ctx context.Context, req *
 func (s *managementServer) ReadAuditLog(req *management.ReadAuditLogRequest, srv grpc.ServerStreamingServer[management.ReadAuditLogResponse]) error {
 	ctx := srv.Context()
 
-	_, err := s.authCheckGRPC(ctx, auth.WithRole(role.Admin))
+	// checked by exact role, as Operator must not be able to read the audit log despite outranking Auditor.
+	_, err := s.authCheckGRPC(ctx, auth.WithExactRoles(role.AuditLogRoles...))
 	if err != nil {
 		return err
 	}

--- a/internal/backend/grpc/management_auditlog_test.go
+++ b/internal/backend/grpc/management_auditlog_test.go
@@ -63,17 +63,44 @@ func TestReadAuditLogFailsClosedOnAuditError(t *testing.T) {
 	require.Empty(t, stream.sent)
 }
 
-func TestReadAuditLogRequiresAdmin(t *testing.T) {
-	auditor := &auditLogAccessAuditor{}
-	server := newAuditLogTestServer(t, auditor)
+// auditLogRoles covers the whole role ordering. Reading the audit log is allowed for exactly Auditor and
+// Admin, so Operator is denied even though it outranks Auditor.
+var auditLogRoles = []struct {
+	role    role.Role
+	allowed bool
+}{
+	{role.None, false},
+	{role.InfraProvider, false},
+	{role.Reader, false},
+	{role.Auditor, true},
+	{role.Operator, false},
+	{role.Admin, true},
+}
 
-	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "user@example.com", role.Operator)}
+func TestReadAuditLogRequiresAuditorOrAdmin(t *testing.T) {
+	for _, tt := range auditLogRoles {
+		t.Run(string(tt.role), func(t *testing.T) {
+			auditor := &auditLogAccessAuditor{events: [][]byte{[]byte(`{"event_type":"create"}`)}}
+			server := newAuditLogTestServer(t, auditor)
 
-	err := server.ReadAuditLog(&management.ReadAuditLogRequest{}, stream)
-	require.Equal(t, codes.PermissionDenied, status.Code(err))
+			stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "user@example.com", tt.role)}
 
-	require.Nil(t, auditor.accessFilters)
-	require.False(t, auditor.readerCalled)
+			err := server.ReadAuditLog(&management.ReadAuditLogRequest{}, stream)
+
+			if !tt.allowed {
+				require.Equal(t, codes.PermissionDenied, status.Code(err))
+				require.Nil(t, auditor.accessFilters)
+				require.False(t, auditor.readerCalled)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, auditor.accessFilters)
+			require.True(t, auditor.readerCalled)
+			require.Equal(t, [][]byte{[]byte(`{"event_type":"create"}`)}, stream.sent)
+		})
+	}
 }
 
 func TestFollowAuditLogRejectsIncompatibleFields(t *testing.T) {
@@ -111,15 +138,37 @@ func TestFollowAuditLogRejectsIncompatibleFields(t *testing.T) {
 	}
 }
 
-func TestFollowAuditLogRequiresAdmin(t *testing.T) {
-	auditor := &auditLogAccessAuditor{}
-	server := newAuditLogTestServer(t, auditor)
+func TestFollowAuditLogRequiresAuditorOrAdmin(t *testing.T) {
+	for _, tt := range auditLogRoles {
+		if tt.allowed {
+			// the success path needs a lease-bounded reader, which the dedicated follow tests cover.
+			continue
+		}
 
-	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "user@example.com", role.Operator)}
+		t.Run(string(tt.role), func(t *testing.T) {
+			auditor := &auditLogAccessAuditor{}
+			server := newAuditLogTestServer(t, auditor)
+
+			stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "user@example.com", tt.role)}
+
+			err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true}, stream)
+			require.Equal(t, codes.PermissionDenied, status.Code(err))
+			require.Empty(t, stream.numResponses())
+		})
+	}
+}
+
+func TestFollowAuditLogAllowsAuditor(t *testing.T) {
+	auditor := &auditLogAccessAuditor{}
+	server := newAuditLogTestServer(t, auditor, grpcomni.WithAuditLogFollowLease(100*time.Millisecond))
+
+	stream := &auditLogStream{ctx: managementPowerTestContext(t.Context(), "auditor@example.com", role.Auditor)}
 
 	err := server.ReadAuditLog(&management.ReadAuditLogRequest{Follow: true}, stream)
-	require.Equal(t, codes.PermissionDenied, status.Code(err))
-	require.Empty(t, stream.numResponses())
+	require.NoError(t, err, "an Auditor must be allowed to follow the audit log")
+
+	require.True(t, auditor.followAudited)
+	require.Len(t, stream.snapshotResponses(), 1, "the auditor must receive the acknowledgment")
 }
 
 func TestFollowAuditLogFailsClosedOnAuditError(t *testing.T) {

--- a/internal/backend/runtime/omni/validations/auth.go
+++ b/internal/backend/runtime/omni/validations/auth.go
@@ -21,6 +21,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/cosi/labels"
 	authres "github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/validated"
+	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
@@ -152,8 +153,11 @@ func samlLabelRuleValidationOptions() []validated.StateOption {
 			return fmt.Errorf("assignroleonregistration is deprecated, please use assignrole instead")
 		}
 
-		if _, err := role.Parse(res.TypedSpec().Value.AssignRole); err != nil {
+		parsedRole, err := role.Parse(res.TypedSpec().Value.AssignRole)
+		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
+		} else if !auth.RoleAssignableByPolicy(parsedRole) {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("role %q cannot be assigned by a SAML label rule", parsedRole))
 		}
 
 		if _, err := labels.ParseSelectors(res.TypedSpec().Value.GetMatchLabels()); err != nil {

--- a/internal/backend/runtime/omni/validations/state_validation_test.go
+++ b/internal/backend/runtime/omni/validations/state_validation_test.go
@@ -1525,10 +1525,20 @@ func TestSAMLLabelRuleValidation(t *testing.T) {
 	assert.ErrorContains(t, err, "unknown role")
 	assert.ErrorContains(t, err, "invalid match labels")
 
+	// roles that parse but must not be reachable through a SAML label rule. This fails open if the
+	// assignability check is dropped, since both parse successfully.
+	for _, r := range []role.Role{role.Auditor, role.InfraProvider} {
+		labelRule.TypedSpec().Value.AssignRole = string(r)
+
+		err = st.Create(ctx, labelRule)
+		assert.ErrorContains(t, err, "cannot be assigned by a SAML label rule", "role %q", r)
+	}
+
 	labelRule.TypedSpec().Value.AssignRole = string(role.Operator)
 
 	err = st.Create(ctx, labelRule)
 	assert.ErrorContains(t, err, "invalid match labels")
+	assert.NotContains(t, err.Error(), "cannot be assigned by a SAML label rule")
 
 	labelRule.TypedSpec().Value.MatchLabels = []string{"a", "b"}
 

--- a/internal/backend/runtime/omni/virtual/state.go
+++ b/internal/backend/runtime/omni/virtual/state.go
@@ -294,8 +294,11 @@ func (v *State) permissions(ctx context.Context) (*virtual.Permissions, error) {
 	isAdmin := userRole.Check(role.Admin) == nil
 	permissions.TypedSpec().Value.CanManageUsers = isAdmin
 	permissions.TypedSpec().Value.CanManageBackupStore = isAdmin
-	permissions.TypedSpec().Value.CanReadAuditLog = isAdmin
 	permissions.TypedSpec().Value.CanManageJoinTokens = isAdmin
+
+	// audit log access is restricted by exact role, so that Operator does not get it by outranking Auditor.
+	// This shares its definition with the check on the ReadAuditLog RPC so the two cannot drift.
+	permissions.TypedSpec().Value.CanReadAuditLog = role.CanReadAuditLog(userRole)
 
 	if !permissions.TypedSpec().Value.CanCreateClusters {
 		_, err := safe.StateGet[*authres.AccessPolicy](ctx, v.PrimaryState, authres.NewAccessPolicy().Metadata())

--- a/internal/integration/auth_test.go
+++ b/internal/integration/auth_test.go
@@ -456,6 +456,22 @@ func AssertAPIAuthz(rootCtx context.Context, rootCli *client.Client, clientFacto
 		assert.ErrorContainsf(t, err, "insufficient role", "unexpected error: %v", err)
 	}
 
+	// the audit log is gated by exact role rather than by rank, so a denied actor is not "insufficient":
+	// an Operator is rejected while outranking the allowed Auditor.
+	assertDisallowedRoleFailure := func(t *testing.T, err error) {
+		assert.Equalf(t, codes.PermissionDenied, status.Code(err), "unexpected error: %v", err)
+	}
+
+	readAuditLog := func(ctx context.Context, cli *client.Client) error {
+		for _, err := range cli.Management().ReadAuditLog(ctx, nil) {
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
 	return func(t *testing.T) {
 		testCases := []apiAuthzTestCase{
 			// Management API tests - global
@@ -701,21 +717,22 @@ func AssertAPIAuthz(rootCtx context.Context, rootCli *client.Client, clientFacto
 					return err
 				},
 			},
-			// Audit log
+			// Audit log, allowed for an Admin and denied for the Operator right below it.
 			{
 				namePrefix:    "audit-logs",
 				requiredRole:  role.Admin,
 				assertSuccess: assertSuccess,
-				assertFailure: assertMissingRoleFailure,
-				fn: func(ctx context.Context, cli *client.Client) error {
-					for _, err := range cli.Management().ReadAuditLog(ctx, nil) {
-						if err != nil {
-							return err
-						}
-					}
-
-					return nil
-				},
+				assertFailure: assertDisallowedRoleFailure,
+				fn:            readAuditLog,
+			},
+			// The same, for the Auditor the role exists to serve: allowed even though it does not
+			// outrank the rejected Operator above, and denied for the Reader right below it.
+			{
+				namePrefix:    "audit-logs-auditor",
+				requiredRole:  role.Auditor,
+				assertSuccess: assertSuccess,
+				assertFailure: assertDisallowedRoleFailure,
+				fn:            readAuditLog,
 			},
 		}
 

--- a/internal/pkg/auth/accesspolicy/accesspolicy.go
+++ b/internal/pkg/auth/accesspolicy/accesspolicy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	pkgauth "github.com/siderolabs/omni/internal/pkg/auth"
 )
 
 // GroupPrefix is the special prefix used in the AccessPolicy rules to denote a group of users or clusters.
@@ -129,8 +130,11 @@ func Validate(accessPolicy *auth.AccessPolicy) error {
 	// check rules
 	for _, rule := range accessPolicySpec.GetRules() {
 		if rule.Role != "" {
-			if _, err := role.Parse(rule.Role); err != nil {
+			parsedRole, err := role.Parse(rule.Role)
+			if err != nil {
 				validationErrs = multierror.Append(validationErrs, err)
+			} else if !pkgauth.RoleAssignableByPolicy(parsedRole) {
+				validationErrs = multierror.Append(validationErrs, fmt.Errorf("role %q cannot be assigned by an access policy", parsedRole))
 			}
 		}
 	}

--- a/internal/pkg/auth/accesspolicy/accesspolicy_test.go
+++ b/internal/pkg/auth/accesspolicy/accesspolicy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
 
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/auth/accesspolicy"
@@ -163,6 +164,37 @@ func TestInvalidRole(t *testing.T) {
 
 	err := accesspolicy.Validate(accessPolicy)
 	assert.ErrorContains(t, err, "unknown role")
+}
+
+// TestUnassignableRole covers the roles that parse but must not be reachable through an access policy.
+// This fails open if the check is dropped, since both roles parse successfully.
+func TestUnassignableRole(t *testing.T) {
+	for _, r := range []role.Role{role.Auditor, role.InfraProvider} {
+		t.Run(string(r), func(t *testing.T) {
+			accessPolicy := getAccessPolicy(t, aclValidRaw)
+
+			accessPolicy.TypedSpec().Value.Rules[1].Role = string(r)
+
+			err := accesspolicy.Validate(accessPolicy)
+			assert.ErrorContains(t, err, "cannot be assigned by an access policy")
+		})
+	}
+}
+
+// TestAssignableRolesStillAccepted checks only that the assignability check does not fire. The fixture
+// carries its own expectations that a changed rule role trips, so a bare NoError would not isolate this.
+func TestAssignableRolesStillAccepted(t *testing.T) {
+	for _, r := range []role.Role{role.None, role.Reader, role.Operator, role.Admin} {
+		t.Run(string(r), func(t *testing.T) {
+			accessPolicy := getAccessPolicy(t, aclValidRaw)
+
+			accessPolicy.TypedSpec().Value.Rules[1].Role = string(r)
+
+			if err := accesspolicy.Validate(accessPolicy); err != nil {
+				assert.NotContains(t, err.Error(), "cannot be assigned by an access policy")
+			}
+		})
+	}
 }
 
 func getAccessPolicy(t *testing.T, raw []byte) *auth.AccessPolicy {

--- a/internal/pkg/auth/check.go
+++ b/internal/pkg/auth/check.go
@@ -78,6 +78,18 @@ func WithExactRoles(roles ...role.Role) CheckOption {
 	}
 }
 
+// policyAssignableRoles are the roles an access policy or a SAML label rule may assign.
+//
+// This is an allowlist rather than a denylist so that a newly added role is unassignable until someone
+// deliberately allows it. Auditor is absent because audit log access is not expressible as a point on the
+// role ordering, and InfraProvider because it is a service identity rather than a user role.
+var policyAssignableRoles = []role.Role{role.None, role.Reader, role.Operator, role.Admin}
+
+// RoleAssignableByPolicy reports whether an access policy or a SAML label rule may assign the role.
+func RoleAssignableByPolicy(r role.Role) bool {
+	return slices.Contains(policyAssignableRoles, r)
+}
+
 // WithValidSignature checks if the context has a valid signature.
 //
 // If the required role set via WithRole is other than role.None, this setting is ignored and the signature is always checked.
@@ -154,7 +166,9 @@ func Check(ctx context.Context, opt ...CheckOption) (CheckResult, error) {
 		found := slices.Contains(opts.ExactRoles, ctxRole)
 
 		if !found {
-			return CheckResult{}, fmt.Errorf("%w: required exact roles not found", ErrUnauthorized)
+			// deliberately not phrased as an insufficient role: an exact-role check can reject an actor
+			// that outranks every allowed role, which is the point of using one.
+			return CheckResult{}, fmt.Errorf("%w: role %q is not one of the allowed roles %v", ErrUnauthorized, ctxRole, opts.ExactRoles)
 		}
 	} else if opts.Role != role.None {
 		err := ctxRole.Check(opts.Role)


### PR DESCRIPTION
Reading the audit log required the Admin role, so the audit log exporter had to be granted user management and full administrative access to every managed Kubernetes cluster just to consume events.

The new Auditor role grants read access plus the audit log, and nothing else. It is checked by exact role rather than by rank, so an Operator, which outranks an Auditor, still cannot read the audit log. It can be assigned to users and service accounts, but not by access control policies or SAML label rules, which now reject roles that are not meant to be assigned that way. The settings navigation is no longer administrator only, so an Auditor can reach the audit log view.

Part of siderolabs/omni#2985.