### PR TITLE
fix(frontend): fix reset wizard

### DIFF
--- a/frontend/e2e/talemu/installation_media.spec.ts
+++ b/frontend/e2e/talemu/installation_media.spec.ts
@@ -10,9 +10,7 @@ import { expect, test } from '../auth_fixtures'
 
 test.describe.configure({ mode: 'parallel' })
 
-test('Download installation media', async ({ page }, testInfo) => {
-  test.slow()
-
+test.beforeEach(async ({ page }) => {
   await test.step('Go to wizard', async () => {
     await page.goto('/')
     await page
@@ -35,6 +33,10 @@ test('Download installation media', async ({ page }, testInfo) => {
 
     await expect(firstStepHeading).toBeVisible()
   })
+})
+
+test('Create, download, and delete an installation media', async ({ page }, testInfo) => {
+  test.slow()
 
   await test.step('Entry step', async () => {
     await page.getByRole('radio', { name: 'Bare-metal Machine' }).click()
@@ -215,5 +217,37 @@ test('Download installation media', async ({ page }, testInfo) => {
 
     await expect(page.getByText(`Deleted preset ${savedPresetName}`)).toBeVisible()
     await expect(presetRow).toBeHidden()
+  })
+})
+
+test('Reset wizard state', async ({ page }) => {
+  await test.step('Entry step', async () => {
+    await page.getByRole('radio', { name: 'Single Board Computer' }).click()
+    await expect(page.getByRole('radio', { name: 'Single Board Computer' })).toBeChecked()
+
+    await page.getByRole('link', { name: 'Next' }).click()
+  })
+
+  await test.step('Talos version step', async () => {
+    await page.getByRole('link', { name: 'Next' }).click()
+  })
+
+  await test.step('Architecture step', async () => {
+    await page.getByRole('link', { name: 'Next' }).click()
+  })
+
+  await test.step('System extensions step', async () => {
+    await page.getByRole('link', { name: 'Next' }).click()
+  })
+
+  await test.step('Extra args step', async () => {
+    await page.getByRole('link', { name: 'Next' }).click()
+  })
+
+  await test.step('Reset wizard', async () => {
+    await page.getByRole('button', { name: 'reset wizard' }).click()
+
+    await expect(page.getByText('Hardware Type')).toBeVisible()
+    await expect(page.getByRole('radio', { name: 'Bare-metal Machine' })).toBeChecked()
   })
 })

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create.spec.ts
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create.spec.ts
@@ -134,6 +134,10 @@ describe('InstallationMediaCreate', () => {
   })
 
   test('renders correct content for different routes', async () => {
+    useFormState().formState.value = {
+      hardwareType: 'metal',
+    }
+
     await router.push({ name: 'InstallationMediaCreateTalosVersion' })
     await router.isReady()
 

--- a/frontend/src/pages/(authenticated)/machines/installation-media/create.vue
+++ b/frontend/src/pages/(authenticated)/machines/installation-media/create.vue
@@ -133,13 +133,18 @@ function onStepperChange(stepperValue?: number) {
 }
 
 const savePresetModalOpen = ref(false)
+
+// This is to prevent rendering intermediary views when resetting wizard state
+const isFormResetting = computed(
+  () => currentStepName.value !== 'InstallationMediaCreateEntry' && !formState.value.hardwareType,
+)
 </script>
 
 <template>
   <PageContainer disable-padding class="flex h-full flex-col">
     <div class="flex grow flex-col gap-6 overflow-auto p-6">
       <h1 class="shrink-0 text-xl font-medium text-naturals-n14">Create New Media</h1>
-      <RouterView v-model="formState" />
+      <RouterView v-if="!isFormResetting" v-model="formState" />
     </div>
 
     <div


### PR DESCRIPTION
Fix reset wizard functionality for installation media wizard. There was a race condition that was trying to load intermediary views with a blank formState, which the wizard does not support.