### PR TITLE
test: make integration tests pass against a non-CI Omni instance

### DIFF
--- a/internal/integration/kubernetes_test.go
+++ b/internal/integration/kubernetes_test.go
@@ -329,6 +329,12 @@ func AssertKubernetesUpgradeIsRevertible(testCtx context.Context, st state.State
 
 			return nil
 		})
+		if isInvalidArgumentError(err) {
+			// The disable-validation annotation set above only works on debug builds of Omni. A release
+			// build rejects the fake version on the update, so there is no failed upgrade to revert.
+			t.Skipf("this Omni rejects the fake version, skipping the revert flow: %s", err)
+		}
+
 		require.NoError(t, err)
 
 		// upgrade should start

--- a/internal/integration/maintenance_test.go
+++ b/internal/integration/maintenance_test.go
@@ -9,7 +9,10 @@ package integration_test
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -21,11 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	siderolinkres "github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
+	siderolinkclient "github.com/siderolabs/omni/client/pkg/siderolink"
 )
-
-const testPatch = `apiVersion: v1alpha1
-kind: EventSinkConfig
-endpoint: '[fdae:41e4:649b:9303::1]:8091'`
 
 // AssertMaintenanceTestConfigIsPresent asserts that the test configuration is present on a machine in maintenance mode.
 func AssertMaintenanceTestConfigIsPresent(ctx context.Context, omniState state.State, cluster resource.ID, machineIndex int) TestFunc {
@@ -45,6 +46,14 @@ func AssertMaintenanceTestConfigIsPresent(ctx context.Context, omniState state.S
 		require.Less(t, machineIndex, len(ids), "machine index out of range")
 
 		machineID := ids[machineIndex]
+
+		// Build the expected event sink endpoint the same way the machine config generation builds it.
+		apiConfig, err := safe.StateGetByID[*siderolinkres.APIConfig](timeoutCtx, omniState, siderolinkres.ConfigID)
+		require.NoError(t, err)
+
+		sinkEndpoint := net.JoinHostPort(siderolinkclient.GetListenHost(), strconv.Itoa(int(apiConfig.TypedSpec().Value.EventsPort)))
+
+		testPatch := fmt.Sprintf("apiVersion: v1alpha1\nkind: EventSinkConfig\nendpoint: '%s'", sinkEndpoint)
 
 		rtestutils.AssertResource[*omni.RedactedClusterMachineConfig](timeoutCtx, t, omniState, machineID, func(r *omni.RedactedClusterMachineConfig, assertion *assert.Assertions) {
 			buffer, bufferErr := r.TypedSpec().Value.GetUncompressedData()

--- a/internal/integration/talos_test.go
+++ b/internal/integration/talos_test.go
@@ -496,6 +496,11 @@ const upgradeGateClosedMessage = "upgrade gate is closed: cluster is not marked 
 // Kubernetes cluster.
 const talemuInfraProviderID = "talemu"
 
+// talemuKernelArg is the kernel arg every talemu-emulated machine reports, in both the infra provider
+// and the static mode. Machines of the static mode join on their own and have no infra provider label,
+// so the kernel args are the only way to detect them.
+const talemuKernelArg = "talemu=1"
+
 // clusterUsesEmulatedMachines reports whether the cluster's machines are provided by the talemu emulator.
 // Emulated machines don't run a real Kubernetes cluster, so workload-based healthchecks can't be exercised.
 func clusterUsesEmulatedMachines(ctx context.Context, t *testing.T, st state.State, clusterName string) bool {
@@ -504,6 +509,10 @@ func clusterUsesEmulatedMachines(ctx context.Context, t *testing.T, st state.Sta
 
 	for machine := range machines.All() {
 		if providerID, _ := machine.Metadata().Labels().Get(omni.LabelInfraProviderID); providerID == talemuInfraProviderID {
+			return true
+		}
+
+		if slices.Contains(strings.Fields(machine.TypedSpec().Value.KernelCmdline), talemuKernelArg) {
 			return true
 		}
 	}
@@ -848,6 +857,21 @@ func AssertTalosExtensionsUpdateFlow(testCtx context.Context, client *client.Cli
 	}
 }
 
+// isInvalidArgumentError checks if the error has the gRPC code InvalidArgument. The state client loses
+// the gRPC status when it wraps server errors, so as a fallback, the code is matched in the error message.
+func isInvalidArgumentError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var grpcStatus interface{ GRPCStatus() *status.Status }
+	if errors.As(err, &grpcStatus) {
+		return grpcStatus.GRPCStatus().Code() == codes.InvalidArgument
+	}
+
+	return strings.Contains(err.Error(), "rpc error: code = "+codes.InvalidArgument.String())
+}
+
 // AssertTalosUpgradeIsRevertible tries to upgrade to invalid Talos version, and verifies that upgrade starts, fails, and can be reverted.
 func AssertTalosUpgradeIsRevertible(testCtx context.Context, st state.State, clusterName, currentTalosVersion string) TestFunc {
 	return func(t *testing.T) {
@@ -866,6 +890,12 @@ func AssertTalosUpgradeIsRevertible(testCtx context.Context, st state.State, clu
 
 			return nil
 		})
+		if isInvalidArgumentError(err) {
+			// The disable-validation annotation set above only works on debug builds of Omni. A release
+			// build rejects the fake version on the update, so there is no failed upgrade to revert.
+			t.Skipf("this Omni rejects the fake version, skipping the revert flow: %s", err)
+		}
+
 		require.NoError(t, err)
 
 		// upgrade should start


### PR DESCRIPTION
The integration tests carried assumptions that only hold in the CI setup. Machines emulated by talemu's static mode were not recognized as emulated, so the workload-based upgrade healthchecks ran against machines that cannot run them and the upgrade tests got stuck until their timeout. The failed-upgrade revert tests assumed the fake target version is accepted, which only debug builds of Omni allow, so they failed against a release build. The maintenance config assertion expected a hardcoded event sink endpoint, which only matches the CI environment.

Detect emulated machines by the kernel arg talemu reports in both of its modes, skip the revert tests when the instance rejects the fake version, and build the expected event sink endpoint from the instance's siderolink configuration, the same way the machine config generation builds it.

This allows running the integration tests against a real Omni instance, e.g. a staging one, for release smoke testing.