### PR TITLE
feat: for kubespan quick start use correct patch for the cluster

### DIFF
--- a/client/api/omni/specs/virtual.pb.go
+++ b/client/api/omni/specs/virtual.pb.go
@@ -995,6 +995,50 @@ func (x *QuirksSpec) GetSupportsEmbeddedConfig() bool {
 	return false
 }
 
+type VersionContractSpec struct {
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	KubeSpanMultidocConfig bool                   `protobuf:"varint,1,opt,name=kube_span_multidoc_config,json=kubeSpanMultidocConfig,proto3" json:"kube_span_multidoc_config,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *VersionContractSpec) Reset() {
+	*x = VersionContractSpec{}
+	mi := &file_omni_specs_virtual_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VersionContractSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VersionContractSpec) ProtoMessage() {}
+
+func (x *VersionContractSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_omni_specs_virtual_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VersionContractSpec.ProtoReflect.Descriptor instead.
+func (*VersionContractSpec) Descriptor() ([]byte, []int) {
+	return file_omni_specs_virtual_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *VersionContractSpec) GetKubeSpanMultidocConfig() bool {
+	if x != nil {
+		return x.KubeSpanMultidocConfig
+	}
+	return false
+}
+
 type LabelsCompletionSpec_Values struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Items         []string               `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
@@ -1004,7 +1048,7 @@ type LabelsCompletionSpec_Values struct {
 
 func (x *LabelsCompletionSpec_Values) Reset() {
 	*x = LabelsCompletionSpec_Values{}
-	mi := &file_omni_specs_virtual_proto_msgTypes[10]
+	mi := &file_omni_specs_virtual_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1016,7 +1060,7 @@ func (x *LabelsCompletionSpec_Values) String() string {
 func (*LabelsCompletionSpec_Values) ProtoMessage() {}
 
 func (x *LabelsCompletionSpec_Values) ProtoReflect() protoreflect.Message {
-	mi := &file_omni_specs_virtual_proto_msgTypes[10]
+	mi := &file_omni_specs_virtual_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1142,7 +1186,9 @@ const file_omni_specs_virtual_proto_rawDesc = "" +
 	"QuirksSpec\x12<\n" +
 	"\x1asupports_unified_installer\x18\x01 \x01(\bR\x18supportsUnifiedInstaller\x12:\n" +
 	"\x19supports_factory_talosctl\x18\x02 \x01(\bR\x17supportsFactoryTalosctl\x128\n" +
-	"\x18supports_embedded_config\x18\x03 \x01(\bR\x16supportsEmbeddedConfigB2Z0github.com/siderolabs/omni/client/api/omni/specsb\x06proto3"
+	"\x18supports_embedded_config\x18\x03 \x01(\bR\x16supportsEmbeddedConfig\"P\n" +
+	"\x13VersionContractSpec\x129\n" +
+	"\x19kube_span_multidoc_config\x18\x01 \x01(\bR\x16kubeSpanMultidocConfigB2Z0github.com/siderolabs/omni/client/api/omni/specsb\x06proto3"
 
 var (
 	file_omni_specs_virtual_proto_rawDescOnce sync.Once
@@ -1157,7 +1203,7 @@ func file_omni_specs_virtual_proto_rawDescGZIP() []byte {
 }
 
 var file_omni_specs_virtual_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_omni_specs_virtual_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_omni_specs_virtual_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_omni_specs_virtual_proto_goTypes = []any{
 	(PlatformConfigSpec_BootMethod)(0),  // 0: specs.PlatformConfigSpec.BootMethod
 	(PlatformConfigSpec_Arch)(0),        // 1: specs.PlatformConfigSpec.Arch
@@ -1171,15 +1217,16 @@ var file_omni_specs_virtual_proto_goTypes = []any{
 	(*OfficeHoursConfig)(nil),           // 9: specs.OfficeHoursConfig
 	(*SupportSpec)(nil),                 // 10: specs.SupportSpec
 	(*QuirksSpec)(nil),                  // 11: specs.QuirksSpec
-	(*LabelsCompletionSpec_Values)(nil), // 12: specs.LabelsCompletionSpec.Values
-	nil,                                 // 13: specs.LabelsCompletionSpec.ItemsEntry
+	(*VersionContractSpec)(nil),         // 12: specs.VersionContractSpec
+	(*LabelsCompletionSpec_Values)(nil), // 13: specs.LabelsCompletionSpec.Values
+	nil,                                 // 14: specs.LabelsCompletionSpec.ItemsEntry
 }
 var file_omni_specs_virtual_proto_depIdxs = []int32{
-	13, // 0: specs.LabelsCompletionSpec.items:type_name -> specs.LabelsCompletionSpec.ItemsEntry
+	14, // 0: specs.LabelsCompletionSpec.items:type_name -> specs.LabelsCompletionSpec.ItemsEntry
 	1,  // 1: specs.PlatformConfigSpec.architectures:type_name -> specs.PlatformConfigSpec.Arch
 	0,  // 2: specs.PlatformConfigSpec.boot_methods:type_name -> specs.PlatformConfigSpec.BootMethod
 	9,  // 3: specs.SupportSpec.office_hours:type_name -> specs.OfficeHoursConfig
-	12, // 4: specs.LabelsCompletionSpec.ItemsEntry.value:type_name -> specs.LabelsCompletionSpec.Values
+	13, // 4: specs.LabelsCompletionSpec.ItemsEntry.value:type_name -> specs.LabelsCompletionSpec.Values
 	5,  // [5:5] is the sub-list for method output_type
 	5,  // [5:5] is the sub-list for method input_type
 	5,  // [5:5] is the sub-list for extension type_name
@@ -1198,7 +1245,7 @@ func file_omni_specs_virtual_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_omni_specs_virtual_proto_rawDesc), len(file_omni_specs_virtual_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/client/api/omni/specs/virtual.proto
+++ b/client/api/omni/specs/virtual.proto
@@ -114,3 +114,7 @@ message QuirksSpec {
   bool supports_factory_talosctl = 2;
   bool supports_embedded_config = 3;
 }
+
+message VersionContractSpec {
+  bool kube_span_multidoc_config = 1;
+}

--- a/client/api/omni/specs/virtual_vtproto.pb.go
+++ b/client/api/omni/specs/virtual_vtproto.pb.go
@@ -279,6 +279,23 @@ func (m *QuirksSpec) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *VersionContractSpec) CloneVT() *VersionContractSpec {
+	if m == nil {
+		return (*VersionContractSpec)(nil)
+	}
+	r := new(VersionContractSpec)
+	r.KubeSpanMultidocConfig = m.KubeSpanMultidocConfig
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *VersionContractSpec) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *CurrentUserSpec) EqualVT(that *CurrentUserSpec) bool {
 	if this == that {
 		return true
@@ -680,6 +697,25 @@ func (this *QuirksSpec) EqualVT(that *QuirksSpec) bool {
 
 func (this *QuirksSpec) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*QuirksSpec)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *VersionContractSpec) EqualVT(that *VersionContractSpec) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.KubeSpanMultidocConfig != that.KubeSpanMultidocConfig {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *VersionContractSpec) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*VersionContractSpec)
 	if !ok {
 		return false
 	}
@@ -1675,6 +1711,49 @@ func (m *QuirksSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *VersionContractSpec) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *VersionContractSpec) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *VersionContractSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.KubeSpanMultidocConfig {
+		i--
+		if m.KubeSpanMultidocConfig {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *CurrentUserSpec) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -2018,6 +2097,19 @@ func (m *QuirksSpec) SizeVT() (n int) {
 		n += 2
 	}
 	if m.SupportsEmbeddedConfig {
+		n += 2
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *VersionContractSpec) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.KubeSpanMultidocConfig {
 		n += 2
 	}
 	n += len(m.unknownFields)
@@ -4362,6 +4454,77 @@ func (m *QuirksSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.SupportsEmbeddedConfig = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *VersionContractSpec) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: VersionContractSpec: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: VersionContractSpec: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KubeSpanMultidocConfig", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.KubeSpanMultidocConfig = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/client/pkg/omni/resources/virtual/version_contract.go
+++ b/client/pkg/omni/resources/virtual/version_contract.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package virtual
+
+import (
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource/protobuf"
+	"github.com/cosi-project/runtime/pkg/resource/typed"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
+)
+
+// NewVersionContract creates a new VersionContract resource.
+func NewVersionContract(id string) *VersionContract {
+	return typed.NewResource[VersionContractSpec, VersionContractExtension](
+		resource.NewMetadata(resources.VirtualNamespace, VersionContractType, id, resource.VersionUndefined),
+		protobuf.NewResourceSpec(&specs.VersionContractSpec{}),
+	)
+}
+
+const (
+	// VersionContractType is the type of VersionContract resource.
+	//
+	// tsgen:VersionContractType
+	VersionContractType = resource.Type("VersionContract.omni.sidero.dev")
+)
+
+// VersionContract resource describes the current Stripe subscription plan.
+type VersionContract = typed.Resource[VersionContractSpec, VersionContractExtension]
+
+// VersionContractSpec wraps specs.VersionContractSpec.
+type VersionContractSpec = protobuf.ResourceSpec[specs.VersionContractSpec, *specs.VersionContractSpec]
+
+// VersionContractExtension provides auxiliary methods for VersionContract resource.
+type VersionContractExtension struct{}
+
+// ResourceDefinition implements [typed.Extension] interface.
+func (VersionContractExtension) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             VersionContractType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: resources.VirtualNamespace,
+		PrintColumns:     []meta.PrintColumn{},
+	}
+}

--- a/frontend/src/api/omni/specs/virtual.pb.ts
+++ b/frontend/src/api/omni/specs/virtual.pb.ts
@@ -114,3 +114,7 @@ export type QuirksSpec = {
   supports_factory_talosctl?: boolean
   supports_embedded_config?: boolean
 }
+
+export type VersionContractSpec = {
+  kube_span_multidoc_config?: boolean
+}

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -308,6 +308,7 @@ export const QuirksType = "Quirks.omni.sidero.dev";
 export const SBCConfigType = "SBCConfigs.omni.sidero.dev";
 export const SupportID = "support";
 export const SupportType = "Supports.omni.sidero.dev";
+export const VersionContractType = "VersionContract.omni.sidero.dev";
 export const MetalNetworkPlatformConfig = 10;
 export const LabelsMeta = 12;
 export const NamespaceType = "Namespaces.meta.cosi.dev";

--- a/frontend/src/views/KubeSpanStatus/KubeSpanStatusQuickStart.stories.ts
+++ b/frontend/src/views/KubeSpanStatus/KubeSpanStatusQuickStart.stories.ts
@@ -6,31 +6,89 @@ import { createWatchStreamHandler } from '@msw/helpers.ts'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { http, HttpResponse } from 'msw'
 
-import type { ClusterSpec, ClusterStatusSpec } from '@/api/omni/specs/omni.pb.ts'
-import type { ClusterPermissionsSpec } from '@/api/omni/specs/virtual.pb.ts'
+import type { Resource } from '@/api/grpc.ts'
+import type { GetRequest, GetResponse } from '@/api/omni/resources/resources.pb.ts'
+import type {
+  ClusterConfigVersionSpec,
+  ClusterSpec,
+  ClusterStatusSpec,
+} from '@/api/omni/specs/omni.pb.ts'
+import type { ClusterPermissionsSpec, VersionContractSpec } from '@/api/omni/specs/virtual.pb.ts'
 import {
+  ClusterConfigVersionType,
+  ClusterPermissionsType,
   ClusterStatusType,
   ClusterType,
   DefaultNamespace,
+  VersionContractType,
   VirtualNamespace,
 } from '@/api/resources.ts'
 
 import KubeSpanStatusQuickStart from './KubeSpanStatusQuickStart.vue'
 
 const clusterId = 'my-cluster'
+const talosVersion = 'v1.10.0'
 
 const clusterHandler = createWatchStreamHandler<ClusterSpec>({
   expectedOptions: {
     namespace: DefaultNamespace,
     type: ClusterType,
+    id: clusterId,
   },
   initialResources: [
     {
-      spec: { talos_version: 'v1.10.0' },
-      metadata: { namespace: DefaultNamespace, type: ClusterType, id: clusterId },
+      spec: {
+        talos_version: talosVersion,
+      },
+      metadata: {
+        namespace: DefaultNamespace,
+        type: ClusterType,
+        id: clusterId,
+      },
     },
   ],
 }).handler
+
+const clusterConfigHandler = createWatchStreamHandler<ClusterConfigVersionSpec>({
+  expectedOptions: {
+    namespace: DefaultNamespace,
+    type: ClusterConfigVersionType,
+    id: clusterId,
+  },
+  initialResources: [
+    {
+      spec: { version: talosVersion },
+      metadata: {
+        namespace: DefaultNamespace,
+        type: ClusterConfigVersionType,
+        id: clusterId,
+      },
+    },
+  ],
+}).handler
+
+function versionContractHandler(spec: VersionContractSpec) {
+  return http.post<never, GetRequest, GetResponse>(
+    '/omni.resources.ResourceService/Get',
+    async ({ request }) => {
+      const { id, type, namespace } = await request.clone().json()
+
+      if (id !== talosVersion || type !== VersionContractType || namespace !== VirtualNamespace)
+        return
+
+      return HttpResponse.json({
+        body: JSON.stringify({
+          metadata: {
+            namespace: VirtualNamespace,
+            type: VersionContractType,
+            id: talosVersion,
+          },
+          spec,
+        } as Resource<VersionContractSpec>),
+      })
+    },
+  )
+}
 
 function clusterStatusHandler(total: number) {
   return createWatchStreamHandler<ClusterStatusSpec>({
@@ -48,13 +106,25 @@ function clusterStatusHandler(total: number) {
 }
 
 function permissionsHandler(spec: ClusterPermissionsSpec) {
-  return http.post('/omni.resources.ResourceService/Get', () =>
-    HttpResponse.json({
-      body: JSON.stringify({
-        metadata: { namespace: VirtualNamespace, id: clusterId },
-        spec,
-      }),
-    }),
+  return http.post<never, GetRequest, GetResponse>(
+    '/omni.resources.ResourceService/Get',
+    async ({ request }) => {
+      const { id, type, namespace } = await request.clone().json()
+
+      if (id !== clusterId || type !== ClusterPermissionsType || namespace !== VirtualNamespace)
+        return
+
+      return HttpResponse.json({
+        body: JSON.stringify({
+          metadata: {
+            namespace: VirtualNamespace,
+            type: ClusterPermissionsType,
+            id: clusterId,
+          },
+          spec,
+        } as Resource<ClusterPermissionsSpec>),
+      })
+    },
   )
 }
 
@@ -81,8 +151,24 @@ export const Default = {
   parameters: {
     msw: {
       handlers: [
+        versionContractHandler({ kube_span_multidoc_config: true }),
         permissionsHandler({ can_manage_config_patches: true }),
         clusterHandler,
+        clusterConfigHandler,
+        clusterStatusHandler(6),
+      ],
+    },
+  },
+} satisfies Story
+
+export const NoMultidoc = {
+  parameters: {
+    msw: {
+      handlers: [
+        versionContractHandler({ kube_span_multidoc_config: false }),
+        permissionsHandler({ can_manage_config_patches: true }),
+        clusterHandler,
+        clusterConfigHandler,
         clusterStatusHandler(6),
       ],
     },
@@ -93,8 +179,10 @@ export const ReadOnly = {
   parameters: {
     msw: {
       handlers: [
+        versionContractHandler({ kube_span_multidoc_config: true }),
         permissionsHandler({ can_manage_config_patches: false }),
         clusterHandler,
+        clusterConfigHandler,
         clusterStatusHandler(6),
       ],
     },
@@ -105,8 +193,10 @@ export const LargeCluster = {
   parameters: {
     msw: {
       handlers: [
+        versionContractHandler({ kube_span_multidoc_config: true }),
         permissionsHandler({ can_manage_config_patches: true }),
         clusterHandler,
+        clusterConfigHandler,
         clusterStatusHandler(64),
       ],
     },

--- a/frontend/src/views/KubeSpanStatus/KubeSpanStatusQuickStart.vue
+++ b/frontend/src/views/KubeSpanStatus/KubeSpanStatusQuickStart.vue
@@ -12,15 +12,24 @@ import { RequestError } from '@/api/fetch.pb'
 import { Code } from '@/api/google/rpc/code.pb'
 import type { Resource } from '@/api/grpc'
 import { ResourceService } from '@/api/grpc'
-import type { ClusterSpec, ClusterStatusSpec, ConfigPatchSpec } from '@/api/omni/specs/omni.pb'
+import type {
+  ClusterConfigVersionSpec,
+  ClusterSpec,
+  ClusterStatusSpec,
+  ConfigPatchSpec,
+} from '@/api/omni/specs/omni.pb'
+import type { VersionContractSpec } from '@/api/omni/specs/virtual.pb'
 import { withRuntime } from '@/api/options'
 import {
+  ClusterConfigVersionType,
   ClusterStatusType,
   ClusterType,
   ConfigPatchName,
   ConfigPatchType,
   DefaultNamespace,
   LabelCluster,
+  VersionContractType,
+  VirtualNamespace,
 } from '@/api/resources'
 import TButton from '@/components/Button/TButton.vue'
 import CodeBlock from '@/components/CodeBlock/CodeBlock.vue'
@@ -32,6 +41,7 @@ import PageContainer from '@/components/PageContainer/PageContainer.vue'
 import TAlert from '@/components/TAlert.vue'
 import { getDocsLink } from '@/methods'
 import { useClusterPermissions } from '@/methods/auth'
+import { useResourceGet } from '@/methods/useResourceGet'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError, showSuccess } from '@/notification'
 
@@ -50,7 +60,26 @@ const { data: cluster } = useResourceWatch<ClusterSpec>(() => ({
   },
 }))
 
-const talosVersion = computed(() => cluster.value?.spec.talos_version)
+const { data: clusterConfig } = useResourceWatch<ClusterConfigVersionSpec>(() => ({
+  resource: {
+    namespace: DefaultNamespace,
+    type: ClusterConfigVersionType,
+    id: clusterId,
+  },
+  runtime: Runtime.Omni,
+}))
+
+const talosVersion = computed(() => clusterConfig.value?.spec.version)
+
+const { data: versionContract } = useResourceGet<VersionContractSpec>(() => ({
+  skip: !talosVersion.value,
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: VirtualNamespace,
+    type: VersionContractType,
+    id: talosVersion.value,
+  },
+}))
 
 const { data: clusterStatus } = useResourceWatch<ClusterStatusSpec>(() => ({
   runtime: Runtime.Omni,
@@ -91,7 +120,16 @@ const features: { icon: IconType; title: string; description: string }[] = [
 // The Talos machine config patch that enables KubeSpan for the whole cluster.
 // Cluster discovery must be enabled for KubeSpan to work; it is on by default,
 // but we set it explicitly to be safe.
-const kubeSpanPatch = `machine:
+const kubeSpanPatch = computed(() => {
+  if (!versionContract.value) return
+
+  if (versionContract.value.spec.kube_span_multidoc_config) {
+    return `apiVersion: v1alpha1
+kind: KubeSpanConfig
+enabled: true`
+  }
+
+  return `machine:
   network:
     kubespan:
       enabled: true
@@ -99,6 +137,7 @@ cluster:
   discovery:
     enabled: true
 `
+})
 
 const confirmOpen = ref(false)
 const enabling = ref(false)
@@ -120,7 +159,7 @@ async function enableKubeSpan() {
       },
     },
     spec: {
-      data: kubeSpanPatch,
+      data: kubeSpanPatch.value,
     },
   }
 
@@ -210,13 +249,13 @@ async function enableKubeSpan() {
             </p>
           </div>
 
-          <CodeBlock>{{ kubeSpanPatch }}</CodeBlock>
+          <CodeBlock v-if="kubeSpanPatch">{{ kubeSpanPatch }}</CodeBlock>
 
           <div class="flex flex-wrap items-center gap-3">
             <TButton
               variant="highlighted"
               icon="cloud-connection"
-              :disabled="!canManageConfigPatches || requested"
+              :disabled="!kubeSpanPatch || !canManageConfigPatches || requested"
               @click="confirmOpen = true"
             >
               {{ requested ? 'KubeSpan enabling…' : 'Enable KubeSpan' }}

--- a/internal/backend/runtime/omni/state_access.go
+++ b/internal/backend/runtime/omni/state_access.go
@@ -510,6 +510,7 @@ func filterAccess(ctx context.Context, access state.Access) error {
 		virtual.CurrentUserType,
 		virtual.ClusterPermissionsType,
 		virtual.QuirksType,
+		virtual.VersionContractType,
 		virtual.PermissionsType:
 		// allow access with just valid signature
 		_, err = auth.CheckGRPC(ctx, auth.WithValidSignature(true))
@@ -680,6 +681,7 @@ func filterAccessByType(access state.Access) error {
 		virtual.KubernetesUsageType,
 		virtual.LabelsCompletionType,
 		virtual.QuirksType,
+		virtual.VersionContractType,
 		virtual.ClusterPermissionsType:
 		// allow read access only. these resources are either managed by controllers or plugins (e.g., infra provider plugins)
 		if access.Verb.Readonly() {

--- a/internal/backend/runtime/omni/virtual/state.go
+++ b/internal/backend/runtime/omni/virtual/state.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	machineryConfig "github.com/siderolabs/talos/pkg/machinery/config"
 	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	"github.com/stripe/stripe-go/v85"
 	"go.uber.org/zap"
@@ -134,6 +135,8 @@ func (v *State) Get(ctx context.Context, ptr resource.Pointer, opts ...state.Get
 		return v.support(ctx, ptr)
 	case virtual.QuirksType:
 		return v.quirks(ctx, ptr)
+	case virtual.VersionContractType:
+		return v.versionContract(ctx, ptr)
 	default:
 		return nil, stateerrors.ErrUnsupported(fmt.Errorf("unsupported resource type for get %q", ptr.Type()))
 	}
@@ -473,6 +476,29 @@ func (v *State) quirks(_ context.Context, ptr resource.Pointer) (*virtual.Quirks
 		SupportsUnifiedInstaller: q.SupportsUnifiedInstaller(),
 		SupportsFactoryTalosctl:  q.SupportsFactoryTalosctlDownload(),
 		SupportsEmbeddedConfig:   q.SupportsEmbeddedConfig(),
+	}
+
+	return res, nil
+}
+
+func (v *State) versionContract(_ context.Context, ptr resource.Pointer) (*virtual.VersionContract, error) {
+	res := virtual.NewVersionContract(ptr.ID())
+
+	version, err := resource.ParseVersion("1")
+	if err != nil {
+		return nil, err
+	}
+
+	var vc *machineryConfig.VersionContract
+
+	vc, err = machineryConfig.ParseContractFromVersion(ptr.ID())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse contract from version: %w", err)
+	}
+
+	res.Metadata().SetVersion(version)
+	res.TypedSpec().Value = &specs.VersionContractSpec{
+		KubeSpanMultidocConfig: vc.KubeSpanMultidocConfig(),
 	}
 
 	return res, nil


### PR DESCRIPTION
For the KubeSpan quick start component, check if the cluster supports multi-doc kubespan configs, and if so, suggest that as the patch.

<img width="1014" height="567" alt="image" src="https://github.com/user-attachments/assets/ece6de36-e1fd-4209-976d-3f8b7a32bf61" />
