### PR TITLE
fix: force re-authentication at the IdP so logout takes effect

### DIFF
--- a/frontend/e2e/saml/auth.spec.ts
+++ b/frontend/e2e/saml/auth.spec.ts
@@ -34,12 +34,16 @@ test('Auth flow', async ({ page }) => {
   })
 
   await test.step('Logout', async () => {
+    // Keycloak answering the LogoutRequest is what proves Single Logout ran, and it has to be watched for
+    // rather than inferred from the login form: every login now carries ForceAuthn, so that form appears
+    // whether or not the IdP session was ended.
+    const logoutResponse = page.waitForRequest((request) => request.url().includes('/saml/slo'))
+
     await page.getByRole('button', { name: 'user actions' }).click()
     await page.getByRole('menuitem', { name: 'Log Out' }).click()
 
-    // Landing back on the login form means Single Logout ended the Keycloak session too.
-    // If the LogoutRequest had been rejected, Keycloak would answer the next /login
-    // redirect from its own SSO cookie and drop us straight back on the home page.
+    await logoutResponse
+
     await expect(page.getByRole('heading', { name: 'Sign in to your account' })).toBeVisible()
   })
 })

--- a/internal/backend/oidc/export_test.go
+++ b/internal/backend/oidc/export_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package oidc
+
+import "golang.org/x/oauth2"
+
+// NewTestHandler builds a Handler pointed at the given authorization endpoint, skipping the provider
+// discovery that NewOIDCHandler needs a live identity provider for.
+func NewTestHandler(authURL string) *Handler {
+	return &Handler{
+		key:      "test-key",
+		endpoint: "https://omni.example.com",
+		oauth2Config: oauth2.Config{
+			ClientID:    "omni",
+			RedirectURL: "https://omni.example.com" + RedirectURL,
+			Endpoint: oauth2.Endpoint{
+				AuthURL: authURL,
+			},
+		},
+	}
+}

--- a/internal/backend/oidc/handlers.go
+++ b/internal/backend/oidc/handlers.go
@@ -130,7 +130,13 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 
 	setCallbackCookie(w, r, "state", state)
 
-	http.Redirect(w, r, h.oauth2Config.AuthCodeURL(state), http.StatusFound)
+	// The provider session outlives an Omni logout whenever there is no end-session endpoint, so every
+	// login asks for credentials rather than accepting whoever the provider still has. Without this,
+	// logging out returns the same user immediately. Auth0 gets the same effect from a short max_age, and
+	// SAML from ForceAuthn.
+	forceReauth := oauth2.SetAuthURLParam("prompt", "login")
+
+	http.Redirect(w, r, h.oauth2Config.AuthCodeURL(state, forceReauth), http.StatusFound)
 }
 
 // Logout handles the logout flow of OIDC auth.

--- a/internal/backend/oidc/handlers_test.go
+++ b/internal/backend/oidc/handlers_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package oidc_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/internal/backend/oidc"
+)
+
+const testAuthURL = "https://idp.example.com/authorize"
+
+// TestLoginForcesReauthentication pins the behavior that makes logging out of Omni mean something. The
+// provider session survives an Omni logout when it publishes no end-session endpoint, so without
+// prompt=login the next authorization request is answered with the user who just logged out.
+func TestLoginForcesReauthentication(t *testing.T) {
+	for _, target := range []string{
+		"/login?flow=frontend",
+		"/login?flow=cli&public-key-id=key-id",
+		"/login",
+	} {
+		t.Run(target, func(t *testing.T) {
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			oidc.NewTestHandler(testAuthURL).Login(rec, req)
+
+			resp := rec.Result()
+			defer resp.Body.Close() //nolint:errcheck
+
+			require.Equal(t, http.StatusFound, resp.StatusCode)
+
+			redirectURL, err := url.Parse(resp.Header.Get("Location"))
+			require.NoError(t, err)
+
+			assert.Equal(t, "idp.example.com", redirectURL.Host)
+			assert.Equal(t, "login", redirectURL.Query().Get("prompt"))
+		})
+	}
+}

--- a/internal/backend/saml/saml.go
+++ b/internal/backend/saml/saml.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/crewjam/saml"
@@ -29,6 +30,10 @@ import (
 
 // NameIDCookieName is the cookie used to store the SAML session data for SLO.
 const NameIDCookieName = "saml_name_id"
+
+// trackedRequestTTL is how long a pending AuthnRequest stays matchable, sized for a person completing a
+// password and an MFA challenge rather than for a redirect.
+const trackedRequestTTL = 15 * time.Minute
 
 // sloSessionData holds the SAML assertion fields needed to build a LogoutRequest.
 type sloSessionData struct {
@@ -50,9 +55,13 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 	}
 
 	opts := samlsp.Options{
-		URL:               *rootURL,
-		IDPMetadata:       idpMetadata,
-		LogoutBindings:    []string{saml.HTTPRedirectBinding, saml.HTTPPostBinding},
+		URL:            *rootURL,
+		IDPMetadata:    idpMetadata,
+		LogoutBindings: []string{saml.HTTPRedirectBinding, saml.HTTPPostBinding},
+		// The IdP session outlives an Omni logout whenever single logout is unavailable, so asking it to
+		// re-authenticate is what stops it answering with whoever it still has. Without this, logging out
+		// lands the same user straight back inside, and switching users is impossible.
+		ForceAuthn:        true,
 		AllowIDPInitiated: true,
 	}
 
@@ -64,6 +73,11 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 
 	requestTracker := samlsp.DefaultRequestTracker(opts, &serviceProvider)
 	requestTracker.Codec = &Encoder{}
+	// The library defaults this to MaxIssueDelay, 90 seconds, which was ample while the trip to the IdP
+	// was a silent redirect. Now that ForceAuthn makes every login a password and an MFA challenge, the
+	// cookie has to outlast a person: lose it and CreateSession cannot match the response to its request,
+	// which ends at /forbidden.
+	requestTracker.MaxAge = trackedRequestTTL
 
 	m := &samlsp.Middleware{
 		ServiceProvider: serviceProvider,

--- a/internal/backend/saml/saml_test.go
+++ b/internal/backend/saml/saml_test.go
@@ -6,20 +6,27 @@
 package saml_test
 
 import (
+	"bytes"
+	"compress/flate"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/siderolabs/omni/client/api/omni/specs"
 	omnisaml "github.com/siderolabs/omni/internal/backend/saml"
 )
 
@@ -87,6 +94,74 @@ func newMiddleware(t *testing.T, sloEndpoint string) *samlsp.Middleware {
 	}
 
 	return &samlsp.Middleware{ServiceProvider: sp}
+}
+
+// startAuthFlow builds a handler the way the server does and drives one login through it, returning the
+// response so both the AuthnRequest and the cookies it set can be inspected.
+func startAuthFlow(t *testing.T) *http.Response {
+	t.Helper()
+
+	m, err := omnisaml.NewHandler(
+		state.WrapCore(namespaced.NewState(inmem.Build)),
+		&specs.AuthConfigSpec_SAML{Metadata: "testdata/samlsp_metadata.xml"},
+		zaptest.NewLogger(t),
+		testAdvertisedURL,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/login?flow=frontend", nil)
+	rec := httptest.NewRecorder()
+
+	m.HandleStartAuthFlow(rec, req)
+
+	return rec.Result()
+}
+
+// TestLoginForcesReauthentication pins the behavior that makes logging out of Omni mean something. The
+// IdP session survives an Omni logout whenever single logout is unavailable, so without ForceAuthn the
+// next AuthnRequest is answered with the user who just logged out.
+func TestLoginForcesReauthentication(t *testing.T) {
+	resp := startAuthFlow(t)
+	defer resp.Body.Close() //nolint:errcheck
+
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	redirectURL, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+
+	deflated, err := base64.StdEncoding.DecodeString(redirectURL.Query().Get("SAMLRequest"))
+	require.NoError(t, err)
+
+	r := flate.NewReader(bytes.NewReader(deflated))
+	defer r.Close() //nolint:errcheck
+
+	authnRequest, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(authnRequest), `ForceAuthn="true"`)
+}
+
+// TestTrackedRequestOutlastsAPerson guards the cookie that correlates the AuthnRequest with the response.
+// The library defaults it to MaxIssueDelay, 90 seconds, which was ample while this was a silent redirect.
+// Now that every login means typing a password and clearing MFA, a short lifetime sends anyone who takes
+// their time to /forbidden instead of into Omni.
+func TestTrackedRequestOutlastsAPerson(t *testing.T) {
+	resp := startAuthFlow(t)
+	defer resp.Body.Close() //nolint:errcheck
+
+	for _, cookie := range resp.Cookies() {
+		if !strings.HasPrefix(cookie.Name, "saml_") {
+			continue
+		}
+
+		assert.Greater(t, cookie.MaxAge, int(saml.MaxIssueDelay.Seconds()),
+			"the tracked request cookie %q expires after %ds, too soon for a password and an MFA challenge",
+			cookie.Name, cookie.MaxAge)
+
+		return
+	}
+
+	t.Error("expected the auth flow to set a tracked request cookie")
 }
 
 func TestCreateLogoutHandler_NoCookie(t *testing.T) {


### PR DESCRIPTION
Logging out of Omni destroys Omni's session but it doesn't destroy IdP's session unless explicit configuration is there (Single Logout for SAML, manually configuring via logoutURL for OIDC). User is then redirected to home page, which starts auth process again, since user's IdP session is still available, user is automatically logged back in. This prevents keeping user logged out as well as being able to switch between accounts.

Now Omni asks for re-authentication after logout. So users logging out of Omni get the same treatment of unauthenticated user opening Omni home page for the first time.