### PR TITLE
test: reserve integration test machines against concurrent allocation

### DIFF
--- a/internal/integration/cluster_test.go
+++ b/internal/integration/cluster_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/virtual"
 )
 
@@ -99,58 +100,58 @@ func CreateCluster(testCtx context.Context, testOptions *TestOptions, options Cl
 		st := testOptions.omniClient.Omni().State()
 		require := require.New(t)
 
-		pickUnallocatedMachines(ctx, t, st, options.ControlPlanes+options.Workers, options.PickFilterFunc, func(machineIDs []resource.ID) {
-			if !options.SkipExtensionCheckOnCreate {
-				checkExtensionsWithRetries(ctx, t, testOptions, []string{HelloWorldServiceExtensionName}, machineIDs)
-			}
+		machineIDs := pickUnallocatedMachines(ctx, t, st, options.ControlPlanes+options.Workers, options.PickFilterFunc)
 
-			if options.BeforeClusterCreateFunc != nil {
-				options.BeforeClusterCreateFunc(ctx, t, testOptions.omniClient, machineIDs)
-			}
+		if !options.SkipExtensionCheckOnCreate {
+			checkExtensionsWithRetries(ctx, t, testOptions, []string{HelloWorldServiceExtensionName}, machineIDs)
+		}
 
-			cluster := omni.NewCluster(options.Name)
-			cluster.TypedSpec().Value.TalosVersion = options.MachineOptions.TalosVersion
-			cluster.TypedSpec().Value.KubernetesVersion = options.MachineOptions.KubernetesVersion
-			cluster.TypedSpec().Value.Features = withEmbeddedDiscoveryService(options.Features)
-			cluster.TypedSpec().Value.BackupConfiguration = options.EtcdBackup
+		if options.BeforeClusterCreateFunc != nil {
+			options.BeforeClusterCreateFunc(ctx, t, testOptions.omniClient, machineIDs)
+		}
 
-			require.NoError(st.Create(ctx, cluster))
+		cluster := omni.NewCluster(options.Name)
+		cluster.TypedSpec().Value.TalosVersion = options.MachineOptions.TalosVersion
+		cluster.TypedSpec().Value.KubernetesVersion = options.MachineOptions.KubernetesVersion
+		cluster.TypedSpec().Value.Features = withEmbeddedDiscoveryService(options.Features)
+		cluster.TypedSpec().Value.BackupConfiguration = options.EtcdBackup
 
-			if options.AllowSchedulingOnControlPlanes {
-				ensureAllowSchedulingOnControlPlanesConfigPatch(ctx, t, st, options.Name)
-			}
+		require.NoError(st.Create(ctx, cluster))
 
-			for i := range options.ControlPlanes {
-				t.Logf("Adding machine %q to control plane (cluster %q)", machineIDs[i], options.Name)
-				bindMachine(ctx, t, st, bindMachineOptions{
-					clusterName:                    options.Name,
-					role:                           omni.LabelControlPlaneRole,
-					machineID:                      machineIDs[i],
-					restoreFromEtcdBackupClusterID: options.RestoreFromEtcdBackupClusterID,
-					talosVersion:                   options.MachineOptions.TalosVersion,
-				})
-			}
+		if options.AllowSchedulingOnControlPlanes {
+			ensureAllowSchedulingOnControlPlanesConfigPatch(ctx, t, st, options.Name)
+		}
 
-			for i := options.ControlPlanes; i < options.ControlPlanes+options.Workers; i++ {
-				t.Logf("Adding machine %q to workers (cluster %q)", machineIDs[i], options.Name)
-				bindMachine(ctx, t, st, bindMachineOptions{
-					clusterName:  options.Name,
-					role:         omni.LabelWorkerRole,
-					machineID:    machineIDs[i],
-					talosVersion: options.MachineOptions.TalosVersion,
-				})
-			}
-
-			// assert that machines got allocated (label available is removed)
-			rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
-				assert.True(machineStatus.Metadata().Labels().Matches(
-					resource.LabelTerm{
-						Key:    omni.MachineStatusLabelAvailable,
-						Op:     resource.LabelOpExists,
-						Invert: true,
-					},
-				), resourceDetails(machineStatus))
+		for i := range options.ControlPlanes {
+			t.Logf("Adding machine %q to control plane (cluster %q)", machineIDs[i], options.Name)
+			bindMachine(ctx, t, st, bindMachineOptions{
+				clusterName:                    options.Name,
+				role:                           omni.LabelControlPlaneRole,
+				machineID:                      machineIDs[i],
+				restoreFromEtcdBackupClusterID: options.RestoreFromEtcdBackupClusterID,
+				talosVersion:                   options.MachineOptions.TalosVersion,
 			})
+		}
+
+		for i := options.ControlPlanes; i < options.ControlPlanes+options.Workers; i++ {
+			t.Logf("Adding machine %q to workers (cluster %q)", machineIDs[i], options.Name)
+			bindMachine(ctx, t, st, bindMachineOptions{
+				clusterName:  options.Name,
+				role:         omni.LabelWorkerRole,
+				machineID:    machineIDs[i],
+				talosVersion: options.MachineOptions.TalosVersion,
+			})
+		}
+
+		// assert that machines got allocated (label available is removed)
+		rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+			assert.True(machineStatus.Metadata().Labels().Matches(
+				resource.LabelTerm{
+					Key:    omni.MachineStatusLabelAvailable,
+					Op:     resource.LabelOpExists,
+					Invert: true,
+				},
+			), resourceDetails(machineStatus))
 		})
 	}
 }
@@ -204,7 +205,7 @@ func CreateClusterWithMachineClass(testCtx context.Context, st state.State, opti
 			})
 		} else {
 			createOrUpdate(ctx, t, st, machineClass, func(r *omni.MachineClass) error {
-				r.TypedSpec().Value.MatchLabels = []string{omni.MachineStatusLabelConnected}
+				r.TypedSpec().Value.MatchLabels = []string{omni.MachineStatusLabelConnected + ",!" + pickedByManualAllocation}
 				r.TypedSpec().Value.AutoProvision = nil
 
 				return nil
@@ -250,43 +251,43 @@ func ScaleClusterUp(testCtx context.Context, st state.State, options ClusterOpti
 		ctx, cancel := context.WithTimeout(testCtx, options.ScalingTimeout)
 		defer cancel()
 
-		pickUnallocatedMachines(ctx, t, st, options.ControlPlanes+options.Workers, options.PickFilterFunc, func(machineIDs []resource.ID) {
-			for i := range options.ControlPlanes {
-				t.Logf("Adding machine %q to control plane (cluster %q)", machineIDs[i], options.Name)
+		machineIDs := pickUnallocatedMachines(ctx, t, st, options.ControlPlanes+options.Workers, options.PickFilterFunc)
 
-				bindMachine(ctx, t, st, bindMachineOptions{
-					clusterName:  options.Name,
-					role:         omni.LabelControlPlaneRole,
-					machineID:    machineIDs[i],
-					talosVersion: options.MachineOptions.TalosVersion,
-				})
-			}
+		for i := range options.ControlPlanes {
+			t.Logf("Adding machine %q to control plane (cluster %q)", machineIDs[i], options.Name)
 
-			for i := options.ControlPlanes; i < options.ControlPlanes+options.Workers; i++ {
-				t.Logf("Adding machine %q to workers (cluster %q)", machineIDs[i], options.Name)
-
-				bindMachine(ctx, t, st, bindMachineOptions{
-					clusterName:  options.Name,
-					role:         omni.LabelWorkerRole,
-					machineID:    machineIDs[i],
-					talosVersion: options.MachineOptions.TalosVersion,
-				})
-			}
-
-			// assert that machines got allocated (label available is removed)
-			rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
-				assert.True(machineStatus.Metadata().Labels().Matches(
-					resource.LabelTerm{
-						Key:    omni.MachineStatusLabelAvailable,
-						Op:     resource.LabelOpExists,
-						Invert: true,
-					},
-				), resourceDetails(machineStatus))
+			bindMachine(ctx, t, st, bindMachineOptions{
+				clusterName:  options.Name,
+				role:         omni.LabelControlPlaneRole,
+				machineID:    machineIDs[i],
+				talosVersion: options.MachineOptions.TalosVersion,
 			})
+		}
 
-			// assert that ClusterMachines got created
-			rtestutils.AssertResources(ctx, t, st, machineIDs, func(*omni.ClusterMachine, *assert.Assertions) {})
+		for i := options.ControlPlanes; i < options.ControlPlanes+options.Workers; i++ {
+			t.Logf("Adding machine %q to workers (cluster %q)", machineIDs[i], options.Name)
+
+			bindMachine(ctx, t, st, bindMachineOptions{
+				clusterName:  options.Name,
+				role:         omni.LabelWorkerRole,
+				machineID:    machineIDs[i],
+				talosVersion: options.MachineOptions.TalosVersion,
+			})
+		}
+
+		// assert that machines got allocated (label available is removed)
+		rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+			assert.True(machineStatus.Metadata().Labels().Matches(
+				resource.LabelTerm{
+					Key:    omni.MachineStatusLabelAvailable,
+					Op:     resource.LabelOpExists,
+					Invert: true,
+				},
+			), resourceDetails(machineStatus))
 		})
+
+		// assert that ClusterMachines got created
+		rtestutils.AssertResources(ctx, t, st, machineIDs, func(*omni.ClusterMachine, *assert.Assertions) {})
 	}
 }
 
@@ -340,36 +341,36 @@ func ReplaceControlPlanes(testCtx context.Context, st state.State, options Clust
 			state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, options.Name), resource.LabelExists(omni.LabelControlPlaneRole)),
 		)
 
-		pickUnallocatedMachines(ctx, t, st, len(existingControlPlanes), options.PickFilterFunc, func(machineIDs []resource.ID) {
-			for _, machineID := range machineIDs {
-				t.Logf("Adding machine %q to control plane (cluster %q)", machineID, options.Name)
+		machineIDs := pickUnallocatedMachines(ctx, t, st, len(existingControlPlanes), options.PickFilterFunc)
 
-				bindMachine(ctx, t, st, bindMachineOptions{
-					clusterName:  options.Name,
-					role:         omni.LabelControlPlaneRole,
-					machineID:    machineID,
-					talosVersion: options.MachineOptions.TalosVersion,
-				})
-			}
+		for _, machineID := range machineIDs {
+			t.Logf("Adding machine %q to control plane (cluster %q)", machineID, options.Name)
 
-			t.Logf("Removing machines %q from control planes (cluster %q)", existingControlPlanes, options.Name)
-
-			rtestutils.Destroy[*omni.MachineSetNode](ctx, t, st, existingControlPlanes)
-
-			// assert that machines got allocated (label available is removed)
-			rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
-				assert.True(machineStatus.Metadata().Labels().Matches(
-					resource.LabelTerm{
-						Key:    omni.MachineStatusLabelAvailable,
-						Op:     resource.LabelOpExists,
-						Invert: true,
-					},
-				), resourceDetails(machineStatus))
+			bindMachine(ctx, t, st, bindMachineOptions{
+				clusterName:  options.Name,
+				role:         omni.LabelControlPlaneRole,
+				machineID:    machineID,
+				talosVersion: options.MachineOptions.TalosVersion,
 			})
+		}
 
-			// assert that ClusterMachines got created
-			rtestutils.AssertResources(ctx, t, st, machineIDs, func(*omni.ClusterMachine, *assert.Assertions) {})
+		t.Logf("Removing machines %q from control planes (cluster %q)", existingControlPlanes, options.Name)
+
+		rtestutils.Destroy[*omni.MachineSetNode](ctx, t, st, existingControlPlanes)
+
+		// assert that machines got allocated (label available is removed)
+		rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+			assert.True(machineStatus.Metadata().Labels().Matches(
+				resource.LabelTerm{
+					Key:    omni.MachineStatusLabelAvailable,
+					Op:     resource.LabelOpExists,
+					Invert: true,
+				},
+			), resourceDetails(machineStatus))
 		})
+
+		// assert that ClusterMachines got created
+		rtestutils.AssertResources(ctx, t, st, machineIDs, func(*omni.ClusterMachine, *assert.Assertions) {})
 	}
 }
 
@@ -864,14 +865,53 @@ func getMachineSetNodes(ctx context.Context, t *testing.T, st state.State, clust
 	return machineIDs
 }
 
-// machineAllocationLock makes sure that only one test allocates machines at a time.
-var machineAllocationLock sync.Mutex
+// pickedByManualAllocation marks machines picked by pickUnallocatedMachines, so that the server-side
+// machine allocation (machine-class based machine sets) does not grab them: every machine class used
+// in the tests must exclude this label in its match selector.
+const pickedByManualAllocation = "picked-by-manual-allocation"
 
-func pickUnallocatedMachines(ctx context.Context, t *testing.T, st state.State, count int, filterFunc PickFilterFunc, f func([]resource.ID)) {
-	machineAllocationLock.Lock()
-	defer machineAllocationLock.Unlock()
+// machineReservationSet holds the IDs of the machines currently reserved by running tests.
+type machineReservationSet struct {
+	ids map[resource.ID]struct{}
+	mx  sync.Mutex
+}
 
-	result := make([]resource.ID, 0, count)
+// reservedLocked reports whether the machine is reserved. The caller must hold mx.
+func (s *machineReservationSet) reservedLocked(id resource.ID) bool {
+	_, reserved := s.ids[id]
+
+	return reserved
+}
+
+// reserveLocked adds the machine to the reservation set. The caller must hold mx.
+func (s *machineReservationSet) reserveLocked(id resource.ID) {
+	s.ids[id] = struct{}{}
+}
+
+// release removes the machines from the reservation set.
+func (s *machineReservationSet) release(ids []resource.ID) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	for _, id := range ids {
+		delete(s.ids, id)
+	}
+}
+
+// machineReservations pins the machines picked by a test until that test finishes, so that concurrent
+// tests do not pick them up while they are not (yet) allocated to a cluster, e.g. before the initial
+// binding, between a cluster destroy and a re-bind of the same machine, or during a maintenance
+// install of a machine which is never bound to a cluster at all.
+//
+// The lock also serializes the picks themselves, so that a machine cannot be picked twice before
+// getting reserved. It only protects against concurrent picks: the server-side machine allocation
+// is kept away from the picked machines via the pickedByManualAllocation label instead.
+var machineReservations = machineReservationSet{ids: map[resource.ID]struct{}{}}
+
+// pickUnallocatedMachines picks machines which are not allocated to any cluster and not picked by
+// another still-running test, and reserves them for the test t until it finishes.
+func pickUnallocatedMachines(ctx context.Context, t *testing.T, st state.State, count int, filterFunc PickFilterFunc) []resource.ID {
+	var result []resource.ID
 
 	if filterFunc == nil {
 		filterFunc = func(*omni.MachineStatus, []*omni.MachineStatus) bool { return true }
@@ -879,65 +919,182 @@ func pickUnallocatedMachines(ctx context.Context, t *testing.T, st state.State, 
 
 	logger := zaptest.NewLogger(t)
 
+	loggedLeakedMarkers := map[resource.ID]struct{}{}
+
 	err := retry.Constant(time.Minute).RetryWithContext(ctx, func(ctx context.Context) error {
-		result = result[:0] // clear the result between retries
+		var attemptErr error
 
-		machineStatuses, err := safe.StateListAll[*omni.MachineStatus](ctx, st, state.WithLabelQuery(resource.LabelExists(omni.MachineStatusLabelAvailable)))
-		if err != nil {
-			return err
-		}
+		result, attemptErr = pickUnallocatedMachinesAttempt(ctx, st, count, filterFunc, logger, loggedLeakedMarkers)
 
-		nodeList, err := st.List(ctx, resource.NewMetadata(resources.DefaultNamespace, omni.MachineSetNodeType, "", resource.VersionUndefined))
-		if err != nil {
-			return err
-		}
-
-		nodeMap := xslices.ToMap(nodeList.Items, func(node resource.Resource) (resource.ID, resource.Resource) {
-			return node.Metadata().ID(), node
-		})
-
-		shuffledMachineStatuses := slices.Collect(machineStatuses.All())
-		rand.Shuffle(len(shuffledMachineStatuses), func(i, j int) {
-			shuffledMachineStatuses[i], shuffledMachineStatuses[j] = shuffledMachineStatuses[j], shuffledMachineStatuses[i]
-		})
-
-		pickedMachineStatuses := make([]*omni.MachineStatus, 0, count)
-
-		for _, machineStatus := range shuffledMachineStatuses {
-			allocatedNode, isAllocated := nodeMap[machineStatus.Metadata().ID()]
-			if isAllocated {
-				allocatedCluster, _ := allocatedNode.Metadata().Labels().Get(omni.LabelCluster)
-
-				logger.Error("machine has the label available but is still allocated to a cluster",
-					zap.String("machine_id", machineStatus.Metadata().ID()),
-					zap.String("allocated_cluster", allocatedCluster))
-
-				continue
-			}
-
-			if filterFunc(machineStatus, pickedMachineStatuses) {
-				pickedMachineStatuses = append(pickedMachineStatuses, machineStatus)
-			}
-
-			if len(pickedMachineStatuses) >= count {
-				break
-			}
-		}
-
-		if len(pickedMachineStatuses) < count {
-			return retry.ExpectedErrorf("not enough machines: available %d, requested %d", len(pickedMachineStatuses), count)
-		}
-
-		for _, ms := range pickedMachineStatuses {
-			result = append(result, ms.Metadata().ID())
-		}
-
-		return nil
+		return attemptErr
 	})
 
 	require.NoError(t, err)
 
-	f(result)
+	// Register the cleanup before the fallible marker work below, so that a failure in it cannot
+	// leak the in-memory reservations or already written markers.
+	t.Cleanup(func() {
+		releasePickedMachines(ctx, t, st, result)
+	})
+
+	// Also reserve the picked machines against the server-side machine allocation: mark them with a
+	// label which the machine classes used in the tests exclude, and wait for the label to become
+	// visible on the label projection which the allocation matches against.
+	for _, id := range result {
+		require.NoError(t, safe.StateModify(ctx, st, omni.NewMachineLabels(id), func(machineLabels *omni.MachineLabels) error {
+			machineLabels.Metadata().Labels().Set(pickedByManualAllocation, "")
+
+			return nil
+		}))
+	}
+
+	rtestutils.AssertResources(ctx, t, st, result, func(labels *system.ResourceLabels[*omni.MachineStatus], assert *assert.Assertions) {
+		_, ok := labels.Metadata().Labels().Get(pickedByManualAllocation)
+
+		assert.True(ok)
+	})
+
+	return result
+}
+
+// pickUnallocatedMachinesAttempt makes a single scan over the available machines under the reservation
+// lock and reserves the picked ones before releasing it.
+func pickUnallocatedMachinesAttempt(ctx context.Context, st state.State, count int, filterFunc PickFilterFunc,
+	logger *zap.Logger, loggedLeakedMarkers map[resource.ID]struct{},
+) ([]resource.ID, error) {
+	machineReservations.mx.Lock()
+	defer machineReservations.mx.Unlock()
+
+	machineStatuses, err := safe.StateListAll[*omni.MachineStatus](ctx, st, state.WithLabelQuery(resource.LabelExists(omni.MachineStatusLabelAvailable)))
+	if err != nil {
+		return nil, err
+	}
+
+	nodeList, err := st.List(ctx, resource.NewMetadata(resources.DefaultNamespace, omni.MachineSetNodeType, "", resource.VersionUndefined))
+	if err != nil {
+		return nil, err
+	}
+
+	nodeMap := xslices.ToMap(nodeList.Items, func(node resource.Resource) (resource.ID, resource.Resource) {
+		return node.Metadata().ID(), node
+	})
+
+	shuffledMachineStatuses := slices.Collect(machineStatuses.All())
+	rand.Shuffle(len(shuffledMachineStatuses), func(i, j int) {
+		shuffledMachineStatuses[i], shuffledMachineStatuses[j] = shuffledMachineStatuses[j], shuffledMachineStatuses[i]
+	})
+
+	pickedMachineStatuses := make([]*omni.MachineStatus, 0, count)
+
+	for _, machineStatus := range shuffledMachineStatuses {
+		if machineReservations.reservedLocked(machineStatus.Metadata().ID()) {
+			continue
+		}
+
+		allocatedNode, isAllocated := nodeMap[machineStatus.Metadata().ID()]
+		if isAllocated {
+			allocatedCluster, _ := allocatedNode.Metadata().Labels().Get(omni.LabelCluster)
+
+			logger.Error("machine has the label available but is still allocated to a cluster",
+				zap.String("machine_id", machineStatus.Metadata().ID()),
+				zap.String("allocated_cluster", allocatedCluster))
+
+			continue
+		}
+
+		if _, marked := machineStatus.Metadata().Labels().Get(pickedByManualAllocation); marked {
+			if _, logged := loggedLeakedMarkers[machineStatus.Metadata().ID()]; !logged {
+				loggedLeakedMarkers[machineStatus.Metadata().ID()] = struct{}{}
+
+				logger.Error("available machine carries the manual allocation marker but is not reserved by any test",
+					zap.String("machine_id", machineStatus.Metadata().ID()))
+			}
+		}
+
+		if filterFunc(machineStatus, pickedMachineStatuses) {
+			pickedMachineStatuses = append(pickedMachineStatuses, machineStatus)
+		}
+
+		if len(pickedMachineStatuses) >= count {
+			break
+		}
+	}
+
+	if len(pickedMachineStatuses) < count {
+		return nil, retry.ExpectedErrorf("not enough machines: available %d, requested %d", len(pickedMachineStatuses), count)
+	}
+
+	result := make([]resource.ID, 0, count)
+
+	for _, ms := range pickedMachineStatuses {
+		result = append(result, ms.Metadata().ID())
+
+		machineReservations.reserveLocked(ms.Metadata().ID())
+	}
+
+	return result, nil
+}
+
+// releasePickedMachines removes the manual allocation markers from the machines and releases their
+// in-memory reservations.
+func releasePickedMachines(ctx context.Context, t *testing.T, st state.State, ids []resource.ID) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancel()
+
+	// Release the in-memory reservations last and unconditionally, even when the marker removal
+	// below fails: a permanently reserved machine is worse than a leaked marker, which the pick
+	// scans at least report.
+	defer machineReservations.release(ids)
+
+	removed := make([]resource.ID, 0, len(ids))
+
+	for _, id := range ids {
+		if err := safe.StateModify(cleanupCtx, st, omni.NewMachineLabels(id), func(machineLabels *omni.MachineLabels) error {
+			machineLabels.Metadata().Labels().Delete(pickedByManualAllocation)
+
+			return nil
+		}); err != nil {
+			t.Errorf("failed to remove the manual allocation marker from machine %q: %v", id, err)
+
+			continue
+		}
+
+		removed = append(removed, id)
+	}
+
+	// Wait for the marker removal to propagate before releasing the in-memory reservations, so
+	// that the next picker of the machine cannot pass its marker visibility wait on this test's
+	// stale marker and then lose the machine to the server-side allocation when the removal lands.
+	// A failure here only re-widens that handoff window, and the pick scans report leaked markers
+	// anyway, so log it instead of failing an already finished test.
+	if err := waitManualAllocationMarkersGone(cleanupCtx, st, removed); err != nil {
+		t.Logf("failed to wait for the manual allocation markers to be removed: %v", err)
+	}
+}
+
+// waitManualAllocationMarkersGone waits until the manual allocation marker is no longer visible on the
+// machine status label projections of the given machines. A missing projection counts as gone, since a
+// machine unknown to Omni cannot be allocated.
+func waitManualAllocationMarkersGone(ctx context.Context, st state.State, ids []resource.ID) error {
+	return retry.Constant(time.Minute).RetryWithContext(ctx, func(ctx context.Context) error {
+		for _, id := range ids {
+			labels, err := safe.StateGetByID[*system.ResourceLabels[*omni.MachineStatus]](ctx, st, id)
+			if err != nil {
+				if state.IsNotFoundError(err) {
+					continue
+				}
+
+				// wrap to keep retrying on transient read errors, the enclosing context enforces the deadline
+				return retry.ExpectedError(err)
+			}
+
+			if _, ok := labels.Metadata().Labels().Get(pickedByManualAllocation); ok {
+				return retry.ExpectedErrorf("machine %q still carries the manual allocation marker", id)
+			}
+		}
+
+		return nil
+	})
 }
 
 func createOrUpdate[T resource.Resource](ctx context.Context, t *testing.T, s state.State, res T, update func(T) error, createOpts ...state.CreateOption) {
@@ -998,9 +1155,6 @@ func waitMachineSetNodesSync(ctx context.Context, t *testing.T, st state.State, 
 }
 
 func updateMachineClassMachineSets(ctx context.Context, t *testing.T, st state.State, options ClusterOptions, machineClass *omni.MachineClass) {
-	machineAllocationLock.Lock()
-	defer machineAllocationLock.Unlock()
-
 	for _, role := range []string{omni.LabelControlPlaneRole, omni.LabelWorkerRole} {
 		id := omni.WorkersResourceID(options.Name)
 		machineCount := options.Workers

--- a/internal/integration/embedded_machine_config_test.go
+++ b/internal/integration/embedded_machine_config_test.go
@@ -125,11 +125,7 @@ func AssertMachineConfigPatchAppliedInMaintenance(testCtx context.Context, optio
 			return machineStatus.TypedSpec().Value.Maintenance
 		}
 
-		var machineID resource.ID
-
-		pickUnallocatedMachines(ctx, t, omniState, 1, inMaintenance, func(machineIDs []resource.ID) {
-			machineID = machineIDs[0]
-		})
+		machineID := pickUnallocatedMachines(ctx, t, omniState, 1, inMaintenance)[0]
 
 		t.Logf("applying a config patch to maintenance machine %q", machineID)
 

--- a/internal/integration/machines_test.go
+++ b/internal/integration/machines_test.go
@@ -135,20 +135,20 @@ func AssertUnallocatedMachineDestroyFlow(testCtx context.Context, options *TestO
 
 		require := require.New(t)
 
-		pickUnallocatedMachines(ctx, t, st, 1, nil, func(machineIDs []string) {
-			rtestutils.Destroy[*siderolink.Link](ctx, t, st, machineIDs)
+		machineIDs := pickUnallocatedMachines(ctx, t, st, 1, nil)
 
-			rtestutils.AssertNoResource[*omni.Machine](ctx, t, st, machineIDs[0])
-			rtestutils.AssertNoResource[*omni.MachineStatus](ctx, t, st, machineIDs[0])
+		rtestutils.Destroy[*siderolink.Link](ctx, t, st, machineIDs)
 
-			// reboot a machine
-			require.NoError(restartAMachineFunc(ctx, machineIDs[0]))
+		rtestutils.AssertNoResource[*omni.Machine](ctx, t, st, machineIDs[0])
+		rtestutils.AssertNoResource[*omni.MachineStatus](ctx, t, st, machineIDs[0])
 
-			// machine should re-register and become available
-			rtestutils.AssertResources(ctx, t, st, machineIDs, func(machine *omni.MachineStatus, assert *assert.Assertions) {
-				_, ok := machine.Metadata().Labels().Get(omni.MachineStatusLabelAvailable)
-				assert.True(ok)
-			})
+		// reboot a machine
+		require.NoError(restartAMachineFunc(ctx, machineIDs[0]))
+
+		// machine should re-register and become available
+		rtestutils.AssertResources(ctx, t, st, machineIDs, func(machine *omni.MachineStatus, assert *assert.Assertions) {
+			_, ok := machine.Metadata().Labels().Get(omni.MachineStatusLabelAvailable)
+			assert.True(ok)
 		})
 	}
 }
@@ -195,26 +195,26 @@ func AssertControlPlaneForceReplaceMachine(testCtx context.Context, st state.Sta
 
 		id := freezeMachine(ctx, t, st, clusterName, options.FreezeAMachineFunc, omni.LabelControlPlaneRole)
 
-		pickUnallocatedMachines(ctx, t, st, 1, nil, func(machineIDs []resource.ID) {
-			t.Logf("Adding machine %q to control plane", machineIDs[0])
+		machineIDs := pickUnallocatedMachines(ctx, t, st, 1, nil)
 
-			bindMachine(ctx, t, st, bindMachineOptions{
-				clusterName:  clusterName,
-				role:         omni.LabelControlPlaneRole,
-				machineID:    machineIDs[0],
-				talosVersion: options.MachineOptions.TalosVersion,
-			})
+		t.Logf("Adding machine %q to control plane", machineIDs[0])
 
-			// assert that machines got allocated (label available is removed)
-			rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
-				assert.True(machineStatus.Metadata().Labels().Matches(
-					resource.LabelTerm{
-						Key:    omni.MachineStatusLabelAvailable,
-						Op:     resource.LabelOpExists,
-						Invert: true,
-					},
-				), resourceDetails(machineStatus))
-			})
+		bindMachine(ctx, t, st, bindMachineOptions{
+			clusterName:  clusterName,
+			role:         omni.LabelControlPlaneRole,
+			machineID:    machineIDs[0],
+			talosVersion: options.MachineOptions.TalosVersion,
+		})
+
+		// assert that machines got allocated (label available is removed)
+		rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+			assert.True(machineStatus.Metadata().Labels().Matches(
+				resource.LabelTerm{
+					Key:    omni.MachineStatusLabelAvailable,
+					Op:     resource.LabelOpExists,
+					Invert: true,
+				},
+			), resourceDetails(machineStatus))
 		})
 
 		wipeMachine(ctx, t, st, id, options.WipeAMachineFunc)

--- a/internal/integration/suites_test.go
+++ b/internal/integration/suites_test.go
@@ -1199,25 +1199,30 @@ eventually reports the upgrade target as its running Talos version.`)
 
 		options.claimMachines(t, 1)
 
-		// machineID is set by the MachineShouldBeInstalledInMaintenanceMode and consumed by the MachineShouldBeUpgradedInMaintenanceMode so both run against the same machine.
-		var machineID resource.ID
-
+		// Install and upgrade run in a single subtest: the machine picked by the install step is
+		// reserved only until the test that picked it finishes, so the upgrade step must share that
+		// test to keep the machine protected from concurrent tests.
 		t.Run(
-			"MachineShouldBeInstalledInMaintenanceMode",
-			AssertMachineShouldBeInstalledInMaintenanceMode(
-				t.Context(), options,
-				options.MachineOptions.TalosVersion,
-				&machineID,
-			),
-		)
+			"MachineShouldBeInstalledAndUpgradedInMaintenanceMode",
+			func(t *testing.T) {
+				// machineID is set by the install assertion and consumed by the upgrade assertion so both run against the same machine.
+				var machineID resource.ID
 
-		t.Run(
-			"MachineShouldBeUpgradedInMaintenanceMode",
-			AssertMachineShouldBeUpgradedViaMaintenanceLifecycle(
-				t.Context(), options,
-				&machineID,
-				options.AnotherTalosVersion,
-			),
+				AssertMachineShouldBeInstalledInMaintenanceMode(
+					t.Context(), options,
+					options.MachineOptions.TalosVersion,
+					&machineID,
+				)(t)
+
+				// The upgrade step below may skip the whole subtest even though the install step above ran to completion.
+				t.Log("maintenance install step done, starting the maintenance upgrade step")
+
+				AssertMachineShouldBeUpgradedViaMaintenanceLifecycle(
+					t.Context(), options,
+					&machineID,
+					options.AnotherTalosVersion,
+				)(t)
+			},
 		)
 	}
 }

--- a/internal/integration/talos_test.go
+++ b/internal/integration/talos_test.go
@@ -1024,37 +1024,33 @@ func AssertMachineShouldBeUpgradedInMaintenanceMode(
 		omniClient := options.omniClient
 		omniState := omniClient.Omni().State()
 
-		var allocatedMachineIDs []resource.ID
-
 		t.Logf("creating a cluster on version %q", talosVersion1)
 
-		pickUnallocatedMachines(ctx, t, omniState, 1, nil, func(machineIDs []resource.ID) {
-			allocatedMachineIDs = machineIDs
+		allocatedMachineIDs := pickUnallocatedMachines(ctx, t, omniState, 1, nil)
 
-			cluster := omni.NewCluster(clusterName)
-			cluster.TypedSpec().Value.TalosVersion = talosVersion1
-			cluster.TypedSpec().Value.KubernetesVersion = kubernetesVersion
+		cluster := omni.NewCluster(clusterName)
+		cluster.TypedSpec().Value.TalosVersion = talosVersion1
+		cluster.TypedSpec().Value.KubernetesVersion = kubernetesVersion
 
-			require.NoError(omniState.Create(ctx, cluster))
+		require.NoError(omniState.Create(ctx, cluster))
 
-			t.Logf("Adding machine %q to control plane (cluster %q, version %q)", machineIDs[0], clusterName, talosVersion1)
-			bindMachine(ctx, t, omniState, bindMachineOptions{
-				clusterName:  clusterName,
-				role:         omni.LabelControlPlaneRole,
-				machineID:    machineIDs[0],
-				talosVersion: talosVersion1,
-			})
+		t.Logf("Adding machine %q to control plane (cluster %q, version %q)", allocatedMachineIDs[0], clusterName, talosVersion1)
+		bindMachine(ctx, t, omniState, bindMachineOptions{
+			clusterName:  clusterName,
+			role:         omni.LabelControlPlaneRole,
+			machineID:    allocatedMachineIDs[0],
+			talosVersion: talosVersion1,
+		})
 
-			// assert that machines got allocated (label available is removed)
-			rtestutils.AssertResources(ctx, t, omniState, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
-				assert.True(machineStatus.Metadata().Labels().Matches(
-					resource.LabelTerm{
-						Key:    omni.MachineStatusLabelAvailable,
-						Op:     resource.LabelOpExists,
-						Invert: true,
-					},
-				), resourceDetails(machineStatus))
-			})
+		// assert that machines got allocated (label available is removed)
+		rtestutils.AssertResources(ctx, t, omniState, allocatedMachineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+			assert.True(machineStatus.Metadata().Labels().Matches(
+				resource.LabelTerm{
+					Key:    omni.MachineStatusLabelAvailable,
+					Op:     resource.LabelOpExists,
+					Invert: true,
+				},
+			), resourceDetails(machineStatus))
 		})
 
 		assertClusterReady := func(expectedVersion string) {
@@ -1073,7 +1069,7 @@ func AssertMachineShouldBeUpgradedInMaintenanceMode(
 		t.Logf("creating a cluster on version %q using same machines", talosVersion2)
 
 		// re-create the cluster on talosVersion2
-		cluster := omni.NewCluster(clusterName)
+		cluster = omni.NewCluster(clusterName)
 		cluster.TypedSpec().Value.TalosVersion = talosVersion2
 		cluster.TypedSpec().Value.KubernetesVersion = kubernetesVersion
 
@@ -1127,11 +1123,7 @@ func AssertMachineShouldBeInstalledInMaintenanceMode(testCtx context.Context, op
 			return machineStatus.TypedSpec().Value.Maintenance && !installed && installDisk(machineStatus) != ""
 		}
 
-		var machineID resource.ID
-
-		pickUnallocatedMachines(ctx, t, omniState, 1, notInstalledMaintenance, func(machineIDs []resource.ID) {
-			machineID = machineIDs[0]
-		})
+		machineID := pickUnallocatedMachines(ctx, t, omniState, 1, notInstalledMaintenance)[0]
 
 		machineStatus, err := safe.StateGetByID[*omni.MachineStatus](ctx, omniState, machineID)
 		require.NoError(t, err)

--- a/internal/integration/template_test.go
+++ b/internal/integration/template_test.go
@@ -63,7 +63,6 @@ func AssertClusterTemplateFlow(testCtx context.Context, st state.State, options 
 			additionalWorkersName           = "additional-workers"
 			lockDelete                      = "lockDelete"
 			machineClassBasedMachineSetName = "additional-workers-machine-class"
-			pickedByManualAllocation        = "picked-by-manual-allocation"
 		)
 
 		require := require.New(t)
@@ -82,99 +81,64 @@ func AssertClusterTemplateFlow(testCtx context.Context, st state.State, options 
 			rtestutils.Destroy[*omni.MachineClass](testCtx, t, st, []string{machineClassName})
 		})
 
-		var (
-			machineIDs                     []resource.ID
-			opts                           tmplOptions
-			tmpl1                          []byte
-			automaticallyAllocatedMachines []string
-		)
+		machineIDs := pickUnallocatedMachines(ctx, t, st, 5, nil)
 
-		pickUnallocatedMachines(ctx, t, st, 5, nil, func(mIDs []resource.ID) {
-			machineIDs = mIDs
+		opts := tmplOptions{
+			KubernetesVersion:               "v" + options.KubernetesVersion,
+			TalosVersion:                    "v" + options.TalosVersion,
+			MachineClass:                    machineClassName,
+			MachineClassBasedMachineSetName: machineClassBasedMachineSetName,
 
-			opts = tmplOptions{
-				KubernetesVersion:               "v" + options.KubernetesVersion,
-				TalosVersion:                    "v" + options.TalosVersion,
-				MachineClass:                    machineClassName,
-				MachineClassBasedMachineSetName: machineClassBasedMachineSetName,
+			CP: machineIDs[:3],
+			W:  machineIDs[3:],
+		}
 
-				CP: machineIDs[:3],
-				W:  machineIDs[3:],
-			}
+		tmpl1 := renderTemplate(t, cluster1Tmpl, opts)
 
-			for _, m := range mIDs {
-				err = safe.StateModify(ctx, st, omni.NewMachineLabels(m), func(labels *omni.MachineLabels) error {
-					labels.Metadata().Labels().Set(pickedByManualAllocation, "")
+		require.NoError(operations.ValidateTemplate(bytes.NewReader(tmpl1), nil))
 
-					return nil
-				})
+		t.Log("creating template cluster")
 
-				require.NoError(err)
+		require.NoError(operations.SyncTemplate(ctx, bytes.NewReader(tmpl1), os.Stderr, st, operations.SyncOptions{
+			Verbose: true,
+		}, nil))
 
-				t.Cleanup(func() {
-					err = safe.StateModify(testCtx, st, omni.NewMachineLabels(m), func(labels *omni.MachineLabels) error {
-						labels.Metadata().Labels().Delete(pickedByManualAllocation)
+		// assert that machines got allocated (label available is removed)
+		rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
+			assert.True(machineStatus.Metadata().Labels().Matches(
+				resource.LabelTerm{
+					Key:    omni.MachineStatusLabelAvailable,
+					Op:     resource.LabelOpExists,
+					Invert: true,
+				},
+			), resourceDetails(machineStatus))
+		})
 
-						return nil
-					})
+		machineSet, err := safe.ReaderGetByID[*omni.MachineSet](ctx, st, clusterName+"-"+machineClassBasedMachineSetName)
+		require.NoError(err)
 
-					require.NoError(err)
-				})
-			}
+		automaticallyAllocatedMachines := rtestutils.ResourceIDs[*omni.MachineSetNode](ctx, t, st, state.WithLabelQuery(
+			resource.LabelEqual(omni.LabelMachineSet, machineSet.Metadata().ID()),
+		))
 
-			rtestutils.AssertResources(ctx, t, st, mIDs, func(status *omni.MachineStatus, assert *assert.Assertions) {
-				_, ok := status.Metadata().Labels().Get(pickedByManualAllocation)
+		require.Greater(len(automaticallyAllocatedMachines), 0)
 
-				assert.True(ok)
-			})
+		// add finalizer on the machine set node to make the test fail if it tries to delete the machine set node unexpectedly
+		require.NoError(st.AddFinalizer(
+			ctx,
+			omni.NewMachineSetNode(automaticallyAllocatedMachines[0], machineSet).Metadata(),
+			lockDelete,
+		))
 
-			tmpl1 = renderTemplate(t, cluster1Tmpl, opts)
-
-			require.NoError(operations.ValidateTemplate(bytes.NewReader(tmpl1), nil))
-
-			t.Log("creating template cluster")
-
-			require.NoError(operations.SyncTemplate(ctx, bytes.NewReader(tmpl1), os.Stderr, st, operations.SyncOptions{
-				Verbose: true,
-			}, nil))
-
-			// assert that machines got allocated (label available is removed)
-			rtestutils.AssertResources(ctx, t, st, machineIDs, func(machineStatus *omni.MachineStatus, assert *assert.Assertions) {
-				assert.True(machineStatus.Metadata().Labels().Matches(
-					resource.LabelTerm{
-						Key:    omni.MachineStatusLabelAvailable,
-						Op:     resource.LabelOpExists,
-						Invert: true,
-					},
-				), resourceDetails(machineStatus))
-			})
-
-			machineSet, err := safe.ReaderGetByID[*omni.MachineSet](ctx, st, clusterName+"-"+machineClassBasedMachineSetName)
-			require.NoError(err)
-
-			automaticallyAllocatedMachines = rtestutils.ResourceIDs[*omni.MachineSetNode](ctx, t, st, state.WithLabelQuery(
-				resource.LabelEqual(omni.LabelMachineSet, machineSet.Metadata().ID()),
-			))
-
-			require.Greater(len(automaticallyAllocatedMachines), 0)
-
-			// add finalizer on the machine set node to make the test fail if it tries to delete the machine set node unexpectedly
-			require.NoError(st.AddFinalizer(
-				ctx,
-				omni.NewMachineSetNode(automaticallyAllocatedMachines[0], machineSet).Metadata(),
+		t.Cleanup(func() {
+			err = st.RemoveFinalizer(
+				testCtx,
+				omni.NewMachineSetNode(
+					automaticallyAllocatedMachines[0],
+					omni.NewMachineSet(""),
+				).Metadata(),
 				lockDelete,
-			))
-
-			t.Cleanup(func() {
-				err = st.RemoveFinalizer(
-					testCtx,
-					omni.NewMachineSetNode(
-						automaticallyAllocatedMachines[0],
-						omni.NewMachineSet(""),
-					).Metadata(),
-					lockDelete,
-				)
-			})
+			)
 		})
 
 		t.Log("wait for cluster to be ready")


### PR DESCRIPTION
The integration test suites run in parallel and share a machine pool, but only the machine count was tracked, not which test owns which machine. A test which briefly unallocates a machine it still needs, like the maintenance upgrade flow re-creating a cluster on the same machine, could lose it to a concurrent suite and fail on a cluster ownership validation error.

Picked machines are now reserved until the picking test finishes: in memory against the picks of other tests, and with a marker label against the automatic machine allocation, which the machine classes used in the tests exclude. The maintenance install and upgrade steps now share a single test, so their machine stays reserved across both steps.