### PR TITLE
fix: change incorrect version contract for kubespan

### DIFF
--- a/internal/backend/runtime/omni/virtual/state.go
+++ b/internal/backend/runtime/omni/virtual/state.go
@@ -498,7 +498,7 @@ func (v *State) versionContract(_ context.Context, ptr resource.Pointer) (*virtu
 
 	res.Metadata().SetVersion(version)
 	res.TypedSpec().Value = &specs.VersionContractSpec{
-		KubeSpanMultidocConfig:            vc.VolumeConfigEncryptionSupported(),
+		KubeSpanMultidocConfig:            vc.KubeSpanMultidocConfig(),
 		MultidocKubernetesConfigSupported: vc.MultidocKubernetesConfigSupported(),
 		MultidocNetworkConfigSupported:    vc.MultidocNetworkConfigSupported(),
 		DiscoveryServiceMultidocConfig:    vc.DiscoveryServiceMultidocConfig(),


### PR DESCRIPTION
Fix incorrect version contract for KubeSpanMultidocConfig erroneously checking VolumeConfigEncryptionSupported instead