### PR TITLE
fix: bound the machine config diff by bytes, not just lines

### DIFF
--- a/client/pkg/diff/diff.go
+++ b/client/pkg/diff/diff.go
@@ -18,9 +18,12 @@ import (
 // human can meaningfully review it and the algorithmic cost becomes prohibitive.
 const MaxLines = 75_000
 
+// MaxBytes is the maximum size of the diff returned.
+const MaxBytes = 512 * 1024
+
 // Compute returns a unified diff (without the --- / +++ header) between two
-// byte slices. For inputs whose combined line count exceeds MaxLines it returns
-// a short summary instead.
+// byte slices. Inputs past MaxLines, or a diff past MaxBytes, yield a short
+// summary instead.
 func Compute(previousData, newData []byte) (string, error) {
 	if bytes.Equal(previousData, newData) {
 		return "", nil
@@ -30,7 +33,7 @@ func Compute(previousData, newData []byte) (string, error) {
 	newLines := bytes.Count(newData, []byte("\n"))
 
 	if prevLines+newLines > MaxLines {
-		return fmt.Sprintf("@@ -%d,%d +%d,%d @@ diff too large to display\n", 1, prevLines, 1, newLines), nil
+		return tooLargeSummary(prevLines, newLines), nil
 	}
 
 	result, err := myers.Diff(
@@ -55,5 +58,13 @@ func Compute(previousData, newData []byte) (string, error) {
 		result = after
 	}
 
+	if len(result) > MaxBytes {
+		return tooLargeSummary(prevLines, newLines), nil
+	}
+
 	return result, nil
+}
+
+func tooLargeSummary(prevLines, newLines int) string {
+	return fmt.Sprintf("@@ -%d,%d +%d,%d @@ diff too large to display\n", 1, prevLines, 1, newLines)
 }

--- a/client/pkg/diff/diff_test.go
+++ b/client/pkg/diff/diff_test.go
@@ -259,22 +259,6 @@ func TestComputeDiff_LargeInput(t *testing.T) {
 func TestComputeDiff_MemoryBudget(t *testing.T) {
 	const memoryBudget = 50 * 1024 * 1024 // 50 MB hard ceiling
 
-	// generateLines builds a YAML-like blob with exactly n newline-terminated lines.
-	// When variant > 0 every variant-th line is changed so the diff is non-trivial.
-	generateLines := func(n, variant int) []byte {
-		var sb strings.Builder
-
-		for i := range n {
-			if variant > 0 && i%variant == 0 {
-				fmt.Fprintf(&sb, "line-%d-variant-%d\n", i, variant)
-			} else {
-				fmt.Fprintf(&sb, "line-%d\n", i)
-			}
-		}
-
-		return []byte(sb.String())
-	}
-
 	tests := []struct {
 		old         func() []byte
 		new         func() []byte
@@ -341,6 +325,14 @@ func TestComputeDiff_MemoryBudget(t *testing.T) {
 			new:         func() []byte { return generateLines(38000, 1) },
 			maxMemBytes: 1 * 1024 * 1024, // summary path allocates almost nothing
 		},
+		{
+			// Few enough lines to reach the myers pass, so the full diff gets built and
+			// then dropped for exceeding MaxBytes. The budget covers that wasted work.
+			name:        "few long lines (diff over MaxBytes, returns summary)",
+			old:         func() []byte { return longLines("a") },
+			new:         func() []byte { return longLines("b") },
+			maxMemBytes: 20 * 1024 * 1024,
+		},
 	}
 
 	for _, tt := range tests {
@@ -373,6 +365,96 @@ func TestComputeDiff_MemoryBudget(t *testing.T) {
 				formatBytes(allocated), formatBytes(tt.maxMemBytes))
 		})
 	}
+}
+
+// TestComputeDiff_ByteBound covers inputs that stay under MaxLines but still produce
+// a diff too big to persist as a resource field.
+func TestComputeDiff_ByteBound(t *testing.T) {
+	t.Run("few long lines", func(t *testing.T) {
+		old := longLines("a")
+		newData := longLines("b")
+
+		require.Less(t, bytes.Count(old, []byte("\n"))+bytes.Count(newData, []byte("\n")), diff.MaxLines,
+			"input must stay under the line bound so the byte bound is what fires")
+
+		result, err := diff.Compute(old, newData)
+		require.NoError(t, err)
+		assert.Contains(t, result, "diff too large to display")
+	})
+
+	t.Run("many short lines", func(t *testing.T) {
+		// Replacing every one of many short lines: the diff carries both sides plus a
+		// +/- prefix per line, so it outgrows the inputs.
+		old := generateLines(16500, 0)
+		newData := generateLines(16500, 1)
+
+		require.Less(t, bytes.Count(old, []byte("\n"))+bytes.Count(newData, []byte("\n")), diff.MaxLines,
+			"input must stay under the line bound so the byte bound is what fires")
+
+		result, err := diff.Compute(old, newData)
+		require.NoError(t, err)
+		assert.Contains(t, result, "diff too large to display")
+	})
+
+	t.Run("large inputs with a small diff are returned in full", func(t *testing.T) {
+		// Two configs far bigger than MaxBytes that differ in a couple of short lines:
+		// the diff is small, so it has to come back in full. The long lines trail the
+		// changes to keep them out of the hunk's context.
+		old := append(generateLines(20, 0), longLines("a")...)
+		newData := append(generateLines(20, 10), longLines("a")...)
+
+		require.Greater(t, len(old)+len(newData), diff.MaxBytes)
+
+		result, err := diff.Compute(old, newData)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(result), diff.MaxBytes)
+		assert.NotContains(t, result, "diff too large to display")
+		assert.Contains(t, result, "+line-0-variant-10")
+	})
+
+	t.Run("result under MaxBytes is returned in full", func(t *testing.T) {
+		old := generateLines(1000, 0)
+		newData := generateLines(1000, 10)
+
+		result, err := diff.Compute(old, newData)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(result), diff.MaxBytes)
+		assert.NotContains(t, result, "diff too large to display")
+	})
+}
+
+// longLines mimics cluster.inlineManifests: three lines of 200 KiB, each holding a
+// whole manifest. Two of these blobs sit inside MaxLines, yet replacing them yields
+// a diff past MaxBytes. The marker makes the lines differ between the two sides.
+func longLines(marker string) []byte {
+	const (
+		lines   = 3
+		lineLen = 200 * 1024
+	)
+
+	var sb strings.Builder
+
+	for range lines {
+		fmt.Fprintf(&sb, "  - contents: %s%s\n", marker, strings.Repeat("x", lineLen))
+	}
+
+	return []byte(sb.String())
+}
+
+// generateLines builds a YAML-like blob with exactly n newline-terminated lines.
+// When variant > 0 every variant-th line is changed so the diff is non-trivial.
+func generateLines(n, variant int) []byte {
+	var sb strings.Builder
+
+	for i := range n {
+		if variant > 0 && i%variant == 0 {
+			fmt.Fprintf(&sb, "line-%d-variant-%d\n", i, variant)
+		} else {
+			fmt.Fprintf(&sb, "line-%d\n", i)
+		}
+	}
+
+	return []byte(sb.String())
 }
 
 func formatBytes(b uint64) string {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -37,6 +37,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/diff"
 	"github.com/siderolabs/omni/client/pkg/meta"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
@@ -788,6 +789,67 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 				machineServices.ForEach(func(machineServer *testutils.MachineServiceMock) {
 					assert.GreaterOrEqual(t, len(machineServer.GetResetRequests()), 1)
+				})
+			},
+		)
+	})
+
+	// A config big enough to make the plaintext diff outgrow the state backend's request
+	// limit must still produce a storable MachinePendingUpdates, otherwise every reconcile
+	// fails on the write and the machine never gets its config.
+	t.Run("largeConfigDiff", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+		t.Cleanup(cancel)
+
+		testutils.WithRuntime(
+			ctx, t, testutils.TestOptions{}, addControllers,
+			func(ctx context.Context, testContext testutils.TestContext) {
+				machineServices := testutils.NewMachineServices(t, testContext.State)
+
+				cluster, machines := createCluster(ctx, t, testContext.State, machineServices, "large-config-diff", 1, 1)
+
+				ids := xslices.Map(machines, func(m *omni.ClusterMachine) string {
+					return m.Metadata().ID()
+				})
+
+				// Lock the machines so the pending updates resource sticks around long
+				// enough to assert on, instead of being applied and destroyed.
+				rmock.MockList[*omni.MachineSetNode](
+					ctx, t, testContext.State,
+					options.IDs(ids),
+					options.ItemOptions(
+						options.Modify(func(r *omni.MachineSetNode) error {
+							r.Metadata().Annotations().Set(omni.MachineLocked, "")
+
+							return nil
+						}),
+					),
+				)
+
+				awaitAllMachinesConfigured(ctx, t, testContext.State, cluster.Metadata().ID())
+
+				// One inline manifest per line, the shape that defeats a line-count bound.
+				largeConfig := []byte("cluster:\n  inlineManifests:\n")
+				for i := range 8 {
+					largeConfig = fmt.Appendf(largeConfig, "    - name: manifest-%d\n      contents: %s\n",
+						i, strings.Repeat("x", 128*1024))
+				}
+
+				rmock.MockList[*omni.ClusterMachineConfig](
+					ctx, t, testContext.State,
+					options.IDs(ids),
+					options.ItemOptions(
+						options.Modify(func(r *omni.ClusterMachineConfig) error {
+							return r.TypedSpec().Value.SetUncompressedData(largeConfig)
+						}),
+					),
+				)
+
+				rtestutils.AssertResources(ctx, t, testContext.State, ids, func(res *omni.MachinePendingUpdates, assert *assert.Assertions) {
+					assert.NotEmpty(res.TypedSpec().Value.ConfigDiff)
+					assert.LessOrEqual(len(res.TypedSpec().Value.ConfigDiff), diff.MaxBytes)
 				})
 			},
 		)


### PR DESCRIPTION
The diff operation could produce a diff larger than etcd's write limit, leading to failures when storing it on etcd.

Compute now also compares byte sizes and returns the short summary when either the combined inputs or the resulting diff exceed 512 KiB.