### PR TITLE
fix(frontend): return no-cache for index.html

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -106,6 +106,11 @@ async function setupApp() {
   app.mount('#app')
 }
 
+// A preloadError generally means Omni was updated in the background. Reload the page in this case.
+window.addEventListener('vite:preloadError', () => {
+  window.location.reload()
+})
+
 initState()
 
 setupApp()

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -118,6 +118,7 @@ func (handler *StaticHandler) serveFile(w http.ResponseWriter, r *http.Request, 
 			w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", handler.maxAgeSec))
 			http.ServeContent(w, r, file.Name(), handler.modTime, file)
 		} else {
+			w.Header().Set("Cache-Control", "no-cache")
 			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 
 			b := make([]byte, 10)


### PR DESCRIPTION
When serving index.html return no-cache to the browser, to prevent serving a stale index.html after Omni has been updated.