### PR TITLE
test: fix flaky unit tests on overloaded CI runners

### DIFF
--- a/internal/backend/grpc/configs_test.go
+++ b/internal/backend/grpc/configs_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/siderolabs/go-api-signature/pkg/serviceaccount"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	machineryconfig "github.com/siderolabs/talos/pkg/machinery/config"
-	talossecrets "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -48,6 +47,7 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/auth"
 	"github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/ctxstore"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 //go:embed testdata/admin-kubeconfig.yaml
@@ -167,7 +167,7 @@ func TestGenerateConfigs(t *testing.T) {
 
 		secrets := omni.NewClusterSecrets(clusterName)
 
-		bundle, err := talossecrets.NewBundle(talossecrets.NewFixedClock(time.Now()), machineryconfig.TalosVersion1_7)
+		bundle, err := testsecrets.Bundle(machineryconfig.TalosVersion1_7)
 		require.NoError(t, err)
 
 		var data []byte

--- a/internal/backend/runtime/omni/controllers/helpers/helpers_test.go
+++ b/internal/backend/runtime/omni/controllers/helpers/helpers_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 func TestUpdateInputsVersions(t *testing.T) {
@@ -102,7 +103,7 @@ func TestGetTalosClient(t *testing.T) {
 
 				talosConfig := omni.NewTalosConfig(cluster.Metadata().ID())
 
-				bundle, err := secrets.NewBundle(secrets.NewFixedClock(time.Now()), config.TalosVersion1_10)
+				bundle, err := testsecrets.Bundle(config.TalosVersion1_10)
 				require.NoError(t, err)
 
 				talosConfig.TypedSpec().Value.Ca = base64.StdEncoding.EncodeToString(bundle.Certs.OS.Crt)

--- a/internal/backend/runtime/omni/controllers/omni/cert_refresh_tick_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cert_refresh_tick_test.go
@@ -38,7 +38,7 @@ func (suite *CertRefreshTickSuite) TestReconcile() {
 			suite.Require().Equal(state.Created, ev.Type)
 
 			ticks++
-		case <-time.After(500 * time.Millisecond):
+		case <-suite.ctx.Done():
 			suite.Require().FailNow("timeout waiting for tick")
 		}
 

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/kubernetes_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/kubernetes_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/siderolabs/omni/client/pkg/image"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/kubernetes"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 func TestComponentLess(t *testing.T) {
@@ -70,7 +71,11 @@ func TestComponentPatch(t *testing.T) {
 						components[i], components[j] = components[j], components[i]
 					})
 
-					in, err := generate.NewInput("component-patch-test", "https://127.0.0.1/", "1.34.0", generate.WithVersionContract(vc))
+					secretsBundle, err := testsecrets.Bundle(vc)
+					require.NoError(t, err)
+
+					in, err := generate.NewInput("component-patch-test", "https://127.0.0.1/", "1.34.0",
+						generate.WithVersionContract(vc), generate.WithSecretsBundle(secretsBundle))
 					require.NoError(t, err)
 
 					cfg, err := in.Config(machine.TypeControlPlane)

--- a/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/kubernetes/patch_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/siderolabs/omni/client/pkg/image"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/kubernetes"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 // TestMergePatch verifies that patches for several components accumulate into a single machine patch.
@@ -49,7 +50,11 @@ func TestMergePatch(t *testing.T) {
 			accumulated, err = kubernetes.MergePatch(accumulated, newAPIServerPatch.Patch)
 			require.NoError(t, err)
 
-			in, err := generate.NewInput("merge-patch-test", "https://127.0.0.1/", "1.34.0", generate.WithVersionContract(vc))
+			secretsBundle, err := testsecrets.Bundle(vc)
+			require.NoError(t, err)
+
+			in, err := generate.NewInput("merge-patch-test", "https://127.0.0.1/", "1.34.0",
+				generate.WithVersionContract(vc), generate.WithSecretsBundle(secretsBundle))
 			require.NoError(t, err)
 
 			cfg, err := in.Config(machine.TypeControlPlane)

--- a/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
@@ -45,6 +45,9 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/constants"
 )
 
+// testTimeout bounds each subtest. It is generous on purpose, so that the tests survive CPU starvation on overloaded CI runners, especially when the race detector multiplies the cost.
+const testTimeout = 30 * time.Second
+
 //nolint:maintidx
 func Test_TalosCARotation(t *testing.T) {
 	t.Parallel()
@@ -53,7 +56,7 @@ func Test_TalosCARotation(t *testing.T) {
 	t.Run("no rotation", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*20)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -113,7 +116,7 @@ func Test_TalosCARotation(t *testing.T) {
 	t.Run("rotation", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -212,7 +215,7 @@ func Test_TalosCARotation(t *testing.T) {
 	t.Run("cluster locked", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*20)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -278,7 +281,7 @@ func Test_TalosCARotation(t *testing.T) {
 	t.Run("cluster unhealthy", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*20)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -348,7 +351,7 @@ func Test_TalosCARotation(t *testing.T) {
 	t.Run("machine locked", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -422,7 +425,7 @@ func Test_TalosCARotation(t *testing.T) {
 	t.Run("machine unhealthy", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -496,7 +499,7 @@ func Test_TalosCARotation(t *testing.T) {
 	t.Run("rotation ongoing", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -628,7 +631,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 	t.Run("no rotation", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*20)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -688,7 +691,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 	t.Run("rotation", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -796,7 +799,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 	t.Run("cluster locked", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*20)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -871,7 +874,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 	t.Run("cluster unhealthy", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*20)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -950,7 +953,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 	t.Run("machine locked", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -1033,7 +1036,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 	t.Run("machine unhealthy", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -1116,7 +1119,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 	t.Run("rotation ongoing", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+		ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 		t.Cleanup(cancel)
 
 		testutils.WithRuntime(
@@ -1181,7 +1184,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 func Test_ConcurrentRotationRejection(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second*20)
+	ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 	t.Cleanup(cancel)
 
 	testutils.WithRuntime(
@@ -1230,7 +1233,7 @@ func Test_ConcurrentRotationRejection(t *testing.T) {
 func Test_ComponentIsolationDuringRotation(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second*15)
+	ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
 	t.Cleanup(cancel)
 
 	testutils.WithRuntime(

--- a/internal/backend/runtime/omni/controllers/omni/secrets/talosconfig_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/talosconfig_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock"
 	testoptions "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock/options"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 //nolint:maintidx,dupl
@@ -67,7 +68,7 @@ func Test_Talosconfig(t *testing.T) {
 
 				require.NoError(t, st.Create(ctx, machineSet))
 
-				secretsBundle, err := talossecrets.NewBundle(talossecrets.NewFixedClock(time.Now()), config.TalosVersion1_11)
+				secretsBundle, err := testsecrets.Bundle(config.TalosVersion1_11)
 				require.NoError(t, err)
 				data, err := json.Marshal(secretsBundle)
 				require.NoError(t, err)
@@ -150,7 +151,7 @@ func Test_Talosconfig(t *testing.T) {
 
 				require.NoError(t, st.Create(ctx, machineSet))
 
-				secretsBundle, err := talossecrets.NewBundle(talossecrets.NewFixedClock(time.Now()), config.TalosVersion1_11)
+				secretsBundle, err := testsecrets.Bundle(config.TalosVersion1_11)
 				require.NoError(t, err)
 				data, err := json.Marshal(secretsBundle)
 				require.NoError(t, err)

--- a/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
+++ b/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
@@ -9,7 +9,6 @@ package rmock
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	gensecrets "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	talosconstants "github.com/siderolabs/talos/pkg/machinery/constants"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 
@@ -35,6 +33,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/talosupgrade"
 	"github.com/siderolabs/omni/internal/pkg/certs"
 	"github.com/siderolabs/omni/internal/pkg/constants"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 const (
@@ -212,12 +211,7 @@ func init() {
 			return err
 		}
 
-		bundle, err := gensecrets.NewBundle(gensecrets.NewFixedClock(time.Now()), vc)
-		if err != nil {
-			return err
-		}
-
-		res.TypedSpec().Value.Data, err = json.Marshal(bundle)
+		res.TypedSpec().Value.Data, err = testsecrets.BundleData(vc)
 
 		return err
 	})

--- a/internal/backend/runtime/omni/talosconfig_test.go
+++ b/internal/backend/runtime/omni/talosconfig_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	talossecrets "github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -29,6 +28,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 	"github.com/siderolabs/omni/internal/backend/services/workloadproxy"
 	omniconfig "github.com/siderolabs/omni/internal/pkg/config"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 func TestOperatorTalosconfig(t *testing.T) {
@@ -57,7 +57,7 @@ func TestOperatorTalosconfig(t *testing.T) {
 
 	secrets := omni.NewClusterSecrets("cluster1")
 
-	bundle, err := talossecrets.NewBundle(talossecrets.NewFixedClock(time.Now()), config.TalosVersion1_7)
+	bundle, err := testsecrets.Bundle(config.TalosVersion1_7)
 	require.NoError(t, err)
 
 	data, err := json.Marshal(bundle)

--- a/internal/backend/runtime/talos/clients_test.go
+++ b/internal/backend/runtime/talos/clients_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/talos/pkg/machinery/config/bundle"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -24,6 +25,7 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/secrets"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 func TestGetClientForCluster(t *testing.T) {
@@ -41,11 +43,15 @@ func TestGetClientForCluster(t *testing.T) {
 		_, err := clientFactory.GetForCluster(ctx, clusterName)
 		require.True(t, talos.IsClientNotReadyError(err))
 
+		secretsBundle, err := testsecrets.Bundle(nil)
+		require.NoError(t, err)
+
 		configBundle, err := bundle.NewBundle(bundle.WithInputOptions(
 			&bundle.InputOptions{
 				ClusterName: clusterName,
 				Endpoint:    "https://127.0.0.1:6443",
 				KubeVersion: "1.36.1",
+				GenOptions:  []generate.Option{generate.WithSecretsBundle(secretsBundle)},
 			},
 		))
 		require.NoError(t, err)
@@ -171,11 +177,15 @@ func TestClientLifecycle(t *testing.T) {
 
 		// --- Setup: cluster credentials ---
 
+		secretsBundle, err := testsecrets.Bundle(nil)
+		require.NoError(t, err)
+
 		configBundle, err := bundle.NewBundle(bundle.WithInputOptions(
 			&bundle.InputOptions{
 				ClusterName: clusterName,
 				Endpoint:    "https://127.0.0.1:6443",
 				KubeVersion: "1.36.1",
+				GenOptions:  []generate.Option{generate.WithSecretsBundle(secretsBundle)},
 			},
 		))
 		require.NoError(t, err)
@@ -370,11 +380,15 @@ func TestClusterClientEvictedOnClusterLeave(t *testing.T) {
 		const clusterName = "alpha"
 
 		// Cluster credentials, required to build a secure cluster client.
+		secretsBundle, err := testsecrets.Bundle(nil)
+		require.NoError(t, err)
+
 		configBundle, err := bundle.NewBundle(bundle.WithInputOptions(
 			&bundle.InputOptions{
 				ClusterName: clusterName,
 				Endpoint:    "https://127.0.0.1:6443",
 				KubeVersion: "1.36.1",
+				GenOptions:  []generate.Option{generate.WithSecretsBundle(secretsBundle)},
 			},
 		))
 		require.NoError(t, err)

--- a/internal/pkg/certs/certs_test.go
+++ b/internal/pkg/certs/certs_test.go
@@ -8,20 +8,19 @@ package certs_test
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/siderolabs/talos/pkg/machinery/role"
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/certs"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 func TestIsTalosCertificateStale(t *testing.T) {
-	bundle, err := secrets.NewBundle(secrets.NewFixedClock(time.Now()), config.TalosVersionCurrent)
+	bundle, err := testsecrets.Bundle(config.TalosVersionCurrent)
 	require.NoError(t, err)
 
 	data, err := json.Marshal(bundle)

--- a/internal/pkg/certs/kubernetes_test.go
+++ b/internal/pkg/certs/kubernetes_test.go
@@ -8,20 +8,19 @@ package certs_test
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/siderolabs/talos/pkg/machinery/config"
-	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/pkg/certs"
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
 )
 
 func TestIsKubernetesCertificateStale(t *testing.T) {
-	bundle, err := secrets.NewBundle(secrets.NewFixedClock(time.Now()), config.TalosVersionCurrent)
+	bundle, err := testsecrets.Bundle(config.TalosVersionCurrent)
 	require.NoError(t, err)
 
 	data, err := json.Marshal(bundle)

--- a/internal/pkg/testsecrets/testsecrets.go
+++ b/internal/pkg/testsecrets/testsecrets.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+// Package testsecrets provides Talos secrets bundles for tests.
+//
+// Generating a bundle costs around a second of CPU because of the RSA service account key.
+// Because of this, bundles are generated once per version contract per test process and shared.
+// Tests do not need unique secrets.
+package testsecrets
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/siderolabs/talos/pkg/machinery/config/generate/secrets"
+)
+
+var (
+	cacheMu sync.Mutex
+	cache   = map[string][]byte{}
+)
+
+// Bundle returns a secrets bundle for the given version contract, which may be nil.
+func Bundle(vc *config.VersionContract) (*secrets.Bundle, error) {
+	data, err := BundleData(vc)
+	if err != nil {
+		return nil, err
+	}
+
+	bundle := secrets.Bundle{Clock: secrets.NewClock()}
+
+	if err = json.Unmarshal(data, &bundle); err != nil {
+		return nil, err
+	}
+
+	return &bundle, nil
+}
+
+// BundleData returns a marshaled secrets bundle for the given version contract, which may be nil.
+func BundleData(vc *config.VersionContract) ([]byte, error) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
+	if data, ok := cache[vc.String()]; ok {
+		return bytes.Clone(data), nil
+	}
+
+	bundle, err := secrets.NewBundle(secrets.NewFixedClock(time.Now()), vc)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		return nil, err
+	}
+
+	cache[vc.String()] = data
+
+	return bytes.Clone(data), nil
+}

--- a/internal/pkg/testsecrets/testsecrets_test.go
+++ b/internal/pkg/testsecrets/testsecrets_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package testsecrets_test
+
+import (
+	"testing"
+
+	"github.com/siderolabs/talos/pkg/machinery/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/internal/pkg/testsecrets"
+)
+
+func TestBundle(t *testing.T) {
+	t.Parallel()
+
+	for _, vc := range []*config.VersionContract{nil, config.TalosVersion1_2} {
+		first, err := testsecrets.Bundle(vc)
+		require.NoError(t, err)
+
+		require.NotNil(t, first.Clock)
+		require.NotNil(t, first.Cluster)
+		require.NotNil(t, first.Secrets)
+		require.NotNil(t, first.Certs)
+		require.NotNil(t, first.Certs.OS)
+		require.NotNil(t, first.Certs.K8sServiceAccount)
+
+		// a second call returns an independent copy with the same content
+		second, err := testsecrets.Bundle(vc)
+		require.NoError(t, err)
+
+		assert.NotSame(t, first, second)
+		assert.Equal(t, first.Certs, second.Certs)
+		assert.Equal(t, first.Cluster, second.Cluster)
+	}
+}


### PR DESCRIPTION
Two unit tests failed on a heavily loaded CI runner.

The certificate refresh tick test allowed only a fraction of a second for each tick to arrive, which is too tight on a starved machine. It now uses the same generous deadline as the rest of the suite.

Many tests also generated a fresh secrets bundle for every mocked cluster and every generated machine config, and the RSA service account key generation inside costs around a second of CPU each time. Tests now share generated bundles through a small helper that generates one bundle per Talos version per test process. This makes the heaviest test packages several times faster.

Finally, the secret rotation test deadlines become one generous shared constant. The race detector multiplies the CPU cost, and on a starved runner exactly the subtests with the tightest deadlines ran out of time while their siblings with more generous ones passed.