### PR TITLE
fix: backfill the image factory host of machines enrolled before 1.10

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
@@ -66,11 +66,15 @@ func NewMachineConfigGenOptionsController(imageFactoryClients ImageFactoryClient
 				imageFactoryHost := imageFactoryClient.Host()
 
 				// Migration code: do not change image factory URL if it was already set in the options and the Talos version and schematic ID match the cluster machine Talos version.
-				// Image factory URL will only be upgraded when the Talos version or schematic ID changes, or when the image factory URL is empty.
+				// Image factory URL will only be upgraded when the Talos version or schematic ID changes.
 				if options.TypedSpec().Value.InstallImage != nil && clusterMachineTalosVersion != nil &&
 					(options.TypedSpec().Value.InstallImage.TalosVersion == talosVersion &&
 						options.TypedSpec().Value.InstallImage.SchematicId == schematicID) {
 					imageFactoryHost = options.TypedSpec().Value.InstallImage.ImageFactoryHost
+				}
+
+				if clusterMachineTalosVersion == nil {
+					backfillImageFactoryHost(options.TypedSpec().Value.InstallImage, imageFactoryClients, imageFactoryHost)
 				}
 
 				GenInstallConfig(machineStatus, clusterMachineTalosVersion, options, imageFactoryHost)
@@ -83,6 +87,22 @@ func NewMachineConfigGenOptionsController(imageFactoryClients ImageFactoryClient
 		),
 		qtransform.WithIgnoreTeardownUntil(), // keep the resource until everyone else is done with Machine
 	)
+}
+
+func backfillImageFactoryHost(installImage *specs.MachineConfigGenOptionsSpec_InstallImage, imageFactoryClients ImageFactoryClientProvider, fallbackHost string) {
+	if installImage == nil || installImage.ImageFactoryHost != "" {
+		return
+	}
+
+	// The secondary factory is the one Omni is migrating away from, so it is the factory the schematic of a machine
+	// enrolled before the host was tracked was created on.
+	if secondary, ok := imageFactoryClients.Secondary(); ok {
+		installImage.ImageFactoryHost = secondary.Host()
+
+		return
+	}
+
+	installImage.ImageFactoryHost = fallbackHost
 }
 
 // GenInstallConfig creates a config patch with an automatically picked install disk.

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options_test.go
@@ -6,14 +6,22 @@
 package omni_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
 	"github.com/siderolabs/talos/pkg/machinery/api/storage"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/imagefactory"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock/options"
 )
 
 func TestGenInstallConfig(t *testing.T) {
@@ -177,6 +185,169 @@ func TestGenInstallConfig(t *testing.T) {
 			omnictrl.GenInstallConfig(ms, talosVersion, genOptions, "factory.talos.dev")
 
 			assert.Equal(t, tt.expectedInstallDisk, genOptions.TypedSpec().Value.InstallDisk)
+		})
+	}
+}
+
+// TestMachineConfigGenOptionsFactoryHost covers which image factory host the controller records in the
+// install image of a machine that already has MachineConfigGenOptions, i.e. what an Omni upgrade leaves
+// behind.
+//
+// Regression test for https://github.com/siderolabs/omni/issues/3247: machines enrolled before Omni
+// started tracking the factory host per machine have it empty, and the controller kept carrying that
+// empty value forward, so every install of such a machine failed with "has no image factory host set".
+//
+// The host of a machine that is allocated to a cluster is left alone: its install image describes what
+// the machine is running, and is only ever rewritten by the allocation itself. The empty host is
+// backfilled while the machine is free, which is the state it passes through on its way back into a
+// cluster.
+func TestMachineConfigGenOptionsFactoryHost(t *testing.T) {
+	t.Parallel()
+
+	const (
+		primaryFactoryHost   = "primary.factory.test"
+		secondaryFactoryHost = "secondary.factory.test"
+		recordedFactoryHost  = "recorded.factory.test"
+
+		installedTalosVersion = "1.9.3"
+		upgradeTalosVersion   = "1.10.0"
+
+		// the install disk the controller picks from the mocked machine status hardware
+		expectedInstallDisk = "sda"
+	)
+
+	// installImage is the install image of the machine as it is stored in the state before the
+	// controller reconciles it.
+	installImage := func(talosVersion, factoryHost string) *specs.MachineConfigGenOptionsSpec_InstallImage {
+		return &specs.MachineConfigGenOptionsSpec_InstallImage{
+			TalosVersion:         talosVersion,
+			SchematicId:          defaultSchematic,
+			SchematicInitialized: true,
+			Platform:             "metal",
+			SecurityState:        &specs.SecurityState{},
+			ImageFactoryHost:     factoryHost,
+		}
+	}
+
+	for _, tt := range []struct {
+		storedInstallImage *specs.MachineConfigGenOptionsSpec_InstallImage
+		name               string
+		// the Talos version the machine is allocated with, empty when the machine is not allocated to a cluster
+		allocatedTalosVersion string
+		expectedFactoryHost   string
+		withSecondary         bool
+	}{
+		{
+			// the issue: Omni 1.9.x recorded no factory host, and the machine is now back out of its cluster
+			name:                "backfills the empty factory host of a machine that is not allocated",
+			storedInstallImage:  installImage(installedTalosVersion, ""),
+			expectedFactoryHost: primaryFactoryHost,
+		},
+		{
+			// the secondary factory is the one Omni is migrating away from, so it is the factory the
+			// schematic of a machine enrolled before the upgrade was created on
+			name:                "backfills the empty factory host of a machine that is not allocated from the secondary factory",
+			storedInstallImage:  installImage(installedTalosVersion, ""),
+			withSecondary:       true,
+			expectedFactoryHost: secondaryFactoryHost,
+		},
+		{
+			name:                "keeps the recorded factory host of a machine that is not allocated",
+			storedInstallImage:  installImage(installedTalosVersion, recordedFactoryHost),
+			withSecondary:       true,
+			expectedFactoryHost: recordedFactoryHost,
+		},
+		{
+			// the install image of an allocated machine is left as it is: the machine is running it, and the
+			// install/upgrade path resolves the factory on its own when the host is empty
+			name:                  "leaves the empty factory host of an allocated machine alone",
+			storedInstallImage:    installImage(installedTalosVersion, ""),
+			allocatedTalosVersion: installedTalosVersion,
+			expectedFactoryHost:   "",
+		},
+		{
+			name:                  "keeps the recorded factory host of an allocated machine",
+			storedInstallImage:    installImage(installedTalosVersion, recordedFactoryHost),
+			allocatedTalosVersion: installedTalosVersion,
+			expectedFactoryHost:   recordedFactoryHost,
+		},
+		{
+			name:                  "upgrades the factory host when the Talos version changes",
+			storedInstallImage:    installImage(installedTalosVersion, recordedFactoryHost),
+			allocatedTalosVersion: upgradeTalosVersion,
+			expectedFactoryHost:   primaryFactoryHost,
+		},
+		{
+			name:                  "uses the primary factory for a machine that never had an install image",
+			storedInstallImage:    nil,
+			allocatedTalosVersion: installedTalosVersion,
+			withSecondary:         true,
+			expectedFactoryHost:   primaryFactoryHost,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			const machineID = "machine-1"
+
+			testutils.WithRuntime(
+				ctx, t, testutils.TestOptions{},
+				func(ctx context.Context, tc testutils.TestContext) {
+					primary, err := imagefactory.NewClient("https://"+primaryFactoryHost, "", "")
+					require.NoError(t, err)
+
+					// no TalosVersion resources are created, so ForTalosVersion always resolves to the primary
+					clients := imagefactory.NewClients(tc.State, primary)
+
+					if tt.withSecondary {
+						var secondary *imagefactory.Client
+
+						secondary, err = imagefactory.NewClient("https://"+secondaryFactoryHost, "", "")
+						require.NoError(t, err)
+
+						clients.SetSecondary(secondary)
+					}
+
+					require.NoError(t, tc.Runtime.RegisterQController(omnictrl.NewMachineConfigGenOptionsController(clients)))
+
+					// Seed the resources before the runtime starts: the controller has to see the state left
+					// behind by an Omni upgrade instead of generating the options from scratch.
+					rmock.Mock[*omni.MachineStatus](ctx, t, tc.State, options.WithID(machineID))
+
+					// the machine is allocated to a cluster exactly while it has a ClusterMachineTalosVersion
+					if tt.allocatedTalosVersion != "" {
+						rmock.Mock[*omni.ClusterMachineTalosVersion](
+							ctx, t, tc.State, options.WithID(machineID),
+							options.Modify(func(res *omni.ClusterMachineTalosVersion) error {
+								res.TypedSpec().Value.TalosVersion = tt.allocatedTalosVersion
+								res.TypedSpec().Value.SchematicId = defaultSchematic
+
+								return nil
+							}),
+						)
+					}
+
+					rmock.Mock[*omni.MachineConfigGenOptions](
+						ctx, t, tc.State, options.WithID(machineID),
+						options.Modify(func(res *omni.MachineConfigGenOptions) error {
+							res.TypedSpec().Value.InstallDisk = ""
+							res.TypedSpec().Value.InstallImage = tt.storedInstallImage.CloneVT()
+
+							return nil
+						}),
+					)
+				},
+				func(ctx context.Context, tc testutils.TestContext) {
+					rtestutils.AssertResource(ctx, t, tc.State, machineID, func(res *omni.MachineConfigGenOptions, assertions *assert.Assertions) {
+						// the install disk is only ever written by the controller, so it marks the resource as reconciled
+						assertions.Equal(expectedInstallDisk, res.TypedSpec().Value.InstallDisk)
+						assertions.Equal(tt.expectedFactoryHost, res.TypedSpec().Value.InstallImage.GetImageFactoryHost())
+					})
+				},
+			)
 		})
 	}
 }

--- a/internal/backend/talos/lifecycle/client.go
+++ b/internal/backend/talos/lifecycle/client.go
@@ -46,8 +46,23 @@ func (m *Manager) buildInstallImage(ctx context.Context, machineID string, ms *o
 	}
 
 	if target != nil {
+		// The target is the spec of a cached resource, so patch a copy of it instead of writing through into the cache.
+		target = target.CloneVT()
+
 		if target.TalosVersion == "" {
 			target.TalosVersion = version
+		}
+
+		// A machine enrolled before Omni started tracking the image factory host per machine may still have none:
+		// resolve it the same way as for a machine without a target install image instead of failing the install.
+		// See https://github.com/siderolabs/omni/issues/3247.
+		if target.ImageFactoryHost == "" {
+			imageFactoryClient, err := m.imageFactoryClients.ForTalosVersion(ctx, target.TalosVersion)
+			if err != nil {
+				return "", fmt.Errorf("failed to get image factory client for Talos version %q: %w", target.TalosVersion, err)
+			}
+
+			target.ImageFactoryHost = imageFactoryClient.Host()
 		}
 
 		return installimage.Build(machineID, target, m.talosRegistry)

--- a/internal/backend/talos/lifecycle/client_test.go
+++ b/internal/backend/talos/lifecycle/client_test.go
@@ -57,6 +57,43 @@ func TestBuildInstallImage(t *testing.T) {
 		assert.Equal(t, "factory.talos.dev/metal-installer/target-schematic:v1.14.0", image)
 	})
 
+	// Regression test for https://github.com/siderolabs/omni/issues/3247: a machine enrolled before Omni
+	// started tracking the factory host per machine reaches this path with an empty host in its
+	// MachineConfigGenOptions, and the install fails with "has no image factory host set".
+	t.Run("a target with no factory host falls back to the configured factory", func(t *testing.T) {
+		t.Parallel()
+
+		image, err := m.BuildInstallImageForTest(t.Context(), "machine-1", ms, "1.13.1", &specs.MachineConfigGenOptionsSpec_InstallImage{
+			TalosVersion:         "1.14.0",
+			SchematicId:          "target-schematic",
+			SchematicInitialized: true,
+			Platform:             "metal",
+			SecurityState:        &specs.SecurityState{},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "factory.talos.dev/metal-installer/target-schematic:v1.14.0", image)
+	})
+
+	t.Run("the target install image is not modified", func(t *testing.T) {
+		t.Parallel()
+
+		// the target is the spec of a cached MachineConfigGenOptions resource, so it must be left alone
+		target := &specs.MachineConfigGenOptionsSpec_InstallImage{
+			SchematicId:          "target-schematic",
+			SchematicInitialized: true,
+			Platform:             "metal",
+			SecurityState:        &specs.SecurityState{},
+			ImageFactoryHost:     "factory.talos.dev",
+		}
+
+		image, err := m.BuildInstallImageForTest(t.Context(), "machine-1", ms, "1.13.1", target)
+		require.NoError(t, err)
+
+		assert.Equal(t, "factory.talos.dev/metal-installer/target-schematic:v1.13.1", image)
+		assert.Empty(t, target.TalosVersion)
+	})
+
 	t.Run("nil target falls back to the machine's current schematic", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Fixes: siderolabs/omni#3247