### PR TITLE
fix: siderolink api label

### DIFF
--- a/frontend/src/views/Home/HomeGeneralInformation.vue
+++ b/frontend/src/views/Home/HomeGeneralInformation.vue
@@ -98,7 +98,7 @@ const {
       />
 
       <HomeGeneralInformationCopyable
-        title="API Endpoint"
+        title="SideroLink API Endpoint"
         :value="apiConfigData?.spec.machine_api_advertised_url"
       />
 


### PR DESCRIPTION
Make it clearer that the API endpoint is for SideroLink, not Omni itself.