### PR TITLE
fix: forbid cluster CA and service account key in config patches

### DIFF
--- a/client/pkg/omni/resources/omni/config_patch.go
+++ b/client/pkg/omni/resources/omni/config_patch.go
@@ -36,7 +36,9 @@ var forbiddenFields = []string{
 	"cluster.secret",
 	"cluster.aescbcEncryptionSecret",
 	"cluster.secretboxEncryptionSecret",
+	"cluster.ca",
 	"cluster.acceptedCAs",
+	"cluster.serviceAccount",
 	"machine.token",
 	"machine.ca",
 	"machine.type",
@@ -51,6 +53,10 @@ var forbiddenDocuments = map[string]struct{}{
 	talosk8s.KubeEtcdEncryptionConfig:        {}, // cluster.secretboxEncryptionSecret, cluster.aescbcEncryptionSecret
 	talosk8s.KubeAPIServerCAConfig:           {}, // the Kubernetes CA, private key included
 	talosk8s.KubeAggregatorCAConfig:          {}, // the aggregator CA, private key included
+}
+
+var documentForbiddenFields = map[string][]string{
+	talosk8s.KubeServiceAccountConfig: {"issuer.privateKey"},
 }
 
 type forbiddenElements = map[string]map[any]struct{}
@@ -146,7 +152,7 @@ func ValidateConfigPatch(data []byte) error {
 func validateConfigPatchDocument(document map[string]any) error {
 	var multiErr error
 
-	for _, field := range forbiddenFields {
+	for _, field := range documentFields(document) {
 		if _, ok := getField(document, field); ok {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("overriding %q is not allowed in the config patch", field))
 		}
@@ -179,6 +185,16 @@ func documentKind(document map[string]any) (string, bool) {
 	kind, ok := document["kind"].(string)
 
 	return kind, ok
+}
+
+// documentFields returns the field restrictions that apply to the document.
+func documentFields(document map[string]any) []string {
+	kind, ok := documentKind(document)
+	if !ok {
+		return forbiddenFields
+	}
+
+	return documentForbiddenFields[kind]
 }
 
 // documentElements returns the element restrictions that apply to the document.
@@ -216,8 +232,9 @@ func SanitizeConfigPatch(data []byte) ([]byte, error) {
 
 		sanitized := sanitizeConfigPatch(patch)
 
-		// a patch that held nothing but Omni-controlled fields is dropped rather than emitted empty
-		if len(sanitized) == 0 {
+		// a patch that held nothing but Omni-controlled fields is dropped rather than emitted as an
+		// empty document, or as a kind header that patches nothing
+		if isEmptyDocument(sanitized) {
 			continue
 		}
 
@@ -228,7 +245,7 @@ func SanitizeConfigPatch(data []byte) ([]byte, error) {
 }
 
 func sanitizeConfigPatch(config map[string]any) map[string]any {
-	for _, field := range forbiddenFields {
+	for _, field := range documentFields(config) {
 		if _, ok := getField(config, field); ok {
 			removeField(config, field)
 		}
@@ -264,6 +281,17 @@ func sanitizeConfigPatch(config map[string]any) map[string]any {
 	}
 
 	return config
+}
+
+// isEmptyDocument reports whether the document carries nothing beyond its meta header.
+func isEmptyDocument(document map[string]any) bool {
+	for key := range document {
+		if key != "apiVersion" && key != "kind" {
+			return false
+		}
+	}
+
+	return true
 }
 
 func getField(config map[string]any, field string) (any, bool) {

--- a/client/pkg/omni/resources/omni/config_patch_test.go
+++ b/client/pkg/omni/resources/omni/config_patch_test.go
@@ -122,6 +122,57 @@ allowedKubernetesNamespaces:
 			expectedError: "1 error occurred:\n\t* element \"os:admin\" is not allowed in field \"allowedRoles\"\n\n",
 		},
 		{
+			// the legacy spelling of KubeAPIServerCAConfig and KubeServiceAccountConfig
+			name: "cluster CA and service account signing key",
+			config: strings.TrimSpace(`
+cluster:
+  ca:
+    crt: YWFhCg==
+    key: YmJiCg==
+  serviceAccount:
+    key: YmJiCg==
+`),
+			expectedError: `2 errors occurred:
+	* overriding "cluster.ca" is not allowed in the config patch
+	* overriding "cluster.serviceAccount" is not allowed in the config patch
+
+`,
+		},
+		{
+			// "serviceAccount: {}" blanks the generated key on merge, so it is as forbidden as
+			// spelling the key out
+			name: "empty service account map",
+			config: strings.TrimSpace(`
+cluster:
+  serviceAccount: {}
+`),
+			expectedError: "1 error occurred:\n\t* overriding \"cluster.serviceAccount\" is not allowed in the config patch\n\n",
+		},
+		{
+			name: "service account signing key in its own document",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: KubeServiceAccountConfig
+issuer:
+  privateKey: LS0tCg==
+  issuerURL: https://172.20.0.1:6443
+`),
+			expectedError: "1 error occurred:\n\t* overriding \"issuer.privateKey\" is not allowed in the config patch\n\n",
+		},
+		{
+			// the rest of the document is the user's to set, only the signing key is Omni's
+			name: "service account document without the signing key",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: KubeServiceAccountConfig
+accepted:
+  publicKeys:
+    - LS0tCg==
+  audiences:
+    - https://172.20.0.1:6443
+`),
+		},
+		{
 			name: "talos API access document without the admin role",
 			config: strings.TrimSpace(`
 apiVersion: v1alpha1
@@ -321,6 +372,58 @@ kind: HostnameConfig
 		{
 			name:            "nothing but forbidden documents",
 			config:          "apiVersion: v1alpha1\nkind: UnattendedInstallConfig\ninstaller:\n  image: example.com/installer:v1.14.0",
+			sanitizedConfig: "",
+		},
+		{
+			name: "cluster CA and service account signing key",
+			config: strings.TrimSpace(`
+cluster:
+  ca:
+    crt: YWFhCg==
+    key: YmJiCg==
+  serviceAccount:
+    key: YmJiCg==
+  network:
+    dnsDomain: cluster.local
+`),
+			sanitizedConfig: strings.TrimSpace(`
+cluster:
+  network:
+    dnsDomain: cluster.local
+`),
+		},
+		{
+			// a leftover "serviceAccount: {}" would blank the generated key on apply, so the whole
+			// patch has to go
+			name:            "nothing but the service account signing key",
+			config:          "cluster:\n  serviceAccount:\n    key: YmJiCg==",
+			sanitizedConfig: "",
+		},
+		{
+			name:            "nothing but an empty service account map",
+			config:          "cluster:\n  serviceAccount: {}",
+			sanitizedConfig: "",
+		},
+		{
+			name: "service account signing key is stripped from its document",
+			config: strings.TrimSpace(`
+apiVersion: v1alpha1
+kind: KubeServiceAccountConfig
+issuer:
+  privateKey: LS0tCg==
+  issuerURL: https://172.20.0.1:6443
+`),
+			sanitizedConfig: strings.TrimSpace(`
+apiVersion: v1alpha1
+issuer:
+  issuerURL: https://172.20.0.1:6443
+kind: KubeServiceAccountConfig
+`),
+		},
+		{
+			// nothing but the kind header would be left, which patches nothing
+			name:            "document holding only the service account signing key",
+			config:          "apiVersion: v1alpha1\nkind: KubeServiceAccountConfig\nissuer:\n  privateKey: LS0tCg==",
 			sanitizedConfig: "",
 		},
 		{


### PR DESCRIPTION
Add the Kubernetes CA and the service account signing key to forbiddenFields list. Also create a new documentForbiddenFields list to forbid fields coming from multi-doc documents.