### PR TITLE
fix: compress diffs in the machine pending updates and diff history

### DIFF
--- a/client/api/omni/specs/machine_config_diff.go
+++ b/client/api/omni/specs/machine_config_diff.go
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package specs
+
+import (
+	"errors"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// MarshalJSON implements json.Marshaler interface.
+//
+// It represents compressed fields as uncompressed in the output.
+func (x *MachineConfigDiffSpec) MarshalJSON() ([]byte, error) {
+	obj := x.CloneVT()
+
+	buffer, err := obj.GetUncompressedData()
+	if err != nil {
+		return nil, err
+	}
+
+	defer buffer.Free()
+
+	obj.Diff = string(buffer.Data())
+	obj.CompressedDiff = nil
+
+	return jsonMarshaler.Marshal(obj)
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (x *MachineConfigDiffSpec) UnmarshalJSON(data []byte) error {
+	return unmarshalJSON(x, data)
+}
+
+// MarshalYAML implements yaml.Marshaler interface.
+//
+// It represents compressed fields as uncompressed in the output.
+func (x *MachineConfigDiffSpec) MarshalYAML() (any, error) {
+	obj := x.CloneVT()
+
+	buffer, err := obj.GetUncompressedData()
+	if err != nil {
+		return nil, err
+	}
+
+	defer buffer.Free()
+
+	obj.Diff = string(buffer.Data())
+	obj.CompressedDiff = nil
+
+	type alias *MachineConfigDiffSpec // prevent recursion
+
+	return alias(obj), nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler interface.
+func (x *MachineConfigDiffSpec) UnmarshalYAML(node *yaml.Node) error {
+	type alias MachineConfigDiffSpec // prevent recursion
+
+	aux := (*alias)(x)
+
+	return unmarshalYAML(x, aux, node)
+}
+
+// GetUncompressedData returns the diff from the MachineConfigDiffSpec, decompressing it if necessary.
+func (x *MachineConfigDiffSpec) GetUncompressedData(opts ...CompressionOption) (Buffer, error) {
+	if x == nil {
+		return newNoOpBuffer(nil), nil
+	}
+
+	if len(x.GetCompressedDiff()) == 0 {
+		return newNoOpBuffer([]byte(x.GetDiff())), nil
+	}
+
+	return doDecompress(x.GetCompressedDiff(), getCompressionConfig(opts))
+}
+
+// SetUncompressedData sets the diff in the MachineConfigDiffSpec, compressing it if requested.
+func (x *MachineConfigDiffSpec) SetUncompressedData(data []byte, opts ...CompressionOption) error {
+	if x == nil {
+		return errors.New("MachineConfigDiffSpec is nil")
+	}
+
+	config := getCompressionConfig(opts)
+	compress := config.Enabled
+
+	if !compress || len(data) < config.MinThreshold {
+		x.Diff = string(data)
+		x.CompressedDiff = nil
+
+		return nil
+	}
+
+	compressed := doCompress(data, config)
+
+	x.Diff = ""
+	x.CompressedDiff = compressed
+
+	return nil
+}

--- a/client/api/omni/specs/machine_pending_updates.go
+++ b/client/api/omni/specs/machine_pending_updates.go
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package specs
+
+import (
+	"errors"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// MarshalJSON implements json.Marshaler interface.
+//
+// It represents compressed fields as uncompressed in the output.
+func (x *MachinePendingUpdatesSpec) MarshalJSON() ([]byte, error) {
+	obj := x.CloneVT()
+
+	buffer, err := obj.GetUncompressedData()
+	if err != nil {
+		return nil, err
+	}
+
+	defer buffer.Free()
+
+	obj.ConfigDiff = string(buffer.Data())
+	obj.CompressedConfigDiff = nil
+
+	return jsonMarshaler.Marshal(obj)
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (x *MachinePendingUpdatesSpec) UnmarshalJSON(data []byte) error {
+	return unmarshalJSON(x, data)
+}
+
+// MarshalYAML implements yaml.Marshaler interface.
+//
+// It represents compressed fields as uncompressed in the output.
+func (x *MachinePendingUpdatesSpec) MarshalYAML() (any, error) {
+	obj := x.CloneVT()
+
+	buffer, err := obj.GetUncompressedData()
+	if err != nil {
+		return nil, err
+	}
+
+	defer buffer.Free()
+
+	obj.ConfigDiff = string(buffer.Data())
+	obj.CompressedConfigDiff = nil
+
+	type alias *MachinePendingUpdatesSpec // prevent recursion
+
+	return alias(obj), nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler interface.
+func (x *MachinePendingUpdatesSpec) UnmarshalYAML(node *yaml.Node) error {
+	type alias MachinePendingUpdatesSpec // prevent recursion
+
+	aux := (*alias)(x)
+
+	return unmarshalYAML(x, aux, node)
+}
+
+// GetUncompressedData returns the config diff from the MachinePendingUpdatesSpec, decompressing it if necessary.
+func (x *MachinePendingUpdatesSpec) GetUncompressedData(opts ...CompressionOption) (Buffer, error) {
+	if x == nil {
+		return newNoOpBuffer(nil), nil
+	}
+
+	if len(x.GetCompressedConfigDiff()) == 0 {
+		return newNoOpBuffer([]byte(x.GetConfigDiff())), nil
+	}
+
+	return doDecompress(x.GetCompressedConfigDiff(), getCompressionConfig(opts))
+}
+
+// SetUncompressedData sets the config diff in the MachinePendingUpdatesSpec, compressing it if requested.
+func (x *MachinePendingUpdatesSpec) SetUncompressedData(data []byte, opts ...CompressionOption) error {
+	if x == nil {
+		return errors.New("MachinePendingUpdatesSpec is nil")
+	}
+
+	config := getCompressionConfig(opts)
+	compress := config.Enabled
+
+	if !compress || len(data) < config.MinThreshold {
+		x.ConfigDiff = string(data)
+		x.CompressedConfigDiff = nil
+
+		return nil
+	}
+
+	compressed := doCompress(data, config)
+
+	x.ConfigDiff = ""
+	x.CompressedConfigDiff = compressed
+
+	return nil
+}
+
+// HasConfigDiff reports whether the config diff is set, without decompressing it.
+func (x *MachinePendingUpdatesSpec) HasConfigDiff() bool {
+	return x.GetConfigDiff() != "" || len(x.GetCompressedConfigDiff()) > 0
+}

--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -3749,10 +3749,16 @@ type MachinePendingUpdatesSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Upgrade represents pending machine upgrade.
 	Upgrade *MachinePendingUpdatesSpec_Upgrade `protobuf:"bytes,1,opt,name=upgrade,proto3" json:"upgrade,omitempty"`
-	// ConfigDiff represents the redacted machine config diff.
-	ConfigDiff    string `protobuf:"bytes,2,opt,name=config_diff,json=configDiff,proto3" json:"config_diff,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// ConfigDiff represents the redacted machine config diff. It is only set if the diff is not compressed. Otherwise, CompressedConfigDiff is set instead.
+	//
+	// Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
+	ConfigDiff string `protobuf:"bytes,2,opt,name=config_diff,json=configDiff,proto3" json:"config_diff,omitempty"`
+	// CompressedConfigDiff represents the redacted machine config diff. It is only set if the diff is compressed. Otherwise, ConfigDiff is set instead.
+	//
+	// Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
+	CompressedConfigDiff []byte `protobuf:"bytes,3,opt,name=compressed_config_diff,json=compressedConfigDiff,proto3" json:"compressed_config_diff,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *MachinePendingUpdatesSpec) Reset() {
@@ -3797,6 +3803,13 @@ func (x *MachinePendingUpdatesSpec) GetConfigDiff() string {
 		return x.ConfigDiff
 	}
 	return ""
+}
+
+func (x *MachinePendingUpdatesSpec) GetCompressedConfigDiff() []byte {
+	if x != nil {
+		return x.CompressedConfigDiff
+	}
+	return nil
 }
 
 // ClusterBootstrapStatusSpec keeps track of bootstrap calls for a cluster.
@@ -7949,10 +7962,17 @@ func (x *InfraProviderCombinedStatusSpec) GetVersion() string {
 }
 
 type MachineConfigDiffSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Diff          string                 `protobuf:"bytes,1,opt,name=diff,proto3" json:"diff,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Diff contains the redacted machine config diff. It is only set if the diff is not compressed. Otherwise, CompressedDiff is set instead.
+	//
+	// Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
+	Diff string `protobuf:"bytes,1,opt,name=diff,proto3" json:"diff,omitempty"`
+	// CompressedDiff contains the redacted machine config diff. It is only set if the diff is compressed. Otherwise, Diff is set instead.
+	//
+	// Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
+	CompressedDiff []byte `protobuf:"bytes,2,opt,name=compressed_diff,json=compressedDiff,proto3" json:"compressed_diff,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *MachineConfigDiffSpec) Reset() {
@@ -7990,6 +8010,13 @@ func (x *MachineConfigDiffSpec) GetDiff() string {
 		return x.Diff
 	}
 	return ""
+}
+
+func (x *MachineConfigDiffSpec) GetCompressedDiff() []byte {
+	if x != nil {
+		return x.CompressedDiff
+	}
+	return nil
 }
 
 type InstallationMediaConfigSpec struct {
@@ -11864,11 +11891,12 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	" \x01(\fR\x1fcompressedRedactedMachineConfig\x12+\n" +
 	"\x12pre_reboot_boot_id\x18\v \x01(\tR\x0fpreRebootBootId\x12H\n" +
 	"!applied_high_priority_config_hash\x18\f \x01(\tR\x1dappliedHighPriorityConfigHash\x12,\n" +
-	"\x12image_factory_host\x18\r \x01(\tR\x10imageFactoryHostJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05\"\x98\x02\n" +
+	"\x12image_factory_host\x18\r \x01(\tR\x10imageFactoryHostJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03J\x04\b\x04\x10\x05\"\xce\x02\n" +
 	"\x19MachinePendingUpdatesSpec\x12B\n" +
 	"\aupgrade\x18\x01 \x01(\v2(.specs.MachinePendingUpdatesSpec.UpgradeR\aupgrade\x12\x1f\n" +
 	"\vconfig_diff\x18\x02 \x01(\tR\n" +
-	"configDiff\x1a\x95\x01\n" +
+	"configDiff\x124\n" +
+	"\x16compressed_config_diff\x18\x03 \x01(\fR\x14compressedConfigDiff\x1a\x95\x01\n" +
 	"\aUpgrade\x12%\n" +
 	"\x0efrom_schematic\x18\x01 \x01(\tR\rfromSchematic\x12!\n" +
 	"\fto_schematic\x18\x02 \x01(\tR\vtoSchematic\x12!\n" +
@@ -12347,9 +12375,10 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\x06Health\x12\x1c\n" +
 	"\tconnected\x18\x01 \x01(\bR\tconnected\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12 \n" +
-	"\vinitialized\x18\x03 \x01(\bR\vinitialized\"+\n" +
+	"\vinitialized\x18\x03 \x01(\bR\vinitialized\"T\n" +
 	"\x15MachineConfigDiffSpec\x12\x12\n" +
-	"\x04diff\x18\x01 \x01(\tR\x04diff\"\xfc\x06\n" +
+	"\x04diff\x18\x01 \x01(\tR\x04diff\x12'\n" +
+	"\x0fcompressed_diff\x18\x02 \x01(\fR\x0ecompressedDiff\"\xfc\x06\n" +
 	"\x1bInstallationMediaConfigSpec\x12#\n" +
 	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12B\n" +
 	"\farchitecture\x18\x02 \x01(\x0e2\x1e.specs.PlatformConfigSpec.ArchR\farchitecture\x12-\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -682,8 +682,16 @@ message MachinePendingUpdatesSpec {
 
   // Upgrade represents pending machine upgrade.
   Upgrade upgrade = 1;
-  // ConfigDiff represents the redacted machine config diff.
+
+  // ConfigDiff represents the redacted machine config diff. It is only set if the diff is not compressed. Otherwise, CompressedConfigDiff is set instead.
+  //
+  // Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
   string config_diff = 2;
+
+  // CompressedConfigDiff represents the redacted machine config diff. It is only set if the diff is compressed. Otherwise, ConfigDiff is set instead.
+  //
+  // Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
+  bytes compressed_config_diff = 3;
 }
 
 // ClusterBootstrapStatusSpec keeps track of bootstrap calls for a cluster.
@@ -1611,7 +1619,15 @@ message InfraProviderCombinedStatusSpec {
 }
 
 message MachineConfigDiffSpec {
+  // Diff contains the redacted machine config diff. It is only set if the diff is not compressed. Otherwise, CompressedDiff is set instead.
+  //
+  // Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
   string diff = 1;
+
+  // CompressedDiff contains the redacted machine config diff. It is only set if the diff is compressed. Otherwise, Diff is set instead.
+  //
+  // Deprecated: use accessor methods GetUncompressedData/SetUncompressedData to manage this field.
+  bytes compressed_diff = 2;
 }
 
 message InstallationMediaConfigSpec {

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -1016,6 +1016,11 @@ func (m *MachinePendingUpdatesSpec) CloneVT() *MachinePendingUpdatesSpec {
 	r := new(MachinePendingUpdatesSpec)
 	r.Upgrade = m.Upgrade.CloneVT()
 	r.ConfigDiff = m.ConfigDiff
+	if rhs := m.CompressedConfigDiff; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.CompressedConfigDiff = tmpBytes
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -2926,6 +2931,11 @@ func (m *MachineConfigDiffSpec) CloneVT() *MachineConfigDiffSpec {
 	}
 	r := new(MachineConfigDiffSpec)
 	r.Diff = m.Diff
+	if rhs := m.CompressedDiff; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.CompressedDiff = tmpBytes
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -4725,6 +4735,9 @@ func (this *MachinePendingUpdatesSpec) EqualVT(that *MachinePendingUpdatesSpec) 
 		return false
 	}
 	if this.ConfigDiff != that.ConfigDiff {
+		return false
+	}
+	if string(this.CompressedConfigDiff) != string(that.CompressedConfigDiff) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -7357,6 +7370,9 @@ func (this *MachineConfigDiffSpec) EqualVT(that *MachineConfigDiffSpec) bool {
 		return false
 	}
 	if this.Diff != that.Diff {
+		return false
+	}
+	if string(this.CompressedDiff) != string(that.CompressedDiff) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -10825,6 +10841,13 @@ func (m *MachinePendingUpdatesSpec) MarshalToSizedBufferVT(dAtA []byte) (int, er
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.CompressedConfigDiff) > 0 {
+		i -= len(m.CompressedConfigDiff)
+		copy(dAtA[i:], m.CompressedConfigDiff)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CompressedConfigDiff)))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if len(m.ConfigDiff) > 0 {
 		i -= len(m.ConfigDiff)
@@ -15896,6 +15919,13 @@ func (m *MachineConfigDiffSpec) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.CompressedDiff) > 0 {
+		i -= len(m.CompressedDiff)
+		copy(dAtA[i:], m.CompressedDiff)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CompressedDiff)))
+		i--
+		dAtA[i] = 0x12
+	}
 	if len(m.Diff) > 0 {
 		i -= len(m.Diff)
 		copy(dAtA[i:], m.Diff)
@@ -18134,6 +18164,10 @@ func (m *MachinePendingUpdatesSpec) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.CompressedConfigDiff)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -20123,6 +20157,10 @@ func (m *MachineConfigDiffSpec) SizeVT() (n int) {
 	var l int
 	_ = l
 	l = len(m.Diff)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.CompressedDiff)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -28322,6 +28360,40 @@ func (m *MachinePendingUpdatesSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.ConfigDiff = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CompressedConfigDiff", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CompressedConfigDiff = append(m.CompressedConfigDiff[:0], dAtA[iNdEx:postIndex]...)
+			if m.CompressedConfigDiff == nil {
+				m.CompressedConfigDiff = []byte{}
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -40942,6 +41014,40 @@ func (m *MachineConfigDiffSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Diff = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CompressedDiff", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CompressedDiff = append(m.CompressedDiff[:0], dAtA[iNdEx:postIndex]...)
+			if m.CompressedDiff == nil {
+				m.CompressedDiff = []byte{}
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/client/pkg/compression/compression_diff_test.go
+++ b/client/pkg/compression/compression_diff_test.go
@@ -1,0 +1,295 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:staticcheck // we are ok with accessing the deprecated fields in these tests.
+package compression_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/compression"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+// diffLine is a single line of a payload shaped like a unified machine config diff.
+const diffLine = "+  key: value\n"
+
+// diffString builds a diff-like payload of at least the requested length.
+func diffString(minLength int) string {
+	return strings.Repeat(diffLine, minLength/len(diffLine)+1)
+}
+
+func TestMachinePendingUpdatesYAML(t *testing.T) {
+	res := omni.NewMachinePendingUpdates("test")
+
+	configDiff := diffString(specs.GetCompressionConfig().MinThreshold)
+
+	res.TypedSpec().Value.Upgrade = &specs.MachinePendingUpdatesSpec_Upgrade{
+		FromVersion: "v1.9.0",
+		ToVersion:   "v1.10.0",
+	}
+
+	err := res.TypedSpec().Value.SetUncompressedData([]byte(configDiff))
+	require.NoError(t, err)
+
+	// assert that the diff is compressed
+
+	require.Empty(t, res.TypedSpec().Value.ConfigDiff)
+	require.NotEmpty(t, res.TypedSpec().Value.CompressedConfigDiff)
+	require.True(t, res.TypedSpec().Value.HasConfigDiff())
+
+	// marshal the spec to yaml
+
+	specYAML, err := yaml.Marshal(res.TypedSpec().Value)
+	require.NoError(t, err)
+
+	// assert that the diff is in the YAML in uncompressed form, and the compressed field is emitted empty
+
+	require.Contains(t, string(specYAML), strings.TrimSuffix(diffLine, "\n"))
+	require.Contains(t, string(specYAML), "compressedconfigdiff: []")
+
+	// assert that the sibling fields survive the round-trip through the marshaler
+
+	require.Contains(t, string(specYAML), "v1.10.0")
+
+	t.Logf("yaml:\n%s", string(specYAML))
+
+	// unmarshal the spec from the yaml
+
+	var newSpec specs.MachinePendingUpdatesSpec
+
+	err = yaml.Unmarshal(specYAML, &newSpec)
+	require.NoError(t, err)
+
+	// assert that the diff got compressed again and still decompresses to the original
+
+	require.Empty(t, newSpec.ConfigDiff)
+	require.NotEmpty(t, newSpec.CompressedConfigDiff)
+	require.Equal(t, "v1.10.0", newSpec.GetUpgrade().GetToVersion())
+
+	buffer, err := newSpec.GetUncompressedData()
+	require.NoError(t, err)
+
+	defer buffer.Free()
+
+	require.Equal(t, configDiff, string(buffer.Data()))
+}
+
+// assertDiffSpecJSON round-trips a diff-carrying spec through JSON, asserting that the payload stays
+// compressed in memory while being emitted uncompressed on the wire.
+func assertDiffSpecJSON[T any, S interface {
+	*T
+	specs.FieldCompressor[specs.Buffer, []byte]
+}](t *testing.T, plain func(S) string, compressed func(S) []byte) {
+	t.Helper()
+
+	spec := S(new(T))
+
+	diff := diffString(specs.GetCompressionConfig().MinThreshold)
+
+	require.NoError(t, spec.SetUncompressedData([]byte(diff)))
+
+	// assert that the diff is compressed
+
+	require.Empty(t, plain(spec))
+	require.NotEmpty(t, compressed(spec))
+
+	specJSON, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	// protojson omits the empty bytes field, so the compressed form is absent entirely
+
+	require.Contains(t, string(specJSON), "key: value")
+	require.NotContains(t, string(specJSON), "compressed")
+
+	t.Logf("json:\n%s", string(specJSON))
+
+	// unmarshalling re-compresses, and the payload still round-trips to the original
+
+	newSpec := S(new(T))
+
+	require.NoError(t, json.Unmarshal(specJSON, newSpec))
+	require.Empty(t, plain(newSpec))
+	require.NotEmpty(t, compressed(newSpec))
+
+	buffer, err := newSpec.GetUncompressedData()
+	require.NoError(t, err)
+
+	defer buffer.Free()
+
+	require.Equal(t, diff, string(buffer.Data()))
+}
+
+func TestDiffSpecsJSON(t *testing.T) {
+	t.Run("MachinePendingUpdates", func(t *testing.T) {
+		assertDiffSpecJSON(
+			t,
+			func(s *specs.MachinePendingUpdatesSpec) string { return s.ConfigDiff },
+			func(s *specs.MachinePendingUpdatesSpec) []byte { return s.CompressedConfigDiff },
+		)
+	})
+
+	t.Run("MachineConfigDiff", func(t *testing.T) {
+		assertDiffSpecJSON(
+			t,
+			func(s *specs.MachineConfigDiffSpec) string { return s.Diff },
+			func(s *specs.MachineConfigDiffSpec) []byte { return s.CompressedDiff },
+		)
+	})
+}
+
+func TestMachinePendingUpdatesThreshold(t *testing.T) {
+	res := omni.NewMachinePendingUpdates("test")
+
+	// a diff below the threshold is stored uncompressed
+
+	err := res.TypedSpec().Value.SetUncompressedData([]byte(diffLine))
+	require.NoError(t, err)
+
+	require.Equal(t, diffLine, res.TypedSpec().Value.ConfigDiff)
+	require.Empty(t, res.TypedSpec().Value.CompressedConfigDiff)
+	require.True(t, res.TypedSpec().Value.HasConfigDiff())
+
+	// growing above the threshold moves the data into the compressed field
+
+	err = res.TypedSpec().Value.SetUncompressedData([]byte(diffString(specs.GetCompressionConfig().MinThreshold)))
+	require.NoError(t, err)
+
+	require.Empty(t, res.TypedSpec().Value.ConfigDiff)
+	require.NotEmpty(t, res.TypedSpec().Value.CompressedConfigDiff)
+
+	// shrinking back below the threshold clears the compressed field again
+
+	err = res.TypedSpec().Value.SetUncompressedData([]byte(diffLine))
+	require.NoError(t, err)
+
+	require.Equal(t, diffLine, res.TypedSpec().Value.ConfigDiff)
+	require.Empty(t, res.TypedSpec().Value.CompressedConfigDiff)
+
+	// an empty diff clears both fields
+
+	err = res.TypedSpec().Value.SetUncompressedData(nil)
+	require.NoError(t, err)
+
+	require.Empty(t, res.TypedSpec().Value.ConfigDiff)
+	require.Empty(t, res.TypedSpec().Value.CompressedConfigDiff)
+	require.False(t, res.TypedSpec().Value.HasConfigDiff())
+}
+
+func TestMachineConfigDiffYAML(t *testing.T) {
+	res := omni.NewMachineConfigDiff("test")
+
+	diff := diffString(specs.GetCompressionConfig().MinThreshold)
+
+	err := res.TypedSpec().Value.SetUncompressedData([]byte(diff))
+	require.NoError(t, err)
+
+	// assert that the diff is compressed
+
+	require.Empty(t, res.TypedSpec().Value.Diff)
+	require.NotEmpty(t, res.TypedSpec().Value.CompressedDiff)
+
+	// marshal the spec to yaml
+
+	specYAML, err := yaml.Marshal(res.TypedSpec().Value)
+	require.NoError(t, err)
+
+	require.Contains(t, string(specYAML), strings.TrimSuffix(diffLine, "\n"))
+	require.Contains(t, string(specYAML), "compresseddiff: []")
+
+	t.Logf("yaml:\n%s", string(specYAML))
+
+	// unmarshal the spec from the yaml
+
+	var newSpec specs.MachineConfigDiffSpec
+
+	err = yaml.Unmarshal(specYAML, &newSpec)
+	require.NoError(t, err)
+
+	require.Empty(t, newSpec.Diff)
+	require.NotEmpty(t, newSpec.CompressedDiff)
+
+	buffer, err := newSpec.GetUncompressedData()
+	require.NoError(t, err)
+
+	defer buffer.Free()
+
+	require.Equal(t, diff, string(buffer.Data()))
+}
+
+func TestMachineConfigDiffThreshold(t *testing.T) {
+	res := omni.NewMachineConfigDiff("test")
+
+	err := res.TypedSpec().Value.SetUncompressedData([]byte(diffLine))
+	require.NoError(t, err)
+
+	require.Equal(t, diffLine, res.TypedSpec().Value.Diff)
+	require.Empty(t, res.TypedSpec().Value.CompressedDiff)
+
+	err = res.TypedSpec().Value.SetUncompressedData([]byte(diffString(specs.GetCompressionConfig().MinThreshold)))
+	require.NoError(t, err)
+
+	require.Empty(t, res.TypedSpec().Value.Diff)
+	require.NotEmpty(t, res.TypedSpec().Value.CompressedDiff)
+
+	// setting a small value on an already-compressed spec drops the compressed field
+
+	err = res.TypedSpec().Value.SetUncompressedData([]byte(diffLine))
+	require.NoError(t, err)
+
+	require.Equal(t, diffLine, res.TypedSpec().Value.Diff)
+	require.Empty(t, res.TypedSpec().Value.CompressedDiff)
+}
+
+func TestDiffSpecsCompressionDisabled(t *testing.T) {
+	config, err := compression.BuildConfig(false, true, false)
+	require.NoError(t, err)
+
+	opt := specs.WithConfigCompressionOption(config)
+
+	diff := diffString(specs.GetCompressionConfig().MinThreshold)
+
+	pendingUpdates := omni.NewMachinePendingUpdates("test")
+
+	require.NoError(t, pendingUpdates.TypedSpec().Value.SetUncompressedData([]byte(diff), opt))
+	require.Equal(t, diff, pendingUpdates.TypedSpec().Value.ConfigDiff)
+	require.Empty(t, pendingUpdates.TypedSpec().Value.CompressedConfigDiff)
+
+	configDiff := omni.NewMachineConfigDiff("test")
+
+	require.NoError(t, configDiff.TypedSpec().Value.SetUncompressedData([]byte(diff), opt))
+	require.Equal(t, diff, configDiff.TypedSpec().Value.Diff)
+	require.Empty(t, configDiff.TypedSpec().Value.CompressedDiff)
+}
+
+func TestDiffSpecsUncompressedReadCompatibility(t *testing.T) {
+	// resources written before compression was introduced keep the plain field set, reads must be transparent
+	diff := diffString(specs.GetCompressionConfig().MinThreshold)
+
+	pendingUpdates := &specs.MachinePendingUpdatesSpec{ConfigDiff: diff}
+
+	require.True(t, pendingUpdates.HasConfigDiff())
+
+	buffer, err := pendingUpdates.GetUncompressedData()
+	require.NoError(t, err)
+
+	defer buffer.Free()
+
+	require.Equal(t, diff, string(buffer.Data()))
+
+	configDiff := &specs.MachineConfigDiffSpec{Diff: diff}
+
+	diffBuffer, err := configDiff.GetUncompressedData()
+	require.NoError(t, err)
+
+	defer diffBuffer.Free()
+
+	require.Equal(t, diff, string(diffBuffer.Data()))
+}

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -541,6 +541,7 @@ export type MachinePendingUpdatesSpecUpgrade = {
 export type MachinePendingUpdatesSpec = {
   upgrade?: MachinePendingUpdatesSpecUpgrade
   config_diff?: string
+  compressed_config_diff?: Uint8Array
 }
 
 export type ClusterBootstrapStatusSpec = {
@@ -1068,6 +1069,7 @@ export type InfraProviderCombinedStatusSpec = {
 
 export type MachineConfigDiffSpec = {
   diff?: string
+  compressed_diff?: Uint8Array
 }
 
 export type InstallationMediaConfigSpecCloud = {

--- a/internal/backend/runtime/omni/audit/hooks/hooks.go
+++ b/internal/backend/runtime/omni/audit/hooks/hooks.go
@@ -506,8 +506,16 @@ func machineConfigDiffCreate(_ context.Context, data *auditlog.Data, res resourc
 	initPtrField(&data.MachineConfigDiff)
 
 	data.MachineConfigDiff.ID = machineConfigDiff.Metadata().ID()
-	data.MachineConfigDiff.Diff = machineConfigDiff.TypedSpec().Value.Diff
 	data.MachineConfigDiff.ClusterID, _ = machineConfigDiff.Metadata().Labels().Get(omni.LabelCluster)
+
+	buffer, err := machineConfigDiff.TypedSpec().Value.GetUncompressedData()
+	if err != nil {
+		return err
+	}
+
+	defer buffer.Free()
+
+	data.MachineConfigDiff.Diff = string(buffer.Data())
 
 	return nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/reconciliation_context.go
@@ -200,7 +200,7 @@ func NewReconciliationContext(
 			return false
 		}
 
-		return m.TypedSpec().Value.ConfigDiff != ""
+		return m.TypedSpec().Value.HasConfigDiff()
 	}))
 	rc.idsUpgrading = toSet(xslices.Filter(machinePendingUpdates, func(m *omni.MachinePendingUpdates) bool {
 		return m.TypedSpec().Value.Upgrade != nil

--- a/internal/backend/runtime/omni/controllers/omni/internal/machineset/status_handler_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/machineset/status_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/siderolabs/gen/ensure"
 	"github.com/siderolabs/gen/pair"
 	"github.com/siderolabs/gen/xslices"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,14 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/system"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/machineset"
 )
+
+func newMachinePendingUpdatesWithConfigDiff(id, configDiff string) *omni.MachinePendingUpdates {
+	res := omni.NewMachinePendingUpdates(id)
+
+	ensure.NoError(res.TypedSpec().Value.SetUncompressedData([]byte(configDiff)))
+
+	return res
+}
 
 func newClusterMachineStatus(id string, stage specs.ClusterMachineStatusSpec_Stage, ready, connected bool) *omni.ClusterMachineStatus {
 	res := omni.NewClusterMachineStatus(id)
@@ -123,12 +132,8 @@ func TestStatusHandler(t *testing.T) {
 				omni.NewClusterMachineConfigStatus("b"),
 			},
 			pendingMachineUpdates: []*omni.MachinePendingUpdates{
-				withSpecSetter(omni.NewMachinePendingUpdates("a"), func(res *omni.MachinePendingUpdates) {
-					res.TypedSpec().Value.ConfigDiff = "-"
-				}),
-				withSpecSetter(omni.NewMachinePendingUpdates("b"), func(res *omni.MachinePendingUpdates) {
-					res.TypedSpec().Value.ConfigDiff = "-"
-				}),
+				newMachinePendingUpdatesWithConfigDiff("a", "-"),
+				newMachinePendingUpdatesWithConfigDiff("b", "-"),
 			},
 			expectedStatus: &specs.MachineSetStatusSpec{
 				Phase: specs.MachineSetPhase_Reconfiguring,
@@ -397,12 +402,8 @@ func TestStatusHandler(t *testing.T) {
 				omni.NewClusterMachineConfigStatus("b"),
 			},
 			pendingMachineUpdates: []*omni.MachinePendingUpdates{
-				withSpecSetter(omni.NewMachinePendingUpdates("a"), func(res *omni.MachinePendingUpdates) {
-					res.TypedSpec().Value.ConfigDiff = "something"
-				}),
-				withSpecSetter(omni.NewMachinePendingUpdates("b"), func(res *omni.MachinePendingUpdates) {
-					res.TypedSpec().Value.ConfigDiff = "something"
-				}),
+				newMachinePendingUpdatesWithConfigDiff("a", "something"),
+				newMachinePendingUpdatesWithConfigDiff("b", "something"),
 			},
 			expectedStatus: &specs.MachineSetStatusSpec{
 				Phase: specs.MachineSetPhase_Reconfiguring,

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -1587,9 +1587,7 @@ func (ctrl *StatusController) computePendingUpdates(ctx context.Context, r contr
 			res.TypedSpec().Value.Upgrade = nil
 		}
 
-		res.TypedSpec().Value.ConfigDiff = configDiff
-
-		return nil
+		return res.TypedSpec().Value.SetUncompressedData([]byte(configDiff))
 	})
 }
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -576,7 +576,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 			)
 
 			rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.MachinePendingUpdates, assert *assert.Assertions) {
-				assert.NotEmpty(res.TypedSpec().Value.ConfigDiff)
+				assert.True(res.TypedSpec().Value.HasConfigDiff())
 			})
 
 			rmock.Mock[*omni.MachineStatus](
@@ -761,7 +761,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 				)
 
 				rtestutils.AssertResources(ctx, t, testContext.State, ids, func(res *omni.MachinePendingUpdates, assert *assert.Assertions) {
-					assert.NotEmpty(res.TypedSpec().Value.ConfigDiff)
+					assert.True(res.TypedSpec().Value.HasConfigDiff())
 				})
 
 				// unlock all machines
@@ -848,8 +848,16 @@ func TestMachineConfigStatusController(t *testing.T) {
 				)
 
 				rtestutils.AssertResources(ctx, t, testContext.State, ids, func(res *omni.MachinePendingUpdates, assert *assert.Assertions) {
-					assert.NotEmpty(res.TypedSpec().Value.ConfigDiff)
-					assert.LessOrEqual(len(res.TypedSpec().Value.ConfigDiff), diff.MaxBytes)
+					buf, err := res.TypedSpec().Value.GetUncompressedData()
+
+					assert.NoError(err)
+
+					if err == nil {
+						defer buf.Free()
+					}
+
+					assert.NotEmpty(buf.Data())
+					assert.LessOrEqual(len(buf.Data()), diff.MaxBytes)
 				})
 			},
 		)
@@ -1050,7 +1058,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 					if len(ids) != 0 {
 						rtestutils.AssertResources(ctx, t, testContext.State, ids, func(res *omni.MachinePendingUpdates, assert *assert.Assertions) {
-							assert.NotEmpty(res.TypedSpec().Value.ConfigDiff)
+							assert.True(res.TypedSpec().Value.HasConfigDiff())
 						})
 					}
 

--- a/internal/backend/runtime/omni/controllers/omni/redactedmachineconfig/redacted_cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/redactedmachineconfig/redacted_cluster_machine_config.go
@@ -252,11 +252,9 @@ func (ctrl *Controller) saveDiff(ctx context.Context, r controller.ReaderWriter,
 		res.Metadata().Annotations().Set(ctrl.modifiedAtAnnotationKey, modifiedAt)
 		res.Metadata().Labels().Set(omni.LabelMachine, cmcr.Metadata().ID())
 
-		res.TypedSpec().Value.Diff = diffStr
-
 		helpers.CopyAllLabels(cmcr, res)
 
-		return nil
+		return res.TypedSpec().Value.SetUncompressedData([]byte(diffStr))
 	}); err != nil {
 		return fmt.Errorf("failed to write diff: %w", err)
 	}

--- a/internal/backend/runtime/omni/controllers/omni/redactedmachineconfig/redacted_cluster_machine_config_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/redactedmachineconfig/redacted_cluster_machine_config_test.go
@@ -240,8 +240,12 @@ func updateConfigAssertDiff(ctx context.Context, t *testing.T, st state.State, c
 	assert.Truef(t, strings.HasPrefix(res.Metadata().ID(), expectedPrefix), "expected diff ID to have the prefix %q, got %q", expectedPrefix, res.Metadata().ID())
 	assert.Equalf(t, state.Created, event.Type, "expected event type to be %s, got %s", state.Created, event.Type.String())
 
-	diff := res.TypedSpec().Value.Diff
-	require.Contains(t, diff, fmt.Sprintf("+        %s: %s", testKey, testVal))
+	buffer, err := res.TypedSpec().Value.GetUncompressedData()
+	require.NoError(t, err)
+
+	defer buffer.Free()
+
+	require.Contains(t, string(buffer.Data()), fmt.Sprintf("+        %s: %s", testKey, testVal))
 
 	return res.Metadata().ID()
 }

--- a/internal/integration/omni_upgrade_test.go
+++ b/internal/integration/omni_upgrade_test.go
@@ -129,7 +129,7 @@ func AssertNoPendingMachineUpdates(testCtx context.Context, options *TestOptions
 			require.NoError(t, err)
 
 			assert.Empty(t, res.TypedSpec().Value.Upgrade)
-			assert.Empty(t, res.TypedSpec().Value.ConfigDiff)
+			assert.False(t, res.TypedSpec().Value.HasConfigDiff())
 		}
 	}
 }


### PR DESCRIPTION
Without compression diffs overflow etcd DB max object size.