### PR TITLE
feat: add a recovery admin for SAML lockouts

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -239,6 +239,7 @@ func defineAuthFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *config.P
 	b.StringVar("auth.saml.nameIDFormat", &flagConfig.Auth.Saml.NameIDFormat)
 
 	b.StringSliceVar("auth.initialUsers", &flagConfig.Auth.InitialUsers, flagConfig.Auth.InitialUsers)
+	b.StringVar("auth.recoveryAdmin", &flagConfig.Auth.RecoveryAdmin)
 
 	b.DurationVar("auth.keyPruner.interval", &flagConfig.Auth.KeyPruner.Interval)
 	b.BoolVar("auth.suspended", &flagConfig.Auth.Suspended)

--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -126,6 +126,11 @@ func Run(ctx context.Context, state *omni.State, cfg *config.Params, logger *zap
 		return fmt.Errorf("failed to write initial user resources to state: %w", err)
 	}
 
+	err = user.ElevateRecoveryAdmin(ctx, state.Default(), logger, cfg.Auth.GetRecoveryAdmin())
+	if err != nil {
+		return fmt.Errorf("failed to elevate the recovery admin: %w", err)
+	}
+
 	if cfg.EulaAccept.GetName() != "" && cfg.EulaAccept.GetEmail() != "" {
 		if err = eula.Accept(ctx, state.Default(), eula.AcceptParams{Name: cfg.EulaAccept.GetName(), Email: cfg.EulaAccept.GetEmail()}); err != nil {
 			return fmt.Errorf("failed to accept EULA: %w", err)

--- a/deploy/helm/omni/config-overrides.yaml
+++ b/deploy/helm/omni/config-overrides.yaml
@@ -71,6 +71,7 @@ examples:
     initialUsers:
       - initial-user-1@example.com
       - initial-user-2@example.com
+    recoveryAdmin: admin@example.com
   logs:
     level: info
     format: json

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -312,6 +312,10 @@ config:
     #initialUsers:
     #  - initial-user-1@example.com
     #  - initial-user-2@example.com
+    # RecoveryAdmin is the email of a user raised to the Admin role on every Omni start. The user must already
+    # exist. Once configured, SAML label rules never lower its role. Intended as a break-glass path when a
+    # misconfigured SAML rule removes admin access from everyone.
+    #recoveryAdmin: admin@example.com
     # @ignored
     # KeyPruner contains configuration for the public keys pruner (cleanup of old/expired keys).
     keyPruner:

--- a/internal/backend/saml/export_test.go
+++ b/internal/backend/saml/export_test.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package saml
+
+import "context"
+
+// EnsureUser exposes ensureUser to the external test package.
+func (sp *SessionProvider) EnsureUser(ctx context.Context, email string, samlLabels map[string]string) error {
+	return sp.ensureUser(ctx, email, samlLabels)
+}

--- a/internal/backend/saml/saml.go
+++ b/internal/backend/saml/saml.go
@@ -43,7 +43,7 @@ type sloSessionData struct {
 }
 
 // NewHandler creates new SAML handler.
-func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.Logger, apiURL string) (*samlsp.Middleware, error) {
+func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.Logger, apiURL, recoveryAdmin string) (*samlsp.Middleware, error) {
 	idpMetadata, err := readMetadata(cfg)
 	if err != nil {
 		return nil, err
@@ -88,6 +88,7 @@ func NewHandler(state state.State, cfg *specs.AuthConfigSpec_SAML, logger *zap.L
 			requestTracker,
 			logger.With(logging.Component("saml_session")),
 			cfg.AttributeRules,
+			recoveryAdmin,
 		),
 		RequestTracker:   requestTracker,
 		AssertionHandler: samlsp.DefaultAssertionHandler(samlsp.Options{}),

--- a/internal/backend/saml/saml_test.go
+++ b/internal/backend/saml/saml_test.go
@@ -106,6 +106,7 @@ func startAuthFlow(t *testing.T) *http.Response {
 		&specs.AuthConfigSpec_SAML{Metadata: "testdata/samlsp_metadata.xml"},
 		zaptest.NewLogger(t),
 		testAdvertisedURL,
+		"",
 	)
 	require.NoError(t, err)
 

--- a/internal/backend/saml/session.go
+++ b/internal/backend/saml/session.go
@@ -51,12 +51,19 @@ type UserInfo struct {
 }
 
 // NewSessionProvider creates a new SessionProvider.
-func NewSessionProvider(state state.State, tracker samlsp.RequestTracker, logger *zap.Logger, attributeRules map[string]string) *SessionProvider {
+func NewSessionProvider(
+	state state.State,
+	tracker samlsp.RequestTracker,
+	logger *zap.Logger,
+	attributeRules map[string]string,
+	recoveryAdmin string,
+) *SessionProvider {
 	return &SessionProvider{
 		state:          state,
 		tracker:        tracker,
 		logger:         logger,
 		attributeRules: attributeRules,
+		recoveryAdmin:  strings.ToLower(recoveryAdmin),
 	}
 }
 
@@ -67,6 +74,7 @@ type SessionProvider struct {
 	tracker        samlsp.RequestTracker
 	logger         *zap.Logger
 	attributeRules map[string]string
+	recoveryAdmin  string
 }
 
 // CreateSession is called when we have received a valid SAML assertion and
@@ -305,6 +313,16 @@ func (sp *SessionProvider) ensureUser(ctx context.Context, email string, samlLab
 			r = role.Role(getRoleFromRule(samlLabelRule))
 			updateOnEachLogin = samlLabelRule.TypedSpec().Value.UpdateOnEachLogin
 		}
+	}
+
+	if sp.recoveryAdmin != "" && email == sp.recoveryAdmin && r != role.Admin {
+		sp.logger.Warn(
+			"skipping SAML role update for the recovery admin",
+			zap.String("email", email),
+			zap.String("rule_role", string(r)),
+		)
+
+		updateOnEachLogin = false
 	}
 
 	if err = user.Ensure(ctx, sp.state, email, r, updateOnEachLogin); err != nil {

--- a/internal/backend/saml/session_test.go
+++ b/internal/backend/saml/session_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
@@ -25,6 +26,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/backend/saml"
+	"github.com/siderolabs/omni/internal/pkg/auth/user"
 )
 
 func TestUserInfo(t *testing.T) {
@@ -114,7 +116,7 @@ func TestReadLabelsFromAssertion(t *testing.T) {
 
 	sp := saml.NewSessionProvider(s, nil, zaptest.NewLogger(t), map[string]string{
 		"identity": saml.IdentityAttribute,
-	})
+	}, "")
 
 	authConfig := auth.NewAuthConfig()
 	authConfig.TypedSpec().Value.Saml = &specs.AuthConfigSpec_SAML{
@@ -325,4 +327,131 @@ func TestMatchSAMLLabelRuleNoneWithHigherRulePresent(t *testing.T) {
 
 	require.NotNil(t, matchedRule)
 	require.EqualValues(t, matchedRule.TypedSpec().Value.AssignRole, role.Reader)
+}
+
+const (
+	lockedOutEmail = "locked-out@example.com"
+	colleagueEmail = "colleague@example.com"
+	developerLabel = "saml.omni.sidero.dev/role/developer"
+)
+
+// setupEnsureUser builds a state with two Admin users and one label rule, so ensureUser takes the
+// "users already exist" branch and resolves a rule instead of bootstrapping the first admin.
+func setupEnsureUser(ctx context.Context, t *testing.T, assignRole role.Role, updateOnEachLogin bool) state.State {
+	t.Helper()
+
+	st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+	for _, email := range []string{lockedOutEmail, colleagueEmail} {
+		require.NoError(t, user.Ensure(ctx, st, email, role.Admin, false))
+	}
+
+	rule := auth.NewSAMLLabelRule("assign-to-developer")
+	rule.TypedSpec().Value.MatchLabels = []string{developerLabel}
+	rule.TypedSpec().Value.AssignRole = string(assignRole)
+	rule.TypedSpec().Value.UpdateOnEachLogin = updateOnEachLogin
+
+	require.NoError(t, st.Create(ctx, rule))
+
+	return st
+}
+
+func roleOf(ctx context.Context, t *testing.T, st state.State, email string) string {
+	t.Helper()
+
+	identity, err := safe.StateGetByID[*auth.Identity](ctx, st, email)
+	require.NoError(t, err)
+
+	usr, err := safe.StateGetByID[*auth.User](ctx, st, identity.TypedSpec().Value.UserId)
+	require.NoError(t, err)
+
+	return usr.TypedSpec().Value.Role
+}
+
+func TestEnsureUserRecoveryAdmin(t *testing.T) {
+	t.Parallel()
+
+	samlLabels := map[string]string{developerLabel: ""}
+
+	for _, tt := range []struct {
+		name              string
+		recoveryAdmin     string
+		assignRole        role.Role
+		expectedRole      role.Role
+		updateOnEachLogin bool
+	}{
+		{
+			name:              "recovery admin is not demoted",
+			recoveryAdmin:     lockedOutEmail,
+			assignRole:        role.Reader,
+			updateOnEachLogin: true,
+			expectedRole:      role.Admin,
+		},
+		{
+			name:              "recovery admin is not stripped of every role",
+			recoveryAdmin:     lockedOutEmail,
+			assignRole:        role.None,
+			updateOnEachLogin: true,
+			expectedRole:      role.Admin,
+		},
+		{
+			name:              "recovery admin still matches a rule that assigns Admin",
+			recoveryAdmin:     lockedOutEmail,
+			assignRole:        role.Admin,
+			updateOnEachLogin: true,
+			expectedRole:      role.Admin,
+		},
+		{
+			name:              "email is matched case-insensitively",
+			recoveryAdmin:     "Locked-Out@Example.com",
+			assignRole:        role.Reader,
+			updateOnEachLogin: true,
+			expectedRole:      role.Admin,
+		},
+		{
+			name:              "everyone else is still demoted",
+			assignRole:        role.Reader,
+			updateOnEachLogin: true,
+			expectedRole:      role.Reader,
+		},
+		{
+			name:          "a rule without updateOnEachLogin changes nobody",
+			recoveryAdmin: lockedOutEmail,
+			assignRole:    role.Reader,
+			expectedRole:  role.Admin,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			st := setupEnsureUser(ctx, t, tt.assignRole, tt.updateOnEachLogin)
+
+			sp := saml.NewSessionProvider(st, nil, zaptest.NewLogger(t), nil, tt.recoveryAdmin)
+
+			require.NoError(t, sp.EnsureUser(ctx, lockedOutEmail, samlLabels))
+
+			require.EqualValues(t, tt.expectedRole, roleOf(ctx, t, st, lockedOutEmail))
+
+			// the guard only covers the configured email, everyone else keeps what they had
+			require.EqualValues(t, role.Admin, roleOf(ctx, t, st, colleagueEmail))
+		})
+	}
+}
+
+// TestEnsureUserRecoveryAdminNotCreated checks that a recovery admin with no identity yet is registered
+// with the role its label rule assigns. Elevation happens on the next restart, not here.
+func TestEnsureUserRecoveryAdminNotCreated(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	st := setupEnsureUser(ctx, t, role.Reader, true)
+
+	const newcomer = "newcomer@example.com"
+
+	sp := saml.NewSessionProvider(st, nil, zaptest.NewLogger(t), nil, newcomer)
+
+	require.NoError(t, sp.EnsureUser(ctx, newcomer, map[string]string{developerLabel: ""}))
+
+	require.EqualValues(t, role.Reader, roleOf(ctx, t, st, newcomer))
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -333,7 +333,13 @@ func (s *Server) makeMux(oidcProvider *oidc.Provider) (*http.ServeMux, error) {
 			return nil, nil //nolint:nilnil
 		}
 
-		return saml.NewHandler(s.omniRuntime.ValidatedState(), s.authConfig.TypedSpec().Value.Saml, s.logger, s.cfg.Services.Api.URL())
+		return saml.NewHandler(
+			s.omniRuntime.ValidatedState(),
+			s.authConfig.TypedSpec().Value.Saml,
+			s.logger,
+			s.cfg.Services.Api.URL(),
+			s.cfg.Auth.GetRecoveryAdmin(),
+		)
 	}()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SAML handler: %w", err)

--- a/internal/pkg/auth/user/user.go
+++ b/internal/pkg/auth/user/user.go
@@ -51,6 +51,60 @@ func EnsureInitialResources(ctx context.Context, st state.State, logger *zap.Log
 	return multiErr
 }
 
+// ElevateRecoveryAdmin raises the user with the given email to the Admin role.
+func ElevateRecoveryAdmin(ctx context.Context, st state.State, logger *zap.Logger, email string) error {
+	if email == "" {
+		return nil
+	}
+
+	email = strings.ToLower(email)
+
+	ctx = actor.MarkContextAsInternalActor(ctx)
+
+	identity, err := safe.StateGet[*auth.Identity](ctx, st, auth.NewIdentity(email).Metadata())
+	if err != nil {
+		if state.IsNotFoundError(err) {
+			logger.Error("recovery admin not found, skipping role elevation", zap.String("email", email))
+
+			return nil
+		}
+
+		return err
+	}
+
+	if _, isServiceAccount := identity.Metadata().Labels().Get(auth.LabelIdentityTypeServiceAccount); isServiceAccount {
+		logger.Error("recovery admin is a service account, skipping role elevation", zap.String("email", email))
+
+		return nil
+	}
+
+	var previousRole string
+
+	if _, err = safe.StateUpdateWithConflicts(
+		ctx, st,
+		auth.NewUser(identity.TypedSpec().Value.UserId).Metadata(),
+		func(user *auth.User) error {
+			previousRole = user.TypedSpec().Value.Role
+
+			user.TypedSpec().Value.Role = string(role.Admin)
+
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+
+	if previousRole != string(role.Admin) {
+		logger.Info(
+			"elevated recovery admin, existing sessions must log out and back in to pick up the new role",
+			zap.String("email", email),
+			zap.String("previous_role", previousRole),
+		)
+	}
+
+	return nil
+}
+
 // Create creates a new user with the given email and role.
 // It returns the user ID. It fails if a user with the given email already exists.
 func Create(ctx context.Context, st state.State, email, userRole string) (string, error) {

--- a/internal/pkg/auth/user/user_test.go
+++ b/internal/pkg/auth/user/user_test.go
@@ -10,13 +10,19 @@ import (
 	"testing"
 
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/siderolabs/omni/client/pkg/access"
+	"github.com/siderolabs/omni/client/pkg/access/role"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/auth"
 	"github.com/siderolabs/omni/internal/pkg/auth/user"
 )
@@ -79,4 +85,167 @@ func TestInitialUsers(t *testing.T) {
 
 	// new user doesn't get created, as the state is already initialized
 	assertUsers(ctx, t, st, []string{john, richard})
+}
+
+// roleOf reads the role of the auth.User behind the given email.
+func roleOf(ctx context.Context, t *testing.T, st state.State, email string) string {
+	identity, err := safe.StateGetByID[*auth.Identity](ctx, st, email)
+	require.NoError(t, err)
+
+	usr, err := safe.StateGetByID[*auth.User](ctx, st, identity.TypedSpec().Value.UserId)
+	require.NoError(t, err)
+
+	return usr.TypedSpec().Value.Role
+}
+
+func TestElevateRecoveryAdmin(t *testing.T) {
+	t.Parallel()
+
+	const (
+		locked      = "locked-out@example.com"
+		untouched   = "untouched@example.com"
+		absent      = "absent@example.com"
+		automation  = "automation" + access.ServiceAccountNameSuffix
+		roleAdmin   = string(role.Admin)
+		roleReader  = string(role.Reader)
+		roleNone    = string(role.None)
+		roleUnknown = "Nonsense"
+	)
+
+	setup := func(t *testing.T) (context.Context, state.State, *zap.Logger) {
+		t.Helper()
+
+		st := state.WrapCore(namespaced.NewState(inmem.Build))
+		ctx := t.Context()
+
+		require.NoError(t, user.Ensure(ctx, st, locked, role.None, false))
+		require.NoError(t, user.Ensure(ctx, st, untouched, role.Reader, false))
+
+		return ctx, st, zaptest.NewLogger(t)
+	}
+
+	t.Run("raises the configured user and leaves the rest alone", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, st, logger := setup(t)
+
+		require.NoError(t, user.ElevateRecoveryAdmin(ctx, st, logger, locked))
+
+		assert.Equal(t, roleAdmin, roleOf(ctx, t, st, locked))
+		assert.Equal(t, roleReader, roleOf(ctx, t, st, untouched))
+	})
+
+	t.Run("stays quiet when the user is already Admin", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, st, _ := setup(t)
+
+		require.NoError(t, user.Update(ctx, st, locked, roleAdmin))
+
+		identity, err := safe.StateGetByID[*auth.Identity](ctx, st, locked)
+		require.NoError(t, err)
+
+		before, err := safe.StateGetByID[*auth.User](ctx, st, identity.TypedSpec().Value.UserId)
+		require.NoError(t, err)
+
+		core, logs := observer.New(zapcore.InfoLevel)
+
+		require.NoError(t, user.ElevateRecoveryAdmin(ctx, st, zap.New(core), locked))
+
+		after, err := safe.StateGetByID[*auth.User](ctx, st, identity.TypedSpec().Value.UserId)
+		require.NoError(t, err)
+
+		assert.Equal(t, roleAdmin, after.TypedSpec().Value.Role)
+
+		// an unchanged version means COSI suppressed the write, and with it the audit entry
+		assert.True(t, before.Metadata().Version().Equal(after.Metadata().Version()),
+			"expected no write, version went from %s to %s", before.Metadata().Version(), after.Metadata().Version())
+
+		assert.Empty(t, logs.FilterMessageSnippet("elevated recovery admin").All(),
+			"a restart that changed nothing should not announce an elevation")
+	})
+
+	t.Run("announces a real elevation", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, st, _ := setup(t)
+
+		core, logs := observer.New(zapcore.InfoLevel)
+
+		require.NoError(t, user.ElevateRecoveryAdmin(ctx, st, zap.New(core), locked))
+
+		entries := logs.FilterMessageSnippet("elevated recovery admin").All()
+		require.Len(t, entries, 1)
+		assert.Equal(t, roleNone, entries[0].ContextMap()["previous_role"])
+	})
+
+	t.Run("matches the email case-insensitively", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, st, logger := setup(t)
+
+		require.NoError(t, user.ElevateRecoveryAdmin(ctx, st, logger, "Locked-Out@Example.com"))
+
+		assert.Equal(t, roleAdmin, roleOf(ctx, t, st, locked))
+	})
+
+	t.Run("is a no-op when no email is configured", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, st, logger := setup(t)
+
+		require.NoError(t, user.ElevateRecoveryAdmin(ctx, st, logger, ""))
+
+		assert.Equal(t, roleNone, roleOf(ctx, t, st, locked))
+	})
+
+	t.Run("does not create a user that does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, st, logger := setup(t)
+
+		require.NoError(t, user.ElevateRecoveryAdmin(ctx, st, logger, absent))
+
+		_, err := safe.StateGetByID[*auth.Identity](ctx, st, absent)
+		assert.True(t, state.IsNotFoundError(err), "identity should not have been created, got %v", err)
+	})
+
+	t.Run("skips service accounts", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, st, logger := setup(t)
+
+		require.NoError(t, user.Ensure(ctx, st, automation, role.Reader, false))
+
+		identity, err := safe.StateGetByID[*auth.Identity](ctx, st, automation)
+		require.NoError(t, err)
+
+		identity.Metadata().Labels().Set(auth.LabelIdentityTypeServiceAccount, "")
+		require.NoError(t, st.Update(ctx, identity))
+
+		require.NoError(t, user.ElevateRecoveryAdmin(ctx, st, logger, automation))
+
+		assert.Equal(t, roleReader, roleOf(ctx, t, st, automation))
+	})
+
+	t.Run("overwrites an unparseable role", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, st, logger := setup(t)
+
+		identity, err := safe.StateGetByID[*auth.Identity](ctx, st, locked)
+		require.NoError(t, err)
+
+		_, err = safe.StateUpdateWithConflicts(ctx, st, auth.NewUser(identity.TypedSpec().Value.UserId).Metadata(),
+			func(usr *auth.User) error {
+				usr.TypedSpec().Value.Role = roleUnknown
+
+				return nil
+			})
+		require.NoError(t, err)
+
+		require.NoError(t, user.ElevateRecoveryAdmin(ctx, st, logger, locked))
+
+		assert.Equal(t, roleAdmin, roleOf(ctx, t, st, locked))
+	})
 }

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -39,6 +39,17 @@ func (s *Account) SetName(v string) {
 	s.Name = &v
 }
 
+func (s *Auth) GetRecoveryAdmin() string {
+	if s == nil || s.RecoveryAdmin == nil {
+		return *new(string)
+	}
+	return *s.RecoveryAdmin
+}
+
+func (s *Auth) SetRecoveryAdmin(v string) {
+	s.RecoveryAdmin = &v
+}
+
 func (s *Auth) GetSuspended() bool {
 	if s == nil || s.Suspended == nil {
 		return *new(bool)

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -869,6 +869,11 @@
             "type": "string"
           }
         },
+        "recoveryAdmin": {
+          "description": "RecoveryAdmin is the email of a user raised to the Admin role on every Omni start. The user must already exist. Once configured, SAML label rules never lower its role. Intended as a break-glass path when a misconfigured SAML rule removes admin access from everyone.",
+          "x-cli-flag": "recovery-admin",
+          "type": "string"
+        },
         "keyPruner": {
           "description": "KeyPruner contains configuration for the public keys pruner (cleanup of old/expired keys).",
           "$ref": "#/definitions/KeyPrunerConfig"

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -46,6 +46,12 @@ type Auth struct {
 	// Oidc contains OIDC authentication provider configuration.
 	Oidc OIDC `json:"oidc" yaml:"oidc"`
 
+	// RecoveryAdmin is the email of a user raised to the Admin role on every Omni
+	// start. The user must already exist. Once configured, SAML label rules never
+	// lower its role. Intended as a break-glass path when a misconfigured SAML rule
+	// removes admin access from everyone.
+	RecoveryAdmin *string `json:"recoveryAdmin,omitempty,omitzero" yaml:"recoveryAdmin,omitempty"`
+
 	// Saml contains SAML authentication provider configuration.
 	Saml SAML `json:"saml" yaml:"saml"`
 


### PR DESCRIPTION
A misconfigured SAML attribute rule can strip the Admin role from every user, and once that happens nobody has the permissions left to fix the rule.

The new `auth.recoveryAdmin` config option (`--recovery-admin` cli flag) specifies a user that Omni elevates to Admin role on every start, and SAML label rules are no longer allowed to lower that user's role. The user must already exist: elevation never creates an account, so the option cannot be used to bootstrap access.

Resolves: #3270