### PR TITLE
fix(frontend): fix etcd backup interval not editable

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -42,17 +42,6 @@
       "count": 4
     }
   },
-  "src/components/Form/JsonForm.vue": {
-    "vue/custom-event-name-casing": {
-      "count": 1
-    },
-    "vue/define-props-destructuring": {
-      "count": 1
-    },
-    "vue/no-ref-object-reactivity-loss": {
-      "count": 1
-    }
-  },
   "src/components/Form/NumberRenderer.vue": {
     "vue/define-props-destructuring": {
       "count": 1
@@ -91,25 +80,7 @@
       "count": 1
     }
   },
-  "src/views/Clusters/Management/MachineSetConfig.vue": {
-    "vue/no-setup-props-reactivity-loss": {
-      "count": 5
-    }
-  },
   "src/views/Home/HomeGeneralInformationCopyable.vue": {
-    "vue/define-props-destructuring": {
-      "count": 1
-    }
-  },
-  "src/views/MachineClasses/MachineTemplate.vue": {
-    "vue/custom-event-name-casing": {
-      "count": 6
-    }
-  },
-  "src/views/MachineClasses/ProviderConfig.vue": {
-    "vue/custom-event-name-casing": {
-      "count": 1
-    },
     "vue/define-props-destructuring": {
       "count": 1
     }

--- a/frontend/src/components/Button/TButtonGroup.stories.ts
+++ b/frontend/src/components/Button/TButtonGroup.stories.ts
@@ -9,7 +9,9 @@ import { fn } from 'storybook/test'
 import TButtonGroup from './TButtonGroup.vue'
 
 const meta: Meta<typeof TButtonGroup> = {
-  component: TButtonGroup,
+  // https://github.com/storybookjs/storybook/issues/24238
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: TButtonGroup as any,
   args: {
     'onUpdate:modelValue': fn(),
     deselectEnabled: true,

--- a/frontend/src/components/Button/TButtonGroup.vue
+++ b/frontend/src/components/Button/TButtonGroup.vue
@@ -4,7 +4,7 @@ Copyright (c) 2026 Sidero Labs, Inc.
 Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
-<script setup lang="ts">
+<script setup lang="ts" generic="T extends string | number">
 import { RadioGroup, RadioGroupOption } from '@headlessui/vue'
 
 import Tooltip from '@/components/Tooltip/Tooltip.vue'
@@ -13,7 +13,7 @@ type Props = {
   deselectEnabled?: boolean
   options: {
     label: string
-    value: string | number
+    value: T
     disabled?: boolean
     tooltip?: string
   }[]
@@ -21,7 +21,7 @@ type Props = {
 
 defineProps<Props>()
 
-const modelValue = defineModel<string | number>()
+const modelValue = defineModel<T>()
 </script>
 
 <template>

--- a/frontend/src/components/Form/JsonForm.vue
+++ b/frontend/src/components/Form/JsonForm.vue
@@ -23,7 +23,7 @@ import { JsonForms } from '@jsonforms/vue'
 import { vanillaRenderers } from '@jsonforms/vue-vanilla'
 import { type ErrorObject } from 'ajv'
 import { dump } from 'js-yaml'
-import { computed, ref, toRefs, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { ManagementService } from '@/api/omni/management/management.pb'
 
@@ -40,12 +40,8 @@ import TimeControlRenderer from './TimeControlRenderer.vue'
 
 const errors = ref<ErrorObject[]>([])
 
-const emit = defineEmits<{
-  'update:model-value': [Record<string, unknown>]
-}>()
-
-const onChange = async (event: { data: Record<string, unknown>; errors: unknown }) => {
-  emit('update:model-value', event.data)
+const onChange = (event: { data: Record<string, unknown>; errors: unknown }) => {
+  modelValue.value = event.data
 }
 
 const renderers = [
@@ -92,12 +88,12 @@ const renderers = [
   ...vanillaRenderers,
 ]
 
-const props = defineProps<{
+const { jsonSchema } = defineProps<{
   jsonSchema: string
-  modelValue: unknown
 }>()
 
-const { jsonSchema, modelValue } = toRefs(props)
+const modelValue = defineModel<unknown>({ required: true })
+
 const schema = ref<JsonSchema>()
 const err = ref<Error>()
 
@@ -105,23 +101,19 @@ const renderSchema = () => {
   err.value = undefined
 
   try {
-    schema.value = JSON.parse(jsonSchema.value)
+    schema.value = JSON.parse(jsonSchema)
   } catch (e) {
     err.value = e
   }
 }
 
-watch(modelValue, (val) => {
-  updateErrors(val)
-})
-
 const updateErrors = async (data: unknown) => {
-  if (!jsonSchema.value) {
+  if (!jsonSchema) {
     return
   }
 
   const response = await ManagementService.ValidateJSONSchema({
-    schema: jsonSchema.value,
+    schema: jsonSchema,
     data: dump(data),
   })
 
@@ -137,11 +129,8 @@ const updateErrors = async (data: unknown) => {
     })) ?? []
 }
 
-watch(jsonSchema, renderSchema)
-
-renderSchema()
-
-updateErrors(modelValue.value)
+watch(() => jsonSchema, renderSchema, { immediate: true })
+watch(modelValue, updateErrors, { immediate: true })
 
 const uiSchema = computed(() => {
   if (!schema.value) {

--- a/frontend/src/views/Clusters/ClusterEtcdBackupCheckbox.spec.ts
+++ b/frontend/src/views/Clusters/ClusterEtcdBackupCheckbox.spec.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/vue'
+import { expect, test } from 'vitest'
+
+import ClusterEtcdBackupCheckbox from './ClusterEtcdBackupCheckbox.vue'
+
+const backupStatus = { enabled: true, configurable: true }
+
+test('lets the interval preview be edited to a different value', async () => {
+  const user = userEvent.setup()
+
+  render(ClusterEtcdBackupCheckbox, {
+    props: {
+      backupStatus,
+      cluster: { backup_configuration: { enabled: true, interval: '3600s' } },
+    },
+  })
+
+  await user.click(screen.getByRole('button'))
+
+  const input = screen.getByRole('spinbutton')
+
+  expect(input).toHaveValue(1)
+
+  await user.clear(input)
+  await user.type(input, '5')
+
+  expect(input).toHaveValue(5)
+})

--- a/frontend/src/views/Clusters/ClusterEtcdBackupCheckbox.vue
+++ b/frontend/src/views/Clusters/ClusterEtcdBackupCheckbox.vue
@@ -8,7 +8,7 @@ included in the LICENSE file.
 import { vOnClickOutside } from '@vueuse/components'
 import { Duration } from 'luxon'
 import pluralize from 'pluralize'
-import { computed, ref, watchEffect } from 'vue'
+import { computed, ref } from 'vue'
 
 import type { Duration as GoogleProtobufDuration } from '@/api/google/protobuf/duration.pb'
 import IconButton from '@/components/Button/IconButton.vue'
@@ -49,12 +49,6 @@ const interval = computed(() => {
 })
 
 const backupIntervalPreview = ref<number>()
-const backupIntervalHours = ref<number>()
-
-watchEffect(() => {
-  backupIntervalPreview.value = interval.value?.hours ?? 1
-  backupIntervalHours.value = backupIntervalPreview.value
-})
 
 const toggleBackupsEnabled = (enabled: boolean) => {
   emit('update:cluster', {
@@ -69,12 +63,10 @@ const toggleBackupsEnabled = (enabled: boolean) => {
 
 const startEditingBackupInterval = () => {
   backupIntervalPreview.value = interval.value?.hours ?? 1
-  backupIntervalHours.value = backupIntervalPreview.value
   editingBackupConfig.value = true
 }
 
 const updateBackupInterval = () => {
-  backupIntervalHours.value = backupIntervalPreview.value
   editingBackupConfig.value = false
 
   const c = { ...cluster }
@@ -84,7 +76,7 @@ const updateBackupInterval = () => {
   }
 
   c.backup_configuration.interval = formatDuration(
-    Duration.fromDurationLike({ hours: backupIntervalHours.value }),
+    Duration.fromDurationLike({ hours: backupIntervalPreview.value }),
   )
 
   emit('update:cluster', c)

--- a/frontend/src/views/Clusters/ClusterEtcdBackupCheckbox.vue
+++ b/frontend/src/views/Clusters/ClusterEtcdBackupCheckbox.vue
@@ -21,25 +21,29 @@ import { formatDuration, parseDuration } from '@/methods/time'
 
 const editingBackupConfig = ref(false)
 
+interface ClusterBackupConfiguration {
+  backup_configuration?: {
+    interval?: GoogleProtobufDuration
+    enabled?: boolean
+  }
+}
+
 interface Props {
-  cluster: { backup_configuration?: { interval?: GoogleProtobufDuration; enabled?: boolean } }
   backupStatus: BackupsStatus
 }
 
-const { cluster } = defineProps<Props>()
+defineProps<Props>()
+
+const cluster = defineModel<ClusterBackupConfiguration>('cluster', { required: true })
 
 const { canManageBackupStore } = usePermissions()
 
-const emit = defineEmits<{
-  'update:cluster': [Props['cluster']]
-}>()
-
 const enabled = computed(() => {
-  return cluster.backup_configuration?.enabled === true
+  return cluster.value.backup_configuration?.enabled === true
 })
 
 const interval = computed(() => {
-  const value = cluster.backup_configuration?.interval
+  const value = cluster.value.backup_configuration?.interval
 
   if (!value || value.trim() === '0') {
     return undefined
@@ -51,14 +55,14 @@ const interval = computed(() => {
 const backupIntervalPreview = ref<number>()
 
 const toggleBackupsEnabled = (enabled: boolean) => {
-  emit('update:cluster', {
-    ...cluster,
+  cluster.value = {
+    ...cluster.value,
     backup_configuration: {
-      ...cluster.backup_configuration,
-      interval: cluster.backup_configuration?.interval || `${60 * 60}s`,
+      ...cluster.value.backup_configuration,
+      interval: cluster.value.backup_configuration?.interval || `${60 * 60}s`,
       enabled,
     },
-  })
+  }
 }
 
 const startEditingBackupInterval = () => {
@@ -69,17 +73,13 @@ const startEditingBackupInterval = () => {
 const updateBackupInterval = () => {
   editingBackupConfig.value = false
 
-  const c = { ...cluster }
-
-  if (!c.backup_configuration) {
-    c.backup_configuration = {}
+  cluster.value = {
+    ...cluster.value,
+    backup_configuration: {
+      ...cluster.value.backup_configuration,
+      interval: formatDuration(Duration.fromDurationLike({ hours: backupIntervalPreview.value })),
+    },
   }
-
-  c.backup_configuration.interval = formatDuration(
-    Duration.fromDurationLike({ hours: backupIntervalPreview.value }),
-  )
-
-  emit('update:cluster', c)
 }
 </script>
 

--- a/frontend/src/views/Clusters/Management/MachineSetConfig.vue
+++ b/frontend/src/views/Clusters/Management/MachineSetConfig.vue
@@ -23,118 +23,69 @@ import type { MachineSet } from '@/states/cluster-management'
 import { PatchID } from '@/states/cluster-management'
 import MachineSetConfigEditModal from '@/views/Clusters/components/MachineSetConfigEditModal.vue'
 
-const emit = defineEmits<{
-  'update:modelValue': [MachineSet]
-}>()
-
 enum AllocationMode {
   Manual = 'Manual',
   MachineClass = 'Machine Class',
   RequestSet = 'Machine Request Set',
 }
 
-const allocationModes = computed(() => {
-  const res = [
-    {
-      label: AllocationMode.Manual,
-      value: AllocationMode.Manual,
-    },
-    {
-      label: AllocationMode.MachineClass,
-      value: AllocationMode.MachineClass,
-      disabled: !machineClasses?.length,
-      tooltip: !machineClasses?.length ? 'No Machine Classes Available' : undefined,
-    },
-  ]
-
-  return res
-})
-
-const { machineClasses, modelValue } = defineProps<{
+const { machineClasses } = defineProps<{
   talosVersion?: string
   noRemove?: boolean
-  onRemove?: () => void
   machineClasses?: Resource<MachineClassSpec>[]
-  modelValue: MachineSet
 }>()
 
-const machineClassOptions = computed(() => {
-  return machineClasses?.map((r: Resource) => r.metadata.id!) || []
-})
+defineEmits<{
+  onRemove: []
+}>()
 
-const selectedMachineClass = computed(() => {
-  return machineClasses?.find((item) => item.metadata.id === sourceName.value)
-})
+const machineSet = defineModel<MachineSet>({ required: true })
+
+const allocationModes = computed(() => [
+  {
+    label: AllocationMode.Manual,
+    value: AllocationMode.Manual,
+  },
+  {
+    label: AllocationMode.MachineClass,
+    value: AllocationMode.MachineClass,
+    disabled: !machineClasses?.length,
+    tooltip: !machineClasses?.length ? 'No Machine Classes Available' : undefined,
+  },
+])
 
 const configPatchEditModalOpen = ref(false)
 const machineSetConfigEditModalOpen = ref(false)
-const allocationMode = ref(
-  modelValue.machineAllocation ? AllocationMode.MachineClass : AllocationMode.Manual,
-)
-const useMachineClasses = computed(() => allocationMode.value === AllocationMode.MachineClass)
-const sourceName = ref(modelValue.machineAllocation?.name)
-const machineCount = ref(modelValue.machineAllocation?.size ?? 1)
-const patches = ref(modelValue.patches)
-const unlimited = ref(modelValue.machineAllocation?.size === 'unlimited')
-const allMachines = computed(() => {
-  if (selectedMachineClass?.value?.spec.auto_provision) {
-    return false
-  }
 
-  return unlimited.value
+const machineClassOptions = computed(() => machineClasses?.map((r) => r.metadata.id!) || [])
+const selectedMachineClass = computed(() => {
+  const className = machineSet.value.machineAllocation?.name
+
+  return machineClasses && className
+    ? machineClasses.find((r) => r.metadata.id === className)
+    : undefined
 })
 
-watch(
-  () => modelValue,
-  () => {
-    sourceName.value = modelValue.machineAllocation?.name
-    machineCount.value =
-      typeof modelValue.machineAllocation?.size === 'number'
-        ? modelValue.machineAllocation?.size
-        : 1
-    patches.value = modelValue.patches
-
-    if (modelValue.machineAllocation) {
-      allocationMode.value = AllocationMode.MachineClass
-    }
-  },
-)
-
-watch([sourceName, machineCount, useMachineClasses, patches, allMachines], () => {
-  if (useMachineClasses.value && !sourceName.value && machineClassOptions.value.length > 0) {
-    sourceName.value = machineClassOptions.value[0]
+// Normalise sizing incase the selected class does not support unlimited
+watch(selectedMachineClass, (selectedMachineClass) => {
+  if (
+    selectedMachineClass?.spec.auto_provision &&
+    machineSet.value.machineAllocation?.size === 'unlimited'
+  ) {
+    machineSet.value.machineAllocation.size = 1
   }
-
-  const mc =
-    useMachineClasses.value && sourceName.value !== undefined
-      ? {
-          name: sourceName.value,
-          size: allMachines.value ? 'unlimited' : machineCount.value,
-        }
-      : undefined
-
-  const machineSet: MachineSet = {
-    ...modelValue,
-    machineAllocation: mc,
-    patches: patches.value,
-  }
-
-  emit('update:modelValue', machineSet)
 })
 
 const onSavePatchConfig = (config: string) => {
   if (!config) {
-    delete patches.value[PatchID.Default]
+    delete machineSet.value.patches[PatchID.Default]
 
     return
   }
 
-  patches.value = {
-    [PatchID.Default]: {
-      data: config,
-      weight: PatchBaseWeightMachineSet,
-    },
-    ...patches.value,
+  machineSet.value.patches[PatchID.Default] = {
+    data: config,
+    weight: PatchBaseWeightMachineSet,
   }
 }
 
@@ -147,73 +98,81 @@ const labelId = useId()
     :aria-labelledby="labelId"
   >
     <div class="w-10">
-      <span class="resource-label" :class="modelValue.labelClass">{{ modelValue.id }}</span>
+      <span class="resource-label" :class="machineSet.labelClass">{{ machineSet.id }}</span>
     </div>
 
     <div class="flex flex-1 flex-wrap items-center gap-x-4 gap-y-1">
-      <div :id="labelId" class="w-32 truncate" :title="modelValue.name">
-        {{ modelValue.name }}
+      <div :id="labelId" class="w-32 truncate" :title="machineSet.name">
+        {{ machineSet.name }}
       </div>
       <div class="flex items-center gap-2">
         Allocation Mode:
-        <TButtonGroup v-model="allocationMode" :options="allocationModes" />
+        <TButtonGroup
+          :model-value="
+            machineSet.machineAllocation ? AllocationMode.MachineClass : AllocationMode.Manual
+          "
+          :options="allocationModes"
+          @update:model-value="
+            machineSet.machineAllocation =
+              $event === AllocationMode.MachineClass
+                ? { name: machineClassOptions[0], size: 1 }
+                : undefined
+          "
+        />
       </div>
-      <template v-if="useMachineClasses">
+      <template v-if="machineSet.machineAllocation">
         <TSelectList
           v-if="machineClasses"
+          v-model="machineSet.machineAllocation.name"
           class="h-6 w-48"
           title="Name"
-          :default-value="sourceName ?? machineClassOptions[0]"
+          :default-value="machineClassOptions[0]"
           :values="machineClassOptions"
-          @checked-value="
-            (value: string) => {
-              sourceName = value
-            }
-          "
         />
         <TSpinner v-else class="h-4 w-4" />
       </template>
       <TCheckbox
-        v-if="useMachineClasses && !selectedMachineClass?.spec.auto_provision"
-        v-model="unlimited"
+        v-if="machineSet.machineAllocation && !selectedMachineClass?.spec.auto_provision"
+        :model-value="machineSet.machineAllocation.size === 'unlimited'"
         label="Use All Available Machines"
         class="h-6"
+        @update:model-value="machineSet.machineAllocation.size = $event ? 'unlimited' : 1"
       />
-      <div v-if="!allMachines" class="w-32">
+      <div v-if="machineSet.machineAllocation?.size !== 'unlimited'" class="w-32">
         <TInput
-          v-if="useMachineClasses"
-          v-model="machineCount"
+          v-if="machineSet.machineAllocation"
+          v-model="machineSet.machineAllocation.size"
           class="h-6"
           title="Size"
           type="number"
           :min="0"
           compact
         />
-        <div v-else>{{ pluralize('Machines', Object.keys(modelValue.machines).length, true) }}</div>
+        <div v-else>{{ pluralize('Machines', Object.keys(machineSet.machines).length, true) }}</div>
       </div>
     </div>
     <div class="flex w-24 items-center justify-end gap-2">
-      <TButton v-if="!noRemove" class="h-6" size="sm" @click="onRemove">Remove</TButton>
+      <TButton v-if="!noRemove" class="h-6" size="sm" @click="$emit('onRemove')">Remove</TButton>
       <div class="flex justify-center gap-1">
         <IconButton icon="chart-bar" @click="machineSetConfigEditModalOpen = true" />
         <IconButton
-          :icon="patches[PatchID.Default] ? 'settings-toggle' : 'settings'"
+          :icon="machineSet.patches[PatchID.Default] ? 'settings-toggle' : 'settings'"
           @click="configPatchEditModalOpen = true"
         />
       </div>
     </div>
 
     <ConfigPatchEditModal
-      :id="`Machine Set ${modelValue.name}`"
+      :id="`Machine Set ${machineSet.name}`"
       v-model:open="configPatchEditModalOpen"
-      :config="patches[PatchID.Default]?.data ?? ''"
+      :config="machineSet.patches[PatchID.Default]?.data ?? ''"
       :talos-version="talosVersion"
       @save="onSavePatchConfig"
     />
 
     <MachineSetConfigEditModal
       v-model:open="machineSetConfigEditModalOpen"
-      :machine-set="modelValue"
+      :machine-set="machineSet"
     />
   </li>
 </template>

--- a/frontend/src/views/Clusters/Management/MachineSets.vue
+++ b/frontend/src/views/Clusters/Management/MachineSets.vue
@@ -34,16 +34,11 @@ const addWorkers = () => {
       <MachineSetConfig
         v-for="(machineSet, index) in state.machineSets"
         :key="machineSet.name"
+        v-model="state.machineSets[index]"
         :talos-version="state.cluster.talosVersion"
         :machine-classes="machineClasses"
-        :model-value="machineSet"
         :no-remove="index < 2"
-        :on-remove="
-          () => {
-            state.removeMachineSet(index)
-          }
-        "
-        @update:model-value="(value) => (state.machineSets[index] = value)"
+        @on-remove="state.removeMachineSet(index)"
       />
     </ul>
   </div>

--- a/frontend/src/views/MachineClasses/MachineTemplate.vue
+++ b/frontend/src/views/MachineClasses/MachineTemplate.vue
@@ -21,16 +21,17 @@ enum GRPCTunnelMode {
   Disabled = 'Disabled',
 }
 
-const { infraProvider, initialLabels, kernelArguments, providerConfig, grpcTunnel } = defineProps<{
+const { infraProvider } = defineProps<{
   infraProvider: string
-  initialLabels: Record<string, LabelSelectItem>
-  kernelArguments: string
-  providerConfig: Record<string, unknown>
-  grpcTunnel: GrpcTunnelMode
 }>()
 
+const kernelArguments = defineModel<string>('kernelArguments')
+const initialLabels = defineModel<Record<string, LabelSelectItem>>('initialLabels')
+const providerConfig = defineModel<Record<string, unknown>>('providerConfig', { required: true })
+const grpcTunnel = defineModel<GrpcTunnelMode>('grpcTunnel', { required: true })
+
 const defaultTunnelMode = (() => {
-  switch (grpcTunnel) {
+  switch (grpcTunnel.value) {
     default:
     case GrpcTunnelMode.UNSET:
       return GRPCTunnelMode.Default
@@ -40,13 +41,6 @@ const defaultTunnelMode = (() => {
       return GRPCTunnelMode.Enabled
   }
 })()
-
-const emit = defineEmits<{
-  'update:kernel-arguments': [string | undefined]
-  'update:initial-labels': [Record<string, LabelSelectItem> | undefined]
-  'update:provider-config': [Record<string, unknown>]
-  'update:grpc-tunnel': [GrpcTunnelMode]
-}>()
 
 const { data: infraProviderStatus } = useResourceWatch<InfraProviderStatusSpec>(() => ({
   skip: !infraProvider,
@@ -61,13 +55,13 @@ const { data: infraProviderStatus } = useResourceWatch<InfraProviderStatusSpec>(
 const updateGRPCTunnelMode = (value: GRPCTunnelMode) => {
   switch (value) {
     case GRPCTunnelMode.Default:
-      emit('update:grpc-tunnel', GrpcTunnelMode.UNSET)
+      grpcTunnel.value = GrpcTunnelMode.UNSET
       break
     case GRPCTunnelMode.Enabled:
-      emit('update:grpc-tunnel', GrpcTunnelMode.ENABLED)
+      grpcTunnel.value = GrpcTunnelMode.ENABLED
       break
     case GRPCTunnelMode.Disabled:
-      emit('update:grpc-tunnel', GrpcTunnelMode.DISABLED)
+      grpcTunnel.value = GrpcTunnelMode.DISABLED
       break
   }
 }
@@ -80,18 +74,11 @@ const updateGRPCTunnelMode = (value: GRPCTunnelMode) => {
     <div class="flex flex-col divide-y divide-naturals-n4 border-t-8 border-naturals-n4 text-xs">
       <div class="flex items-center justify-between gap-2 px-4 py-2">
         <span class="whitespace-nowrap">Kernel Arguments</span>
-        <TInput
-          class="h-7 w-56"
-          :model-value="kernelArguments"
-          @update:model-value="(value) => $emit('update:kernel-arguments', value)"
-        />
+        <TInput v-model="kernelArguments" class="h-7 w-56" />
       </div>
       <div class="flex items-center justify-between gap-2 px-4 py-2">
         <span class="whitespace-nowrap">Initial Labels</span>
-        <Labels
-          :model-value="initialLabels"
-          @update:model-value="(value) => $emit('update:initial-labels', value)"
-        />
+        <Labels v-model="initialLabels" />
       </div>
       <div class="flex items-center justify-between gap-2 px-4 py-2">
         <span class="whitespace-nowrap">Use gRPC Tunnel</span>
@@ -109,11 +96,7 @@ const updateGRPCTunnelMode = (value: GRPCTunnelMode) => {
       {{ infraProviderStatus.spec.name }} Provider Config
     </div>
     <div class="flex flex-col divide-y divide-naturals-n4 border-t-8 border-naturals-n4 text-xs">
-      <JsonForm
-        :model-value="providerConfig"
-        :json-schema="infraProviderStatus.spec.schema"
-        @update:model-value="(value) => $emit('update:provider-config', value)"
-      />
+      <JsonForm v-model="providerConfig" :json-schema="infraProviderStatus.spec.schema" />
     </div>
   </div>
 </template>

--- a/frontend/src/views/MachineClasses/ProviderConfig.vue
+++ b/frontend/src/views/MachineClasses/ProviderConfig.vue
@@ -5,7 +5,7 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { computed, ref, toRefs } from 'vue'
+import { computed, ref } from 'vue'
 import WordHighlighter from 'vue-word-highlighter'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -20,15 +20,7 @@ import IconButton from '@/components/Button/IconButton.vue'
 import TIcon from '@/components/Icon/TIcon.vue'
 import TList from '@/components/List/TList.vue'
 
-const props = defineProps<{
-  infraProvider?: string
-}>()
-
-const emit = defineEmits<{
-  'update:infra-provider': [string]
-}>()
-
-const { infraProvider } = toRefs(props)
+const infraProvider = defineModel<string>('infraProvider')
 
 const selectingProvider = ref(false)
 const showAllProviders = computed(() => {
@@ -51,8 +43,7 @@ const setInfraProvider = (item: Resource<InfraProviderStatusSpec>) => {
   }
 
   selectingProvider.value = false
-
-  emit('update:infra-provider', item.metadata.id!)
+  infraProvider.value = item.metadata.id
 }
 </script>
 


### PR DESCRIPTION
Fix the hours input for the etcd backup interval not being editable. Also separately refactor the last instances of `val` + `update:val` on the definition side to use `defineModel`.