### PR TITLE
fix: log out of Omni and the IdP when /logout is opened directly

### DIFF
--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -10,6 +10,7 @@ export const AuthFlowQueryParam = "flow";
 export const CLIAuthFlow = "cli";
 export const FrontendAuthFlow = "frontend";
 export const WorkloadProxyAuthFlow = "workload-proxy";
+export const IdPLogoutPath = "/idp-logout";
 export const SignatureHeaderKey = "x-sidero-signature";
 export const TimestampHeaderKey = "x-sidero-timestamp";
 export const PayloadHeaderKey = "x-sidero-payload";

--- a/frontend/src/methods/auth.spec.ts
+++ b/frontend/src/methods/auth.spec.ts
@@ -13,7 +13,7 @@ import { RequestError } from '@/api/fetch.pb'
 import { Code } from '@/api/google/rpc/code.pb'
 import { AuthService } from '@/api/omni/auth/auth.pb'
 import type { ClusterPermissionsSpec } from '@/api/omni/specs/virtual.pb'
-import { ClusterPermissionsType, VirtualNamespace } from '@/api/resources'
+import { ClusterPermissionsType, IdPLogoutPath, VirtualNamespace } from '@/api/resources'
 import { AuthType, authType } from '@/methods'
 import { useClusterPermissions, useLogout } from '@/methods/auth'
 import { useIdentity } from '@/methods/identity'
@@ -164,7 +164,7 @@ describe('useLogout', () => {
   })
 
   test.each([AuthType.SAML, AuthType.OIDC, AuthType.None])(
-    'should redirect to logout URL when authType is %s',
+    'should redirect to the identity provider logout when authType is %s',
     async (mockAuthType) => {
       vi.mocked(AuthService.RevokePublicKey).mockResolvedValue(
         {} as Awaited<ReturnType<typeof AuthService.RevokePublicKey>>,
@@ -175,7 +175,7 @@ describe('useLogout', () => {
       await logout()
 
       expect(mockAuth0.logout).not.toHaveBeenCalled()
-      expect(window.location.href).toBe('/logout?flow=frontend')
+      expect(window.location.href).toBe(IdPLogoutPath)
       expect(mockKeys.clear).toHaveBeenCalled()
       expect(mockIdentity.clear).toHaveBeenCalled()
     },

--- a/frontend/src/methods/auth.ts
+++ b/frontend/src/methods/auth.ts
@@ -20,12 +20,11 @@ import type {
 } from '@/api/omni/specs/virtual.pb'
 import { withRuntime } from '@/api/options'
 import {
-  AuthFlowQueryParam,
   ClusterPermissionsType,
   CurrentUserID,
   CurrentUserType,
   DefaultNamespace,
-  FrontendAuthFlow,
+  IdPLogoutPath,
   JoinTokenType,
   PermissionsID,
   PermissionsType,
@@ -230,7 +229,7 @@ export function useLogout() {
         },
       })
     } else {
-      redirectToURL(`/logout?${AuthFlowQueryParam}=${FrontendAuthFlow}`)
+      redirectToURL(IdPLogoutPath)
     }
   }
 }

--- a/frontend/src/pages/logout.vue
+++ b/frontend/src/pages/logout.vue
@@ -9,7 +9,6 @@ import { onBeforeMount } from 'vue'
 
 import PageContainer from '@/components/PageContainer/PageContainer.vue'
 import TSpinner from '@/components/Spinner/TSpinner.vue'
-import { AuthType, authType } from '@/methods'
 import { useLogout } from '@/methods/auth'
 
 definePage({
@@ -19,10 +18,6 @@ definePage({
 const logout = useLogout()
 
 onBeforeMount(() => {
-  // For SAML and OIDC the backend registers its own /logout handler
-  // Hard reload to hit backend forcibly if we are here accidentally
-  if (authType.value !== AuthType.Auth0) window.location.reload()
-
   logout()
 })
 </script>

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -889,13 +889,7 @@ func makeMux(
 
 	muxHandle("/", frontendHandler, "static")
 
-	if err := registerAuthHandlers(
-		mux,
-		samlHandler,
-		oidcProvider,
-		logger,
-		cfg,
-	); err != nil {
+	if err := registerAuthHandlers(mux, samlHandler, oidcProvider, logger, cfg); err != nil {
 		return nil, err
 	}
 
@@ -944,7 +938,13 @@ func makeMux(
 	return mux, nil
 }
 
-func registerAuthHandlers(mux *http.ServeMux, samlHandler *samlsp.Middleware, oidcProvider *coidc.Provider, logger *zap.Logger, cfg *config.Params) error {
+func registerAuthHandlers(
+	mux *http.ServeMux,
+	samlHandler *samlsp.Middleware,
+	oidcProvider *coidc.Provider,
+	logger *zap.Logger,
+	cfg *config.Params,
+) error {
 	var (
 		loginHandler  http.HandlerFunc
 		logoutHandler http.HandlerFunc
@@ -980,7 +980,7 @@ func registerAuthHandlers(mux *http.ServeMux, samlHandler *samlsp.Middleware, oi
 	}
 
 	if logoutHandler != nil {
-		mux.Handle("/logout", monitoring.NewHandler(
+		mux.Handle(auth.IdPLogoutPath, monitoring.NewHandler(
 			logging.NewHandler(logoutHandler, logger),
 			promLabel,
 		))

--- a/internal/pkg/auth/auth.go
+++ b/internal/pkg/auth/auth.go
@@ -36,4 +36,12 @@ const (
 	//
 	// tsgen:WorkloadProxyAuthFlow
 	ProxyAuthFlow = "workload-proxy"
+
+	// IdPLogoutPath is the path that ends the identity provider session, for SAML and OIDC.
+	//
+	// The frontend sends the browser here after revoking its public key, to finish the
+	// logout it serves at /logout.
+	//
+	// tsgen:IdPLogoutPath
+	IdPLogoutPath = "/idp-logout"
 )


### PR DESCRIPTION
Only the frontend can revoke the public key that authenticates a browser against Omni, so for SAML and OIDC, where the backend owned /logout outright, opening the URL ended the session at the identity provider and left the user signed in to Omni. A bare /logout now serves the frontend, and the identity provider logout runs once the frontend comes back with flow=frontend.