### PR TITLE
fix(frontend): fix incorrect machine route params

### DIFF
--- a/frontend/e2e/qemu/clusters.spec.ts
+++ b/frontend/e2e/qemu/clusters.spec.ts
@@ -82,6 +82,18 @@ test('machine overview tabs', async ({ page }) => {
     await page.getByRole('tab', { name: 'Extensions', exact: true }).click()
     await expect.soft(page.getByText('siderolabs/hello-world-service')).toBeVisible()
   })
+
+  await test.step('Validate kernel args tab', async () => {
+    await page.getByRole('tab', { name: 'Kernel Args', exact: true }).click()
+
+    const cmdLine = page.getByLabel('Current Kernel Cmdline')
+    const extraArgs = page.getByLabel('Extra Kernel Args', { exact: true })
+
+    await expect.soft(cmdLine.getByText('siderolink.api=')).toBeVisible()
+    await expect.soft(cmdLine.getByText('talos.events.sink=')).toBeVisible()
+    await expect.soft(cmdLine.getByText('talos.logging.kernel=')).toBeVisible()
+    await expect.soft(extraArgs.getByText('console=tty0 console=ttyS0')).toBeVisible()
+  })
 })
 
 test('create cluster', async ({ page }) => {
@@ -526,6 +538,16 @@ test('node overview tabs', async ({ page }) => {
     await page.getByRole('tab', { name: 'Extensions', exact: true }).click()
     await expect(page.getByText('siderolabs/hello-world-service')).toBeVisible()
     await expect(page.getByText('siderolabs/usb-modem-drivers')).toBeVisible()
+  })
+
+  await test.step('Validate kernel args tab', async () => {
+    await page.getByRole('tab', { name: 'Kernel Args', exact: true }).click()
+
+    const cmdLine = page.getByLabel('Current Kernel Cmdline')
+    const extraArgs = page.getByLabel('Extra Kernel Args', { exact: true })
+
+    await expect.soft(cmdLine.getByText('talos.platform=metal')).toBeVisible()
+    await expect.soft(extraArgs.getByText('console=tty0 console=ttyS0')).toBeVisible()
   })
 
   await page.getByRole('link', { name: 'Clusters' }).click()

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/kernel-args.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/kernel-args.vue
@@ -11,5 +11,5 @@ definePage({ name: 'NodeKernelArgs' })
 </script>
 
 <template>
-  <MachineKernelArgs :machine="$route.params.machine" />
+  <MachineKernelArgs :machine-id="$route.params.machine" />
 </template>

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/patches.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/patches.vue
@@ -13,6 +13,6 @@ definePage({ name: 'NodePatches' })
 
 <template>
   <PageContainer>
-    <Patches :cluster="$route.params.cluster" :machine="$route.params.machine" />
+    <Patches :cluster-id="$route.params.cluster" :machine-id="$route.params.machine" />
   </PageContainer>
 </template>

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/patches.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/patches.vue
@@ -17,6 +17,6 @@ definePage({ name: 'ClusterConfigPatches' })
     <div class="flex items-start">
       <PageHeader class="flex-1" :title="`Cluster ${$route.params.cluster} Config Patches`" />
     </div>
-    <Patches :cluster="$route.params.cluster" />
+    <Patches :cluster-id="$route.params.cluster" />
   </PageContainer>
 </template>

--- a/frontend/src/pages/(authenticated)/machines/[machine]/kernel-args.vue
+++ b/frontend/src/pages/(authenticated)/machines/[machine]/kernel-args.vue
@@ -11,5 +11,5 @@ definePage({ name: 'MachineKernelArgs' })
 </script>
 
 <template>
-  <MachineKernelArgs :machine="$route.params.machine" />
+  <MachineKernelArgs :machine-id="$route.params.machine" />
 </template>

--- a/frontend/src/pages/(authenticated)/machines/[machine]/patches/index.vue
+++ b/frontend/src/pages/(authenticated)/machines/[machine]/patches/index.vue
@@ -13,6 +13,6 @@ definePage({ name: 'MachineConfigPatches' })
 
 <template>
   <PageContainer>
-    <Patches :machine="$route.params.machine" />
+    <Patches :machine-id="$route.params.machine" />
   </PageContainer>
 </template>

--- a/frontend/src/views/Config/Patches.stories.ts
+++ b/frontend/src/views/Config/Patches.stories.ts
@@ -199,7 +199,7 @@ type Story = StoryObj<typeof meta>
 
 /** Cluster-scoped view with patches spread across every group and full manage permissions. */
 export const Cluster: Story = {
-  args: { cluster: CLUSTER },
+  args: { clusterId: CLUSTER },
 
   beforeEach({ msw }) {
     msw.use(clusterPatchesHandler(), machineStatusesHandler, clusterPermissionsHandler(true))
@@ -208,7 +208,7 @@ export const Cluster: Story = {
 
 /** Same data, but the user cannot manage patches — create, toggle and delete are disabled. */
 export const ClusterReadOnly: Story = {
-  args: { cluster: CLUSTER },
+  args: { clusterId: CLUSTER },
 
   beforeEach({ msw }) {
     msw.use(clusterPatchesHandler(), machineStatusesHandler, clusterPermissionsHandler(false))
@@ -217,7 +217,7 @@ export const ClusterReadOnly: Story = {
 
 /** Machine-scoped view: patches attached to a single machine. */
 export const Machine: Story = {
-  args: { machine: MACHINE },
+  args: { machineId: MACHINE },
 
   beforeEach({ msw }) {
     msw.use(
@@ -244,7 +244,7 @@ export const Machine: Story = {
 
 /** No patches associated — renders the empty-state alert. */
 export const Empty: Story = {
-  args: { cluster: CLUSTER },
+  args: { clusterId: CLUSTER },
 
   beforeEach({ msw }) {
     msw.use(clusterPatchesHandler([]), machineStatusesHandler, clusterPermissionsHandler(true))
@@ -253,7 +253,7 @@ export const Empty: Story = {
 
 /** Watches never bootstrap — the loading spinner stays visible. */
 export const Loading: Story = {
-  args: { cluster: CLUSTER },
+  args: { clusterId: CLUSTER },
 
   beforeEach({ msw }) {
     msw.use(

--- a/frontend/src/views/Config/Patches.vue
+++ b/frontend/src/views/Config/Patches.vue
@@ -50,9 +50,9 @@ import { useResourceWatch } from '@/methods/useResourceWatch'
 import { showError } from '@/notification'
 import ConfigPatchDestroyModal from '@/views/Config/components/ConfigPatchDestroyModal.vue'
 
-const { machine, cluster } = defineProps<{
-  cluster?: string
-  machine?: string
+const { machineId, clusterId } = defineProps<{
+  clusterId?: string
+  machineId?: string
 }>()
 
 const filter = useRouteQuery('q', '')
@@ -61,16 +61,16 @@ const configPatchDestroyModalPatchId = ref<string>()
 
 const { canManageMachineConfigPatches } = usePermissions()
 const { canManageConfigPatches: canManageClusterMachineConfigPatches } = useClusterPermissions(
-  () => cluster,
+  () => clusterId,
 )
 
 const selectors = computed(() => {
   const res: string[] = []
 
-  if (machine) {
-    res.push(`${LabelMachine}=${machine}`, `${LabelClusterMachine}=${machine}`)
-  } else if (cluster) {
-    res.push(`${LabelCluster}=${cluster}`)
+  if (machineId) {
+    res.push(`${LabelMachine}=${machineId}`, `${LabelClusterMachine}=${machineId}`)
+  } else if (clusterId) {
+    res.push(`${LabelCluster}=${clusterId}`)
   } else {
     return
   }
@@ -125,32 +125,32 @@ interface RouteItem {
 const patchTypeCluster = 'Cluster'
 
 function getRouteForPatch(patch = `500-${uuidv4()}`): RouteLocationRaw {
-  if (cluster && machine) {
+  if (clusterId && machineId) {
     return {
       name: 'ClusterMachinePatchEdit',
       params: {
-        cluster,
-        machine,
+        cluster: clusterId,
+        machine: machineId,
         patch,
       },
     }
   }
 
-  if (cluster) {
+  if (clusterId) {
     return {
       name: 'ClusterPatchEdit',
       params: {
-        cluster,
+        cluster: clusterId,
         patch,
       },
     }
   }
 
-  if (machine) {
+  if (machineId) {
     return {
       name: 'MachinePatchEdit',
       params: {
-        machine,
+        machine: machineId,
         patch,
       },
     }
@@ -201,7 +201,7 @@ const routes = computed(() => {
     } else if (labels[LabelMachineSet]) {
       const id = labels[LabelMachineSet]
 
-      const title = machineSetTitle(cluster, id)
+      const title = machineSetTitle(clusterId, id)
 
       addToGroup(`${title}`, r)
     } else if (labels[LabelCluster]) {
@@ -251,8 +251,8 @@ const routes = computed(() => {
 })
 
 const canManageConfigPatches = computed(() => {
-  if (cluster) return canManageClusterMachineConfigPatches.value
-  if (machine) return canManageMachineConfigPatches.value
+  if (clusterId) return canManageClusterMachineConfigPatches.value
+  if (machineId) return canManageMachineConfigPatches.value
 
   return false
 })
@@ -297,10 +297,10 @@ const toggleDisabled = async (item: RouteItem) => {
       <TAlert v-else-if="patches.length === 0" title="No Config Patches" type="info">
         There are no config patches
         {{
-          machine
-            ? `associated with machine ${machine}`
-            : cluster
-              ? `associated with cluster ${cluster}`
+          machineId
+            ? `associated with machine ${machineId}`
+            : clusterId
+              ? `associated with cluster ${clusterId}`
               : `on the account`
         }}
       </TAlert>

--- a/frontend/src/views/Machines/MachineKernelArgs.stories.ts
+++ b/frontend/src/views/Machines/MachineKernelArgs.stories.ts
@@ -15,8 +15,8 @@ const machineId = faker.string.uuid()
 
 const meta: Meta<typeof MachineKernelArgs> = {
   component: MachineKernelArgs,
-  parameters: {
-    machine: machineId,
+  args: {
+    machineId,
   },
 }
 

--- a/frontend/src/views/Machines/MachineKernelArgs.vue
+++ b/frontend/src/views/Machines/MachineKernelArgs.vue
@@ -16,8 +16,8 @@ import Tooltip from '@/components/Tooltip/Tooltip.vue'
 import { useResourceWatch } from '@/methods/useResourceWatch'
 import EditKernelArgsModal from '@/views/Machines/EditKernelArgsModal.vue'
 
-const { machine } = defineProps<{
-  machine: string
+const { machineId } = defineProps<{
+  machineId: string
 }>()
 
 const editKernelArgsModalOpen = ref(false)
@@ -25,7 +25,7 @@ const editKernelArgsModalOpen = ref(false)
 const { data: status } = useResourceWatch<KernelArgsStatusSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
-    id: machine,
+    id: machineId,
     namespace: DefaultNamespace,
     type: KernelArgsStatusType,
   },
@@ -34,7 +34,7 @@ const { data: status } = useResourceWatch<KernelArgsStatusSpec>(() => ({
 const { data: kernelArgs } = useResourceWatch<KernelArgsSpec>(() => ({
   runtime: Runtime.Omni,
   resource: {
-    id: machine,
+    id: machineId,
     namespace: DefaultNamespace,
     type: KernelArgsType,
   },
@@ -45,30 +45,46 @@ const currentCmdline = computed(() => status.value?.spec.current_cmdline ?? '')
 </script>
 
 <template>
-  <PageContainer class="flex flex-col gap-2">
-    <div class="text-sm font-semibold text-naturals-n14">Current Kernel Cmdline</div>
-    <code class="rounded bg-naturals-n6 px-2.5 py-2 font-mono text-xs text-naturals-n13">
-      {{ currentCmdline || 'none' }}
-    </code>
+  <PageContainer>
+    <dl class="flex flex-col gap-2">
+      <dt id="current-kernel-cmdline" class="text-sm font-semibold text-naturals-n14">
+        Current Kernel Cmdline
+      </dt>
+      <dd
+        aria-labelledby="current-kernel-cmdline"
+        class="rounded bg-naturals-n6 px-2.5 py-2 text-xs"
+      >
+        <code class="font-mono break-all whitespace-pre-wrap text-naturals-n13">
+          {{ currentCmdline || 'none' }}
+        </code>
+      </dd>
 
-    <div class="text-sm font-semibold text-naturals-n14">Extra Kernel Args</div>
-    <div class="my-0.5 flex items-center gap-2 rounded bg-naturals-n6 pr-2">
-      <code class="flex-1 rounded bg-naturals-n6 px-2.5 py-2 font-mono text-xs text-naturals-n13">
-        {{ currentArgs || 'none' }}
-      </code>
+      <dt id="extra-kernel-args" class="text-sm font-semibold text-naturals-n14">
+        Extra Kernel Args
+      </dt>
+      <dd
+        aria-labelledby="extra-kernel-args"
+        class="my-0.5 flex items-center gap-2 rounded bg-naturals-n6 pr-2 text-xs"
+      >
+        <code
+          class="flex-1 rounded bg-naturals-n6 px-2.5 py-2 font-mono break-all whitespace-pre-wrap text-naturals-n13"
+        >
+          {{ currentArgs || 'none' }}
+        </code>
 
-      <Tooltip description="Edit Extra Kernel Args">
-        <IconButton
-          aria-label="Edit Extra Kernel Args"
-          icon="edit"
-          @click="editKernelArgsModalOpen = true"
-        />
-      </Tooltip>
-    </div>
+        <Tooltip description="Edit Extra Kernel Args">
+          <IconButton
+            aria-label="Edit Extra Kernel Args"
+            icon="edit"
+            @click="editKernelArgsModalOpen = true"
+          />
+        </Tooltip>
+      </dd>
+    </dl>
 
     <EditKernelArgsModal
       v-model:open="editKernelArgsModalOpen"
-      :machine-id="machine"
+      :machine-id="machineId"
       :kernel-args
       :kernel-args-status="status"
     />


### PR DESCRIPTION
Machine ID param for kernel args being overwritten with a machine resource object, which was breaking the resource loading for that page when accessed through a /cluster/machine/xxx route.

Fixes #3264 