### PR TITLE
fix: drop noisy WireGuard handshake warnings for offline peers

### DIFF
--- a/internal/backend/logging/logging.go
+++ b/internal/backend/logging/logging.go
@@ -7,6 +7,9 @@
 package logging
 
 import (
+	"slices"
+	"strings"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -26,4 +29,34 @@ func IncreaseLevel(logger *zap.Logger, lvl zapcore.Level) *zap.Logger {
 	}
 
 	return logger.WithOptions(zap.IncreaseLevel(lvl))
+}
+
+// DropMessagesContaining discards entries whose message contains any of the given substrings.
+func DropMessagesContaining(logger *zap.Logger, substrings ...string) *zap.Logger {
+	if len(substrings) == 0 {
+		return logger
+	}
+
+	return logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return &dropMessagesCore{Core: core, substrings: substrings}
+	}))
+}
+
+type dropMessagesCore struct {
+	zapcore.Core
+
+	substrings []string
+}
+
+func (c *dropMessagesCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if slices.ContainsFunc(c.substrings, func(substring string) bool { return strings.Contains(ent.Message, substring) }) {
+		return ce
+	}
+
+	return c.Core.Check(ent, ce)
+}
+
+// With has to rewrap, otherwise a logger.With call inside the library escapes the filter.
+func (c *dropMessagesCore) With(fields []zapcore.Field) zapcore.Core {
+	return &dropMessagesCore{Core: c.Core.With(fields), substrings: c.substrings}
 }

--- a/internal/backend/logging/logging_test.go
+++ b/internal/backend/logging/logging_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package logging_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/siderolabs/omni/internal/backend/logging"
+)
+
+func TestDropMessagesContaining(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := logging.DropMessagesContaining(zap.New(core), "no known endpoint for peer", "MTU not updated")
+
+	logger.Warn("peer(abcd…wxyz) - Failed to send handshake initiation: no known endpoint for peer")
+	logger.With(zap.String("component", "siderolink")).
+		Warn("peer(abcd…wxyz) - Failed to send data packets: no known endpoint for peer")
+	logger.Warn("MTU not updated to negative value: -1")
+	logger.Warn("peer(abcd…wxyz) - Failed to send handshake initiation: write udp: connection refused")
+	logger.Info("wireguard device set up")
+
+	entries := logs.All()
+
+	require.Len(t, entries, 2)
+	require.Equal(t, "peer(abcd…wxyz) - Failed to send handshake initiation: write udp: connection refused", entries[0].Message)
+	require.Equal(t, "wireguard device set up", entries[1].Message)
+
+	// the filter must leave the reported level alone
+	require.Equal(t, zapcore.DebugLevel, logger.Level())
+}
+
+func TestDropMessagesContainingWithoutSubstrings(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	require.Same(t, logger, logging.DropMessagesContaining(logger))
+
+	logger.Warn("nothing is filtered")
+
+	require.Equal(t, 1, logs.Len())
+}

--- a/internal/pkg/siderolink/manager.go
+++ b/internal/pkg/siderolink/manager.go
@@ -489,7 +489,7 @@ func (manager *Manager) startWireguard(ctx context.Context, eg *errgroup.Group, 
 			}
 		}()
 
-		return manager.wgHandler.Run(ctx, logging.IncreaseLevel(manager.logger, zap.InfoLevel))
+		return manager.wgHandler.Run(ctx, wireguardLogger(manager.logger))
 	})
 
 	return nil

--- a/internal/pkg/siderolink/wireguard.go
+++ b/internal/pkg/siderolink/wireguard.go
@@ -16,7 +16,24 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/internal/backend/logging"
 )
+
+// noKnownEndpointError is what wireguard-go reports when it has to send to a peer it has never heard from.
+//
+// It comes from an inline errors.New, so there is no sentinel to compare against.
+const noKnownEndpointError = "no known endpoint for peer"
+
+// wireguardLogger builds the logger for the WireGuard device.
+//
+// A peer keeps its configuration while its machine is offline, so every keepalive-triggered handshake
+// attempt fails until that machine dials in, and wireguard-go reports each failure. That works out to
+// about one warning every four seconds per offline machine, which buries everything else once a few of
+// them pile up. Nothing is lost by dropping them, since the Link resource already reports whether a
+// machine is connected.
+func wireguardLogger(logger *zap.Logger) *zap.Logger {
+	return logging.DropMessagesContaining(logging.IncreaseLevel(logger, zap.InfoLevel), noKnownEndpointError)
+}
 
 // WireguardHandler abstraction around peer handler and wgDevice.
 type WireguardHandler interface {


### PR DESCRIPTION
Omni keeps a WireGuard peer for every registered machine, so wireguard-go warns about a handshake it cannot send about every four seconds per offline machine. The Link resource already reports whether a machine is connected, so the warning adds nothing. The logger handed to the device now runs through logging.DropMessagesContaining, which discards entries whose message matches a given substring.

Fixes #2873
