### PR TITLE
fix: stop a link to an exposed service from starting a login flow

### DIFF
--- a/internal/backend/grpc/auth.go
+++ b/internal/backend/grpc/auth.go
@@ -47,6 +47,13 @@ const (
 	awaitPublicKeyConfirmationTimeout = 5 * time.Minute
 )
 
+// workloadProxyCookieSameSite is Lax so that a link to an exposed service still works when someone
+// follows it from outside the instance domain. Strict withholds these cookies on that navigation and
+// turns the click into a full login round trip for a person who is already logged in. The proxy
+// handler reads fetch metadata to refuse cross-site subresource loads and unsafe methods, which is
+// the part SameSite cannot express on its own.
+const workloadProxyCookieSameSite = http.SameSiteLaxMode
+
 type authServer struct {
 	authpb.UnimplementedAuthServiceServer
 
@@ -265,7 +272,7 @@ func (s *authServer) RevokePublicKey(ctx context.Context, request *authpb.Revoke
 			HttpOnly: true,
 			Secure:   true,
 			Domain:   s.workloadProxyCookieDomain,
-			SameSite: http.SameSiteStrictMode,
+			SameSite: workloadProxyCookieSameSite,
 		},
 		&http.Cookie{
 			Name:     workloadproxy.PublicKeyIDSignatureBase64Cookie,
@@ -274,7 +281,7 @@ func (s *authServer) RevokePublicKey(ctx context.Context, request *authpb.Revoke
 			HttpOnly: true,
 			Secure:   true,
 			Domain:   s.workloadProxyCookieDomain,
-			SameSite: http.SameSiteStrictMode,
+			SameSite: workloadProxyCookieSameSite,
 		},
 	); err != nil {
 		return nil, err
@@ -364,7 +371,7 @@ func (s *authServer) ConfirmPublicKey(ctx context.Context, request *authpb.Confi
 					HttpOnly: true,
 					Secure:   true,
 					Domain:   s.workloadProxyCookieDomain,
-					SameSite: http.SameSiteStrictMode,
+					SameSite: workloadProxyCookieSameSite,
 				},
 				&http.Cookie{
 					Name:     workloadproxy.PublicKeyIDSignatureBase64Cookie,
@@ -374,7 +381,7 @@ func (s *authServer) ConfirmPublicKey(ctx context.Context, request *authpb.Confi
 					HttpOnly: true,
 					Secure:   true,
 					Domain:   s.workloadProxyCookieDomain,
-					SameSite: http.SameSiteStrictMode,
+					SameSite: workloadProxyCookieSameSite,
 				},
 			); err != nil {
 				return nil, err

--- a/internal/backend/services/workloadproxy/handler.go
+++ b/internal/backend/services/workloadproxy/handler.go
@@ -20,6 +20,16 @@ import (
 	"github.com/siderolabs/omni/internal/pkg/auth"
 )
 
+// Fetch metadata request headers, see https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header.
+const (
+	secFetchSiteHeader = "Sec-Fetch-Site"
+	secFetchModeHeader = "Sec-Fetch-Mode"
+	secFetchDestHeader = "Sec-Fetch-Dest"
+
+	secFetchModeNavigate = "navigate"
+	secFetchDestDocument = "document"
+)
+
 // ProxyProvider is a provider of HTTP proxies for the exposed services.
 type ProxyProvider interface {
 	GetProxy(alias string) (http.Handler, resource.ID, error)
@@ -111,6 +121,10 @@ func (h *HTTPHandler) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 
+	if !h.checkFetchMetadata(writer, request) {
+		return
+	}
+
 	alias := h.parseServiceAliasFromHost(request)
 	if alias == "" {
 		http.NotFound(writer, request)
@@ -166,9 +180,56 @@ func (h *HTTPHandler) isWorkloadProxyRequest(request *http.Request) bool {
 	return false
 }
 
+// checkFetchMetadata decides whether a request may reach an exposed service at all, before any
+// credential is looked at.
+//
+// A browser attaches the Lax auth cookies to a top-level navigation whatever page it started from,
+// which is what makes a link to an exposed service work. Anything else a cross-origin page can
+// start, a subresource load or a form post, is refused here rather than sent to the login flow,
+// since re-authenticating a request nobody asked for only completes it.
+//
+// A request without fetch metadata passes. Browsers are the only clients that attach these cookies
+// on their own, and every browser that does so also sends these headers, so their absence means the
+// caller presented the credential deliberately.
+func (h *HTTPHandler) checkFetchMetadata(writer http.ResponseWriter, request *http.Request) (valid bool) {
+	switch request.Header.Get(secFetchSiteHeader) {
+	case "", "same-origin", "same-site", "none":
+		return true
+	}
+
+	safeMethod := request.Method == http.MethodGet || request.Method == http.MethodHead
+
+	if request.Header.Get(secFetchModeHeader) == secFetchModeNavigate &&
+		request.Header.Get(secFetchDestHeader) == secFetchDestDocument &&
+		safeMethod {
+		return true
+	}
+
+	h.logger.Warn(
+		"reject cross-site workload proxy request",
+		zap.String("request_uri", request.Host+request.URL.RequestURI()),
+		zap.String("method", request.Method),
+		zap.String("sec_fetch_mode", request.Header.Get(secFetchModeHeader)),
+		zap.String("sec_fetch_dest", request.Header.Get(secFetchDestHeader)),
+	)
+
+	http.Error(writer, "cross-site request to an exposed service is not allowed", http.StatusForbidden)
+
+	return false
+}
+
 func (h *HTTPHandler) checkCookies(writer http.ResponseWriter, request *http.Request, clusterID resource.ID) (valid bool) {
 	publicKeyID, publicKeyIDSignatureBase64 := h.getSignatureCookies(request)
 	if publicKeyID == "" || publicKeyIDSignatureBase64 == "" {
+		// Only a navigation can come back from the login flow with a cookie. A subresource fetch would
+		// get HTML in place of the asset and no cookie either way. A page manifest is the usual one to
+		// hit this, since the browser requests it with credentials omitted.
+		if mode := request.Header.Get(secFetchModeHeader); mode != "" && mode != secFetchModeNavigate {
+			http.Error(writer, "unauthenticated", http.StatusUnauthorized)
+
+			return false
+		}
+
 		h.redirectToLogin(writer, request)
 
 		return false

--- a/internal/backend/services/workloadproxy/handler_test.go
+++ b/internal/backend/services/workloadproxy/handler_test.go
@@ -296,6 +296,183 @@ func TestHandlerUseOmniSubdomainEmptySubdomain(t *testing.T) {
 	})
 }
 
+func TestHandlerFetchMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	mainURL, err := url.Parse("https://omni.example.com")
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name       string
+		site       string
+		mode       string
+		dest       string
+		method     string
+		withCookie bool
+		wantCode   int
+	}{
+		{
+			name:       "link followed from another site",
+			site:       "cross-site",
+			mode:       "navigate",
+			dest:       "document",
+			method:     http.MethodGet,
+			withCookie: true,
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "head request from another site",
+			site:       "cross-site",
+			mode:       "navigate",
+			dest:       "document",
+			method:     http.MethodHead,
+			withCookie: true,
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "typed into the address bar",
+			site:       "none",
+			mode:       "navigate",
+			dest:       "document",
+			method:     http.MethodGet,
+			withCookie: true,
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "link followed from the omni ui",
+			site:       "same-site",
+			mode:       "navigate",
+			dest:       "document",
+			method:     http.MethodGet,
+			withCookie: true,
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "asset of the exposed service itself",
+			site:       "same-origin",
+			mode:       "no-cors",
+			dest:       "image",
+			method:     http.MethodGet,
+			withCookie: true,
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "client that sends no fetch metadata",
+			method:     http.MethodPost,
+			withCookie: true,
+			wantCode:   http.StatusOK,
+		},
+		{
+			name:       "image loaded by a cross-origin page",
+			site:       "cross-site",
+			mode:       "no-cors",
+			dest:       "image",
+			method:     http.MethodGet,
+			withCookie: true,
+			wantCode:   http.StatusForbidden,
+		},
+		{
+			name:       "fetch from a cross-origin page",
+			site:       "cross-site",
+			mode:       "cors",
+			dest:       "empty",
+			method:     http.MethodGet,
+			withCookie: true,
+			wantCode:   http.StatusForbidden,
+		},
+		{
+			name:       "framed by a cross-origin page",
+			site:       "cross-site",
+			mode:       "navigate",
+			dest:       "iframe",
+			method:     http.MethodGet,
+			withCookie: true,
+			wantCode:   http.StatusForbidden,
+		},
+		{
+			name:       "form posted from a cross-origin page",
+			site:       "cross-site",
+			mode:       "navigate",
+			dest:       "document",
+			method:     http.MethodPost,
+			withCookie: true,
+			wantCode:   http.StatusForbidden,
+		},
+		{
+			name:     "unauthenticated navigation goes to login",
+			site:     "cross-site",
+			mode:     "navigate",
+			dest:     "document",
+			method:   http.MethodGet,
+			wantCode: http.StatusSeeOther,
+		},
+		{
+			name:     "unauthenticated manifest fetch is refused",
+			site:     "same-origin",
+			mode:     "cors",
+			dest:     "manifest",
+			method:   http.MethodGet,
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "unauthenticated client without fetch metadata goes to login",
+			method:   http.MethodGet,
+			wantCode: http.StatusSeeOther,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			next := &mockHandler{}
+			proxyProvider := &mockProxyProvider{}
+			accessValidator := &mockAccessValidator{}
+			logger := zaptest.NewLogger(t)
+
+			handler, err := workloadproxy.NewHTTPHandler(next, proxyProvider, accessValidator, mainURL, "proxy", true, logger, redirectSignature)
+			require.NoError(t, err)
+
+			req, err := http.NewRequestWithContext(ctx, test.method, "https://grafana.proxy.omni.example.com/dashboard", nil)
+			require.NoError(t, err)
+
+			for header, value := range map[string]string{
+				"Sec-Fetch-Site": test.site,
+				"Sec-Fetch-Mode": test.mode,
+				"Sec-Fetch-Dest": test.dest,
+			} {
+				if value != "" {
+					req.Header.Set(header, value)
+				}
+			}
+
+			if test.withCookie {
+				req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDCookie, Value: testPublicKeyID})
+				req.AddCookie(&http.Cookie{Name: workloadproxy.PublicKeyIDSignatureBase64Cookie, Value: base64.StdEncoding.EncodeToString([]byte("test-signed-public-key-id"))})
+			}
+
+			rr := httptest.NewRecorder()
+
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, test.wantCode, rr.Code)
+
+			switch test.wantCode {
+			case http.StatusOK:
+				require.Equal(t, []string{"grafana"}, proxyProvider.aliases)
+				require.Equal(t, []string{testPublicKeyID}, accessValidator.publicKeyIDs)
+			case http.StatusForbidden:
+				// the request is refused before the alias is even looked up
+				require.Empty(t, proxyProvider.aliases)
+				require.Empty(t, accessValidator.publicKeyIDs)
+			default:
+				require.Empty(t, accessValidator.publicKeyIDs)
+			}
+		})
+	}
+}
+
 func testUseOmniSubdomainWithCookies(ctx context.Context, t *testing.T, mainURL *url.URL, subdomain, requestURL, expectedAlias string) {
 	t.Helper()
 


### PR DESCRIPTION
The workload proxy auth cookies were Strict, so a browser withheld them from any top-level navigation starting outside the instance domain. Someone already logged in to Omni who followed a link to an exposed service was pushed through the whole login flow, and since every AuthnRequest carries ForceAuthn, that flow now stops at an interactive prompt from the IdP.

Lax attaches the cookies to that navigation, so the click reaches the service. Strict was not denying those requests in the first place: it redirected them to login, signed the caller's own URL into the redirect parameter, and served them once a session existed. The handler now makes that decision itself, reading fetch metadata to refuse cross-site subresource loads, frames and unsafe methods, and answering an unauthenticated non-navigation with 401 rather than sending an asset request to a login page.
