### PR TITLE
fix: don't sign users out of Omni on Kubernetes OIDC logout

### DIFF
--- a/internal/backend/oidc/oidc.go
+++ b/internal/backend/oidc/oidc.go
@@ -50,7 +50,7 @@ func NewProvider(store Storage, issuerEndpoint string) (*Provider, error) {
 
 	cfg := &op.Config{
 		CryptoKey:                cryptoKey,
-		DefaultLogoutRedirectURI: "/logout",
+		DefaultLogoutRedirectURI: "/",
 		CodeMethodS256:           true,
 		AuthMethodPost:           true,
 		AuthMethodPrivateKeyJWT:  true,


### PR DESCRIPTION
This provider is Omni acting as the identity provider for Kubernetes API access, not for Omni's own session. A redirect back to /logout would push the user into Omni's own sign-out flow. Ending a Kubernetes OIDC session should leave the Omni session alone, so land on the root page instead.