### PR TITLE
feat(frontend): improve legibility for unallocated and user partitions

### DIFF
--- a/frontend/src/views/Machines/MachineDisks.stories.ts
+++ b/frontend/src/views/Machines/MachineDisks.stories.ts
@@ -2,6 +2,7 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
+import { faker } from '@faker-js/faker'
 import { createWatchStreamHandler } from '@msw/helpers'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
@@ -44,7 +45,6 @@ export const WithData = {
               },
               spec: {
                 dev_path: '/dev/vda',
-                pretty_size: '20 GB',
                 size: 21474836480,
                 transport: 'virtio',
               },
@@ -66,7 +66,6 @@ export const WithData = {
               },
               spec: {
                 dev_path: '/dev/vda',
-                pretty_size: '20 GB',
                 size: 21474836480,
                 type: 'disk',
               },
@@ -83,7 +82,6 @@ export const WithData = {
                 parent: 'vda',
                 partition_index: 1,
                 partition_label: 'EFI',
-                pretty_size: '105 MB',
                 size: 105906176,
                 type: 'partition',
               },
@@ -100,7 +98,6 @@ export const WithData = {
                 parent: 'vda',
                 partition_index: 2,
                 partition_label: 'BOOT',
-                pretty_size: '1.0 GB',
                 size: 1073741824,
                 type: 'partition',
               },
@@ -117,7 +114,6 @@ export const WithData = {
                 parent: 'vda',
                 partition_index: 3,
                 partition_label: 'STATE',
-                pretty_size: '104 MB',
                 size: 104857600,
                 type: 'partition',
               },
@@ -134,9 +130,25 @@ export const WithData = {
                 parent: 'vda',
                 partition_index: 4,
                 partition_label: 'EPHEMERAL',
-                pretty_size: '4.1 GB',
                 size: 4131389440,
-                uuid: 'faa1a56a-4934-4317-b6d1-272712353c5c',
+                uuid: faker.string.uuid(),
+                type: 'partition',
+              },
+            },
+            {
+              metadata: {
+                id: 'vda5',
+                namespace: TalosRuntimeNamespace,
+                type: TalosDiscoveredVolumeType,
+              },
+              spec: {
+                dev_path: '/dev/vda4',
+                name: 'xfs',
+                parent: 'vda',
+                partition_index: 4,
+                partition_label: 'USER',
+                size: 3267896320,
+                uuid: faker.string.uuid(),
                 type: 'partition',
               },
             },
@@ -244,7 +256,6 @@ export const WithCdrom: Story = {
               spec: {
                 cdrom: true,
                 dev_path: '/dev/sr0',
-                pretty_size: '750 MB',
                 size: 786432000,
                 readonly: true,
                 transport: 'ata',
@@ -260,7 +271,6 @@ export const WithCdrom: Story = {
               spec: {
                 cdrom: true,
                 dev_path: '/dev/sr1',
-                pretty_size: '0 B',
                 size: 0,
                 readonly: true,
               },
@@ -284,7 +294,6 @@ export const WithCdrom: Story = {
               spec: {
                 dev_path: '/dev/sr0',
                 name: 'iso9660',
-                pretty_size: '750 MB',
                 size: 786432000,
                 type: 'disk',
               },
@@ -301,7 +310,6 @@ export const WithCdrom: Story = {
               spec: {
                 dev_path: '/dev/sr1',
                 name: '',
-                pretty_size: '0 B',
                 size: 0,
                 type: 'disk',
               },
@@ -339,7 +347,6 @@ export const WithLuksEncryption: Story = {
               },
               spec: {
                 dev_path: '/dev/vda',
-                pretty_size: '20 GB',
                 size: 21474836480,
                 transport: 'virtio',
               },
@@ -354,7 +361,6 @@ export const WithLuksEncryption: Story = {
               },
               spec: {
                 dev_path: '/dev/dm-0',
-                pretty_size: '104 MB',
                 size: 104857600,
               },
             },
@@ -379,7 +385,6 @@ export const WithLuksEncryption: Story = {
                 parent: 'vda',
                 partition_index: 1,
                 partition_label: 'EFI',
-                pretty_size: '105 MB',
                 size: 105906176,
                 type: 'partition',
               },
@@ -398,7 +403,6 @@ export const WithLuksEncryption: Story = {
                 parent: 'vda',
                 partition_index: 2,
                 partition_label: 'EPHEMERAL',
-                pretty_size: '19 GB',
                 size: 20265148416,
                 type: 'partition',
               },

--- a/frontend/src/views/Nodes/components/DiskUsageBar.vue
+++ b/frontend/src/views/Nodes/components/DiskUsageBar.vue
@@ -32,25 +32,46 @@ const unallocatedPercent = computed(() => {
   return Math.max(0, partitionPercent(diskSize - usedSpace.value, diskSize))
 })
 
-const getVolumeClass = (volume: Resource<DiscoveredVolumeSpec>) => {
-  const fsType = volume.spec.name?.toLowerCase()
-  const label = volume.spec.partition_label?.toLowerCase()
+const knownLabelColors = {
+  efi: 'bg-yellow-500',
+  boot: 'bg-orange-500',
+  state: 'bg-purple-500',
+  ephemeral: 'bg-blue-500',
+}
 
-  if (label?.includes('efi')) return 'bg-yellow-500'
-  if (label?.includes('boot')) return 'bg-orange-500'
-  if (label?.includes('state')) return 'bg-purple-500'
-  if (label?.includes('ephemeral')) return 'bg-blue-500'
-  if (fsType?.includes('luks')) return 'bg-indigo-500'
-  if (fsType?.includes('xfs') || fsType?.includes('ext')) return 'bg-green-600'
-  if (fsType?.includes('vfat') || fsType?.includes('fat')) return 'bg-yellow-600'
-  if (fsType?.includes('swap')) return 'bg-red-500'
-  return 'bg-naturals-n9'
+const unknownLabelColors = computed(
+  () =>
+    new Map(
+      volumes
+        .filter((v) => {
+          const label = v.spec.partition_label?.toLowerCase()
+
+          return !label || !(label in knownLabelColors)
+        })
+        .map((v, i) => {
+          const hue = ((i + 1) * 137.508) % 360
+
+          return [v.metadata.id!, `hsl(${hue.toFixed(1)}deg 55% 30%)`] as const
+        }),
+    ),
+)
+
+const getVolumeClass = (volume: Resource<DiscoveredVolumeSpec>) => {
+  const label = volume.spec.partition_label?.toLowerCase() as keyof typeof knownLabelColors
+
+  return label ? knownLabelColors[label] : undefined
+}
+
+const getVolumeStyle = (volume: Resource<DiscoveredVolumeSpec>) => {
+  const color = unknownLabelColors.value.get(volume.metadata.id!)
+
+  return color ? { backgroundColor: color } : undefined
 }
 </script>
 
 <template>
   <div>
-    <div class="flex h-8 w-full overflow-hidden rounded bg-naturals-n5">
+    <div class="flex h-8 w-full overflow-hidden rounded bg-naturals-n5 text-xs">
       <div
         v-for="volume in volumes"
         :key="volume.metadata.id"
@@ -58,12 +79,13 @@ const getVolumeClass = (volume: Resource<DiscoveredVolumeSpec>) => {
         :class="getVolumeClass(volume)"
         :style="{
           width: `${partitionPercent(volume.spec.size, disk.spec.size)}%`,
+          ...getVolumeStyle(volume),
         }"
-        class="flex min-w-0 items-center justify-center overflow-hidden text-xs text-naturals-n14 last:border-r-0"
+        class="flex min-w-0 items-center justify-center overflow-hidden text-naturals-n14 last:border-r-0"
       >
         <span
           v-if="partitionPercent(volume.spec.size, disk.spec.size) > 10"
-          class="truncate px-1.5 text-xs font-medium drop-shadow-xs drop-shadow-black"
+          class="truncate px-1.5 font-medium drop-shadow-xs drop-shadow-black"
         >
           {{ volume.spec.partition_label || volume.spec.label || '' }}
           <span class="opacity-80">
@@ -71,13 +93,19 @@ const getVolumeClass = (volume: Resource<DiscoveredVolumeSpec>) => {
           </span>
         </span>
       </div>
+
       <div
         v-if="unallocatedPercent > 0"
         :style="{ width: `${unallocatedPercent}%` }"
         title="Unallocated"
-        class="flex min-w-0 items-center justify-center overflow-hidden text-xs text-naturals-n12"
+        class="flex min-w-0 items-center justify-center overflow-hidden bg-[repeating-linear-gradient(-45deg,var(--stripe-color),var(--stripe-color)_var(--stripe-size),transparent_var(--stripe-size),transparent_calc(var(--stripe-size)*2))] text-naturals-n12 [--stripe-color:var(--color-naturals-n7)] [--stripe-size:12px]"
       >
-        <span v-if="unallocatedPercent > 10" class="truncate px-1.5">Unallocated</span>
+        <span
+          v-if="unallocatedPercent > 10"
+          class="truncate px-1.5 font-medium drop-shadow-xs drop-shadow-black"
+        >
+          Unallocated
+        </span>
       </div>
     </div>
 
@@ -87,7 +115,11 @@ const getVolumeClass = (volume: Resource<DiscoveredVolumeSpec>) => {
         :key="'legend-' + volume.metadata.id"
         class="flex items-center gap-1.5"
       >
-        <span class="inline-block size-2.5 rounded-sm" :class="getVolumeClass(volume)" />
+        <span
+          class="inline-block size-2.5 rounded-sm"
+          :class="getVolumeClass(volume)"
+          :style="getVolumeStyle(volume)"
+        />
         <span class="font-medium text-naturals-n12">
           {{ volume.spec.partition_label || volume.spec.label || volume.spec.dev_path }}
         </span>


### PR DESCRIPTION
Add stripes to unallocated space, to distinguish it from allocated space. For unknown volumes, cycle through a wheel of colors.

<img width="863" height="496" alt="image" src="https://github.com/user-attachments/assets/7a3475ff-de2f-4d64-bbda-73ece96bb210" />
