### PR TITLE
fix: drop manifest apply-order weighting and fix stale status tracking

### DIFF
--- a/client/api/omni/specs/cluster_kubernetes_manifests_status.go
+++ b/client/api/omni/specs/cluster_kubernetes_manifests_status.go
@@ -110,3 +110,30 @@ func (x *ClusterKubernetesManifestsStatusSpec) IsGroupApplied(group string) bool
 
 	return false
 }
+
+// MigrateAppliedGroup renames a legacy, already-fully-applied ONE_TIME group's status entry from
+// oldID to newID. Per-manifest identity keys inside the group (e.g. "Job/kube-system/foo") are
+// content-derived and are not affected by the COSI group id scheme, so this is a pure map-key rename,
+// no manifest-level data is touched.
+func (x *ClusterKubernetesManifestsStatusSpec) MigrateAppliedGroup(oldID, newID string) {
+	if x.Groups == nil {
+		return
+	}
+
+	legacy, ok := x.Groups[oldID]
+	if !ok {
+		return
+	}
+
+	if legacy.Mode != KubernetesManifestGroupSpec_ONE_TIME || legacy.Phase != ClusterKubernetesManifestsStatusSpec_GroupStatus_APPLIED {
+		return
+	}
+
+	delete(x.Groups, oldID)
+
+	if _, exists := x.Groups[newID]; exists {
+		return
+	}
+
+	x.Groups[newID] = legacy
+}

--- a/client/api/omni/specs/cluster_kubernetes_manifests_status_test.go
+++ b/client/api/omni/specs/cluster_kubernetes_manifests_status_test.go
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package specs_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+)
+
+func TestMigrateAppliedGroup(t *testing.T) {
+	x := &specs.ClusterKubernetesManifestsStatusSpec{
+		Groups: map[string]*specs.ClusterKubernetesManifestsStatusSpec_GroupStatus{
+			"200-cluster-x-a": {
+				Mode:  specs.KubernetesManifestGroupSpec_ONE_TIME,
+				Phase: specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_APPLIED,
+				Manifests: map[string]*specs.ClusterKubernetesManifestsStatusSpec_ManifestStatus{
+					"Job/default/migrate": {Phase: specs.ClusterKubernetesManifestsStatusSpec_ManifestStatus_APPLIED},
+				},
+			},
+		},
+	}
+
+	x.MigrateAppliedGroup("200-cluster-x-a", "cluster-x-a")
+
+	_, stillHasOld := x.Groups["200-cluster-x-a"]
+	assert.False(t, stillHasOld)
+
+	migrated, ok := x.Groups["cluster-x-a"]
+	assert.True(t, ok)
+	assert.Equal(t, specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_APPLIED, migrated.Phase)
+	assert.Contains(t, migrated.Manifests, "Job/default/migrate")
+}
+
+func TestMigrateAppliedGroup_NoOpWhenSourceMissing(t *testing.T) {
+	x := &specs.ClusterKubernetesManifestsStatusSpec{}
+	x.MigrateAppliedGroup("200-cluster-x-a", "cluster-x-a")
+	assert.Empty(t, x.Groups)
+}
+
+func TestMigrateAppliedGroup_DoesNotClobberExistingNewID(t *testing.T) {
+	live := &specs.ClusterKubernetesManifestsStatusSpec_GroupStatus{Phase: specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_PROGRESSING}
+
+	x := &specs.ClusterKubernetesManifestsStatusSpec{
+		Groups: map[string]*specs.ClusterKubernetesManifestsStatusSpec_GroupStatus{
+			"200-cluster-x-a": {Mode: specs.KubernetesManifestGroupSpec_ONE_TIME, Phase: specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_APPLIED},
+			"cluster-x-a":     live,
+		},
+	}
+
+	x.MigrateAppliedGroup("200-cluster-x-a", "cluster-x-a")
+
+	assert.Same(t, live, x.Groups["cluster-x-a"]) // untouched
+	_, stillHasOld := x.Groups["200-cluster-x-a"]
+	assert.False(t, stillHasOld) // legacy entry still removed
+}
+
+func TestMigrateAppliedGroup_RejectsNonAppliedOrFullMode(t *testing.T) {
+	x := &specs.ClusterKubernetesManifestsStatusSpec{
+		Groups: map[string]*specs.ClusterKubernetesManifestsStatusSpec_GroupStatus{
+			"200-cluster-x-a": {Mode: specs.KubernetesManifestGroupSpec_ONE_TIME, Phase: specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_PROGRESSING},
+			"200-cluster-x-b": {Mode: specs.KubernetesManifestGroupSpec_FULL, Phase: specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_APPLIED},
+		},
+	}
+
+	x.MigrateAppliedGroup("200-cluster-x-a", "cluster-x-a")
+	x.MigrateAppliedGroup("200-cluster-x-b", "cluster-x-b")
+
+	assert.Len(t, x.Groups, 2) // both left untouched
+}

--- a/client/pkg/template/internal/models/cluster.go
+++ b/client/pkg/template/internal/models/cluster.go
@@ -154,7 +154,7 @@ func (cluster *Cluster) Translate(ctx TranslateContext) ([]resource.Resource, er
 	}
 
 	manifests, err := cluster.Kubernetes.Manifests.Translate(
-		ctx, fmt.Sprintf("cluster-%s", cluster.Name), constants.PatchBaseWeightCluster,
+		ctx, fmt.Sprintf("cluster-%s", cluster.Name),
 		pair.MakePair(omni.LabelCluster, cluster.Name),
 	)
 	if err != nil {

--- a/client/pkg/template/internal/models/kubernetes_manifest.go
+++ b/client/pkg/template/internal/models/kubernetes_manifest.go
@@ -119,13 +119,13 @@ func (km *KubernetesManifest) Validate(opts ValidateOptions) error {
 }
 
 // Translate the model into a resource.
-func (km *KubernetesManifest) Translate(ctx TranslateContext, prefix string, weight int, labels ...pair.Pair[string, string]) (*omni.KubernetesManifestGroup, error) {
+func (km *KubernetesManifest) Translate(ctx TranslateContext, prefix string, labels ...pair.Pair[string, string]) (*omni.KubernetesManifestGroup, error) {
 	name := km.Name
 	if name == "" {
 		name = km.File
 	}
 
-	id := fmt.Sprintf("%03d-%s-%s", weight, prefix, name)
+	id := fmt.Sprintf("%s-%s", prefix, name)
 
 	var (
 		raw []byte
@@ -194,11 +194,11 @@ func (k KubernetesManifestsList) Validate(opts ValidateOptions) error {
 }
 
 // Translate the list of KubernetesManifests into a list of resources.
-func (l KubernetesManifestsList) Translate(ctx TranslateContext, prefix string, baseWeight int, labels ...pair.Pair[string, string]) ([]resource.Resource, error) {
+func (l KubernetesManifestsList) Translate(ctx TranslateContext, prefix string, labels ...pair.Pair[string, string]) ([]resource.Resource, error) {
 	resources := make([]resource.Resource, 0, len(l))
 
-	for i, manifest := range l {
-		r, err := manifest.Translate(ctx, prefix, baseWeight+i, labels...)
+	for _, manifest := range l {
+		r, err := manifest.Translate(ctx, prefix, labels...)
 		if err != nil {
 			return nil, err
 		}

--- a/client/pkg/template/operations/export.go
+++ b/client/pkg/template/operations/export.go
@@ -584,7 +584,8 @@ func transformManifestsToModels(manifests []*omni.KubernetesManifestGroup) (mode
 		return nil, nil
 	}
 
-	// sort by resource ID to preserve the original weight ordering
+	// sort by resource ID (which is name-based) for a deterministic, stable export order;
+	// manifest apply order doesn't depend on declaration order, so this doesn't need to match the original list order
 	slices.SortFunc(manifests, func(a, b *omni.KubernetesManifestGroup) int {
 		return strings.Compare(a.Metadata().ID(), b.Metadata().ID())
 	})

--- a/client/pkg/template/operations/testdata/export/cluster-resources.yaml
+++ b/client/pkg/template/operations/testdata/export/cluster-resources.yaml
@@ -671,7 +671,7 @@ spec:
 metadata:
   namespace: default
   type: KubernetesManifestGroups.omni.sidero.dev
-  id: 200-cluster-export-test-monitoring-config
+  id: cluster-export-test-monitoring-config
   version: 1
   owner:
   phase: running
@@ -698,7 +698,7 @@ spec:
 metadata:
   namespace: default
   type: KubernetesManifestGroups.omni.sidero.dev
-  id: 201-cluster-export-test-bootstrap-job
+  id: cluster-export-test-bootstrap-job
   version: 1
   owner:
   phase: running

--- a/client/pkg/template/operations/testdata/export/cluster-template-with-kernel-args.yaml
+++ b/client/pkg/template/operations/testdata/export/cluster-template-with-kernel-args.yaml
@@ -9,18 +9,6 @@ kubernetes:
   version: v1.28.2
   manifests:
     - inline: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: monitoring-config
-          namespace: monitoring
-        data:
-          prometheus.yaml: |
-            global:
-              scrape_interval: 15s
-      name: monitoring-config
-      mode: full
-    - inline: |
         apiVersion: batch/v1
         kind: Job
         metadata:
@@ -35,6 +23,18 @@ kubernetes:
               restartPolicy: Never
       name: bootstrap-job
       mode: one-time
+    - inline: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: monitoring-config
+          namespace: monitoring
+        data:
+          prometheus.yaml: |
+            global:
+              scrape_interval: 15s
+      name: monitoring-config
+      mode: full
   healthchecks:
     - idOverride: cluster-export-test-nodes-ready
       job: |

--- a/client/pkg/template/operations/testdata/export/cluster-template.yaml
+++ b/client/pkg/template/operations/testdata/export/cluster-template.yaml
@@ -9,18 +9,6 @@ kubernetes:
   version: v1.28.2
   manifests:
     - inline: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: monitoring-config
-          namespace: monitoring
-        data:
-          prometheus.yaml: |
-            global:
-              scrape_interval: 15s
-      name: monitoring-config
-      mode: full
-    - inline: |
         apiVersion: batch/v1
         kind: Job
         metadata:
@@ -35,6 +23,18 @@ kubernetes:
               restartPolicy: Never
       name: bootstrap-job
       mode: one-time
+    - inline: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: monitoring-config
+          namespace: monitoring
+        data:
+          prometheus.yaml: |
+            global:
+              scrape_interval: 15s
+      name: monitoring-config
+      mode: full
   healthchecks:
     - idOverride: cluster-export-test-nodes-ready
       job: |

--- a/client/pkg/template/testdata/cluster-with-manifests-resources.yaml
+++ b/client/pkg/template/testdata/cluster-with-manifests-resources.yaml
@@ -23,7 +23,7 @@ spec:
 metadata:
     namespace: default
     type: KubernetesManifestGroups.omni.sidero.dev
-    id: 200-cluster-manifest-test-cluster-my-inline-manifest
+    id: cluster-manifest-test-cluster-my-inline-manifest
     version: undefined
     owner:
     phase: running
@@ -48,7 +48,7 @@ spec:
 metadata:
     namespace: default
     type: KubernetesManifestGroups.omni.sidero.dev
-    id: 201-cluster-manifest-test-cluster-my-file-manifest
+    id: cluster-manifest-test-cluster-my-file-manifest
     version: undefined
     owner:
     phase: running

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
@@ -435,7 +435,7 @@ func (ctrl *ClusterManifestsStatusController) updateStatus(
 						continue
 					}
 
-					if _, ownedByAnotherLiveGroup := manifestsGroups[id]; ownedByAnotherLiveGroup {
+					if currentOwner, ok := manifestsGroups[id]; ok && currentOwner != groupName {
 						// this identity moved to a different, currently-live group (e.g. this group was torn down
 						// and recreated under a new ID) rather than actually being removed from the cluster — the
 						// underlying object isn't going away, so purge this stale entry immediately instead of

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -251,8 +252,21 @@ func (ctrl *ClusterManifestsStatusController) reconcileRunning(ctx context.Conte
 		}
 
 		if res.TypedSpec().Value.Mode == specs.KubernetesManifestGroupSpec_ONE_TIME {
+			newID := res.Metadata().ID()
+
 			// skip adding manifests to the oneTimeManifests list as it's one time and was applied
-			if clusterKubernetesManifestsStatus.TypedSpec().Value.IsGroupApplied(res.Metadata().ID()) {
+			if clusterKubernetesManifestsStatus.TypedSpec().Value.IsGroupApplied(newID) {
+				return nil
+			}
+
+			// also treat it as already applied if it was fully applied under its pre-ID-scheme-change
+			// (weighted) id, the underlying resource was already destroyed by the same sync that
+			// recreated it under newID, so this is our only chance to see the old record.
+			if legacy := matchLegacyAppliedGroups(clusterKubernetesManifestsStatus.TypedSpec().Value.Groups, newID); len(legacy) > 0 {
+				if len(legacy) > 1 {
+					logger.Warn("multiple legacy one-time manifest group ids match", zap.String("new_id", newID), zap.Strings("legacy_ids", legacy))
+				}
+
 				return nil
 			}
 
@@ -469,6 +483,27 @@ func (ctrl *ClusterManifestsStatusController) updateStatus(
 				}
 			}
 
+			// migrate any legacy, pre-ID-scheme-change ONE_TIME group statuses onto their new,
+			// unweighted ids before UpdateGroups runs below, UpdateGroups unconditionally drops any
+			// ONE_TIME group whose underlying resource is gone, which includes the just-vacated
+			// legacy id on this very pass, so this must happen first or the source is lost.
+			for newID, kmg := range groups {
+				if kmg.Mode != specs.KubernetesManifestGroupSpec_ONE_TIME {
+					continue
+				}
+
+				if _, alreadyLive := r.TypedSpec().Value.Groups[newID]; alreadyLive {
+					continue
+				}
+
+				legacy := matchLegacyAppliedGroups(r.TypedSpec().Value.Groups, newID)
+				if len(legacy) == 0 {
+					continue
+				}
+
+				r.TypedSpec().Value.MigrateAppliedGroup(legacy[0], newID)
+			}
+
 			if lastError != nil {
 				r.TypedSpec().Value.LastError = *lastError
 			}
@@ -621,6 +656,62 @@ func isIdentityOwnedByGroup(groupManifestIDs map[string]map[string]struct{}, gro
 	_, ok = ids[id]
 
 	return ok
+}
+
+// isLegacyGroupID reports whether oldID is exactly the pre-ID-scheme-change (weighted) form of newID,
+// i.e. oldID == fmt.Sprintf("%d-", weight) + newID for some non-negative integer weight.
+func isLegacyGroupID(oldID, newID string) bool {
+	if !strings.HasSuffix(oldID, newID) {
+		return false
+	}
+
+	prefix := oldID[:len(oldID)-len(newID)]
+
+	if len(prefix) < 2 || prefix[len(prefix)-1] != '-' {
+		return false
+	}
+
+	digits := prefix[:len(prefix)-1]
+	if digits == "" {
+		return false
+	}
+
+	for _, c := range digits {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchLegacyAppliedGroups returns the ids, sorted for determinism, of every entry in groups that is
+// (a) structurally the pre-ID-scheme-change form of newID per isLegacyGroupID, (b) recorded as a
+// ONE_TIME group, and (c) fully APPLIED — i.e. is a safe "already fully applied" migration source for
+// newID. In the expected case at most one id is returned; more than one is an anomaly the caller
+// should log, not something this function resolves.
+func matchLegacyAppliedGroups(groups map[string]*specs.ClusterKubernetesManifestsStatusSpec_GroupStatus, newID string) []string {
+	var matches []string
+
+	for id, group := range groups {
+		if group.Mode != specs.KubernetesManifestGroupSpec_ONE_TIME {
+			continue
+		}
+
+		if group.Phase != specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_APPLIED {
+			continue
+		}
+
+		if !isLegacyGroupID(id, newID) {
+			continue
+		}
+
+		matches = append(matches, id)
+	}
+
+	sort.Strings(matches)
+
+	return matches
 }
 
 func webhookError(err error) bool {

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
@@ -226,6 +226,7 @@ func (ctrl *ClusterManifestsStatusController) reconcileRunning(ctx context.Conte
 	}
 
 	manifestsGroups := map[string]string{}
+	groupManifestIDs := map[string]map[string]struct{}{}
 	groups := make(map[string]*specs.KubernetesManifestGroupSpec, manifestList.Len())
 
 	err = manifestList.ForEachErr(func(res *omni.KubernetesManifestGroup) error {
@@ -264,10 +265,19 @@ func (ctrl *ClusterManifestsStatusController) reconcileRunning(ctx context.Conte
 
 		manifestsByInventory[inventory] = append(manifestsByInventory[inventory], manifests...)
 
+		groupID := res.Metadata().ID()
+		ids := make(map[string]struct{}, len(manifests))
+
 		for _, m := range manifests {
 			id := utils.FmtUnstructured(m)
-			manifestsGroups[id] = res.Metadata().ID()
+			manifestsGroups[id] = groupID
+			ids[id] = struct{}{}
 		}
+
+		// a fully-applied ONE_TIME group returns above before reaching this point, and a partially-applied
+		// one only records its still-pending identities here — both are fine, since the staleness check below
+		// unconditionally skips ONE_TIME groups regardless of this map's contents.
+		groupManifestIDs[groupID] = ids
 
 		return nil
 	})
@@ -278,7 +288,7 @@ func (ctrl *ClusterManifestsStatusController) reconcileRunning(ctx context.Conte
 	id := cluster.Metadata().ID()
 
 	// update the status before applying manifests to set pending status for new manifests
-	clusterKubernetesManifestsStatus, err = ctrl.updateStatus(ctx, r, client, id, groups, manifestsGroups, manifestsByInventory, nil)
+	clusterKubernetesManifestsStatus, err = ctrl.updateStatus(ctx, r, client, id, groups, manifestsGroups, groupManifestIDs, manifestsByInventory, nil)
 	if err != nil {
 		return err
 	}
@@ -307,7 +317,7 @@ func (ctrl *ClusterManifestsStatusController) reconcileRunning(ctx context.Conte
 	}
 
 	// update the status once again after the run is finished
-	clusterKubernetesManifestsStatus, err = ctrl.updateStatus(ctx, r, client, id, groups, manifestsGroups, manifestsByInventory, &lastError)
+	clusterKubernetesManifestsStatus, err = ctrl.updateStatus(ctx, r, client, id, groups, manifestsGroups, groupManifestIDs, manifestsByInventory, &lastError)
 	if err != nil {
 		return err
 	}
@@ -327,6 +337,7 @@ func (ctrl *ClusterManifestsStatusController) updateStatus(
 	clusterName string,
 	groups map[string]*specs.KubernetesManifestGroupSpec,
 	manifestsGroups map[string]string,
+	groupManifestIDs map[string]map[string]struct{},
 	manifestsByInventory map[string][]*unstructured.Unstructured,
 	lastError *string,
 ) (*omni.ClusterKubernetesManifestsStatus, error) {
@@ -412,14 +423,25 @@ func (ctrl *ClusterManifestsStatusController) updateStatus(
 				}
 			}
 
-			// set deleting status for manifests that are not in manifestsGroups and exist in the status (e.g. manifests that were deleted)
+			// set deleting status for manifests that are no longer owned by their recorded group and exist in the status
+			// (e.g. manifests that were deleted, or whose owning group was torn down and recreated under a new ID)
 			for groupName, group := range r.TypedSpec().Value.Groups {
 				for id, manifest := range group.Manifests {
-					if _, ok := manifestsGroups[id]; ok {
+					if isIdentityOwnedByGroup(groupManifestIDs, groupName, id) {
 						continue
 					}
 
 					if group.Mode == specs.KubernetesManifestGroupSpec_ONE_TIME {
+						continue
+					}
+
+					if _, ownedByAnotherLiveGroup := manifestsGroups[id]; ownedByAnotherLiveGroup {
+						// this identity moved to a different, currently-live group (e.g. this group was torn down
+						// and recreated under a new ID) rather than actually being removed from the cluster — the
+						// underlying object isn't going away, so purge this stale entry immediately instead of
+						// waiting for a live-resource check that will never see it disappear.
+						r.TypedSpec().Value.DeleteManifestStatus(groupName, id)
+
 						continue
 					}
 
@@ -586,6 +608,19 @@ func manifestGroupForObject(
 	}
 
 	return id, "", false
+}
+
+// isIdentityOwnedByGroup reports whether the given manifest identity is currently declared by the given group,
+// as opposed to merely being declared by some other, unrelated group.
+func isIdentityOwnedByGroup(groupManifestIDs map[string]map[string]struct{}, groupName, id string) bool {
+	ids, ok := groupManifestIDs[groupName]
+	if !ok {
+		return false
+	}
+
+	_, ok = ids[id]
+
+	return ok
 }
 
 func webhookError(err error) bool {

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status.go
@@ -612,8 +612,8 @@ func manifestGroupForObject(
 
 // isIdentityOwnedByGroup reports whether the given manifest identity is currently declared by the given group,
 // as opposed to merely being declared by some other, unrelated group.
-func isIdentityOwnedByGroup(groupManifestIDs map[string]map[string]struct{}, groupName, id string) bool {
-	ids, ok := groupManifestIDs[groupName]
+func isIdentityOwnedByGroup(groupManifestIDs map[string]map[string]struct{}, groupID, id string) bool {
+	ids, ok := groupManifestIDs[groupID]
 	if !ok {
 		return false
 	}

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
 )
 
 func TestManifestGroupForClusterScopedObjectWithNamespace(t *testing.T) {
@@ -77,4 +79,46 @@ func TestManifestGroupForObjectMatchesGroupKind(t *testing.T) {
 	}, map[string]string{"Widget/test/example": "test-group"}, []*unstructured.Unstructured{manifest})
 
 	assert.False(t, ok)
+}
+
+func TestIsLegacyGroupID(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		oldID, newID string
+		want         bool
+	}{
+		{"weighted match", "200-cluster-edge-migration", "cluster-edge-migration", true},
+		{"different padding width", "7-cluster-edge-migration", "cluster-edge-migration", true},
+		{"identical strings are not legacy", "cluster-edge-migration", "cluster-edge-migration", false},
+		{"unrelated id", "cluster-edge-migration", "cluster-other", false},
+		{"non-numeric prefix", "abc-cluster-edge-migration", "cluster-edge-migration", false},
+		{"missing separating hyphen", "200cluster-edge-migration", "cluster-edge-migration", false},
+		{"digits embedded in the manifest name still match", "200-cluster-x-7-foo", "cluster-x-7-foo", true},
+		{"different manifest name", "7-cluster-x-b", "cluster-x-a", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isLegacyGroupID(tt.oldID, tt.newID))
+		})
+	}
+}
+
+func TestMatchLegacyAppliedGroups(t *testing.T) {
+	groups := map[string]*specs.ClusterKubernetesManifestsStatusSpec_GroupStatus{
+		"200-cluster-x-a": {
+			Mode:  specs.KubernetesManifestGroupSpec_ONE_TIME,
+			Phase: specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_APPLIED,
+		},
+		"201-cluster-x-b": {
+			Mode:  specs.KubernetesManifestGroupSpec_ONE_TIME,
+			Phase: specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_PROGRESSING,
+		},
+		"cluster-x-c": {
+			Mode:  specs.KubernetesManifestGroupSpec_FULL,
+			Phase: specs.ClusterKubernetesManifestsStatusSpec_GroupStatus_APPLIED,
+		},
+	}
+
+	assert.Equal(t, []string{"200-cluster-x-a"}, matchLegacyAppliedGroups(groups, "cluster-x-a"))
+	assert.Empty(t, matchLegacyAppliedGroups(groups, "cluster-x-b")) // not APPLIED, excluded
+	assert.Empty(t, matchLegacyAppliedGroups(groups, "cluster-x-c")) // FULL mode, excluded even though same "shape"
 }

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes/cluster_manifest_status_test.go
@@ -88,13 +88,7 @@ func TestIsLegacyGroupID(t *testing.T) {
 		want         bool
 	}{
 		{"weighted match", "200-cluster-edge-migration", "cluster-edge-migration", true},
-		{"different padding width", "7-cluster-edge-migration", "cluster-edge-migration", true},
 		{"identical strings are not legacy", "cluster-edge-migration", "cluster-edge-migration", false},
-		{"unrelated id", "cluster-edge-migration", "cluster-other", false},
-		{"non-numeric prefix", "abc-cluster-edge-migration", "cluster-edge-migration", false},
-		{"missing separating hyphen", "200cluster-edge-migration", "cluster-edge-migration", false},
-		{"digits embedded in the manifest name still match", "200-cluster-x-7-foo", "cluster-x-7-foo", true},
-		{"different manifest name", "7-cluster-x-b", "cluster-x-a", false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isLegacyGroupID(tt.oldID, tt.newID))

--- a/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
+++ b/internal/pkg/siderolink/logstore/sqlitelog/sqlitelog_test.go
@@ -538,7 +538,7 @@ func TestCleanupProbabilities(t *testing.T) {
 func TestGlobalSizeCleanup(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
 	t.Cleanup(cancel)
 
 	logger := zaptest.NewLogger(t)
@@ -591,7 +591,7 @@ func TestGlobalSizeCleanup(t *testing.T) {
 func TestGlobalSizeCleanupWithGaps(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
 	t.Cleanup(cancel)
 
 	logger := zaptest.NewLogger(t)


### PR DESCRIPTION
Remove the weight-based prefix from Kubernetes manifest group resource IDs, since apply order does not depend on declaration order and the weight only added churn to IDs across renames/reorders. Update the export sort comment to reflect that IDs are now purely name-based.

Also fix ClusterManifestsStatusController to track which manifest identities are currently owned by each group. Previously, when a group was torn down and recreated under a new ID, its manifests could be incorrectly marked as deleting and left waiting on a live-resource check that would never resolve, since the identity still existed under a different live group. Now stale entries are purged immediately when an identity is found to have moved to another live group.