### PR TITLE
fix: never change a machine's tunnel address after registration

### DIFF
--- a/internal/pkg/siderolink/provision.go
+++ b/internal/pkg/siderolink/provision.go
@@ -260,7 +260,7 @@ func updateNodeUniqueToken(ctx context.Context, logger *zap.Logger, st state.Sta
 	)
 }
 
-func updateResource[T res](ctx context.Context, logger *zap.Logger,
+func updateResource[T res](ctx context.Context,
 	st state.State, provisionContext *provisionContext, r T, annotationsToAdd []string, annotationsToRemove []string,
 ) (T, error) {
 	return safe.StateUpdateWithConflicts(ctx, st, r.Metadata(), func(link T) error {
@@ -268,12 +268,6 @@ func updateResource[T res](ctx context.Context, logger *zap.Logger,
 
 		if link.Metadata().Type() == siderolinkres.PendingMachineType {
 			link.Metadata().Annotations().Set("timestamp", time.Now().String())
-		}
-
-		if provisionContext.pendingMachine != nil {
-			s.NodeSubnet = provisionContext.pendingMachine.TypedSpec().Value.NodeSubnet
-
-			logger.Info("updated subnet", zap.String("subnet", s.NodeSubnet))
 		}
 
 		var err error
@@ -448,7 +442,7 @@ func establishLink[T res](ctx context.Context, h *ProvisionHandler, provisionCon
 			return nil, err
 		}
 
-		link, err = updateResource(ctx, logger, st, provisionContext, link, annotationsToAdd, annotationsToRemove)
+		link, err = updateResource(ctx, st, provisionContext, link, annotationsToAdd, annotationsToRemove)
 		if err != nil {
 			if state.IsPhaseConflictError(err) {
 				return nil, status.Errorf(codes.AlreadyExists, "the machine with the same UUID is already registered in Omni and is in the tearing down phase")

--- a/internal/pkg/siderolink/provision_test.go
+++ b/internal/pkg/siderolink/provision_test.go
@@ -278,6 +278,53 @@ func TestProvision(t *testing.T) {
 		})
 	}
 
+	t.Run("divergent pending machine does not rewrite the link address", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*5)
+		defer cancel()
+
+		state, provisionHandler := setup(ctx, t, config.SiderolinkServiceJoinTokensModeStrict)
+
+		linkSubnet := "fdae:41e4:649b:9303::1:1/64"
+
+		request := &pb.ProvisionRequest{
+			NodeUuid:        "machine-divergent-pending",
+			NodePublicKey:   genKey(),
+			TalosVersion:    new("v1.9.0"),
+			JoinToken:       new(validToken),
+			NodeUniqueToken: &validToken,
+		}
+
+		link := siderolinkres.NewLink(request.NodeUuid, &specs.SiderolinkSpec{
+			NodePublicKey: request.NodePublicKey,
+			NodeSubnet:    linkSubnet,
+		})
+
+		require.NoError(t, state.Create(ctx, link))
+
+		// a leftover pending machine for the same public key carrying a different
+		// address must never overwrite the link's address on re-provision
+		pendingMachine := siderolinkres.NewPendingMachine(request.NodePublicKey, &specs.SiderolinkSpec{
+			NodePublicKey: request.NodePublicKey,
+			NodeSubnet:    "fdae:41e4:649b:9303::2:2/64",
+		})
+
+		require.NoError(t, state.Create(ctx, pendingMachine))
+
+		response, err := provisionHandler.Provision(ctx, request)
+		require.NoError(t, err)
+
+		require.Equal(t, linkSubnet, response.NodeAddressPrefix)
+
+		rtestutils.AssertResources(
+			ctx, t, state, []string{request.NodeUuid},
+			func(r *siderolinkres.Link, assertion *assert.Assertions) {
+				assertion.Equal(linkSubnet, r.TypedSpec().Value.NodeSubnet)
+			},
+		)
+	})
+
 	for _, mode := range []struct {
 		name string
 		mode config.SiderolinkServiceJoinTokensMode


### PR DESCRIPTION
When a machine re-provisions while a pending machine record still exists for it, the provisioning handler copied the pending record's tunnel address onto the machine's link, and the provision response then moved the machine itself onto that address. The two usually hold the same address, but they can diverge: a request reads the pending record at the start and writes it back at the end, so a slow request can write back an address from an already deleted generation of the record, and nothing serializes provisioning per machine, so two overlapping join requests can create the link and the pending record with two different randomly generated addresses.

The WireGuard peer is not reconfigured on address changes, so a machine moved this way keeps a healthy handshake and shows as connected while all of its traffic is dropped, until its public key rotates, which only happens when Talos reboots.

The address is now assigned exactly once, when the link is created. The creation path already inherits the address from the pending record when a machine is promoted, and a pending record created next to an existing link already inherits the link's address, so the copy was redundant in every valid flow and could only take effect when its snapshot was stale.