### PR TITLE
fix(frontend): add missing credentials to security pages

### DIFF
--- a/frontend/src/components/AppToast/AppToast.vue
+++ b/frontend/src/components/AppToast/AppToast.vue
@@ -29,7 +29,7 @@ import TIcon from '@/components/Icon/TIcon.vue'
         icon: 'size-5 shrink-0 self-center *:size-full',
         content: 'flex flex-col gap-1',
         title: 'text-sm text-naturals-n14',
-        description: 'overflow-auto text-xs text-naturals-n11',
+        description: 'overflow-auto text-xs whitespace-pre-wrap text-naturals-n11',
 
         error: 'border-l-4 border-l-red-r1 text-red-r1',
         success: 'border-l-4 border-l-green-g1 text-green-g1',

--- a/frontend/src/methods/useImageFactoryAuth.ts
+++ b/frontend/src/methods/useImageFactoryAuth.ts
@@ -7,7 +7,6 @@ import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 import { Runtime } from '@/api/common/omni.pb'
 import type { ImageFactoryAuthSpec } from '@/api/omni/specs/omni.pb'
 import { DefaultNamespace, ImageFactoryAuthType } from '@/api/resources'
-import { useFeatures } from '@/methods/features'
 import { useResourceGet } from '@/methods/useResourceGet'
 
 export interface FactoryCredentials {
@@ -15,22 +14,9 @@ export interface FactoryCredentials {
   password?: string
 }
 
-// ImageFactoryAuth resources are keyed by the factory URL with any trailing slash stripped.
-function trimTrailingSlash(url: string): string {
-  return url.replace(/\/+$/, '')
-}
-
 // useImageFactoryAuth reads the credentials of a specific image factory, identified by its URL.
-// It falls back to the primary factory when no URL is given, and resolves to undefined for a
-// factory that has no credentials configured (i.e. a public one).
 export function useImageFactoryAuth(factoryURL?: MaybeRefOrGetter<string | undefined>) {
-  const { data: features } = useFeatures()
-
-  const id = computed(() => {
-    const url = toValue(factoryURL) || features.value?.spec.image_factory_base_url
-
-    return url ? trimTrailingSlash(url) : undefined
-  })
+  const id = computed(() => toValue(factoryURL)?.replace(/\/+$/, ''))
 
   const { data } = useResourceGet<ImageFactoryAuthSpec>(() => ({
     runtime: Runtime.Omni,
@@ -57,5 +43,5 @@ export function withImageFactoryAuth(url: string, credentials?: FactoryCredentia
   u.username = credentials.username
   u.password = credentials.password
 
-  return u.toString()
+  return u.href.replace(/\/$/, '')
 }

--- a/frontend/src/methods/useResolvedFactory.ts
+++ b/frontend/src/methods/useResolvedFactory.ts
@@ -5,24 +5,22 @@
 import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 
 import { useFeatures } from '@/methods/features'
-import { useImageFactoryAuth } from '@/methods/useImageFactoryAuth'
+import { useImageFactoryAuth, withImageFactoryAuth } from '@/methods/useImageFactoryAuth'
 
 // useResolvedFactory resolves a factory URL (as recorded on the selected Talos version) to the
 // configured image factory that serves it. All assets of a given Talos version - image, PXE,
 // installer, SBOM - must go to that factory and authenticate with its credentials, never mix in the
 // primary factory by default.
-export function useResolvedFactory(factoryURL: MaybeRefOrGetter<string | undefined>) {
+export function useResolvedFactory(factoryURL?: MaybeRefOrGetter<string | undefined>) {
   const { data: features } = useFeatures()
-  const auth = useImageFactoryAuth(factoryURL)
 
   // The factories Omni currently has configured, primary first.
   const configuredFactories = computed(() => {
     const spec = features.value?.spec
-    const list: { url: string; base: string; pxe?: string }[] = []
+    const list: { base: string; pxe?: string }[] = []
 
     if (spec?.image_factory_base_url) {
       list.push({
-        url: spec.image_factory_base_url,
         base: spec.image_factory_base_url,
         pxe: spec.image_factory_pxe_base_url,
       })
@@ -30,7 +28,6 @@ export function useResolvedFactory(factoryURL: MaybeRefOrGetter<string | undefin
 
     if (spec?.secondary_image_factory_base_url) {
       list.push({
-        url: spec.secondary_image_factory_base_url,
         base: spec.secondary_image_factory_base_url,
         pxe: spec.secondary_image_factory_pxe_base_url,
       })
@@ -41,31 +38,26 @@ export function useResolvedFactory(factoryURL: MaybeRefOrGetter<string | undefin
 
   // The factory URL to resolve, falling back to the primary factory when the version does not record
   // one (older presets, or versions served before secondary factories existed).
-  const resolvedURL = computed(
-    () => toValue(factoryURL) || features.value?.spec.image_factory_base_url || '',
+  const resolvedFactory = computed(() => {
+    const url = toValue(factoryURL)
+    if (!url) return configuredFactories.value.at(0)
+
+    return configuredFactories.value.find((factory) => factory.base === url)
+  })
+
+  const credentials = useImageFactoryAuth(() => resolvedFactory.value?.base)
+
+  const url = computed(() =>
+    resolvedFactory.value?.base
+      ? withImageFactoryAuth(resolvedFactory.value.base, credentials.value)
+      : undefined,
   )
 
-  const resolvedFactory = computed(() =>
-    configuredFactories.value.find((factory) => factory.url === resolvedURL.value),
+  const pxeUrl = computed(() =>
+    resolvedFactory.value?.pxe
+      ? withImageFactoryAuth(resolvedFactory.value.pxe, credentials.value)
+      : undefined,
   )
 
-  // The version targets a factory URL that Omni no longer has configured.
-  const orphaned = computed(
-    () => features.value !== undefined && resolvedFactory.value === undefined,
-  )
-
-  const base = computed(
-    () => resolvedFactory.value?.base ?? features.value?.spec.image_factory_base_url,
-  )
-
-  const pxe = computed(
-    () => resolvedFactory.value?.pxe ?? features.value?.spec.image_factory_pxe_base_url,
-  )
-
-  // Credentials of the resolved factory, matched by its base URL. Both the image and the PXE links of
-  // a factory authenticate with the same credentials, even though the PXE endpoint lives on a
-  // different host.
-  const credentials = computed(() => auth.value)
-
-  return { base, pxe, credentials, orphaned }
+  return { url, pxeUrl, credentials }
 }

--- a/frontend/src/pages/(authenticated)/machines/installation-media/[presetId].stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/[presetId].stories.ts
@@ -63,7 +63,7 @@ export const Default: Story = {
           },
         ],
       }).handler,
-      ...confirmationHandlers,
+      ...confirmationHandlers(),
     )
   },
 }

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create.stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create.stories.ts
@@ -90,7 +90,7 @@ export const Default: Story = {
     msw.use(
       ...savePresetModalHandlers,
       ...cloudProviderHandlers,
-      ...confirmationHandlers,
+      ...confirmationHandlers(),
       ...extraArgsHandlers,
       ...machineArchHandlers,
       ...sbcTypeHandlers,

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.mocks.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.mocks.ts
@@ -13,7 +13,11 @@ import {
   type CreateSchematicResponse,
 } from '@/api/omni/management/management.pb'
 import type { GetRequest, GetResponse } from '@/api/omni/resources/resources.pb'
-import { type FeaturesConfigSpec } from '@/api/omni/specs/omni.pb'
+import {
+  type FeaturesConfigSpec,
+  type ImageFactoryAuthSpec,
+  type TalosVersionSpec,
+} from '@/api/omni/specs/omni.pb'
 import {
   type PlatformConfigSpec,
   PlatformConfigSpecArch,
@@ -26,18 +30,20 @@ import {
   DefaultNamespace,
   FeaturesConfigID,
   FeaturesConfigType,
+  ImageFactoryAuthType,
   LabelsMeta,
   MetalPlatformConfigType,
   PlatformMetalID,
   QuirksType,
   SBCConfigType,
+  TalosVersionType,
   VirtualNamespace,
 } from '@/api/resources'
 import type { TalosctlDownloadsResponse } from '@/methods/useTalosctlDownloads'
 import report from '@/views/InstallationMedia/vulnerabilities/sample-report.json'
 import type { ScansResponse } from '@/views/InstallationMedia/vulnerabilities/useVulnerabilityReport'
 
-export const handlers = [
+export const handlers = (enterprise = true) => [
   createWatchStreamHandler<FeaturesConfigSpec>({
     expectedOptions: {
       namespace: DefaultNamespace,
@@ -46,11 +52,18 @@ export const handlers = [
     },
     initialResources: [
       {
-        spec: {
-          image_factory_base_url: 'https://factory-enterprise.talos.dev',
-          image_factory_pxe_base_url: 'https://pxe.factory-enterprise.talos.dev',
-          is_enterprise_image_factory: true,
-        },
+        spec: enterprise
+          ? {
+              image_factory_base_url: 'https://factory-enterprise.talos.dev',
+              image_factory_pxe_base_url: 'https://pxe.factory-enterprise.talos.dev',
+              secondary_image_factory_base_url: 'https://factory.talos.dev',
+              secondary_image_factory_pxe_base_url: 'https://pxe.factory.talos.dev',
+              is_enterprise_image_factory: true,
+            }
+          : {
+              image_factory_base_url: 'https://factory.talos.dev',
+              image_factory_pxe_base_url: 'https://pxe.factory.talos.dev',
+            },
         metadata: {
           namespace: DefaultNamespace,
           type: FeaturesConfigType,
@@ -59,6 +72,51 @@ export const handlers = [
       },
     ],
   }).handler,
+  http.post<never, GetRequest, GetResponse>(
+    '/omni.resources.ResourceService/Get',
+    async ({ request }) => {
+      const { id, type, namespace } = await request.clone().json()
+
+      if (type !== TalosVersionType || namespace !== DefaultNamespace) return
+
+      return HttpResponse.json({
+        body: JSON.stringify({
+          metadata: {
+            namespace,
+            type,
+            id,
+          },
+          spec: {
+            is_enterprise: enterprise,
+          },
+        } satisfies Resource<TalosVersionSpec>),
+      })
+    },
+  ),
+  http.post<never, GetRequest, GetResponse>(
+    '/omni.resources.ResourceService/Get',
+    async ({ request }) => {
+      const { id, type, namespace } = await request.clone().json()
+
+      if (type !== ImageFactoryAuthType || namespace !== DefaultNamespace) return
+
+      return HttpResponse.json({
+        body: JSON.stringify({
+          metadata: {
+            namespace,
+            type,
+            id,
+          },
+          spec: enterprise
+            ? {
+                username: 'admin',
+                password: '123',
+              }
+            : {},
+        } satisfies Resource<ImageFactoryAuthSpec>),
+      })
+    },
+  ),
   http.post<never, GetRequest, GetResponse>(
     '/omni.resources.ResourceService/Get',
     async ({ request }) => {

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.stories.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create/confirmation.stories.ts
@@ -3,12 +3,9 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 import { faker } from '@faker-js/faker'
-import { createWatchStreamHandler } from '@msw/helpers'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
-import { type FeaturesConfigSpec } from '@/api/omni/specs/omni.pb'
 import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
-import { DefaultNamespace, FeaturesConfigID, FeaturesConfigType } from '@/api/resources'
 import { AUTOMATIC_VERSION } from '@/views/InstallationMedia/useFormState'
 
 import { handlers } from './confirmation.mocks'
@@ -26,7 +23,7 @@ const meta: Meta<typeof Confirmation> = {
       },
       systemExtensions: ['siderolabs/potato', 'siderolabs/tomato'],
       cmdline: '-console console=tty0',
-      secureBoot: true,
+      secureBoot: false,
       useGrpcTunnel: false,
       joinToken: faker.string.alphanumeric(44),
     },
@@ -36,37 +33,26 @@ const meta: Meta<typeof Confirmation> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
+export const Enterprise: Story = {
   beforeEach({ msw }) {
-    msw.use(...handlers)
+    msw.use(...handlers())
+  },
+}
+
+export const EnterpriseSecureBoot: Story = {
+  args: {
+    modelValue: {
+      ...meta.args?.modelValue,
+      secureBoot: true,
+    },
+  },
+  beforeEach({ msw }) {
+    msw.use(...handlers())
   },
 }
 
 export const NotEnterprise: Story = {
   beforeEach({ msw }) {
-    msw.use(
-      createWatchStreamHandler<FeaturesConfigSpec>({
-        expectedOptions: {
-          namespace: DefaultNamespace,
-          type: FeaturesConfigType,
-          id: FeaturesConfigID,
-        },
-        initialResources: [
-          {
-            spec: {
-              image_factory_base_url: 'https://factory.talos.dev',
-              image_factory_pxe_base_url: 'https://pxe.factory.talos.dev',
-              is_enterprise_image_factory: false,
-            },
-            metadata: {
-              namespace: DefaultNamespace,
-              type: FeaturesConfigType,
-              id: FeaturesConfigID,
-            },
-          },
-        ],
-      }).handler,
-      ...handlers,
-    )
+    msw.use(...handlers(false))
   },
 }

--- a/frontend/src/views/ClusterSecurity/ClusterSecurity.vue
+++ b/frontend/src/views/ClusterSecurity/ClusterSecurity.vue
@@ -32,6 +32,7 @@ import TAlert from '@/components/TAlert.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { getDocsLink } from '@/methods'
 import { useIsEnterprise } from '@/methods/features'
+import { useResolvedFactory } from '@/methods/useResolvedFactory'
 import { useResourceList } from '@/methods/useResourceList'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import SeverityBadges from '@/views/ClusterSecurity/components/SeverityBadges.vue'
@@ -58,27 +59,6 @@ const { data: clusterStatus, loading: statusLoading } = useResourceWatch<Cluster
   },
 }))
 
-const { data: configStatuses, loading: configLoading } =
-  useResourceWatch<ClusterMachineConfigStatusSpec>(() => ({
-    skip: !isEnterpriseFactory.value,
-    runtime: Runtime.Omni,
-    resource: {
-      namespace: DefaultNamespace,
-      type: ClusterMachineConfigStatusType,
-    },
-    selectors: [`${LabelCluster}=${clusterId}`],
-  }))
-
-const { data: machineStatuses } = useResourceWatch<MachineStatusSpec>(() => ({
-  skip: !isEnterpriseFactory.value,
-  runtime: Runtime.Omni,
-  resource: {
-    namespace: DefaultNamespace,
-    type: MachineStatusType,
-  },
-  selectors: [`${LabelCluster}=${clusterId}`],
-}))
-
 const { data: talosVersions } = useResourceList<TalosVersionSpec>(() => ({
   skip: !isEnterpriseFactory.value,
   runtime: Runtime.Omni,
@@ -89,6 +69,35 @@ const { data: talosVersions } = useResourceList<TalosVersionSpec>(() => ({
 }))
 
 const currentVersion = computed(() => clusterStatus.value?.spec.talos_version)
+
+const talosVersion = computed(() =>
+  talosVersions.value.find((v) => v.metadata.id === currentVersion.value),
+)
+
+const { url: factoryUrl } = useResolvedFactory(() => talosVersion.value?.spec.image_factory_url)
+
+const isTalosVersionEnterpriseFactory = computed(() => talosVersion.value?.spec.is_enterprise)
+
+const { data: configStatuses, loading: configLoading } =
+  useResourceWatch<ClusterMachineConfigStatusSpec>(() => ({
+    skip: !isEnterpriseFactory.value || !isTalosVersionEnterpriseFactory.value,
+    runtime: Runtime.Omni,
+    resource: {
+      namespace: DefaultNamespace,
+      type: ClusterMachineConfigStatusType,
+    },
+    selectors: [`${LabelCluster}=${clusterId}`],
+  }))
+
+const { data: machineStatuses } = useResourceWatch<MachineStatusSpec>(() => ({
+  skip: !isEnterpriseFactory.value || !isTalosVersionEnterpriseFactory.value,
+  runtime: Runtime.Omni,
+  resource: {
+    namespace: DefaultNamespace,
+    type: MachineStatusType,
+  },
+  selectors: [`${LabelCluster}=${clusterId}`],
+}))
 
 const archByMachine = computed(
   () => new Map(machineStatuses.value.map((m) => [m.metadata.id!, m.spec.hardware?.arch])),
@@ -230,6 +239,14 @@ function openDetails(schematicId: string, arch: string, version: string, matches
       Vulnerability scanning requires the enterprise image factory.
     </TAlert>
 
+    <TAlert
+      v-else-if="!isTalosVersionEnterpriseFactory"
+      type="info"
+      title="Vulnerability scanning unavailable"
+    >
+      Vulnerability scanning requires using a talos version from the enterprise image factory.
+    </TAlert>
+
     <p v-else-if="initialLoading" class="flex items-center gap-1.5 text-sm text-naturals-n11">
       <TSpinner class="size-4" />
       Loading cluster information…
@@ -317,11 +334,12 @@ function openDetails(schematicId: string, arch: string, version: string, matches
     </template>
 
     <ScanDetailsModal
-      v-if="detailsModal"
+      v-if="detailsModal && factoryUrl"
       v-model:open="detailsModal.open"
       :matches="detailsModal.matches"
       :schematic-id="detailsModal.schematicId"
       :talos-version="detailsModal.version"
+      :factory-url
       :arch="archEnum(detailsModal.arch)"
     />
   </section>

--- a/frontend/src/views/InstallationMedia/Confirmation.vue
+++ b/frontend/src/views/InstallationMedia/Confirmation.vue
@@ -34,7 +34,6 @@ import TSpinner from '@/components/Spinner/TSpinner.vue'
 import TAlert from '@/components/TAlert.vue'
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { getDocsLink, majorMinorVersion } from '@/methods'
-import { useImageFactoryAuth, withImageFactoryAuth } from '@/methods/useImageFactoryAuth'
 import { useResolvedFactory } from '@/methods/useResolvedFactory'
 import { useResourceGet } from '@/methods/useResourceGet'
 import { useTalosctlDownloads } from '@/methods/useTalosctlDownloads'
@@ -76,21 +75,13 @@ const { data: talosVersion } = useResourceGet<TalosVersionSpec>(() => ({
   },
 }))
 
-const { base: factoryBaseURL, credentials: factoryCredentialsRef } = useResolvedFactory(
+const { url: factoryUrl, credentials: imageFactoryAuth } = useResolvedFactory(
   () => talosVersion.value?.spec.image_factory_url,
 )
 
 const isEnterpriseFactory = computed(() => talosVersion.value?.spec.is_enterprise)
 
-const imageFactoryAuth = useImageFactoryAuth(
-  computed(() => talosVersion.value?.spec.image_factory_url),
-)
-
-const { data: talosctlPathsRaw } = useTalosctlDownloads(() => resolvedTalosVersion.value)
-
-const talosctlPaths = computed(() =>
-  talosctlPathsRaw.value.map((path) => withImageFactoryAuth(path, imageFactoryAuth.value)!),
-)
+const { data: talosctlPaths } = useTalosctlDownloads(resolvedTalosVersion)
 
 const { data: selectedCloudProvider } = useResourceGet<PlatformConfigSpec>(() => ({
   skip: formState.value.hardwareType !== 'cloud',
@@ -152,15 +143,17 @@ const resolvedPreset = computed(() => ({
 const { schematic, schematicLoading, schematicError } = usePresetSchematic(resolvedPreset)
 const schematicId = computed(() => schematic.value?.id ?? '')
 
-const { links } = usePresetDownloadLinks(schematicId, resolvedPreset)
+const { links, orphaned } = usePresetDownloadLinks(schematicId, resolvedPreset)
 
-const factoryHost = computed(() => (factoryBaseURL.value ? new URL(factoryBaseURL.value).host : ''))
+const factoryHost = computed(() => (factoryUrl.value ? new URL(factoryUrl.value).host : ''))
 
-const installerImage = computed(() =>
-  supportsUnifiedInstaller.value
+const installerImage = computed(() => {
+  if (!factoryHost.value) return
+
+  return supportsUnifiedInstaller.value
     ? `${factoryHost.value}/${formState.value.hardwareType}-installer${secureBootSuffix.value}/${schematicId.value}:${resolvedTalosVersion.value}`
-    : `${factoryHost.value}/installer/${schematicId.value}:${resolvedTalosVersion.value}`,
-)
+    : `${factoryHost.value}/installer/${schematicId.value}:${resolvedTalosVersion.value}`
+})
 
 const quote = (input: string) => {
   if (/["\s\\]/.test(input) && !/'/.test(input)) {
@@ -175,16 +168,18 @@ const quote = (input: string) => {
 }
 
 const clusterCreateCommand = computed(() => {
+  if (!factoryUrl.value) return
+
   const parts = [
     'talosctl cluster create qemu',
-    `--image-factory-url=${factoryBaseURL.value}`,
+    `--image-factory-url=${factoryUrl.value}`,
     `--schematic-id=${schematicId.value}`,
     `--talos-version=v${resolvedTalosVersion.value}`,
   ]
 
   // The local cluster pulls the installer from the factory that serves this version, so it must
   // authenticate with that factory's credentials.
-  const { username, password } = factoryCredentialsRef.value ?? {}
+  const { username, password } = imageFactoryAuth.value ?? {}
   if (username && password) {
     parts.push(`--image-factory-auth=${quote(`${username}:${password}`)}`)
   }
@@ -193,22 +188,23 @@ const clusterCreateCommand = computed(() => {
 })
 
 const SPDXBaseURL = computed(() =>
-  factoryBaseURL.value
-    ? `${factoryBaseURL.value}/spdx/${schematicId.value}/v${resolvedTalosVersion.value}/amd64`
+  factoryUrl.value
+    ? `${factoryUrl.value}/spdx/${schematicId.value}/v${resolvedTalosVersion.value}/amd64`
     : '',
 )
 
 const VEXBaseURL = computed(() =>
-  factoryBaseURL.value ? `${factoryBaseURL.value}/vex/v${resolvedTalosVersion.value}/vex.json` : '',
+  factoryUrl.value ? `${factoryUrl.value}/vex/v${resolvedTalosVersion.value}/vex.json` : '',
 )
 </script>
 
 <template>
   <div v-if="schematic" class="flex flex-col gap-4 text-xs">
     <Scan
-      v-if="isEnterpriseFactory"
+      v-if="isEnterpriseFactory && factoryUrl"
       :schematic-id
       :talos-version="resolvedTalosVersion"
+      :factory-url="factoryUrl"
       :arch="formState.machineArch!"
     />
 
@@ -242,8 +238,13 @@ const VEXBaseURL = computed(() =>
     <p v-else-if="selectedSBC">Use the following disk image for {{ selectedSBC.spec.label }}:</p>
 
     <dl class="flex flex-col gap-2">
+      <TAlert v-if="orphaned" title="Orphaned" type="warn">
+        The factory used to create this preset is no longer configured with Omni
+      </TAlert>
+
       <template
         v-for="{ label, link, documentation, withChecksums, copyOnly } in links"
+        v-else
         :key="link"
       >
         <dt class="font-medium text-naturals-n14 not-first-of-type:mt-2">
@@ -313,7 +314,7 @@ const VEXBaseURL = computed(() =>
       </template>
     </dl>
 
-    <template v-if="notOnlyDiskImage">
+    <template v-if="notOnlyDiskImage && installerImage">
       <h3 class="text-sm text-naturals-n14">Initial Installation</h3>
       <p>
         For the initial installation of Talos Linux (not applicable for disk image boot), add the
@@ -326,7 +327,7 @@ const VEXBaseURL = computed(() =>
       />
     </template>
 
-    <template v-if="gte(resolvedTalosVersion, '1.12.0-alpha.2')">
+    <template v-if="gte(resolvedTalosVersion, '1.12.0-alpha.2') && clusterCreateCommand">
       <h3 class="text-sm text-naturals-n14">Local Test Cluster</h3>
       <p>
         To create a local Talos Linux test cluster from this schematic on macOS (Apple Silicon) or

--- a/frontend/src/views/InstallationMedia/DownloadPresetModal.vue
+++ b/frontend/src/views/InstallationMedia/DownloadPresetModal.vue
@@ -154,6 +154,8 @@ const schematicId = computed(() => schematic.value?.id ?? '')
 
 const { schematic } = usePresetSchematic(resolvedPreset)
 const { links, orphaned } = usePresetDownloadLinks(schematicId, resolvedPreset)
+
+const orphanedError = 'The factory used to create this preset is no longer configured with Omni'
 </script>
 
 <template>
@@ -208,7 +210,7 @@ const { links, orphaned } = usePresetDownloadLinks(schematicId, resolvedPreset)
 
             <TableCell class="w-0">
               <div class="flex gap-1">
-                <Tooltip description="Download">
+                <Tooltip :description="orphaned ? orphanedError : 'Download'">
                   <IconButton
                     is="a"
                     :href="link"
@@ -220,7 +222,7 @@ const { links, orphaned } = usePresetDownloadLinks(schematicId, resolvedPreset)
                   />
                 </Tooltip>
 
-                <Tooltip description="Copy link">
+                <Tooltip :description="orphaned ? orphanedError : 'Copy link'">
                   <IconButton
                     aria-label="copy link"
                     icon="copy"

--- a/frontend/src/views/InstallationMedia/usePresetDownloadLinks.ts
+++ b/frontend/src/views/InstallationMedia/usePresetDownloadLinks.ts
@@ -19,7 +19,6 @@ import {
 } from '@/api/resources'
 import { getDocsLink } from '@/methods'
 import { useIsEnterprise } from '@/methods/features'
-import { withImageFactoryAuth } from '@/methods/useImageFactoryAuth'
 import { useResolvedFactory } from '@/methods/useResolvedFactory'
 import { useResourceGet } from '@/methods/useResourceGet'
 
@@ -69,76 +68,73 @@ export function usePresetDownloadLinks(
     }
   })
 
-  // Resolve which configured factory this preset targets. The preset stores the factory URL it was
-  // created against; when that URL is no longer among the configured factories the preset is orphaned
-  // and its images can no longer be downloaded.
-  const {
-    base: factoryBaseURL,
-    pxe: factoryPxeBaseURL,
-    credentials,
-    orphaned,
-  } = useResolvedFactory(() => toValue(presetRef).image_factory_url)
+  const { url: factoryBaseURL, pxeUrl: factoryPxeBaseURL } = useResolvedFactory(
+    () => toValue(presetRef).image_factory_url,
+  )
+
+  // If the resolved factory is no longer configured in Omni, this preset is orphaned
+  const orphaned = computed(() => !factoryBaseURL.value)
 
   const imageBaseURL = computed(() =>
-    withImageFactoryAuth(
-      `${factoryBaseURL.value}/image/${toValue(schematicId)}/${toValue(presetRef).talos_version}`,
-      credentials.value,
-    ),
+    factoryBaseURL.value
+      ? `${factoryBaseURL.value}/image/${toValue(schematicId)}/${toValue(presetRef).talos_version}`
+      : undefined,
   )
 
   const pxeBaseURL = computed(() =>
-    withImageFactoryAuth(
-      `${factoryPxeBaseURL.value}/pxe/${toValue(schematicId)}/${toValue(presetRef).talos_version}`,
-      credentials.value,
-    ),
+    factoryPxeBaseURL.value
+      ? `${factoryPxeBaseURL.value}/pxe/${toValue(schematicId)}/${toValue(presetRef).talos_version}`
+      : undefined,
   )
 
-  const sbcDiskImagePath = computed(() => `${imageBaseURL.value}/metal-${arch.value}.raw.xz`)
+  const sbcDiskImagePath = computed(() =>
+    imageBaseURL.value ? `${imageBaseURL.value}/metal-${arch.value}.raw.xz` : undefined,
+  )
 
   const pxeBootURL = computed(() =>
-    selectedPlatform.value
+    selectedPlatform.value && pxeBaseURL.value
       ? `${pxeBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}${secureBootSuffix.value}`
       : undefined,
   )
 
   const platformDiskImagePath = computed(() =>
-    selectedPlatform.value
+    selectedPlatform.value && imageBaseURL.value
       ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}${secureBootSuffix.value}.${selectedPlatform.value.spec.disk_image_suffix}`
       : undefined,
   )
 
   const qcow2DiskImagePath = computed(() =>
-    selectedPlatform.value
+    selectedPlatform.value && imageBaseURL.value
       ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}.qcow2`
       : undefined,
   )
 
   const isoPath = computed(() =>
-    selectedPlatform.value
+    selectedPlatform.value && imageBaseURL.value
       ? `${imageBaseURL.value}/${selectedPlatform.value.metadata.id}-${arch.value}${secureBootSuffix.value}.iso`
       : undefined,
   )
 
-  const links = computed(() => {
+  interface DownloadLink {
+    label: string
+    link: string
+    withChecksums?: boolean
+    copyOnly?: boolean
+    documentation?: {
+      label: string
+      link: string
+    }
+  }
+
+  const links = computed<DownloadLink[]>(() => {
     const preset = toValue(presetRef)
 
-    if (preset.sbc) {
+    if (preset.sbc && sbcDiskImagePath.value) {
       return [{ label: 'Disk Image', link: sbcDiskImagePath.value, withChecksums: true }]
     }
 
     if (!selectedPlatform.value?.spec.boot_methods) {
       return []
-    }
-
-    interface DownloadLink {
-      label: string
-      link: string
-      withChecksums?: boolean
-      copyOnly?: boolean
-      documentation?: {
-        label: string
-        link: string
-      }
     }
 
     return selectedPlatform.value.spec.boot_methods

--- a/frontend/src/views/InstallationMedia/vulnerabilities/Scan.vue
+++ b/frontend/src/views/InstallationMedia/vulnerabilities/Scan.vue
@@ -16,9 +16,10 @@ import TAlert from '@/components/TAlert.vue'
 import ScanDetailsModal from '@/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue'
 import { useVulnerabilityReport } from '@/views/InstallationMedia/vulnerabilities/useVulnerabilityReport'
 
-const { schematicId, talosVersion, arch } = defineProps<{
+const { schematicId, talosVersion, factoryUrl, arch } = defineProps<{
   schematicId: string
   talosVersion: string
+  factoryUrl: string
   arch: PlatformConfigSpecArch
 }>()
 
@@ -78,6 +79,7 @@ const {
     :matches="matches"
     :schematic-id
     :talos-version
+    :factory-url
     :arch
   />
 </template>

--- a/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.stories.ts
+++ b/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.stories.ts
@@ -3,12 +3,9 @@
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
 import { faker } from '@faker-js/faker'
-import { createWatchStreamHandler } from '@msw/helpers'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
-import type { FeaturesConfigSpec } from '@/api/omni/specs/omni.pb'
 import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
-import { DefaultNamespace, FeaturesConfigID, FeaturesConfigType } from '@/api/resources'
 
 import report from './sample-report.json'
 import ScanDetailsModal from './ScanDetailsModal.vue'
@@ -19,6 +16,7 @@ const meta: Meta<typeof ScanDetailsModal> = {
     open: true,
     schematicId: faker.string.uuid(),
     arch: PlatformConfigSpecArch.AMD64,
+    factoryUrl: 'https://factory-enterprise.talos.dev',
     talosVersion: '1.13.0',
   },
   parameters: {
@@ -32,30 +30,5 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     matches: report.matches,
-  },
-
-  beforeEach({ msw }) {
-    msw.use(
-      createWatchStreamHandler<FeaturesConfigSpec>({
-        expectedOptions: {
-          namespace: DefaultNamespace,
-          type: FeaturesConfigType,
-          id: FeaturesConfigID,
-        },
-        initialResources: [
-          {
-            spec: {
-              image_factory_base_url: 'https://factory-enterprise.talos.dev',
-              image_factory_pxe_base_url: 'https://pxe.factory-enterprise.talos.dev',
-            },
-            metadata: {
-              namespace: DefaultNamespace,
-              type: FeaturesConfigType,
-              id: FeaturesConfigID,
-            },
-          },
-        ],
-      }).handler,
-    )
   },
 }

--- a/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue
+++ b/frontend/src/views/InstallationMedia/vulnerabilities/ScanDetailsModal.vue
@@ -10,7 +10,6 @@ import { computed, ref, watchEffect } from 'vue'
 import { PlatformConfigSpecArch } from '@/api/omni/specs/virtual.pb'
 import TButton from '@/components/Button/TButton.vue'
 import Modal from '@/components/Modals/Modal.vue'
-import { useFeatures } from '@/methods/features'
 import SeverityBadges from '@/views/ClusterSecurity/components/SeverityBadges.vue'
 import VulnerabilityList from '@/views/ClusterSecurity/components/VulnerabilityList.vue'
 import type { Match } from '@/views/InstallationMedia/vulnerabilities/ReportTypes'
@@ -19,17 +18,18 @@ const {
   matches,
   schematicId,
   talosVersion,
+  factoryUrl,
   arch: archEnum,
 } = defineProps<{
   matches: Match[]
   schematicId: string
   talosVersion: string
+  factoryUrl: string
   arch: PlatformConfigSpecArch
 }>()
 
 const open = defineModel<boolean>('open', { default: false })
 
-const { data: features } = useFeatures()
 const severityFilter = ref<string>()
 
 watchEffect(() => {
@@ -87,7 +87,7 @@ function toggleSeverityFilter(severity: string) {
           >
             <TButton
               is="a"
-              :href="`${features?.spec.image_factory_base_url}/scans/${schematicId}/v${talosVersion}/${arch}/${filename}`"
+              :href="`${factoryUrl}/scans/${schematicId}/v${talosVersion}/${arch}/${filename}`"
               target="_blank"
               rel="noopener noreferrer"
               size="sm"


### PR DESCRIPTION
- Consolidate credential URL logic into useResolvedFactory.
- Add missing factory auth credentials to enterprise security pages in the frontend.
- Remove credentials from talosctl downloads as they are not required there.
- Add messages to inform user about orphaned presets rather than just disabling buttons in some cases, and rendering undefined URLs in others.