### PR TITLE
fix: respect the user's install disk selection in maintenance installs

### DIFF
--- a/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
@@ -64,6 +64,11 @@ const blockdevices = computed(() => item.spec.hardware?.blockdevices || [])
 const systemDiskPath = computed(
   () => blockdevices.value.find((device) => device.system_disk)?.linux_name,
 )
+
+// TODO: This filter is a diverged copy of the backend's install disk candidate logic, which also
+//       filters by minimum size and virtual bus path and puts USB disks last. The filtering should be
+//       centralized on the backend. See internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+//       and https://github.com/siderolabs/omni/issues/3199.
 const disks = computed(() =>
   blockdevices.value
     .filter((device) => !device.readonly && device.type !== 'CD')

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
@@ -97,12 +97,27 @@ func GenInstallConfig(machineStatus *omni.MachineStatus, clusterMachineTalosVers
 		)
 	}
 
+	// TODO: This logic does not take the user's install disk selection into account.
+	//       If there's an existing system disk, it picks it as the install disk (which is a no-op after installation anyway),
+	//       otherwise, it runs the disk selection logic to pick the most suitable disk.
+	//       The user's install disk preference is a config patch (.machine.install.disk) at the moment,
+	//       so it is read later from the merged machine config, in machineconfig.BuildReconciliationContext.
+	//       When we introduce a first-class resource for the install disk, e.g., MachineInstallDiskConfig,
+	//       we should probably read it already here and apply the override it contains.
+	//       See https://github.com/siderolabs/omni/issues/3199.
+
 	if machineStatus.TypedSpec().Value.Hardware == nil {
 		return
 	}
 
 	installDisk := omni.GetMachineStatusSystemDisk(machineStatus)
 
+	// Base install disk determination: not read only, above the min size, not virtual, etc.
+	//
+	// TODO: The frontend disk dropdown has a diverged copy of this candidate filtering (it only excludes
+	//       read-only and CD devices), while the default disk itself is already read from this resource.
+	//       The filtering should be centralized on the backend.
+	//       See frontend/src/views/Clusters/Management/ClusterMachineItem.vue and https://github.com/siderolabs/omni/issues/3199.
 	if installDisk == "" {
 		const transportUSB = "usb"
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
@@ -136,7 +136,7 @@ func (rc *ReconciliationContext) ID() string {
 
 // BuildReconciliationContext is the COSI reader dependent method to build the reconciliation context.
 //
-//nolint:gocognit,gocyclo,cyclop
+//nolint:gocognit,gocyclo,cyclop,maintidx
 func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 	machineConfig *omni.ClusterMachineConfig, machineConfigStatus *omni.ClusterMachineConfigStatus,
 ) (*ReconciliationContext, error) {
@@ -234,7 +234,21 @@ func BuildReconciliationContext(ctx context.Context, r controller.Reader,
 		return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("%q install image not found", machineConfig.Metadata().ID())
 	}
 
+	// Start with the automatically picked default install disk, then let the merged machine config
+	// override it: the config carries the user's install disk config patch (.machine.install.disk),
+	// while MachineConfigGenOptions only carries the default.
+	//
+	// TODO: This is an interim fix to respect the user's disk selection.
+	//       Since .machine.install is deprecated for removal, the install disk should stop being
+	//       managed through a config patch and become a first-class resource instead.
+	//       See https://github.com/siderolabs/omni/issues/3199.
 	rc.installDisk = genOptions.TypedSpec().Value.InstallDisk
+
+	// Machine() is nil when the config carries no v1alpha1 document.
+	// Install() is never nil, it returns an empty section when the config has none.
+	if m := config.Machine(); m != nil && m.Install().Disk() != "" {
+		rc.installDisk = m.Install().Disk()
+	}
 
 	schematicMismatch := false
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -1066,6 +1067,66 @@ func TestMachineConfigStatusController(t *testing.T) {
 		)
 	})
 
+	// maintenanceInstallConfigDisk verifies which disk a maintenance install targets: the disk in the
+	// merged machine config (where the user's install disk patch lands) wins over the automatically
+	// picked default on MachineConfigGenOptions, and the default is used when the config carries no
+	// install disk.
+	t.Run("maintenanceInstallConfigDisk", func(t *testing.T) {
+		t.Parallel()
+
+		for i, tt := range []struct {
+			name         string
+			genOptsDisk  string
+			configDisk   string
+			expectedDisk string
+		}{
+			{name: "config disk overrides default", genOptsDisk: "/dev/vda", configDisk: "/dev/vdb", expectedDisk: "/dev/vdb"},
+			{name: "no config disk falls back to default", genOptsDisk: "/dev/vda", configDisk: "", expectedDisk: "/dev/vda"},
+			{name: "config disk works without default", genOptsDisk: "", configDisk: "/dev/vdb", expectedDisk: "/dev/vdb"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+				t.Cleanup(cancel)
+
+				clusterName := fmt.Sprintf("maint-install-config-disk-%d", i)
+				bootID := fmt.Sprintf("boot-before-install-%d", i)
+
+				testutils.WithRuntime(
+					ctx, t, testutils.TestOptions{},
+					func(_ context.Context, tc testutils.TestContext) {
+						require.NoError(t, tc.Runtime.RegisterQController(
+							machineconfig.NewStatusController(testutils.NewLifecycleManager(t, tc.State, nil)),
+						))
+					},
+					func(ctx context.Context, tc testutils.TestContext) {
+						st := tc.State
+						machineServices := testutils.NewMachineServices(t, st)
+
+						id := setupMaintenanceMachineWithHook(ctx, t, st, machineServices, clusterName, false, bootID, func(id string) {
+							setConfigInstallDisk(ctx, t, st, id, tt.configDisk)
+
+							rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+								res.TypedSpec().Value.InstallDisk = tt.genOptsDisk
+
+								return nil
+							}))
+						})
+
+						rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+							a.Equal(bootID, res.TypedSpec().Value.PreRebootBootId)
+						})
+
+						installs := machineServices.Get(id).GetLifecycleInstallRequests()
+						require.NotEmpty(t, installs)
+						assert.Equal(t, tt.expectedDisk, installs[0].GetDestination().GetDisk())
+					},
+				)
+			})
+		}
+	})
+
 	// maintenanceUpgrade verifies a maintenance machine that already has Talos on disk gets a
 	// LifecycleService.Upgrade (not Install).
 	t.Run("maintenanceUpgrade", func(t *testing.T) {
@@ -2031,6 +2092,17 @@ func setupMaintenanceMachine(
 	clusterName string, hasSystemDisk bool, bootID string,
 	configureService ...func(*testutils.MachineServiceMock),
 ) string {
+	return setupMaintenanceMachineWithHook(ctx, t, st, machineServices, clusterName, hasSystemDisk, bootID, nil, configureService...)
+}
+
+// setupMaintenanceMachineWithHook is setupMaintenanceMachine with a hook that runs right before the
+// trigger resources are mocked, i.e. before the controller can start the install/upgrade operation.
+func setupMaintenanceMachineWithHook(
+	ctx context.Context, t *testing.T, st state.State, machineServices *testutils.MachineServices,
+	clusterName string, hasSystemDisk bool, bootID string,
+	beforeTrigger func(id string),
+	configureService ...func(*testutils.MachineServiceMock),
+) string {
 	_, machines := createCluster(
 		ctx, t, st, machineServices, clusterName, 1, 0,
 		withMachineStatusModifier(func(res *omni.MachineStatus) error {
@@ -2060,6 +2132,10 @@ func setupMaintenanceMachine(
 		return nil
 	}))
 
+	if beforeTrigger != nil {
+		beforeTrigger(id)
+	}
+
 	// The maintenance config controller has applied its config for the current connection, so the
 	// install/upgrade gate in reconcileUpgrade is open.
 	markMaintenanceConfigApplied(ctx, t, st, id)
@@ -2072,6 +2148,44 @@ func setupMaintenanceMachine(
 	}))
 
 	return id
+}
+
+// setConfigInstallDisk replaces the install disk in the machine's merged config.
+// An empty disk removes the install section from the config entirely.
+func setConfigInstallDisk(ctx context.Context, t *testing.T, st state.State, id, disk string) {
+	rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.ClusterMachineConfig) error {
+		buf, err := res.TypedSpec().Value.GetUncompressedData()
+		if err != nil {
+			return err
+		}
+
+		defer buf.Free()
+
+		cfg, err := configloader.NewFromBytes(buf.Data())
+		if err != nil {
+			return err
+		}
+
+		patched, err := cfg.PatchV1Alpha1(func(c *v1alpha1.Config) error {
+			if disk == "" {
+				c.MachineConfig.MachineInstall = nil
+			} else {
+				c.MachineConfig.MachineInstall.InstallDisk = disk
+			}
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		data, err := patched.EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
+		if err != nil {
+			return err
+		}
+
+		return res.TypedSpec().Value.SetUncompressedData(data)
+	}))
 }
 
 // markMaintenanceConfigApplied sets up a machine so the status controller's maintenance install/upgrade


### PR DESCRIPTION
Talos 1.13+ machines are installed through the lifecycle API, which receives the install disk explicitly instead of reading it from the applied machine config. The disk passed there was the automatically picked default, so an install disk selected by the user through the UI or a cluster template was silently ignored.

Read the effective install disk from the final machine config, where the user's selection is already applied on top of the default, and pass that to the install operation.

This is an interim fix. A first-class resource will replace the config patch based disk selection later. Part of siderolabs/omni#3199.
