### PR TITLE
fix(frontend): check for navigation in preload error events

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -25,6 +25,7 @@ import {
 import App from '@/App.vue'
 import AppUnavailable, { appUnavailableError } from '@/AppUnavailable.vue'
 import { AuthType, authType, eulaAccepted, suspended } from '@/methods'
+import { registerPreloadListener } from '@/methods/registerPreloadListener'
 import router from '@/router'
 
 import { withRuntime, withTimeout } from './api/options'
@@ -106,10 +107,7 @@ async function setupApp() {
   app.mount('#app')
 }
 
-// A preloadError generally means Omni was updated in the background. Reload the page in this case.
-window.addEventListener('vite:preloadError', () => {
-  window.location.reload()
-})
+registerPreloadListener()
 
 initState()
 

--- a/frontend/src/methods/registerPreloadListener.ts
+++ b/frontend/src/methods/registerPreloadListener.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+const preloadReloadedKey = 'vite-preload-reloaded'
+
+export function registerPreloadListener() {
+  let navigatingAway = false
+
+  // On firefox, cancelled requests from navigation triggers vite:preloadError.
+  // This can cause a redirect loop when unauthenticated and being redirected to auth.
+  window.addEventListener('beforeunload', () => {
+    navigatingAway = true
+  })
+
+  // A preloadError occurs when frontend fails to load hashed assets.
+  // This usually means Omni was updated, and we are running on outdated code.
+  window.addEventListener('vite:preloadError', () => {
+    if (navigatingAway || sessionStorage.getItem(preloadReloadedKey)) return
+
+    // Avoid looping forever if reloading doesn't actually fix the failure.
+    sessionStorage.setItem(preloadReloadedKey, 'true')
+
+    window.location.reload()
+  })
+
+  // Re-arm the guard once the app has had a reasonable window to finish loading, so a genuine
+  // future preload failure (e.g. a later deploy) still gets its one automatic retry.
+  setTimeout(() => sessionStorage.removeItem(preloadReloadedKey), 10_000)
+}


### PR DESCRIPTION
Before deciding to reload the page, check that we arent actually just trying to navigate away. In Firefox cancelling in-flight requests triggers vite:preloadError which would send us into a reload loop. Also add a session storage flag so that any other future/unknown paths can only at most result in 1 reload.