### PR TITLE
feat: classify installer exit codes and skip retrying permanent ones

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -221,6 +221,12 @@ func (ctrl *StatusController) reconcileRunning(
 	}
 
 	if err = ctrl.reconcileUpgrade(ctx, logger, r, rc); err != nil {
+		// LifecycleManager reported that underlying Talos API call failed with a permanent error,
+		// so we don't retry the operation and just record the error in status.
+		if lifecycle.IsPermanentInstallerFailure(err) {
+			return nil
+		}
+
 		return err
 	}
 
@@ -682,6 +688,12 @@ func (ctrl *StatusController) runMaintenanceLifecycle(
 		logger.Info(operationName+" already in flight", zap.String("machine", machineID))
 
 		return false, controller.NewRequeueInterval(lifecycle.RetryInterval)
+	case lifecycle.IsPermanentInstallerFailure(err):
+		rc.machineConfigStatus.TypedSpec().Value.LastConfigError = lifecycle.WrapErr(err, fmt.Sprintf("%s failed", operationName)).Error()
+
+		logger.Error(operationName+" failed permanently", zap.String("machine", machineID), zap.Error(err))
+
+		return false, err
 	case err != nil:
 		// Returning a raw error would make qtransform drop the output write and lose LastConfigError.
 		rc.machineConfigStatus.TypedSpec().Value.LastConfigError = lifecycle.WrapErr(err, fmt.Sprintf("%s failed", operationName)).Error()
@@ -790,6 +802,12 @@ func (ctrl *StatusController) runClusterLifecycle(
 		logger.Info("upgrade already in flight", zap.String("machine", machineID))
 
 		return false, controller.NewRequeueInterval(lifecycle.RetryInterval)
+	case lifecycle.IsPermanentInstallerFailure(err):
+		rc.machineConfigStatus.TypedSpec().Value.LastConfigError = lifecycle.WrapErr(err, "upgrade failed").Error()
+
+		logger.Error("upgrade failed permanently", zap.String("machine", machineID), zap.Error(err))
+
+		return false, err
 	case err != nil:
 		// Returning a raw error would make qtransform drop the output write and lose LastConfigError.
 		rc.machineConfigStatus.TypedSpec().Value.LastConfigError = lifecycle.WrapErr(err, "upgrade failed").Error()

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -28,8 +28,10 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/security"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	ktesting "k8s.io/client-go/testing"
@@ -1260,7 +1262,9 @@ func TestMachineConfigStatusController(t *testing.T) {
 				id := setupMaintenanceMachine(
 					ctx, t, st, machineServices, "maint-error", false, "boot-error",
 					func(svc *testutils.MachineServiceMock) {
-						svc.SetLifecycleInstallHandler(func(*machine.LifecycleServiceInstallRequest) error {
+						svc.SetLifecycleInstallHandler(func(
+							*machine.LifecycleServiceInstallRequest, grpc.ServerStreamingServer[machine.LifecycleServiceInstallResponse],
+						) error {
 							return errors.New("installer blew up")
 						})
 					},
@@ -1268,6 +1272,49 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
 					a.Contains(res.TypedSpec().Value.LastConfigError, "installer blew up")
+					a.Empty(res.TypedSpec().Value.PreRebootBootId, "a failed operation must not record the boot ID")
+				})
+			},
+		)
+	})
+
+	// maintenanceLifecyclePermanentExitCode verifies the installer's exit code is translated into a
+	// reason the operator can act on, rather than the bare number Talos reports.
+	t.Run("maintenanceLifecyclePermanentExitCode", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{},
+			func(_ context.Context, tc testutils.TestContext) {
+				require.NoError(t, tc.Runtime.RegisterQController(
+					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, tc.State, nil)),
+				))
+			},
+			func(ctx context.Context, tc testutils.TestContext) {
+				st := tc.State
+				machineServices := testutils.NewMachineServices(t, st)
+
+				id := setupMaintenanceMachine(
+					ctx, t, st, machineServices, "maint-exit-code", false, "boot-exit-code",
+					func(svc *testutils.MachineServiceMock) {
+						svc.SetLifecycleInstallHandler(func(
+							_ *machine.LifecycleServiceInstallRequest, srv grpc.ServerStreamingServer[machine.LifecycleServiceInstallResponse],
+						) error {
+							return srv.Send(&machine.LifecycleServiceInstallResponse{
+								Progress: &machine.LifecycleServiceInstallProgress{
+									Response: &machine.LifecycleServiceInstallProgress_ExitCode{ExitCode: constants.ExitInvalidInput},
+								},
+							})
+						})
+					},
+				)
+
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+					a.Contains(res.TypedSpec().Value.LastConfigError, "machine configuration")
+					a.Contains(res.TypedSpec().Value.LastConfigError, "installer exit code 2")
 					a.Empty(res.TypedSpec().Value.PreRebootBootId, "a failed operation must not record the boot ID")
 				})
 			},
@@ -1304,7 +1351,9 @@ func TestMachineConfigStatusController(t *testing.T) {
 				id := setupMaintenanceMachine(
 					ctx, t, st, machineServices, "maint-inflight", false, "boot-inflight",
 					func(svc *testutils.MachineServiceMock) {
-						svc.SetLifecycleInstallHandler(func(*machine.LifecycleServiceInstallRequest) error {
+						svc.SetLifecycleInstallHandler(func(
+							*machine.LifecycleServiceInstallRequest, grpc.ServerStreamingServer[machine.LifecycleServiceInstallResponse],
+						) error {
 							once.Do(func() { close(installEntered) })
 							<-release
 

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
@@ -233,7 +233,25 @@ func (ctrl *StatusController) transform(ctx context.Context, r controller.Reader
 			return nil
 		}
 
-		return err
+		// A bare requeue is the "come back later" signal from ctrl.upgrade, not a failed upgrade,
+		// so leave the status alone and let it through.
+		if reqErr, ok := errors.AsType[*controller.RequeueError](err); ok && reqErr.Err() == nil {
+			return err
+		}
+
+		logger.Error("Talos upgrade failed", zap.Error(err))
+
+		status.TypedSpec().Value.Phase = specs.MachineUpgradeStatusSpec_Unknown
+		status.TypedSpec().Value.Status = ""
+		status.TypedSpec().Value.Error = err.Error()
+
+		// LifecycleManager reported that underlying Talos API call failed with a permanent error,
+		// so we don't retry the operation and just record the error in status.
+		if lifecycle.IsPermanentInstallerFailure(err) {
+			return nil
+		}
+
+		return controller.NewRequeueInterval(lifecycle.RetryInterval)
 	}
 
 	logger.Info("Talos upgrade initiated")

--- a/internal/backend/runtime/omni/controllers/testutils/machine_service.go
+++ b/internal/backend/runtime/omni/controllers/testutils/machine_service.go
@@ -179,8 +179,8 @@ type MachineServiceMock struct {
 	versionHandler          func(ctx context.Context, _ *emptypb.Empty) (*machine.VersionResponse, error)
 	readHandler             func(*machine.ReadRequest, grpc.ServerStreamingServer[common.Data]) error
 
-	lifecycleInstallHandler func(*machine.LifecycleServiceInstallRequest) error
-	lifecycleUpgradeHandler func(*machine.LifecycleServiceUpgradeRequest) error
+	lifecycleInstallHandler func(*machine.LifecycleServiceInstallRequest, grpc.ServerStreamingServer[machine.LifecycleServiceInstallResponse]) error
+	lifecycleUpgradeHandler func(*machine.LifecycleServiceUpgradeRequest, grpc.ServerStreamingServer[machine.LifecycleServiceUpgradeResponse]) error
 	rebootHandler           func() error
 
 	lifecycleInstallRequests []*machine.LifecycleServiceInstallRequest
@@ -387,27 +387,27 @@ type lifecycleServiceMock struct {
 	ms *MachineServiceMock
 }
 
-func (l *lifecycleServiceMock) Install(req *machine.LifecycleServiceInstallRequest, _ grpc.ServerStreamingServer[machine.LifecycleServiceInstallResponse]) error {
+func (l *lifecycleServiceMock) Install(req *machine.LifecycleServiceInstallRequest, srv grpc.ServerStreamingServer[machine.LifecycleServiceInstallResponse]) error {
 	l.ms.lock.Lock()
 	l.ms.lifecycleInstallRequests = append(l.ms.lifecycleInstallRequests, req)
 	handler := l.ms.lifecycleInstallHandler
 	l.ms.lock.Unlock()
 
 	if handler != nil {
-		return handler(req)
+		return handler(req, srv)
 	}
 
 	return nil
 }
 
-func (l *lifecycleServiceMock) Upgrade(req *machine.LifecycleServiceUpgradeRequest, _ grpc.ServerStreamingServer[machine.LifecycleServiceUpgradeResponse]) error {
+func (l *lifecycleServiceMock) Upgrade(req *machine.LifecycleServiceUpgradeRequest, srv grpc.ServerStreamingServer[machine.LifecycleServiceUpgradeResponse]) error {
 	l.ms.lock.Lock()
 	l.ms.lifecycleUpgradeRequests = append(l.ms.lifecycleUpgradeRequests, req)
 	handler := l.ms.lifecycleUpgradeHandler
 	l.ms.lock.Unlock()
 
 	if handler != nil {
-		return handler(req)
+		return handler(req, srv)
 	}
 
 	return nil
@@ -421,14 +421,22 @@ func (imageServiceMock) Pull(*machine.ImageServicePullRequest, grpc.ServerStream
 	return nil
 }
 
-func (ms *MachineServiceMock) SetLifecycleInstallHandler(handler func(*machine.LifecycleServiceInstallRequest) error) {
+// SetLifecycleInstallHandler sets the handler for LifecycleService.Install. The handler gets the
+// server stream so it can relay installer progress, including a non-zero exit code.
+func (ms *MachineServiceMock) SetLifecycleInstallHandler(
+	handler func(*machine.LifecycleServiceInstallRequest, grpc.ServerStreamingServer[machine.LifecycleServiceInstallResponse]) error,
+) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
 	ms.lifecycleInstallHandler = handler
 }
 
-func (ms *MachineServiceMock) SetLifecycleUpgradeHandler(handler func(*machine.LifecycleServiceUpgradeRequest) error) {
+// SetLifecycleUpgradeHandler sets the handler for LifecycleService.Upgrade. The handler gets the
+// server stream so it can relay installer progress, including a non-zero exit code.
+func (ms *MachineServiceMock) SetLifecycleUpgradeHandler(
+	handler func(*machine.LifecycleServiceUpgradeRequest, grpc.ServerStreamingServer[machine.LifecycleServiceUpgradeResponse]) error,
+) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 

--- a/internal/backend/talos/lifecycle/client.go
+++ b/internal/backend/talos/lifecycle/client.go
@@ -14,6 +14,7 @@ import (
 
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -252,8 +253,8 @@ func relayProgress(
 			}
 		}
 	case *machineapi.LifecycleServiceInstallProgress_ExitCode:
-		if payload.ExitCode != 0 {
-			return status.Errorf(codes.Internal, "%s failed with exit code %d", operationLabel, payload.ExitCode)
+		if payload.ExitCode != constants.ExitSuccess {
+			return &InstallerExitError{Operation: operationLabel, Code: payload.ExitCode}
 		}
 	}
 

--- a/internal/backend/talos/lifecycle/client_test.go
+++ b/internal/backend/talos/lifecycle/client_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -81,5 +83,59 @@ func TestBuildInstallImage(t *testing.T) {
 
 		_, err := m.BuildInstallImageForTest(t.Context(), "machine-bare", bare, "", nil)
 		require.Error(t, err)
+	})
+}
+
+func TestRelayProgress(t *testing.T) {
+	t.Parallel()
+
+	t.Run("messages are split into lines and prefixed", func(t *testing.T) {
+		t.Parallel()
+
+		var got []string
+
+		err := lifecycle.RelayProgressForTest(
+			&machineapi.LifecycleServiceInstallProgress{
+				Response: &machineapi.LifecycleServiceInstallProgress_Message{Message: "wiping disk  \n\nwriting image\n"},
+			},
+			"installation",
+			func(msg string) { got = append(got, msg) },
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"[talos] wiping disk", "[talos] writing image"}, got)
+	})
+
+	t.Run("a zero exit code reports success", func(t *testing.T) {
+		t.Parallel()
+
+		err := lifecycle.RelayProgressForTest(
+			&machineapi.LifecycleServiceInstallProgress{
+				Response: &machineapi.LifecycleServiceInstallProgress_ExitCode{ExitCode: constants.ExitSuccess},
+			},
+			"installation",
+			nil,
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("a non-zero exit code becomes a classified installer error", func(t *testing.T) {
+		t.Parallel()
+
+		err := lifecycle.RelayProgressForTest(
+			&machineapi.LifecycleServiceInstallProgress{
+				Response: &machineapi.LifecycleServiceInstallProgress_ExitCode{ExitCode: constants.ExitInvalidInput},
+			},
+			"installation",
+			nil,
+		)
+		require.Error(t, err)
+
+		var exitErr *lifecycle.InstallerExitError
+
+		require.ErrorAs(t, err, &exitErr)
+		assert.Equal(t, "installation", exitErr.Operation)
+		assert.EqualValues(t, constants.ExitInvalidInput, exitErr.Code)
+		assert.True(t, lifecycle.IsPermanentInstallerFailure(err))
 	})
 }

--- a/internal/backend/talos/lifecycle/exitcode.go
+++ b/internal/backend/talos/lifecycle/exitcode.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lifecycle
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// InstallerExitError reports a non-zero exit from the installer container Talos ran for an install or upgrade.
+type InstallerExitError struct {
+	// Operation labels the failed operation for the operator, e.g. "installation" or "upgrade".
+	Operation string
+	Code      int32
+}
+
+// Error implements the error interface.
+func (e *InstallerExitError) Error() string {
+	return fmt.Sprintf("%s failed: %s (installer exit code %d)", e.Operation, classifyInstallerExit(e.Code).reason, e.Code)
+}
+
+// GRPCStatus carries the mapped code through WrapErr and the management API, both of which read it
+// back with status.FromError.
+func (e *InstallerExitError) GRPCStatus() *status.Status {
+	return status.New(classifyInstallerExit(e.Code).grpcCode, e.Error())
+}
+
+// Permanent reports whether rerunning the same installer over the same inputs can only fail the same way.
+func (e *InstallerExitError) Permanent() bool {
+	return classifyInstallerExit(e.Code).permanent
+}
+
+// IsPermanentInstallerFailure reports whether err is an installer failure that no retry can fix.
+func IsPermanentInstallerFailure(err error) bool {
+	var exitErr *InstallerExitError
+
+	return errors.As(err, &exitErr) && exitErr.Permanent()
+}
+
+// installerExitInfo is Omni's presentation of one installer exit code.
+type installerExitInfo struct {
+	reason    string
+	grpcCode  codes.Code
+	permanent bool
+}
+
+// classifyInstallerExit maps a Talos installer exit code onto an operator-facing reason and a gRPC code.
+// Installers older than Talos 1.14 exit 1 for every failure, which lands on the generic entry below and stays retryable.
+func classifyInstallerExit(code int32) installerExitInfo {
+	switch code {
+	case constants.ExitInvalidInput:
+		return installerExitInfo{
+			reason:    "the installer rejected its input, the machine configuration or the install options are not valid for this Talos version",
+			grpcCode:  codes.InvalidArgument,
+			permanent: true,
+		}
+	case constants.ExitUnsupported:
+		return installerExitInfo{
+			reason:    "the installer does not support this operation for the selected version, platform or feature set",
+			grpcCode:  codes.FailedPrecondition,
+			permanent: true,
+		}
+	case constants.ExitEnvironment:
+		return installerExitInfo{
+			reason:    "the machine does not meet the installer's prerequisites, or its pre-flight checks failed",
+			grpcCode:  codes.FailedPrecondition,
+			permanent: false,
+		}
+	case constants.ExitDependency:
+		return installerExitInfo{
+			reason:    "an external dependency failed, such as the installer image pull, signature verification or post-processing",
+			grpcCode:  codes.Unavailable,
+			permanent: false,
+		}
+	case constants.ExitIO:
+		return installerExitInfo{
+			reason:    "the installer hit a filesystem or I/O error on the machine",
+			grpcCode:  codes.Internal,
+			permanent: false,
+		}
+	case constants.ExitInstall:
+		return installerExitInfo{
+			reason:    "writing Talos to the disk failed",
+			grpcCode:  codes.Internal,
+			permanent: false,
+		}
+	default:
+		return installerExitInfo{
+			reason:    "the installer reported no specific reason, check the machine logs",
+			grpcCode:  codes.Internal,
+			permanent: false,
+		}
+	}
+}

--- a/internal/backend/talos/lifecycle/exitcode_test.go
+++ b/internal/backend/talos/lifecycle/exitcode_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lifecycle_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
+)
+
+func TestInstallerExitError(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name         string
+		reasonPhrase string
+		code         int32
+		grpcCode     codes.Code
+		permanent    bool
+	}{
+		{
+			name:         "invalid input is permanent",
+			code:         constants.ExitInvalidInput,
+			reasonPhrase: "machine configuration",
+			grpcCode:     codes.InvalidArgument,
+			permanent:    true,
+		},
+		{
+			name:         "unsupported is permanent",
+			code:         constants.ExitUnsupported,
+			reasonPhrase: "does not support this operation",
+			grpcCode:     codes.FailedPrecondition,
+			permanent:    true,
+		},
+		{
+			name:         "environment is retryable",
+			code:         constants.ExitEnvironment,
+			reasonPhrase: "pre-flight checks failed",
+			grpcCode:     codes.FailedPrecondition,
+			permanent:    false,
+		},
+		{
+			name:         "dependency is retryable",
+			code:         constants.ExitDependency,
+			reasonPhrase: "external dependency failed",
+			grpcCode:     codes.Unavailable,
+			permanent:    false,
+		},
+		{
+			name:         "io is retryable",
+			code:         constants.ExitIO,
+			reasonPhrase: "filesystem or I/O error",
+			grpcCode:     codes.Internal,
+			permanent:    false,
+		},
+		{
+			name:         "install is retryable",
+			code:         constants.ExitInstall,
+			reasonPhrase: "writing Talos to the disk failed",
+			grpcCode:     codes.Internal,
+			permanent:    false,
+		},
+		{
+			// Installers older than Talos 1.14 exit 1 for every failure, so this entry has to stay generic
+			// and retryable.
+			name:         "unknown error is generic and retryable",
+			code:         constants.ExitUnknownError,
+			reasonPhrase: "no specific reason",
+			grpcCode:     codes.Internal,
+			permanent:    false,
+		},
+		{
+			name:         "an unrecognized code falls back to the generic entry",
+			code:         42,
+			reasonPhrase: "no specific reason",
+			grpcCode:     codes.Internal,
+			permanent:    false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := &lifecycle.InstallerExitError{Operation: "upgrade", Code: tt.code}
+
+			assert.Contains(t, err.Error(), tt.reasonPhrase)
+			assert.Contains(t, err.Error(), "upgrade failed")
+			assert.Contains(t, err.Error(), fmt.Sprintf("installer exit code %d", tt.code))
+
+			assert.Equal(t, tt.grpcCode, status.Code(err))
+			assert.Equal(t, tt.permanent, lifecycle.IsPermanentInstallerFailure(err))
+		})
+	}
+}
+
+// TestInstallerExitErrorSurvivesWrapping covers how the controllers actually see the error: the
+// gRPC code has to survive WrapErr, and the permanence check has to survive plain error wrapping.
+func TestInstallerExitErrorSurvivesWrapping(t *testing.T) {
+	t.Parallel()
+
+	err := &lifecycle.InstallerExitError{Operation: "installation", Code: constants.ExitInvalidInput}
+
+	wrapped := lifecycle.WrapErr(err, "maintenance install failed")
+
+	assert.Equal(t, codes.InvalidArgument, status.Code(wrapped))
+	assert.Contains(t, wrapped.Error(), "maintenance install failed")
+	assert.Contains(t, wrapped.Error(), "machine configuration")
+
+	assert.True(t, lifecycle.IsPermanentInstallerFailure(fmt.Errorf("relaying progress: %w", err)))
+}
+
+func TestIsPermanentInstallerFailureOnOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, lifecycle.IsPermanentInstallerFailure(nil))
+	assert.False(t, lifecycle.IsPermanentInstallerFailure(errors.New("connection refused")))
+	assert.False(t, lifecycle.IsPermanentInstallerFailure(status.Error(codes.InvalidArgument, "not an installer failure")))
+}

--- a/internal/backend/talos/lifecycle/export_test.go
+++ b/internal/backend/talos/lifecycle/export_test.go
@@ -8,9 +8,16 @@ package lifecycle
 import (
 	"context"
 
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
+
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
+
+// RelayProgressForTest exposes relayProgress to external tests.
+func RelayProgressForTest(progress *machineapi.LifecycleServiceInstallProgress, operationLabel string, send func(string)) error {
+	return relayProgress(progress, operationLabel, send)
+}
 
 // BuildInstallImageForTest exposes buildInstallImage to external tests.
 func (m *Manager) BuildInstallImageForTest(


### PR DESCRIPTION
LifecycleService API before 1.14 only had 1 exit code for all failures. Now it has distinct exit codes for what went wrong. Omni maps these codes to an installerExitInfo struct with a descriptive reason for each failure. Among failure scenarios `invalid input` and `unsupported operations` are permanent, since the machine config or the install options have to change before another attempt can work, so the machine config and machine upgrade controllers record the error in the status and stop. Everything else stays retryable, including the exit 1 that pre-1.14 installers report for every failure.

Resolves: #3032
