### PR TITLE
feat: validate multi-doc config patches

### DIFF
--- a/client/pkg/clusterimport/clusterimport.go
+++ b/client/pkg/clusterimport/clusterimport.go
@@ -275,6 +275,7 @@ func collectNodeInfo(ctx context.Context, talosCli talosClientWrapper, node stri
 	return info, nil
 }
 
+//nolint:gocognit
 func newContext(input Input, talosCli talosClientWrapper, imageFactoryClients *imagefactory.Clients, nodeInfoMap map[string]nodeInfo,
 	joinOptions *siderolink.JoinOptions, omniState state.State, clusterID string, versions Versions,
 ) (*Context, error) {
@@ -381,6 +382,11 @@ func newContext(input Input, talosCli talosClientWrapper, imageFactoryClients *i
 			sanitizedDiffBytes, patchErr := omni.SanitizeConfigPatch(patchBytes)
 			if patchErr != nil {
 				return nil, fmt.Errorf("failed to sanitize config patch for node %q: %w", node, patchErr)
+			}
+
+			// An empty patch would fail validation on create, so skip instead.
+			if len(sanitizedDiffBytes) == 0 {
+				continue
 			}
 
 			configPatchID := fmt.Sprintf("%d-%s", (i+1)*10, info.machineID)

--- a/client/pkg/omni/resources/omni/config_patch.go
+++ b/client/pkg/omni/resources/omni/config_patch.go
@@ -18,6 +18,9 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/siderolabs/gen/pair"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	taloscluster "github.com/siderolabs/talos/pkg/machinery/config/types/cluster"
+	talosk8s "github.com/siderolabs/talos/pkg/machinery/config/types/k8s"
+	talosruntime "github.com/siderolabs/talos/pkg/machinery/config/types/runtime"
 	talosrole "github.com/siderolabs/talos/pkg/machinery/role"
 	"go.yaml.in/yaml/v4"
 
@@ -41,9 +44,28 @@ var forbiddenFields = []string{
 	"machine.acceptedCAs",
 }
 
-var forbiddenSliceElements = map[string]map[any]struct{}{
+var forbiddenDocuments = map[string]struct{}{
+	talosruntime.UnattendedInstallConfigKind: {}, // not supported in Omni
+	taloscluster.DiscoveryIdentityKind:       {}, // cluster.id, cluster.secret
+	talosk8s.KubeClusterConfig:               {}, // cluster.clusterName, cluster.controlPlane.endpoint
+	talosk8s.KubeEtcdEncryptionConfig:        {}, // cluster.secretboxEncryptionSecret, cluster.aescbcEncryptionSecret
+	talosk8s.KubeAPIServerCAConfig:           {}, // the Kubernetes CA, private key included
+	talosk8s.KubeAggregatorCAConfig:          {}, // the aggregator CA, private key included
+}
+
+type forbiddenElements = map[string]map[any]struct{}
+
+var forbiddenSliceElements = forbiddenElements{
 	"machine.features.kubernetesTalosAPIAccess.allowedRoles": {
 		string(talosrole.Admin): {},
+	},
+}
+
+var documentForbiddenSliceElements = map[string]forbiddenElements{
+	talosk8s.KubeTalosAPIAccessConfig: {
+		"allowedRoles": {
+			string(talosrole.Admin): {},
+		},
 	},
 }
 
@@ -95,23 +117,43 @@ func ValidateConfigPatch(data []byte) error {
 		return err
 	}
 
-	var config map[string]any
-
-	err = yaml.Unmarshal(data, &config)
+	documents, err := decodeFromYAML(data)
 	if err != nil {
 		return err
 	}
 
 	var multiErr error
 
+	// every document has to be checked: the v1alpha1 one that forbiddenFields describes can appear
+	// at any position, and a forbidden document can appear more than once
+	for _, document := range documents {
+		if kind, ok := documentKind(document); ok {
+			if _, forbidden := forbiddenDocuments[kind]; forbidden {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("the %q document is not allowed in the config patch", kind))
+
+				continue
+			}
+		}
+
+		if documentErr := validateConfigPatchDocument(document); documentErr != nil {
+			multiErr = multierror.Append(multiErr, documentErr)
+		}
+	}
+
+	return multiErr
+}
+
+func validateConfigPatchDocument(document map[string]any) error {
+	var multiErr error
+
 	for _, field := range forbiddenFields {
-		if _, ok := getField(config, field); ok {
+		if _, ok := getField(document, field); ok {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("overriding %q is not allowed in the config patch", field))
 		}
 	}
 
-	for field, forbiddenElementSet := range forbiddenSliceElements {
-		val, ok := getField(config, field)
+	for field, forbiddenElementSet := range documentElements(document) {
+		val, ok := getField(document, field)
 		if !ok {
 			continue
 		}
@@ -131,6 +173,24 @@ func ValidateConfigPatch(data []byte) error {
 	return multiErr
 }
 
+// documentKind returns the kind of a multi-document config document. The legacy v1alpha1 document
+// carries no kind, so it reports false.
+func documentKind(document map[string]any) (string, bool) {
+	kind, ok := document["kind"].(string)
+
+	return kind, ok
+}
+
+// documentElements returns the element restrictions that apply to the document.
+func documentElements(document map[string]any) forbiddenElements {
+	kind, ok := documentKind(document)
+	if !ok {
+		return forbiddenSliceElements
+	}
+
+	return documentForbiddenSliceElements[kind]
+}
+
 // SanitizeConfigPatch parses the config patch data using Talos config loader,
 // then sanitizes that the config patch so it doesn't have fields that are controlled by omni.
 func SanitizeConfigPatch(data []byte) ([]byte, error) {
@@ -145,9 +205,23 @@ func SanitizeConfigPatch(data []byte) ([]byte, error) {
 	}
 
 	sanitizedPatches := make([]map[string]any, 0, len(patches))
+
 	for _, patch := range patches {
-		sanitizePatch := sanitizeConfigPatch(patch)
-		sanitizedPatches = append(sanitizedPatches, sanitizePatch)
+		// filter out patches for forbidden documents altogether
+		if kind, ok := documentKind(patch); ok {
+			if _, forbidden := forbiddenDocuments[kind]; forbidden {
+				continue
+			}
+		}
+
+		sanitized := sanitizeConfigPatch(patch)
+
+		// a patch that held nothing but Omni-controlled fields is dropped rather than emitted empty
+		if len(sanitized) == 0 {
+			continue
+		}
+
+		sanitizedPatches = append(sanitizedPatches, sanitized)
 	}
 
 	return encodeToYAML(sanitizedPatches)
@@ -171,7 +245,7 @@ func sanitizeConfigPatch(config map[string]any) map[string]any {
 		}
 	}
 
-	for field, forbiddenElementSet := range forbiddenSliceElements {
+	for field, forbiddenElementSet := range documentElements(config) {
 		val, ok := getField(config, field)
 		if !ok {
 			continue
@@ -293,6 +367,11 @@ func removeFieldElement(m map[string]any, field string, element any) {
 }
 
 func encodeToYAML(docs []map[string]any) ([]byte, error) {
+	// the encoder rejects a Close without a document, which happens when every document was dropped
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
 	var buf bytes.Buffer
 
 	enc := yaml.NewEncoder(&buf)

--- a/client/pkg/omni/resources/omni/config_patch_test.go
+++ b/client/pkg/omni/resources/omni/config_patch_test.go
@@ -5,6 +5,7 @@
 package omni_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -81,6 +82,56 @@ machine:
 `),
 			expectedError: "1 error occurred:\n\t* element \"os:admin\" is not allowed in field \"machine.features.kubernetesTalosAPIAccess.allowedRoles\"\n\n",
 		},
+		{
+			// the forbidden fields live in the v1alpha1 document, which is not the first one here
+			name: "forbidden fields behind another document",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: abcd
+---
+machine:
+  token: aaa
+`),
+			expectedError: "1 error occurred:\n\t* overriding \"machine.token\" is not allowed in the config patch\n\n",
+		},
+		{
+			name: "multi-doc patch of documents Omni does not own",
+			config: strings.TrimSpace(`
+machine:
+  network:
+    hostname: abcd
+---
+apiVersion: v1alpha1
+kind: KubeletConfig
+extraArgs:
+  rotate-server-certificates: "true"
+`),
+		},
+		{
+			name: "os admin talos API access in its own document",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles:
+  - os:reader
+  - os:admin
+allowedKubernetesNamespaces:
+  - kube-system
+`),
+			expectedError: "1 error occurred:\n\t* element \"os:admin\" is not allowed in field \"allowedRoles\"\n\n",
+		},
+		{
+			name: "talos API access document without the admin role",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles:
+  - os:reader
+allowedKubernetesNamespaces:
+  - kube-system
+`),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := omni.ValidateConfigPatch([]byte(tt.config))
@@ -90,6 +141,49 @@ machine:
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestForbiddenDocuments(t *testing.T) {
+	for _, tt := range []struct {
+		kind string
+		body string
+	}{
+		{
+			kind: "UnattendedInstallConfig",
+			body: "installer:\n  image: example.com/installer:v1.14.0",
+		},
+		{
+			kind: "DiscoveryIdentityConfig",
+			body: "clusterID: YWFhCg==\nclusterSecret: YmJiCg==",
+		},
+		{
+			kind: "KubeClusterConfig",
+			body: "clusterName: talos-default\nendpoint: https://172.20.0.1:6443",
+		},
+		{
+			kind: "KubeEtcdEncryptionConfig",
+			body: "config:\n  resources:\n    - secrets",
+		},
+		{
+			kind: "KubeAPIServerCAConfig",
+			body: "issuingCA:\n  cert: YWFhCg==\n  key: YmJiCg==",
+		},
+		{
+			kind: "KubeAggregatorCAConfig",
+			body: "issuingCA:\n  cert: YWFhCg==\n  key: YmJiCg==",
+		},
+	} {
+		t.Run(tt.kind, func(t *testing.T) {
+			patch := fmt.Appendf(nil, "apiVersion: v1alpha1\nkind: %s\n%s\n", tt.kind, tt.body)
+
+			require.EqualError(t, omni.ValidateConfigPatch(patch),
+				fmt.Sprintf("1 error occurred:\n\t* the %q document is not allowed in the config patch\n\n", tt.kind))
+
+			sanitized, err := omni.SanitizeConfigPatch(patch)
+			require.NoError(t, err)
+			require.Empty(t, sanitized)
 		})
 	}
 }
@@ -114,14 +208,13 @@ machine:
 `),
 		},
 		{
+			// nothing survives, and an empty document would be rejected by the Talos config loader
 			name: "token",
 			config: strings.TrimSpace(`
 machine:
   token: aaa
 `),
-			sanitizedConfig: strings.TrimSpace(`
-{}
-`),
+			sanitizedConfig: "",
 		},
 		{
 			name: "several fields",
@@ -185,11 +278,83 @@ machine:
         - os:operator
 `),
 		},
+		{
+			name: "forbidden documents are dropped whole",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+installer:
+  image: example.com/installer:v1.14.0
+---
+machine:
+  network:
+    hostname: abcd
+---
+apiVersion: v1alpha1
+kind: KubeAPIServerCAConfig
+issuingCA:
+  cert: YWFhCg==
+  key: YmJiCg==
+`),
+			sanitizedConfig: strings.TrimSpace(`
+machine:
+  network:
+    hostname: abcd
+`),
+		},
+		{
+			name: "forbidden fields behind another document",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: abcd
+---
+machine:
+  token: aaa
+`),
+			sanitizedConfig: strings.TrimSpace(`
+apiVersion: v1alpha1
+hostname: abcd
+kind: HostnameConfig
+`),
+		},
+		{
+			name:            "nothing but forbidden documents",
+			config:          "apiVersion: v1alpha1\nkind: UnattendedInstallConfig\ninstaller:\n  image: example.com/installer:v1.14.0",
+			sanitizedConfig: "",
+		},
+		{
+			name: "os admin talos API access in its own document",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles:
+  - os:reader
+  - os:admin
+  - os:operator
+allowedKubernetesNamespaces:
+  - kube-system
+`),
+			sanitizedConfig: strings.TrimSpace(`
+allowedKubernetesNamespaces:
+  - kube-system
+allowedRoles:
+  - os:reader
+  - os:operator
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+`),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			sanitizedPatch, err := omni.SanitizeConfigPatch([]byte(tt.config))
 			require.NoError(t, err)
 			require.Equal(t, tt.sanitizedConfig, strings.TrimSpace(string(sanitizedPatch)))
+
+			// whatever survives has to be storable as a config patch again
+			if len(sanitizedPatch) > 0 {
+				require.NoError(t, omni.ValidateConfigPatch(sanitizedPatch))
+			}
 		})
 	}
 }


### PR DESCRIPTION
Talos 1.14 moves cluster identity, CAs and encryption secrets into documents of their own. Those documents are now rejected outright, and the os:admin restriction follows Talos API access into its own document.

Resolves: #3025, #3104