### PR TITLE
fix: track namespaced cluster-scoped manifests as applied

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
@@ -358,22 +358,22 @@ func (ctrl *ClusterManifestsStatusController) updateStatus(
 				omniconsts.SSAOmniUserInventory,
 				omniconsts.SSAOmniOneTimeSyncInventory,
 			} {
+				manifests := manifestsByInventory[inventory]
+
 				inv, err := ssa.GetInventory(ctx, client.Clientset(), constants.KubernetesInventoryNamespace, inventory)
 				if err != nil {
 					return fmt.Errorf("failed to get inventory %q: %w", inventory, err)
 				}
 
 				for _, obj := range inv.Get() {
-					id := utils.FmtObjMetadata(obj)
+					id, groupName, ok := manifestGroupForObject(obj, manifestsGroups, manifests)
+					if !ok {
+						continue
+					}
 
 					objMetadata := object.ObjMetadata(obj)
 
 					visited[id] = struct{}{}
-
-					groupName, ok := manifestsGroups[id]
-					if !ok {
-						continue
-					}
 
 					_, err = getResource(id, objMetadata)
 					if err != nil {
@@ -531,9 +531,9 @@ func (ctrl *ClusterManifestsStatusController) sync(
 	})
 
 	for _, change := range changes {
-		group := groups[change.Subject]
+		id, group, _ := manifestGroupForObject(change.ObjMetadata, groups, objects)
 
-		obj := objectsMap[change.Subject]
+		obj := objectsMap[id]
 		if obj == nil {
 			continue
 		}
@@ -557,6 +557,35 @@ func (ctrl *ClusterManifestsStatusController) sync(
 	}
 
 	return nil
+}
+
+func manifestGroupForObject(
+	obj fluxobject.ObjMetadata,
+	groups map[string]string,
+	manifests []*unstructured.Unstructured,
+) (string, string, bool) {
+	id := utils.FmtObjMetadata(obj)
+
+	group, ok := groups[id]
+	if ok || obj.Namespace != "" {
+		return id, group, ok
+	}
+
+	for _, manifest := range manifests {
+		manifestObj := fluxobject.UnstructuredToObjMetadata(manifest)
+		if manifestObj.GroupKind != obj.GroupKind || manifestObj.Name != obj.Name {
+			continue
+		}
+
+		manifestID := utils.FmtObjMetadata(manifestObj)
+		group, ok = groups[manifestID]
+
+		if ok {
+			return manifestID, group, true
+		}
+	}
+
+	return id, "", false
 }
 
 func webhookError(err error) bool {

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package kubernetes //nolint:testpackage // exercises unexported manifestGroupForObject.
+
+import (
+	"testing"
+
+	fluxobject "github.com/fluxcd/cli-utils/pkg/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestManifestGroupForClusterScopedObjectWithNamespace(t *testing.T) {
+	manifest := &unstructured.Unstructured{}
+	manifest.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "example.dev",
+		Version: "v1",
+		Kind:    "Widget",
+	})
+	manifest.SetNamespace("test")
+	manifest.SetName("example")
+
+	const manifestID = "Widget/test/example"
+
+	groups := map[string]string{manifestID: "test-group"}
+
+	id, group, ok := manifestGroupForObject(fluxobject.ObjMetadata{
+		GroupKind: manifest.GroupVersionKind().GroupKind(),
+		Name:      manifest.GetName(),
+	}, groups, []*unstructured.Unstructured{manifest})
+
+	require.True(t, ok)
+	assert.Equal(t, manifestID, id)
+	assert.Equal(t, "test-group", group)
+}
+
+func TestManifestGroupForObjectDoesNotIgnoreNamespaceForNamespacedObject(t *testing.T) {
+	manifest := &unstructured.Unstructured{}
+	manifest.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "example.dev",
+		Version: "v1",
+		Kind:    "Widget",
+	})
+	manifest.SetNamespace("first")
+	manifest.SetName("example")
+
+	_, _, ok := manifestGroupForObject(fluxobject.ObjMetadata{
+		GroupKind: manifest.GroupVersionKind().GroupKind(),
+		Namespace: "second",
+		Name:      manifest.GetName(),
+	}, map[string]string{"Widget/first/example": "test-group"}, []*unstructured.Unstructured{manifest})
+
+	assert.False(t, ok)
+}
+
+func TestManifestGroupForObjectMatchesGroupKind(t *testing.T) {
+	manifest := &unstructured.Unstructured{}
+	manifest.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "first.example.dev",
+		Version: "v1",
+		Kind:    "Widget",
+	})
+	manifest.SetNamespace("test")
+	manifest.SetName("example")
+
+	_, _, ok := manifestGroupForObject(fluxobject.ObjMetadata{
+		GroupKind: schema.GroupKind{
+			Group: "second.example.dev",
+			Kind:  manifest.GetKind(),
+		},
+		Name: manifest.GetName(),
+	}, map[string]string{"Widget/test/example": "test-group"}, []*unstructured.Unstructured{manifest})
+
+	assert.False(t, ok)
+}

--- a/internal/integration/kubernetes_test.go
+++ b/internal/integration/kubernetes_test.go
@@ -668,6 +668,13 @@ func AssertKubernetesManifestsSync(testCtx context.Context, rootClient *client.C
 				assert.Equal(specs.ClusterKubernetesManifestsStatusSpec_ManifestStatus_APPLIED, status.Phase)
 			}
 
+			status, ok = group.Manifests["Namespace/ignored/nginx"]
+			assert.True(ok, "manifests should contain Namespace/ignored/nginx, got: %v", group.Manifests)
+
+			if ok {
+				assert.Equal(specs.ClusterKubernetesManifestsStatusSpec_ManifestStatus_APPLIED, status.Phase)
+			}
+
 			assert.Len(group.Manifests, 2)
 			assert.Len(r.TypedSpec().Value.Groups, 2)
 		})

--- a/internal/integration/testdata/deployment.tmpl.yaml
+++ b/internal/integration/testdata/deployment.tmpl.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Namespace }}
+  # Verify that manifest status tracking handles a namespace which the API
+  # server strips from a cluster-scoped resource.
+  namespace: ignored
 ---
 {{- end }}
 apiVersion: apps/v1


### PR DESCRIPTION
Kubernetes strips metadata.namespace from cluster-scoped resources, and SSA records the normalized identity in its inventory. Omni compared that identity with the source manifest ID exactly, leaving successful applies pending forever.

Match normalized inventory entries back to source manifests by group kind and name while retaining the source ID. Cover the matching behavior with unit tests and the complete status path with an integration fixture.