### PR TITLE
test: make the install disk selection test deterministic

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
-	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -1068,21 +1067,21 @@ func TestMachineConfigStatusController(t *testing.T) {
 	})
 
 	// maintenanceInstallConfigDisk verifies which disk a maintenance install targets: the disk in the
-	// merged machine config (where the user's install disk patch lands) wins over the automatically
-	// picked default on MachineConfigGenOptions, and the default is used when the config carries no
-	// install disk.
+	// merged machine config wins over the default on MachineConfigGenOptions, and the default is used
+	// when the config disk is empty. The config carries its disk from its very first version (shaped
+	// through the gen options its mock preset renders from), matching the contract that the selection
+	// is settled before the machine becomes installable. The gen options re-mock in the setup then
+	// resets the default disk to /dev/vda, making the config disk and the default diverge.
 	t.Run("maintenanceInstallConfigDisk", func(t *testing.T) {
 		t.Parallel()
 
 		for i, tt := range []struct {
 			name         string
-			genOptsDisk  string
 			configDisk   string
 			expectedDisk string
 		}{
-			{name: "config disk overrides default", genOptsDisk: "/dev/vda", configDisk: "/dev/vdb", expectedDisk: "/dev/vdb"},
-			{name: "no config disk falls back to default", genOptsDisk: "/dev/vda", configDisk: "", expectedDisk: "/dev/vda"},
-			{name: "config disk works without default", genOptsDisk: "", configDisk: "/dev/vdb", expectedDisk: "/dev/vdb"},
+			{name: "config disk overrides default", configDisk: "/dev/vdb", expectedDisk: "/dev/vdb"},
+			{name: "empty config disk falls back to default", configDisk: "", expectedDisk: "/dev/vda"},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
@@ -1104,15 +1103,14 @@ func TestMachineConfigStatusController(t *testing.T) {
 						st := tc.State
 						machineServices := testutils.NewMachineServices(t, st)
 
-						id := setupMaintenanceMachineWithHook(ctx, t, st, machineServices, clusterName, false, bootID, func(id string) {
-							setConfigInstallDisk(ctx, t, st, id, tt.configDisk)
+						id := setupMaintenanceMachineWithClusterOpts(ctx, t, st, machineServices, clusterName, false, bootID,
+							[]createClusterOption{
+								withGenOptionsModifier(func(res *omni.MachineConfigGenOptions) error {
+									res.TypedSpec().Value.InstallDisk = tt.configDisk
 
-							rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
-								res.TypedSpec().Value.InstallDisk = tt.genOptsDisk
-
-								return nil
-							}))
-						})
+									return nil
+								}),
+							})
 
 						rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
 							a.Equal(bootID, res.TypedSpec().Value.PreRebootBootId)
@@ -1641,6 +1639,7 @@ type createClusterOption func(*createClusterOptions)
 
 type createClusterOptions struct {
 	machineStatusModifier func(*omni.MachineStatus) error
+	genOptionsModifier    func(*omni.MachineConfigGenOptions) error
 	clusterOpts           []options.MockOption
 }
 
@@ -1657,6 +1656,15 @@ func withClusterMockOption(opt options.MockOption) createClusterOption {
 func withMachineStatusModifier(fn func(*omni.MachineStatus) error) createClusterOption {
 	return func(o *createClusterOptions) {
 		o.machineStatusModifier = fn
+	}
+}
+
+// withGenOptionsModifier applies an additional modifier to every MachineConfigGenOptions created by
+// createCluster, before the ClusterMachineConfig preset renders the config from the gen options, so
+// the very first version of the config reflects the modification, e.g. its install disk.
+func withGenOptionsModifier(fn func(*omni.MachineConfigGenOptions) error) createClusterOption {
+	return func(o *createClusterOptions) {
+		o.genOptionsModifier = fn
 	}
 }
 
@@ -1802,7 +1810,14 @@ func createCluster(
 		rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.SameID(machine))
 		rmock.Mock[*omni.ClusterMachineConfigPatches](ctx, t, st, options.SameID(machine))
 		rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.SameID(machine))
-		rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.SameID(machine))
+
+		genOptionsOpts := []options.MockOption{options.SameID(machine)}
+
+		if clusterOpts.genOptionsModifier != nil {
+			genOptionsOpts = append(genOptionsOpts, options.Modify(clusterOpts.genOptionsModifier))
+		}
+
+		rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, genOptionsOpts...)
 		rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.SameID(machine))
 	}
 
@@ -2216,29 +2231,31 @@ func setupMaintenanceMachine(
 	clusterName string, hasSystemDisk bool, bootID string,
 	configureService ...func(*testutils.MachineServiceMock),
 ) string {
-	return setupMaintenanceMachineWithHook(ctx, t, st, machineServices, clusterName, hasSystemDisk, bootID, nil, configureService...)
+	return setupMaintenanceMachineWithClusterOpts(ctx, t, st, machineServices, clusterName, hasSystemDisk, bootID, nil, configureService...)
 }
 
-// setupMaintenanceMachineWithHook is setupMaintenanceMachine with a hook that runs right before the
-// trigger resources are mocked, i.e. before the controller can start the install/upgrade operation.
-func setupMaintenanceMachineWithHook(
+// setupMaintenanceMachineWithClusterOpts is setupMaintenanceMachine with additional createCluster
+// options, e.g. to shape the machine config at its creation.
+func setupMaintenanceMachineWithClusterOpts(
 	ctx context.Context, t *testing.T, st state.State, machineServices *testutils.MachineServices,
 	clusterName string, hasSystemDisk bool, bootID string,
-	beforeTrigger func(id string),
+	clusterOpts []createClusterOption,
 	configureService ...func(*testutils.MachineServiceMock),
 ) string {
 	_, machines := createCluster(
 		ctx, t, st, machineServices, clusterName, 1, 0,
-		withMachineStatusModifier(func(res *omni.MachineStatus) error {
-			res.TypedSpec().Value.Maintenance = true
-			res.TypedSpec().Value.TalosVersion = maintenanceMachineVersion
+		append([]createClusterOption{
+			withMachineStatusModifier(func(res *omni.MachineStatus) error {
+				res.TypedSpec().Value.Maintenance = true
+				res.TypedSpec().Value.TalosVersion = maintenanceMachineVersion
 
-			if !hasSystemDisk {
-				res.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{}
-			}
+				if !hasSystemDisk {
+					res.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{}
+				}
 
-			return nil
-		}),
+				return nil
+			}),
+		}, clusterOpts...)...,
 	)
 
 	id := machines[0].Metadata().ID()
@@ -2256,10 +2273,6 @@ func setupMaintenanceMachineWithHook(
 		return nil
 	}))
 
-	if beforeTrigger != nil {
-		beforeTrigger(id)
-	}
-
 	// The maintenance config controller has applied its config for the current connection, so the
 	// install/upgrade gate in reconcileUpgrade is open.
 	markMaintenanceConfigApplied(ctx, t, st, id)
@@ -2272,44 +2285,6 @@ func setupMaintenanceMachineWithHook(
 	}))
 
 	return id
-}
-
-// setConfigInstallDisk replaces the install disk in the machine's merged config.
-// An empty disk removes the install section from the config entirely.
-func setConfigInstallDisk(ctx context.Context, t *testing.T, st state.State, id, disk string) {
-	rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.ClusterMachineConfig) error {
-		buf, err := res.TypedSpec().Value.GetUncompressedData()
-		if err != nil {
-			return err
-		}
-
-		defer buf.Free()
-
-		cfg, err := configloader.NewFromBytes(buf.Data())
-		if err != nil {
-			return err
-		}
-
-		patched, err := cfg.PatchV1Alpha1(func(c *v1alpha1.Config) error {
-			if disk == "" {
-				c.MachineConfig.MachineInstall = nil //nolint:staticcheck
-			} else {
-				c.MachineConfig.MachineInstall.InstallDisk = disk //nolint:staticcheck
-			}
-
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-
-		data, err := patched.EncodeBytes(encoder.WithComments(encoder.CommentsDisabled))
-		if err != nil {
-			return err
-		}
-
-		return res.TypedSpec().Value.SetUncompressedData(data)
-	}))
 }
 
 // markMaintenanceConfigApplied sets up a machine so the status controller's maintenance install/upgrade


### PR DESCRIPTION
The test injected the user's install disk by updating the already-created machine config, producing a second version, and then opened the install gates. The controller reads the config through the resource cache, so on loaded runners it could act on the first version and install to the default disk, failing the assertion.

Shape the disk at the config's creation instead, through the generation options its mock preset renders from: the config then carries the disk from its very first version, and the later generation options update resets the default disk, so the config disk and the default still diverge. The race is gone by construction.

The underlying staleness window the test manufactured exists in the runtime in general but is vanishingly rare in practice. It is being addressed at the root by making the resource cache consistent, and the patch-based install disk mechanism itself is replaced by a first-class resource in #3199, so only the test is fixed here.
