### PR TITLE
feat: authenticate boot asset downloads with image factory tokens

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -1755,6 +1755,9 @@ type BootAssetURLRequest struct {
 	//
 	// When this is set, Headers on the response will be empty. It is implied for PXE assets, which are
 	// fetched by firmware that cannot send headers.
+	//
+	// Leaving it unset does not promise headers: a factory that authenticates downloads with a token puts it
+	// in the URL for every caller. Send Headers whenever it is not empty, instead of deciding from this field.
 	StandaloneUrl bool                              `protobuf:"varint,3,opt,name=standalone_url,json=standaloneUrl,proto3" json:"standalone_url,omitempty"`
 	BootAssetKind BootAssetURLRequest_BootAssetKind `protobuf:"varint,4,opt,name=boot_asset_kind,json=bootAssetKind,proto3,enum=management.BootAssetURLRequest_BootAssetKind" json:"boot_asset_kind,omitempty"`
 	// Platform, Architecture, Format and SecureBoot name the asset. Omni assembles the image factory
@@ -1765,10 +1768,17 @@ type BootAssetURLRequest struct {
 	Architecture string `protobuf:"bytes,6,opt,name=architecture,proto3" json:"architecture,omitempty"`
 	// Format is the disk image format of the disk kind, e.g. "raw.xz" or "qcow2.gz", and unused by every
 	// other kind, whose format the kind itself implies.
-	Format        string `protobuf:"bytes,7,opt,name=format,proto3" json:"format,omitempty"`
-	SecureBoot    bool   `protobuf:"varint,8,opt,name=secure_boot,json=secureBoot,proto3" json:"secure_boot,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Format     string `protobuf:"bytes,7,opt,name=format,proto3" json:"format,omitempty"`
+	SecureBoot bool   `protobuf:"varint,8,opt,name=secure_boot,json=secureBoot,proto3" json:"secure_boot,omitempty"`
+	// DownloadTokenTtl is how long the caller needs the URL to keep working, for a factory that
+	// authenticates downloads with a token. Unset takes Omni's default, which suits a fetch performed right
+	// away. Ask for more when something else performs it later, such as a hypervisor import queue.
+	//
+	// The factory refuses a lifetime outside its configured bounds, which comes back as InvalidArgument.
+	// Ignored by a factory that authenticates downloads with credentials instead.
+	DownloadTokenTtl *durationpb.Duration `protobuf:"bytes,9,opt,name=download_token_ttl,json=downloadTokenTtl,proto3" json:"download_token_ttl,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *BootAssetURLRequest) Reset() {
@@ -1857,6 +1867,13 @@ func (x *BootAssetURLRequest) GetSecureBoot() bool {
 	return false
 }
 
+func (x *BootAssetURLRequest) GetDownloadTokenTtl() *durationpb.Duration {
+	if x != nil {
+		return x.DownloadTokenTtl
+	}
+	return nil
+}
+
 type BootAssetURLResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Url   string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
@@ -1872,7 +1889,13 @@ type BootAssetURLResponse struct {
 	//
 	// Treat it as opaque. Omni may change how it is derived, which costs a caller one re-download of the
 	// assets it already holds.
-	StorageKey    string `protobuf:"bytes,4,opt,name=storage_key,json=storageKey,proto3" json:"storage_key,omitempty"`
+	StorageKey string `protobuf:"bytes,4,opt,name=storage_key,json=storageKey,proto3" json:"storage_key,omitempty"`
+	// ExpiresAt is when the URL stops working, for a caller that does not perform the fetch itself, such as
+	// one handing the URL to a hypervisor download API. Unset when the URL does not expire.
+	//
+	// It is Omni's estimate rather than a guarantee, so treat it as the earliest moment the URL may stop
+	// working.
+	ExpiresAt     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1933,6 +1956,13 @@ func (x *BootAssetURLResponse) GetStorageKey() string {
 		return x.StorageKey
 	}
 	return ""
+}
+
+func (x *BootAssetURLResponse) GetExpiresAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return nil
 }
 
 type GetSupportBundleRequest struct {
@@ -3864,7 +3894,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\fschematic_id\x18\x01 \x01(\tR\vschematicId\x12\x17\n" +
 	"\apxe_url\x18\x02 \x01(\tR\x06pxeUrl\x12.\n" +
 	"\x13grpc_tunnel_enabled\x18\x03 \x01(\bR\x11grpcTunnelEnabled\x12#\n" +
-	"\rschematic_yml\x18\x04 \x01(\tR\fschematicYml\"\xcc\x03\n" +
+	"\rschematic_yml\x18\x04 \x01(\tR\fschematicYml\"\x95\x04\n" +
 	"\x13BootAssetURLRequest\x12#\n" +
 	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12!\n" +
 	"\fschematic_id\x18\x02 \x01(\tR\vschematicId\x12%\n" +
@@ -3874,18 +3904,21 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\farchitecture\x18\x06 \x01(\tR\farchitecture\x12\x16\n" +
 	"\x06format\x18\a \x01(\tR\x06format\x12\x1f\n" +
 	"\vsecure_boot\x18\b \x01(\bR\n" +
-	"secureBoot\"v\n" +
+	"secureBoot\x12G\n" +
+	"\x12download_token_ttl\x18\t \x01(\v2\x19.google.protobuf.DurationR\x10downloadTokenTtl\"v\n" +
 	"\rBootAssetKind\x12\x19\n" +
 	"\x15BOOT_ASSET_KIND_UNSET\x10\x00\x12\x17\n" +
 	"\x13BOOT_ASSET_KIND_PXE\x10\x01\x12\x17\n" +
 	"\x13BOOT_ASSET_KIND_ISO\x10\x02\x12\x18\n" +
-	"\x14BOOT_ASSET_KIND_DISK\x10\x03\"\xfc\x01\n" +
+	"\x14BOOT_ASSET_KIND_DISK\x10\x03\"\xb7\x02\n" +
 	"\x14BootAssetURLResponse\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12G\n" +
 	"\aheaders\x18\x02 \x03(\v2-.management.BootAssetURLResponse.HeadersEntryR\aheaders\x12,\n" +
 	"\x12image_factory_host\x18\x03 \x01(\tR\x10imageFactoryHost\x12\x1f\n" +
 	"\vstorage_key\x18\x04 \x01(\tR\n" +
-	"storageKey\x1a:\n" +
+	"storageKey\x129\n" +
+	"\n" +
+	"expires_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcb\x01\n" +
@@ -4165,82 +4198,84 @@ var file_omni_management_management_proto_depIdxs = []int32{
 	60, // 8: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
 	0,  // 9: management.CreateSchematicRequest.bootloader:type_name -> management.SchematicBootloader
 	7,  // 10: management.BootAssetURLRequest.boot_asset_kind:type_name -> management.BootAssetURLRequest.BootAssetKind
-	62, // 11: management.BootAssetURLResponse.headers:type_name -> management.BootAssetURLResponse.HeadersEntry
-	63, // 12: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
-	2,  // 13: management.ReadAuditLogRequest.order_by_field:type_name -> management.AuditLogOrderByField
-	3,  // 14: management.ReadAuditLogRequest.order_by_dir:type_name -> management.AuditLogOrderByDir
-	1,  // 15: management.ReadAuditLogRequest.event_type:type_name -> management.AuditLogEventType
-	64, // 16: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	8,  // 17: management.MaintenanceLifecycleRequest.operation:type_name -> management.MaintenanceLifecycleRequest.Operation
-	68, // 18: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
-	65, // 19: management.ListUsersResponse.users:type_name -> management.ListUsersResponse.User
-	59, // 20: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
-	68, // 21: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
-	68, // 22: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.created:type_name -> google.protobuf.Timestamp
-	68, // 23: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.last_used:type_name -> google.protobuf.Timestamp
-	64, // 24: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
-	66, // 25: management.ListUsersResponse.User.saml_labels:type_name -> management.ListUsersResponse.User.SamlLabelsEntry
-	21, // 26: management.ManagementService.Kubeconfig:input_type -> management.KubeconfigRequest
-	14, // 27: management.ManagementService.Talosconfig:input_type -> management.TalosconfigRequest
-	69, // 28: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
-	12, // 29: management.ManagementService.MachineLogs:input_type -> management.MachineLogsRequest
-	13, // 30: management.ManagementService.ValidateConfig:input_type -> management.ValidateConfigRequest
-	36, // 31: management.ManagementService.ValidateJSONSchema:input_type -> management.ValidateJsonSchemaRequest
-	15, // 32: management.ManagementService.CreateServiceAccount:input_type -> management.CreateServiceAccountRequest
-	17, // 33: management.ManagementService.RenewServiceAccount:input_type -> management.RenewServiceAccountRequest
-	69, // 34: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
-	19, // 35: management.ManagementService.DestroyServiceAccount:input_type -> management.DestroyServiceAccountRequest
-	22, // 36: management.ManagementService.KubernetesUpgradePreChecks:input_type -> management.KubernetesUpgradePreChecksRequest
-	25, // 37: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
-	27, // 38: management.ManagementService.CreateSchematic:input_type -> management.CreateSchematicRequest
-	28, // 39: management.ManagementService.CreateSchematicFromRaw:input_type -> management.CreateSchematicFromRawRequest
-	30, // 40: management.ManagementService.GetBootAssetURL:input_type -> management.BootAssetURLRequest
-	32, // 41: management.ManagementService.GetSupportBundle:input_type -> management.GetSupportBundleRequest
-	34, // 42: management.ManagementService.ReadAuditLog:input_type -> management.ReadAuditLogRequest
-	38, // 43: management.ManagementService.MaintenanceUpgrade:input_type -> management.MaintenanceUpgradeRequest
-	40, // 44: management.ManagementService.MaintenanceLifecycle:input_type -> management.MaintenanceLifecycleRequest
-	42, // 45: management.ManagementService.GetMachineJoinConfig:input_type -> management.GetMachineJoinConfigRequest
-	45, // 46: management.ManagementService.CreateJoinToken:input_type -> management.CreateJoinTokenRequest
-	47, // 47: management.ManagementService.ResetNodeUniqueToken:input_type -> management.ResetNodeUniqueTokenRequest
-	49, // 48: management.ManagementService.CreateUser:input_type -> management.CreateUserRequest
-	69, // 49: management.ManagementService.ListUsers:input_type -> google.protobuf.Empty
-	51, // 50: management.ManagementService.UpdateUser:input_type -> management.UpdateUserRequest
-	52, // 51: management.ManagementService.DestroyUser:input_type -> management.DestroyUserRequest
-	53, // 52: management.ManagementService.MachinePowerOff:input_type -> management.MachinePowerOffRequest
-	55, // 53: management.ManagementService.MachinePowerOn:input_type -> management.MachinePowerOnRequest
-	9,  // 54: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
-	10, // 55: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
-	11, // 56: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
-	70, // 57: management.ManagementService.MachineLogs:output_type -> common.Data
-	69, // 58: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
-	37, // 59: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
-	16, // 60: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
-	18, // 61: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
-	20, // 62: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
-	69, // 63: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
-	23, // 64: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
-	26, // 65: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
-	29, // 66: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
-	29, // 67: management.ManagementService.CreateSchematicFromRaw:output_type -> management.CreateSchematicResponse
-	31, // 68: management.ManagementService.GetBootAssetURL:output_type -> management.BootAssetURLResponse
-	33, // 69: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
-	35, // 70: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
-	39, // 71: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
-	41, // 72: management.ManagementService.MaintenanceLifecycle:output_type -> management.MaintenanceLifecycleResponse
-	43, // 73: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
-	46, // 74: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
-	48, // 75: management.ManagementService.ResetNodeUniqueToken:output_type -> management.ResetNodeUniqueTokenResponse
-	50, // 76: management.ManagementService.CreateUser:output_type -> management.CreateUserResponse
-	57, // 77: management.ManagementService.ListUsers:output_type -> management.ListUsersResponse
-	69, // 78: management.ManagementService.UpdateUser:output_type -> google.protobuf.Empty
-	69, // 79: management.ManagementService.DestroyUser:output_type -> google.protobuf.Empty
-	54, // 80: management.ManagementService.MachinePowerOff:output_type -> management.MachinePowerOffResponse
-	56, // 81: management.ManagementService.MachinePowerOn:output_type -> management.MachinePowerOnResponse
-	54, // [54:82] is the sub-list for method output_type
-	26, // [26:54] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	67, // 11: management.BootAssetURLRequest.download_token_ttl:type_name -> google.protobuf.Duration
+	62, // 12: management.BootAssetURLResponse.headers:type_name -> management.BootAssetURLResponse.HeadersEntry
+	68, // 13: management.BootAssetURLResponse.expires_at:type_name -> google.protobuf.Timestamp
+	63, // 14: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
+	2,  // 15: management.ReadAuditLogRequest.order_by_field:type_name -> management.AuditLogOrderByField
+	3,  // 16: management.ReadAuditLogRequest.order_by_dir:type_name -> management.AuditLogOrderByDir
+	1,  // 17: management.ReadAuditLogRequest.event_type:type_name -> management.AuditLogEventType
+	64, // 18: management.ValidateJsonSchemaResponse.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	8,  // 19: management.MaintenanceLifecycleRequest.operation:type_name -> management.MaintenanceLifecycleRequest.Operation
+	68, // 20: management.CreateJoinTokenRequest.expiration_time:type_name -> google.protobuf.Timestamp
+	65, // 21: management.ListUsersResponse.users:type_name -> management.ListUsersResponse.User
+	59, // 22: management.ListServiceAccountsResponse.ServiceAccount.pgp_public_keys:type_name -> management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
+	68, // 23: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.expiration:type_name -> google.protobuf.Timestamp
+	68, // 24: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.created:type_name -> google.protobuf.Timestamp
+	68, // 25: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey.last_used:type_name -> google.protobuf.Timestamp
+	64, // 26: management.ValidateJsonSchemaResponse.Error.errors:type_name -> management.ValidateJsonSchemaResponse.Error
+	66, // 27: management.ListUsersResponse.User.saml_labels:type_name -> management.ListUsersResponse.User.SamlLabelsEntry
+	21, // 28: management.ManagementService.Kubeconfig:input_type -> management.KubeconfigRequest
+	14, // 29: management.ManagementService.Talosconfig:input_type -> management.TalosconfigRequest
+	69, // 30: management.ManagementService.Omniconfig:input_type -> google.protobuf.Empty
+	12, // 31: management.ManagementService.MachineLogs:input_type -> management.MachineLogsRequest
+	13, // 32: management.ManagementService.ValidateConfig:input_type -> management.ValidateConfigRequest
+	36, // 33: management.ManagementService.ValidateJSONSchema:input_type -> management.ValidateJsonSchemaRequest
+	15, // 34: management.ManagementService.CreateServiceAccount:input_type -> management.CreateServiceAccountRequest
+	17, // 35: management.ManagementService.RenewServiceAccount:input_type -> management.RenewServiceAccountRequest
+	69, // 36: management.ManagementService.ListServiceAccounts:input_type -> google.protobuf.Empty
+	19, // 37: management.ManagementService.DestroyServiceAccount:input_type -> management.DestroyServiceAccountRequest
+	22, // 38: management.ManagementService.KubernetesUpgradePreChecks:input_type -> management.KubernetesUpgradePreChecksRequest
+	25, // 39: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
+	27, // 40: management.ManagementService.CreateSchematic:input_type -> management.CreateSchematicRequest
+	28, // 41: management.ManagementService.CreateSchematicFromRaw:input_type -> management.CreateSchematicFromRawRequest
+	30, // 42: management.ManagementService.GetBootAssetURL:input_type -> management.BootAssetURLRequest
+	32, // 43: management.ManagementService.GetSupportBundle:input_type -> management.GetSupportBundleRequest
+	34, // 44: management.ManagementService.ReadAuditLog:input_type -> management.ReadAuditLogRequest
+	38, // 45: management.ManagementService.MaintenanceUpgrade:input_type -> management.MaintenanceUpgradeRequest
+	40, // 46: management.ManagementService.MaintenanceLifecycle:input_type -> management.MaintenanceLifecycleRequest
+	42, // 47: management.ManagementService.GetMachineJoinConfig:input_type -> management.GetMachineJoinConfigRequest
+	45, // 48: management.ManagementService.CreateJoinToken:input_type -> management.CreateJoinTokenRequest
+	47, // 49: management.ManagementService.ResetNodeUniqueToken:input_type -> management.ResetNodeUniqueTokenRequest
+	49, // 50: management.ManagementService.CreateUser:input_type -> management.CreateUserRequest
+	69, // 51: management.ManagementService.ListUsers:input_type -> google.protobuf.Empty
+	51, // 52: management.ManagementService.UpdateUser:input_type -> management.UpdateUserRequest
+	52, // 53: management.ManagementService.DestroyUser:input_type -> management.DestroyUserRequest
+	53, // 54: management.ManagementService.MachinePowerOff:input_type -> management.MachinePowerOffRequest
+	55, // 55: management.ManagementService.MachinePowerOn:input_type -> management.MachinePowerOnRequest
+	9,  // 56: management.ManagementService.Kubeconfig:output_type -> management.KubeconfigResponse
+	10, // 57: management.ManagementService.Talosconfig:output_type -> management.TalosconfigResponse
+	11, // 58: management.ManagementService.Omniconfig:output_type -> management.OmniconfigResponse
+	70, // 59: management.ManagementService.MachineLogs:output_type -> common.Data
+	69, // 60: management.ManagementService.ValidateConfig:output_type -> google.protobuf.Empty
+	37, // 61: management.ManagementService.ValidateJSONSchema:output_type -> management.ValidateJsonSchemaResponse
+	16, // 62: management.ManagementService.CreateServiceAccount:output_type -> management.CreateServiceAccountResponse
+	18, // 63: management.ManagementService.RenewServiceAccount:output_type -> management.RenewServiceAccountResponse
+	20, // 64: management.ManagementService.ListServiceAccounts:output_type -> management.ListServiceAccountsResponse
+	69, // 65: management.ManagementService.DestroyServiceAccount:output_type -> google.protobuf.Empty
+	23, // 66: management.ManagementService.KubernetesUpgradePreChecks:output_type -> management.KubernetesUpgradePreChecksResponse
+	26, // 67: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
+	29, // 68: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
+	29, // 69: management.ManagementService.CreateSchematicFromRaw:output_type -> management.CreateSchematicResponse
+	31, // 70: management.ManagementService.GetBootAssetURL:output_type -> management.BootAssetURLResponse
+	33, // 71: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
+	35, // 72: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
+	39, // 73: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse
+	41, // 74: management.ManagementService.MaintenanceLifecycle:output_type -> management.MaintenanceLifecycleResponse
+	43, // 75: management.ManagementService.GetMachineJoinConfig:output_type -> management.GetMachineJoinConfigResponse
+	46, // 76: management.ManagementService.CreateJoinToken:output_type -> management.CreateJoinTokenResponse
+	48, // 77: management.ManagementService.ResetNodeUniqueToken:output_type -> management.ResetNodeUniqueTokenResponse
+	50, // 78: management.ManagementService.CreateUser:output_type -> management.CreateUserResponse
+	57, // 79: management.ManagementService.ListUsers:output_type -> management.ListUsersResponse
+	69, // 80: management.ManagementService.UpdateUser:output_type -> google.protobuf.Empty
+	69, // 81: management.ManagementService.DestroyUser:output_type -> google.protobuf.Empty
+	54, // 82: management.ManagementService.MachinePowerOff:output_type -> management.MachinePowerOffResponse
+	56, // 83: management.ManagementService.MachinePowerOn:output_type -> management.MachinePowerOnResponse
+	56, // [56:84] is the sub-list for method output_type
+	28, // [28:56] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_omni_management_management_proto_init() }

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -214,6 +214,9 @@ message BootAssetURLRequest {
   //
   // When this is set, Headers on the response will be empty. It is implied for PXE assets, which are
   // fetched by firmware that cannot send headers.
+  //
+  // Leaving it unset does not promise headers: a factory that authenticates downloads with a token puts it
+  // in the URL for every caller. Send Headers whenever it is not empty, instead of deciding from this field.
   bool standalone_url = 3;
   BootAssetKind boot_asset_kind = 4;
 
@@ -227,6 +230,14 @@ message BootAssetURLRequest {
   // other kind, whose format the kind itself implies.
   string format = 7;
   bool secure_boot = 8;
+
+  // DownloadTokenTtl is how long the caller needs the URL to keep working, for a factory that
+  // authenticates downloads with a token. Unset takes Omni's default, which suits a fetch performed right
+  // away. Ask for more when something else performs it later, such as a hypervisor import queue.
+  //
+  // The factory refuses a lifetime outside its configured bounds, which comes back as InvalidArgument.
+  // Ignored by a factory that authenticates downloads with credentials instead.
+  google.protobuf.Duration download_token_ttl = 9;
 }
 
 message BootAssetURLResponse {
@@ -244,6 +255,13 @@ message BootAssetURLResponse {
   // Treat it as opaque. Omni may change how it is derived, which costs a caller one re-download of the
   // assets it already holds.
   string storage_key = 4;
+
+  // ExpiresAt is when the URL stops working, for a caller that does not perform the fetch itself, such as
+  // one handing the URL to a hypervisor download API. Unset when the URL does not expire.
+  //
+  // It is Omni's estimate rather than a guarantee, so treat it as the earliest moment the URL may stop
+  // working.
+  google.protobuf.Timestamp expires_at = 5;
 }
 
 message GetSupportBundleRequest {

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -541,6 +541,7 @@ func (m *BootAssetURLRequest) CloneVT() *BootAssetURLRequest {
 	r.Architecture = m.Architecture
 	r.Format = m.Format
 	r.SecureBoot = m.SecureBoot
+	r.DownloadTokenTtl = (*durationpb.Duration)((*durationpb1.Duration)(m.DownloadTokenTtl).CloneVT())
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -560,6 +561,7 @@ func (m *BootAssetURLResponse) CloneVT() *BootAssetURLResponse {
 	r.Url = m.Url
 	r.ImageFactoryHost = m.ImageFactoryHost
 	r.StorageKey = m.StorageKey
+	r.ExpiresAt = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.ExpiresAt).CloneVT())
 	if rhs := m.Headers; rhs != nil {
 		tmpContainer := make(map[string]string, len(rhs))
 		for k, v := range rhs {
@@ -1829,6 +1831,9 @@ func (this *BootAssetURLRequest) EqualVT(that *BootAssetURLRequest) bool {
 	if this.SecureBoot != that.SecureBoot {
 		return false
 	}
+	if !(*durationpb1.Duration)(this.DownloadTokenTtl).EqualVT((*durationpb1.Duration)(that.DownloadTokenTtl)) {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -1864,6 +1869,9 @@ func (this *BootAssetURLResponse) EqualVT(that *BootAssetURLResponse) bool {
 		return false
 	}
 	if this.StorageKey != that.StorageKey {
+		return false
+	}
+	if !(*timestamppb1.Timestamp)(this.ExpiresAt).EqualVT((*timestamppb1.Timestamp)(that.ExpiresAt)) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -3989,6 +3997,16 @@ func (m *BootAssetURLRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.DownloadTokenTtl != nil {
+		size, err := (*durationpb1.Duration)(m.DownloadTokenTtl).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x4a
+	}
 	if m.SecureBoot {
 		i--
 		if m.SecureBoot {
@@ -4081,6 +4099,16 @@ func (m *BootAssetURLResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.ExpiresAt != nil {
+		size, err := (*timestamppb1.Timestamp)(m.ExpiresAt).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
 	}
 	if len(m.StorageKey) > 0 {
 		i -= len(m.StorageKey)
@@ -6114,6 +6142,10 @@ func (m *BootAssetURLRequest) SizeVT() (n int) {
 	if m.SecureBoot {
 		n += 2
 	}
+	if m.DownloadTokenTtl != nil {
+		l = (*durationpb1.Duration)(m.DownloadTokenTtl).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -6142,6 +6174,10 @@ func (m *BootAssetURLResponse) SizeVT() (n int) {
 	}
 	l = len(m.StorageKey)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.ExpiresAt != nil {
+		l = (*timestamppb1.Timestamp)(m.ExpiresAt).SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -10311,6 +10347,42 @@ func (m *BootAssetURLRequest) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.SecureBoot = bool(v != 0)
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DownloadTokenTtl", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DownloadTokenTtl == nil {
+				m.DownloadTokenTtl = &durationpb.Duration{}
+			}
+			if err := (*durationpb1.Duration)(m.DownloadTokenTtl).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10584,6 +10656,42 @@ func (m *BootAssetURLResponse) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.StorageKey = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpiresAt", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ExpiresAt == nil {
+				m.ExpiresAt = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.ExpiresAt).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/client/pkg/clusterimport/clusterimport_test.go
+++ b/client/pkg/clusterimport/clusterimport_test.go
@@ -212,6 +212,10 @@ func (m *mockImageFactoryClient) ExtensionsVersions(_ context.Context, _ string)
 	return nil, nil
 }
 
+func (m *mockImageFactoryClient) DownloadToken(_ context.Context, _ time.Duration) (string, error) {
+	return "", &client.HTTPError{Code: http.StatusNotFound, Message: "not found"}
+}
+
 func (m *mockImageFactoryClient) CachedIsEnterprise() bool {
 	return false
 }

--- a/client/pkg/imagefactory/bootasset.go
+++ b/client/pkg/imagefactory/bootasset.go
@@ -14,11 +14,14 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/image-factory/pkg/client"
 	"github.com/siderolabs/talos/pkg/machinery/platforms"
+	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -140,6 +143,15 @@ type BootAsset struct {
 	// authentication, or when it travels inside the URL instead.
 	Headers http.Header
 
+	// ExpiresAt is when URL stops working, for a caller that does not perform the fetch itself and has
+	// to know how long the URL it passed on stays good. Zero when the URL does not expire: an anonymous
+	// factory, or one authenticated with credentials rather than a token.
+	//
+	// It is an estimate. The factory confirms only that it granted the lifetime Omni asked for, never the
+	// instant it started counting, and it allows another 30s of clock leeway when verifying. Treat it as
+	// the earliest moment the URL may stop working.
+	ExpiresAt time.Time
+
 	// URL of the boot asset.
 	URL string
 
@@ -166,7 +178,13 @@ type BootAsset struct {
 // logged BootAsset would leak them. What remains identifies the asset just as well. This covers %v and
 // zap.Any, which prefer a Stringer, but not reflection or json.Marshal.
 func (a BootAsset) String() string {
-	return fmt.Sprintf("BootAsset{host: %q, schematic: %q, key: %q}", a.ImageFactoryHost, a.SchematicID, a.StorageKey)
+	var expires string
+
+	if !a.ExpiresAt.IsZero() {
+		expires = ", expires: " + a.ExpiresAt.Format(time.RFC3339)
+	}
+
+	return fmt.Sprintf("BootAsset{host: %q, schematic: %q, key: %q%s}", a.ImageFactoryHost, a.SchematicID, a.StorageKey, expires)
 }
 
 // storageKey derives the identity of an asset from everything that decides its content: the factory
@@ -185,15 +203,136 @@ func storageKey(factoryBaseURL, pathPrefix, schematicID, version, filename strin
 	return hex.EncodeToString(digest[:])
 }
 
+// ResolveOption configures how an asset is resolved. With no options, the download is authenticated with
+// the basic auth credentials Omni holds.
+type ResolveOption func(*resolveOptions)
+
+type resolveOptions struct {
+	downloadTokens *DownloadTokenOptions
+}
+
+// DownloadTokenOptions is what Omni needs to authenticate a download with a token issued by the factory
+// rather than with the basic auth credentials it holds.
+type DownloadTokenOptions struct {
+	Factories *Clients
+	Logger    *zap.Logger
+	TTL       time.Duration
+}
+
+// logger returns the logger the caller supplied, or a no-op one.
+func (o *DownloadTokenOptions) logger() *zap.Logger {
+	if o == nil || o.Logger == nil {
+		return zap.NewNop()
+	}
+
+	return o.Logger
+}
+
+// defaultDownloadTokenTTL is what Omni asks for when the caller asks for nothing.
+const defaultDownloadTokenTTL = 5 * time.Minute
+
+// downloadTokenRequestTimeout bounds the token request on its own, since the factory client's timeout is
+// sized for the slowest thing it does.
+const downloadTokenRequestTimeout = 30 * time.Second
+
+// WithDownloadTokens authenticates an image download with a short-lived token issued by the factory
+// instead of the basic auth credentials Omni holds.
+func WithDownloadTokens(opts DownloadTokenOptions) ResolveOption {
+	return func(o *resolveOptions) {
+		o.downloadTokens = &opts
+	}
+}
+
+// requestDownloadToken returns a token authenticating a download from the factory at baseURL and the
+// moment it stops working.
+func requestDownloadToken(ctx context.Context, baseURL string, opts *DownloadTokenOptions) (string, time.Time, bool, error) {
+	// A caller that cannot ask for a token, such as the provider-side fallback against an older Omni,
+	// passes nothing.
+	if opts == nil || opts.Factories == nil {
+		return "", time.Time{}, false, nil
+	}
+
+	logger := opts.logger()
+
+	factory := opts.Factories.ForURL(baseURL)
+	if factory == nil {
+		logger.Warn("no image factory client is configured for the factory serving this asset, so no download token was requested",
+			zap.String("factory_url", baseURL))
+
+		return "", time.Time{}, false, nil
+	}
+
+	ttl := opts.TTL
+	if ttl == 0 {
+		ttl = defaultDownloadTokenTTL
+	}
+
+	tokenCtx, cancel := context.WithTimeout(ctx, downloadTokenRequestTimeout)
+	defer cancel()
+
+	requestedAt := time.Now()
+	token, err := factory.DownloadToken(tokenCtx, ttl)
+
+	switch {
+	case err == nil && token == "":
+		logger.Warn("the image factory returned an empty download token",
+			zap.String("factory_url", baseURL))
+
+		return "", time.Time{}, false, nil
+	case err == nil:
+		return token, requestedAt.Add(ttl), true, nil
+	case client.IsHTTPErrorCode(err, http.StatusNotFound), client.IsHTTPErrorCode(err, http.StatusMethodNotAllowed):
+		logger.Debug("the image factory does not issue download tokens",
+			zap.String("factory_url", baseURL), zap.Error(err))
+
+		return "", time.Time{}, false, nil
+	case client.IsInvalidSchematicError(err):
+		if opts.TTL != 0 {
+			logger.Warn("the image factory refused the requested download token lifetime",
+				zap.String("factory_url", baseURL), zap.Duration("ttl", ttl), zap.Error(err))
+
+			return "", time.Time{}, false, fmt.Errorf("%w: the image factory refused a download token lifetime of %s: %w", ErrInvalidInput, ttl, err)
+		}
+
+		logger.Warn("the image factory refused the default download token lifetime",
+			zap.String("factory_url", baseURL), zap.Duration("ttl", ttl), zap.Error(err))
+
+		return "", time.Time{}, false, nil
+	case ctx.Err() != nil:
+		return "", time.Time{}, false, fmt.Errorf("failed to request an image factory download token: %w: %w", ctx.Err(), err)
+	default:
+		logger.Warn("failed to obtain an image factory download token",
+			zap.String("factory_url", baseURL), zap.Error(err))
+
+		return "", time.Time{}, false, nil
+	}
+}
+
 // ResolveBootAsset returns the boot asset the given schematic produces, served by whichever image
 // factory Omni uses for the given Talos version. An empty version means the default Talos version.
 //
 // Set standalone when the fetch cannot carry headers, such as a hypervisor download API handed a bare
 // URL: any authentication then travels inside the URL and Headers comes back empty. The PXE kind is
 // always resolved that way, since the firmware fetching the script cannot send headers either.
-func ResolveBootAsset(ctx context.Context, st state.State, talosVersion string, spec AssetSpec, schematicID string, standalone bool) (BootAsset, error) {
+//
+// Headers can come back empty without standalone too, since a factory issuing download tokens
+// authenticates the download inside the URL for every caller. Send Headers whenever it is not empty,
+// instead of deciding from what was asked for.
+func ResolveBootAsset(
+	ctx context.Context, st state.State, talosVersion string, spec AssetSpec, schematicID string, standalone bool, opts ...ResolveOption,
+) (BootAsset, error) {
+	var options resolveOptions
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	if err := spec.Validate(); err != nil {
 		return BootAsset{}, err
+	}
+
+	if options.downloadTokens != nil && options.downloadTokens.TTL < 0 {
+		return BootAsset{}, fmt.Errorf("%w: download token lifetime %s is negative", ErrInvalidInput, options.downloadTokens.TTL)
 	}
 
 	if talosVersion == "" {
@@ -237,11 +376,32 @@ func ResolveBootAsset(ctx context.Context, st state.State, talosVersion string, 
 	switch {
 	case resolved.username == "" || resolved.password == "":
 		// The factory serves this anonymously, so there is nothing to place.
-	case standalone || spec.Kind == BootAssetKindPXE:
+	case spec.Kind == BootAssetKindPXE:
 		assetURL.User = url.UserPassword(resolved.username, resolved.password)
 	default:
-		asset.Headers = http.Header{
-			"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte(resolved.username+":"+resolved.password))},
+		token, expiresAt, ok, err := requestDownloadToken(ctx, resolved.baseURL, options.downloadTokens)
+
+		switch {
+		case err != nil:
+			return BootAsset{}, err
+		case ok:
+			query := assetURL.Query()
+			query.Set("token", token)
+			assetURL.RawQuery = query.Encode()
+
+			asset.ExpiresAt = expiresAt
+		case standalone:
+			assetURL.User = url.UserPassword(resolved.username, resolved.password)
+
+			options.downloadTokens.logger().Debug("authenticating the boot asset download with credentials in the URL",
+				zap.String("factory_url", resolved.baseURL))
+		default:
+			asset.Headers = http.Header{
+				"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte(resolved.username+":"+resolved.password))},
+			}
+
+			options.downloadTokens.logger().Debug("authenticating the boot asset download with a credentials header",
+				zap.String("factory_url", resolved.baseURL))
 		}
 	}
 

--- a/client/pkg/imagefactory/bootasset_test.go
+++ b/client/pkg/imagefactory/bootasset_test.go
@@ -7,15 +7,21 @@ package imagefactory_test
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/image-factory/pkg/client"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -804,4 +810,409 @@ func TestResolveBootAssetRejectsInvalidPathSegments(t *testing.T) {
 	asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.14.0-alpha.0", diskSpec(), schematicID, false)
 	require.NoError(t, err)
 	require.Contains(t, asset.URL, "/v1.14.0-alpha.0/")
+}
+
+// fakeFactoryClient is an imagefactory.FactoryClient that does only the two things resolving a boot asset
+// asks of one: report the URL it serves, so ForURL can find it, and issue a download token.
+type fakeFactoryClient struct {
+	imagefactory.FactoryClient
+
+	err   error
+	token string
+	url   string
+
+	// onRequest runs while the token request is in flight, for a test that has to change something under it,
+	// such as canceling the caller.
+	onRequest func()
+
+	deadline time.Time
+
+	requests []time.Duration
+
+	hasDeadline bool
+
+	mu sync.Mutex
+}
+
+func (f *fakeFactoryClient) URL() string { return f.url }
+
+func (f *fakeFactoryClient) DownloadToken(ctx context.Context, ttl time.Duration) (string, error) {
+	f.mu.Lock()
+	f.requests = append(f.requests, ttl)
+	f.deadline, f.hasDeadline = ctx.Deadline()
+	f.mu.Unlock()
+
+	if f.onRequest != nil {
+		f.onRequest()
+	}
+
+	return f.token, f.err
+}
+
+// calls returns the lifetimes DownloadToken was asked for, in order.
+func (f *fakeFactoryClient) calls() []time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return slices.Clone(f.requests)
+}
+
+// tokenDeadline returns the deadline the last token request ran under.
+func (f *fakeFactoryClient) tokenDeadline() (time.Time, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.deadline, f.hasDeadline
+}
+
+// newIssuer is a fake configured for the primary factory, which is the one every case here resolves
+// against unless it is testing what happens when none is.
+func newIssuer(token string, err error) *fakeFactoryClient {
+	return &fakeFactoryClient{url: primaryURL, token: token, err: err}
+}
+
+func withIssuer(t *testing.T, st state.State, issuer imagefactory.FactoryClient, ttl time.Duration) imagefactory.ResolveOption {
+	t.Helper()
+
+	return imagefactory.WithDownloadTokens(imagefactory.DownloadTokenOptions{
+		Factories: imagefactory.NewClients(st, issuer),
+		Logger:    zaptest.NewLogger(t),
+		TTL:       ttl,
+	})
+}
+
+// authenticatedState is the common setup: a primary factory Omni holds credentials for.
+func authenticatedState(ctx context.Context, t *testing.T) state.State {
+	t.Helper()
+
+	st := newTestState(t)
+
+	createFeaturesConfig(ctx, t, st, nil)
+	createFactoryAuth(ctx, t, st, primaryURL, "user", "hunter2")
+
+	return st
+}
+
+// TestResolveBootAssetDownloadTokenRequest covers the deadline the token request runs under, and what a
+// caller gets when its own context ends first.
+func TestResolveBootAssetDownloadTokenRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	const (
+		token = "eyJhbGciOiJFUzI1NiJ9.fake.token"
+
+		// requestTimeout pins imagefactory's unexported deadline for the token request.
+		requestTimeout = 30 * time.Second
+	)
+
+	t.Run("the request runs under a deadline of its own", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+		issuer := newIssuer(token, nil)
+
+		before := time.Now()
+
+		_, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		require.NoError(t, err)
+
+		// Without one, a factory that accepts the connection and never answers holds the resolve for the factory
+		// client's own timeout, which is half an hour.
+		deadline, ok := issuer.tokenDeadline()
+		require.True(t, ok)
+		require.WithinRange(t, deadline, before.Add(requestTimeout), time.Now().Add(requestTimeout))
+	})
+
+	t.Run("a caller that goes away is not answered with credentials", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+
+		callerCtx, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+
+		// Canceled while the request is in flight, which is what a caller hanging up looks like.
+		issuer := newIssuer("", errors.New("connection reset"))
+		issuer.onRequest = cancel
+
+		_, err := imagefactory.ResolveBootAsset(callerCtx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, issuer, 0))
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// TestResolveBootAssetDownloadToken covers the authentication a caller gets for an asset under /image/
+// when the factory issues download tokens, and the credential fallback for every factory that does not.
+func TestResolveBootAssetDownloadToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	const (
+		token         = "eyJhbGciOiJFUzI1NiJ9.fake.token"
+		authorization = "Basic dXNlcjpodW50ZXIy" // user:hunter2
+
+		// defaultTTL pins imagefactory's unexported default, which matches the factory's own documented
+		// default. Omni sends it explicitly so that the expiry it reports back is knowable.
+		defaultTTL = 5 * time.Minute
+	)
+
+	assetPath := "/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz"
+
+	t.Run("a token replaces the userinfo on a standalone image", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+		issuer := newIssuer(token, nil)
+
+		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, issuer, 0))
+		require.NoError(t, err)
+
+		require.Equal(t, primaryURL+assetPath+"?token="+url.QueryEscape(token), asset.URL)
+		require.Empty(t, asset.Headers)
+		require.NotContains(t, asset.URL, "hunter2", "the credential must not travel alongside the token")
+	})
+
+	t.Run("a token replaces the header on a non-standalone image", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+		issuer := newIssuer(token, nil)
+
+		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		require.NoError(t, err)
+
+		require.Equal(t, primaryURL+assetPath+"?token="+url.QueryEscape(token), asset.URL)
+		require.Empty(t, asset.Headers, "a token in the URL leaves nothing for the headers to carry")
+	})
+
+	t.Run("PXE keeps its credentials and never asks for a token", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+		issuer := newIssuer(token, nil)
+
+		// The factory reads ?token= only under /image/, and its iPXE script propagates basic auth alone, so
+		// a token would authenticate neither the script nor what it boots.
+		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", pxeSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		require.NoError(t, err)
+
+		require.Equal(t, "https://user:hunter2@pxe.factory.example.org/pxe/"+schematicID+"/v1.13.0/metal-amd64", asset.URL)
+		require.Empty(t, issuer.calls(), "a token that cannot be used must not be requested")
+		require.Zero(t, asset.ExpiresAt)
+	})
+
+	t.Run("an anonymous factory never asks for a token", func(t *testing.T) {
+		t.Parallel()
+
+		st := newTestState(t)
+		createFeaturesConfig(ctx, t, st, nil)
+
+		issuer := newIssuer(token, nil)
+
+		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		require.NoError(t, err)
+
+		require.Equal(t, primaryURL+assetPath, asset.URL)
+		require.Empty(t, asset.Headers)
+		require.Empty(t, issuer.calls(), "there is nothing to authenticate")
+		require.Zero(t, asset.ExpiresAt)
+	})
+
+	t.Run("the lifetime asked for reaches the factory and comes back as the expiry", func(t *testing.T) {
+		t.Parallel()
+
+		for name, tt := range map[string]struct {
+			requested time.Duration
+			expected  time.Duration
+		}{
+			// Never zero: a lifetime Omni did not send is a lifetime Omni cannot report back as an expiry.
+			"nothing requested takes Omni's default": {requested: 0, expected: defaultTTL},
+			"a requested lifetime is sent unchanged": {requested: 90 * time.Minute, expected: 90 * time.Minute},
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				st := authenticatedState(ctx, t)
+				issuer := newIssuer(token, nil)
+
+				before := time.Now()
+
+				asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, tt.requested))
+				require.NoError(t, err)
+
+				require.Equal(t, []time.Duration{tt.expected}, issuer.calls())
+				require.WithinRange(t, asset.ExpiresAt, before.Add(tt.expected), time.Now().Add(tt.expected))
+			})
+		}
+	})
+
+	t.Run("a factory that does not issue tokens falls back to credentials", func(t *testing.T) {
+		t.Parallel()
+
+		// 404 is a factory below 1.5.0, 405 a route that exists for other methods.
+		// Neither is a failure: it is what most deployments look like.
+		for name, err := range map[string]error{
+			"404": &client.HTTPError{Code: http.StatusNotFound, Message: "not found"},
+			"405": &client.HTTPError{Code: http.StatusMethodNotAllowed, Message: "method not allowed"},
+			// A transient problem must not fail the resolve, since falling back is never worse than what a
+			// factory without token support gets.
+			"a transient failure": errors.New("connection reset"),
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				st := authenticatedState(ctx, t)
+
+				standalone, resolveErr := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, newIssuer("", err), 0))
+				require.NoError(t, resolveErr)
+				require.Equal(t, "https://user:hunter2@factory.example.org"+assetPath, standalone.URL)
+				require.Zero(t, standalone.ExpiresAt)
+
+				withHeaders, resolveErr := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, newIssuer("", err), 0))
+				require.NoError(t, resolveErr)
+				require.Equal(t, primaryURL+assetPath, withHeaders.URL)
+				require.Equal(t, authorization, withHeaders.Headers.Get("Authorization"))
+				require.Zero(t, withHeaders.ExpiresAt)
+			})
+		}
+	})
+
+	t.Run("a refused lifetime the caller asked for is the caller's error", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+
+		// The factory refuses anything outside its configured bounds with a 400. Silently handing back a
+		// long-lived credential instead would answer a request the caller did not make.
+		_, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false,
+			withIssuer(t, st, newIssuer("", &client.InvalidSchematicError{}), 100*time.Hour))
+
+		require.ErrorIs(t, err, imagefactory.ErrInvalidInput)
+		require.Contains(t, err.Error(), "100h0m0s")
+	})
+
+	t.Run("a refused default lifetime is not the caller's error", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+
+		// Omni's own guess is not the caller's request, so a factory whose bounds exclude it falls back
+		// rather than failing a provision over a value the caller never chose.
+		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false,
+			withIssuer(t, st, newIssuer("", &client.InvalidSchematicError{}), 0))
+
+		require.NoError(t, err)
+		require.Equal(t, authorization, asset.Headers.Get("Authorization"))
+		require.Zero(t, asset.ExpiresAt)
+	})
+
+	t.Run("a 200 carrying no token falls back", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+
+		// Placing an empty token would build a URL with no credentials anywhere, which only fails at the
+		// download, with nothing in Omni's logs pointing at the token.
+		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, newIssuer("", nil), 0))
+		require.NoError(t, err)
+
+		require.Equal(t, "https://user:hunter2@factory.example.org"+assetPath, asset.URL)
+		require.NotContains(t, asset.URL, "token=")
+		require.Zero(t, asset.ExpiresAt)
+	})
+
+	t.Run("an unroutable factory falls back", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+
+		// A token must come from the factory serving the asset and no other, so a client set with nothing
+		// configured for it issues nothing at all.
+		issuer := &fakeFactoryClient{url: "https://other.example.org", token: token}
+
+		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		require.NoError(t, err)
+
+		require.Equal(t, authorization, asset.Headers.Get("Authorization"))
+		require.Empty(t, issuer.calls())
+	})
+
+	t.Run("a resolve with no token issuer behaves as it did before tokens", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+
+		// This is the provider-side fallback against an Omni that predates the boot asset API.
+		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		require.NoError(t, err)
+
+		require.Equal(t, authorization, asset.Headers.Get("Authorization"))
+		require.Zero(t, asset.ExpiresAt)
+	})
+
+	t.Run("the storage key and the log line are unaffected", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+
+		// The key must not move when a token appears, or every provider re-downloads everything it stores.
+		withToken, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, newIssuer(token, nil), 0))
+		require.NoError(t, err)
+
+		withCredentials, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		require.NoError(t, err)
+
+		require.Equal(t, withCredentials.StorageKey, withToken.StorageKey)
+
+		for _, rendered := range []string{withToken.String(), fmt.Sprintf("%v", withToken)} {
+			require.NotContains(t, rendered, token, "a logged asset must not leak the token")
+			require.NotContains(t, rendered, withToken.URL)
+			require.Contains(t, rendered, withToken.StorageKey)
+			require.Contains(t, rendered, "expires", "the expiry explains a download failing later, and is not a secret")
+		}
+	})
+}
+
+// TestResolveBootAssetNegativeTokenLifetime covers a lifetime the caller got wrong. It is refused the same
+// way for every asset kind, not only for the ones that would have requested a token, so that a bad value
+// cannot pass unnoticed against the public factory and fail only against an authenticated one.
+func TestResolveBootAssetNegativeTokenLifetime(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	const token = "eyJhbGciOiJFUzI1NiJ9.fake.token"
+
+	// The client sends the ttl parameter only when it is positive, so a negative one would reach the
+	// factory as no lifetime at all and come back as an expiry in the past. It is refused the same way
+	// for every kind, including the two that never request a token: accepting it there would let a bad
+	// value through against the public factory and fail only against an authenticated one.
+	for name, tt := range map[string]struct {
+		spec      imagefactory.AssetSpec
+		anonymous bool
+	}{
+		"disk, which would have requested one": {spec: diskSpec()},
+		"PXE, which never requests one":        {spec: pxeSpec()},
+		"an anonymous factory":                 {spec: diskSpec(), anonymous: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			st := newTestState(t)
+			createFeaturesConfig(ctx, t, st, nil)
+
+			if !tt.anonymous {
+				createFactoryAuth(ctx, t, st, primaryURL, "user", "hunter2")
+			}
+
+			issuer := newIssuer(token, nil)
+
+			_, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", tt.spec, schematicID, false, withIssuer(t, st, issuer, -time.Hour))
+
+			require.ErrorIs(t, err, imagefactory.ErrInvalidInput)
+			require.Empty(t, issuer.calls(), "a lifetime that cannot be honored must not reach the factory")
+		})
+	}
 }

--- a/client/pkg/imagefactory/clients.go
+++ b/client/pkg/imagefactory/clients.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
@@ -21,7 +22,7 @@ import (
 )
 
 // FactoryClient is the contract Omni controllers rely on for interacting with a single image factory.
-type FactoryClient interface {
+type FactoryClient interface { //nolint:interfacebloat
 	EnsureSchematic(ctx context.Context, inputSchematic schematic.Schematic) (string, *schematic.Schematic, error)
 	SchematicGet(ctx context.Context, id string) (*schematic.Schematic, error)
 	Host() string
@@ -31,6 +32,7 @@ type FactoryClient interface {
 	ExtensionsVersions(context.Context, string) ([]client.ExtensionInfo, error)
 	CachedIsEnterprise() bool
 	TalosctlList(ctx context.Context, talosVersion string) ([]string, error)
+	DownloadToken(ctx context.Context, ttl time.Duration) (string, error)
 	ReportsClient
 }
 

--- a/client/pkg/infra/export_test.go
+++ b/client/pkg/infra/export_test.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package infra
+
+// Exported for testing: the two conversions between a provision step's spec and the management API, so
+// they can be checked without standing up a management service to answer the RPC.
+var (
+	BootAssetRequest      = bootAssetRequest
+	BootAssetFromResponse = bootAssetFromResponse
+)

--- a/client/pkg/infra/infra.go
+++ b/client/pkg/infra/infra.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller/generic"
 	"github.com/cosi-project/runtime/pkg/controller/runtime"
@@ -23,6 +24,7 @@ import (
 	"go.yaml.in/yaml/v4"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/pkg/client"
@@ -277,21 +279,12 @@ func resolveBootAsset(
 	spec provision.BootAssetSpec,
 	schematicID string,
 ) (imagefactory.BootAsset, error) {
-	kind, ok := bootAssetKinds[spec.Kind]
-	if !ok {
-		return imagefactory.BootAsset{}, fmt.Errorf("unknown boot asset kind %q", spec.Kind)
+	request, err := bootAssetRequest(talosVersion, schematicID, spec)
+	if err != nil {
+		return imagefactory.BootAsset{}, err
 	}
 
-	resp, err := c.Management().GetBootAssetURL(ctx, &management.BootAssetURLRequest{
-		TalosVersion:  talosVersion,
-		SchematicId:   schematicID,
-		StandaloneUrl: spec.StandaloneURL,
-		BootAssetKind: kind,
-		Platform:      spec.Platform,
-		Architecture:  spec.Architecture,
-		Format:        spec.Format,
-		SecureBoot:    spec.SecureBoot,
-	})
+	resp, err := c.Management().GetBootAssetURL(ctx, request)
 	if err != nil {
 		if status.Code(err) != codes.Unimplemented {
 			return imagefactory.BootAsset{}, fmt.Errorf("failed to get the boot asset URL from Omni: %w", err)
@@ -306,6 +299,33 @@ func resolveBootAsset(
 	return asset, nil
 }
 
+// bootAssetRequest converts a provision step's spec into the management API request.
+func bootAssetRequest(talosVersion, schematicID string, spec provision.BootAssetSpec) (*management.BootAssetURLRequest, error) {
+	kind, ok := bootAssetKinds[spec.Kind]
+	if !ok {
+		return nil, fmt.Errorf("unknown boot asset kind %q", spec.Kind)
+	}
+
+	request := &management.BootAssetURLRequest{
+		TalosVersion:  talosVersion,
+		SchematicId:   schematicID,
+		StandaloneUrl: spec.StandaloneURL,
+		BootAssetKind: kind,
+		Platform:      spec.Platform,
+		Architecture:  spec.Architecture,
+		Format:        spec.Format,
+		SecureBoot:    spec.SecureBoot,
+	}
+
+	// A zero duration on the wire would look like a request for no lifetime at all, so it stays unset and
+	// Omni applies its own default.
+	if spec.DownloadTokenTTL != 0 {
+		request.DownloadTokenTtl = durationpb.New(spec.DownloadTokenTTL)
+	}
+
+	return request, nil
+}
+
 // bootAssetFromResponse converts the management API response into the client-side type.
 func bootAssetFromResponse(resp *management.BootAssetURLResponse) imagefactory.BootAsset {
 	var headers http.Header
@@ -318,11 +338,20 @@ func bootAssetFromResponse(resp *management.BootAssetURLResponse) imagefactory.B
 		}
 	}
 
+	var expiresAt time.Time
+
+	// An Omni that predates the field, or a factory whose downloads do not expire, sends nothing, and
+	// AsTime would turn that into the Unix epoch rather than the zero time the field documents.
+	if resp.ExpiresAt != nil {
+		expiresAt = resp.ExpiresAt.AsTime()
+	}
+
 	return imagefactory.BootAsset{
 		URL:              resp.Url,
 		Headers:          headers,
 		StorageKey:       resp.StorageKey,
 		ImageFactoryHost: resp.ImageFactoryHost,
+		ExpiresAt:        expiresAt,
 	}
 }
 

--- a/client/pkg/infra/infra_test.go
+++ b/client/pkg/infra/infra_test.go
@@ -33,7 +33,9 @@ import (
 	"go.uber.org/zap/zaptest"
 	"go.yaml.in/yaml/v4"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/imagefactory"
 	"github.com/siderolabs/omni/client/pkg/infra"
@@ -736,5 +738,85 @@ func TestProvisionStepMutationsRestricted(t *testing.T) {
 
 		_, hasForbidden := mrs.Metadata().Labels().Get(forbiddenLabel)
 		assert.False(hasForbidden)
+	})
+}
+
+// TestBootAssetWireConversion covers the two conversions between a provision step's spec and the
+// management API, since a provider only ever gets what these two carry across.
+func TestBootAssetWireConversion(t *testing.T) {
+	t.Parallel()
+
+	const schematicID = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+
+	diskSpec := func() provision.BootAssetSpec {
+		return provision.BootAssetSpec{
+			AssetSpec: imagefactory.AssetSpec{
+				Kind:         imagefactory.BootAssetKindDisk,
+				Platform:     "nocloud",
+				Architecture: "amd64",
+				Format:       "raw.xz",
+			},
+		}
+	}
+
+	t.Run("the request carries the lifetime the step asked for", func(t *testing.T) {
+		t.Parallel()
+
+		spec := diskSpec()
+		spec.DownloadTokenTTL = 90 * time.Minute
+
+		request, err := infra.BootAssetRequest("v1.13.0", schematicID, spec)
+		require.NoError(t, err)
+
+		require.Equal(t, 90*time.Minute, request.DownloadTokenTtl.AsDuration())
+		require.Equal(t, management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK, request.BootAssetKind)
+		require.Equal(t, schematicID, request.SchematicId)
+	})
+
+	t.Run("a step that asks for no lifetime sends none", func(t *testing.T) {
+		t.Parallel()
+
+		request, err := infra.BootAssetRequest("v1.13.0", schematicID, diskSpec())
+		require.NoError(t, err)
+
+		// Unset rather than zero, so Omni can tell "no preference" from a lifetime and apply its default.
+		require.Nil(t, request.DownloadTokenTtl)
+	})
+
+	t.Run("an unknown kind is refused", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := infra.BootAssetRequest("v1.13.0", schematicID, provision.BootAssetSpec{})
+		require.Error(t, err)
+	})
+
+	t.Run("the response carries the expiry back", func(t *testing.T) {
+		t.Parallel()
+
+		expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+
+		asset := infra.BootAssetFromResponse(&management.BootAssetURLResponse{
+			Url:              "https://factory.example.org/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz?token=abcd",
+			ImageFactoryHost: "factory.example.org",
+			StorageKey:       "key",
+			ExpiresAt:        timestamppb.New(expiresAt),
+		})
+
+		require.Equal(t, expiresAt, asset.ExpiresAt)
+		require.Empty(t, asset.Headers)
+	})
+
+	t.Run("a response without an expiry leaves it zero", func(t *testing.T) {
+		t.Parallel()
+
+		// An Omni that predates the field, or a factory authenticating with credentials, sends nothing.
+		// Reading that as the Unix epoch would look like a URL that expired in 1970.
+		asset := infra.BootAssetFromResponse(&management.BootAssetURLResponse{
+			Url:     "https://factory.example.org/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz",
+			Headers: map[string]string{"Authorization": "Basic dXNlcjpwYXNz"},
+		})
+
+		require.Zero(t, asset.ExpiresAt)
+		require.Equal(t, "Basic dXNlcjpwYXNz", asset.Headers.Get("Authorization"))
 	})
 }

--- a/client/pkg/infra/provision/context.go
+++ b/client/pkg/infra/provision/context.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -98,9 +99,17 @@ type BootAssetSpec struct {
 	// every caller, instead of being dropped by one of the conversions along the way.
 	imagefactory.AssetSpec
 
+	// DownloadTokenTTL is how long this provider needs the URL to keep working for a factory that
+	// authenticates downloads with a token. Zero takes Omni's default, which assumes the fetch happens
+	// right away.
+	DownloadTokenTTL time.Duration
+
 	// StandaloneURL asks for a URL that needs no headers, for a fetch this provider does not perform
 	// itself: a hypervisor download API handed a bare URL, for instance. Any authentication then
 	// travels inside the URL and Headers comes back empty.
+	//
+	// Leaving it unset does not promise headers: a factory that authenticates downloads with a token puts
+	// it in the URL either way. Send Headers whenever it is not empty, instead of deciding from this field.
 	StandaloneURL bool
 }
 
@@ -148,7 +157,8 @@ type Context[T resource.Resource] struct {
 // Fetch BootAsset.URL, sending BootAsset.Headers when they are not empty. See imagefactory.BootAsset
 // for the full contract: the URL is opaque and can carry secrets, so it does not belong in a log line
 // verbatim, it is not a stable input for a persisted name, and it can be short-lived, so use it
-// promptly rather than storing it.
+// promptly rather than storing it. BootAsset.ExpiresAt says when it stops working, for a provider that
+// hands it on rather than fetching it, and BootAssetSpec.DownloadTokenTTL asks for a longer one.
 func (context *Context[T]) EnsureBootAsset(ctx context.Context, logger *zap.Logger, spec BootAssetSpec, opts ...SchematicOption) (imagefactory.BootAsset, error) {
 	// Built before the resolver is checked, so that a schematic the options cannot produce is reported as
 	// such rather than as a missing resolver.

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -227,6 +227,7 @@ export type BootAssetURLRequest = {
   architecture?: string
   format?: string
   secure_boot?: boolean
+  download_token_ttl?: GoogleProtobufDuration.Duration
 }
 
 export type BootAssetURLResponse = {
@@ -234,6 +235,7 @@ export type BootAssetURLResponse = {
   headers?: {[key: string]: string}
   image_factory_host?: string
   storage_key?: string
+  expires_at?: GoogleProtobufTimestamp.Timestamp
 }
 
 export type GetSupportBundleRequest = {

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -17,4 +17,12 @@ platform, architecture and format. Omni creates the schematic, picks the factory
 including the secure boot variant, and answers with a URL and whatever headers the fetch has to carry. A provider that cannot attach a header, because \
 PXE firmware or a hypervisor download API performs the fetch, asks for a self-contained URL instead. Carrying this through the Omni client library for \
 infrastructure providers meant breaking changes, so a provider has to be updated to the new API, and once it is, it needs Omni 1.8 or newer.
+
+Image downloads are now authenticated with a short-lived download token issued by the factory rather than with the factory credentials, so a provider \
+receives something that expires and that only downloads, instead of a credential valid on every factory route until someone rotates it. A provision \
+step that hands the URL to something else, such as a hypervisor import queue that starts later, asks for the lifetime it needs and is told when the \
+URL stops working. A factory that does not issue tokens keeps working unchanged, and so does PXE: the factory accepts a token only on image downloads, \
+and the iPXE script it serves passes on the credentials it was fetched with, so a PXE asset still carries them. Two things change for provider authors. \
+A URL is no longer stable for a given asset, since each one carries a fresh token, so compare the storage key rather than the URL when deciding whether \
+something has already been fetched. And a URL now expires, so fetch it promptly or ask for a lifetime that covers the delay.
 """

--- a/internal/backend/grpc/grpc_test.go
+++ b/internal/backend/grpc/grpc_test.go
@@ -93,7 +93,7 @@ func (suite *GrpcSuite) SetupTest() {
 		suite.Require().NoError(suite.imageFactory.eg.Wait())
 	})
 
-	imageFactoryClient, err := imagefactory.NewClient(suite.imageFactory.address, "", "")
+	imageFactoryClient, err := imagefactory.NewClient(suite.imageFactory.address, testFactoryUsername, testFactoryPassword)
 	suite.Require().NoError(err)
 
 	workloadProxyReconciler := workloadproxy.NewReconciler(logger, zap.InfoLevel, 30*time.Second)

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -22,6 +22,7 @@ import (
 	"go.yaml.in/yaml/v4"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/pkg/access/role"
@@ -206,7 +207,13 @@ func (s *managementServer) GetBootAssetURL(ctx context.Context, request *managem
 		SecureBoot:   request.SecureBoot,
 	}
 
-	asset, err := imagefactory.ResolveBootAsset(ctx, s.omniState, request.TalosVersion, spec, request.SchematicId, request.StandaloneUrl)
+	downloadTokens := imagefactory.WithDownloadTokens(imagefactory.DownloadTokenOptions{
+		Factories: s.imageFactoryClients,
+		Logger:    s.logger,
+		TTL:       request.DownloadTokenTtl.AsDuration(),
+	})
+
+	asset, err := imagefactory.ResolveBootAsset(ctx, s.omniState, request.TalosVersion, spec, request.SchematicId, request.StandaloneUrl, downloadTokens)
 	if err != nil {
 		if errors.Is(err, imagefactory.ErrInvalidInput) {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -221,12 +228,18 @@ func (s *managementServer) GetBootAssetURL(ctx context.Context, request *managem
 		headers[name] = asset.Headers.Get(name)
 	}
 
-	return &management.BootAssetURLResponse{
+	response := &management.BootAssetURLResponse{
 		Url:              asset.URL,
 		Headers:          headers,
 		ImageFactoryHost: asset.ImageFactoryHost,
 		StorageKey:       asset.StorageKey,
-	}, nil
+	}
+
+	if !asset.ExpiresAt.IsZero() {
+		response.ExpiresAt = timestamppb.New(asset.ExpiresAt)
+	}
+
+	return response, nil
 }
 
 func (s *managementServer) getOverlay(ctx context.Context, req *management.CreateSchematicRequest) (schematic.Overlay, error) {

--- a/internal/backend/grpc/schematics_test.go
+++ b/internal/backend/grpc/schematics_test.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -25,6 +27,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/siderolabs/omni/client/api/omni/management"
 	"github.com/siderolabs/omni/client/pkg/meta"
@@ -32,13 +35,94 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 )
 
+// The credentials the boot asset tests configure on both sides: the ImageFactoryAuth resource Omni reads
+// for the fallback, and the factory client Omni requests a download token with.
+const (
+	testFactoryUsername = "user"
+	testFactoryPassword = "hunter2"
+
+	// testFactoryAuthorization is the two of them as the factory sees them on the wire.
+	testFactoryAuthorization = "Basic dXNlcjpodW50ZXIy"
+)
+
 type imageFactoryMock struct {
 	listener   net.Listener
 	schematics map[string]schematic.Schematic
-	eg         errgroup.Group
-	address    string
+
+	// downloadToken decides what POST /download-token answers, returning a status and either the token
+	// or an error body. Nil answers 404, which is what an unregistered route returns and so stands in for
+	// every factory that does not issue tokens.
+	downloadToken func(ttl string) (int, string)
+
+	eg      errgroup.Group
+	address string
+
+	// tokenTTLs records the ttl query parameter of every request, so a test can check what Omni asked for.
+	tokenTTLs []string
+
+	// tokenAuth records the Authorization header of every request, so a test can check that Omni
+	// authenticates the token request rather than relying on the route being open.
+	tokenAuth []string
 
 	schematicMu sync.Mutex
+	tokenMu     sync.Mutex
+}
+
+// setDownloadToken installs what POST /download-token answers and forgets the requests so far, so each
+// case reads only its own.
+func (m *imageFactoryMock) setDownloadToken(handler func(ttl string) (int, string)) {
+	m.tokenMu.Lock()
+	defer m.tokenMu.Unlock()
+
+	m.downloadToken = handler
+	m.tokenTTLs = nil
+	m.tokenAuth = nil
+}
+
+// downloadTokenTTLs returns the lifetimes asked for since the last setDownloadToken, in order.
+func (m *imageFactoryMock) downloadTokenTTLs() []string {
+	m.tokenMu.Lock()
+	defer m.tokenMu.Unlock()
+
+	return slices.Clone(m.tokenTTLs)
+}
+
+// downloadTokenAuth returns the Authorization header of every token request since the last
+// setDownloadToken, in order.
+func (m *imageFactoryMock) downloadTokenAuth() []string {
+	m.tokenMu.Lock()
+	defer m.tokenMu.Unlock()
+
+	return slices.Clone(m.tokenAuth)
+}
+
+func (m *imageFactoryMock) handleDownloadToken(rw http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	m.tokenMu.Lock()
+	m.tokenTTLs = append(m.tokenTTLs, r.URL.Query().Get("ttl"))
+	m.tokenAuth = append(m.tokenAuth, r.Header.Get("Authorization"))
+	handler := m.downloadToken
+	m.tokenMu.Unlock()
+
+	if handler == nil {
+		rw.WriteHeader(http.StatusNotFound)
+
+		return
+	}
+
+	code, body := handler(r.URL.Query().Get("ttl"))
+
+	if code != http.StatusOK {
+		rw.WriteHeader(code)
+		rw.Write([]byte(body)) //nolint:errcheck
+
+		return
+	}
+
+	rw.Header().Add("Content-Type", "application/json")
+
+	// The shape the pinned client decodes. It reads access_token and discards the rest, which is why Omni
+	// derives the expiry from the lifetime it sent rather than from expires_in.
+	rw.Write(fmt.Appendf(nil, `{"access_token":%q,"token_type":"Bearer","expires_in":300}`, body)) //nolint:errcheck
 }
 
 func (m *imageFactoryMock) run(ctx context.Context) error {
@@ -59,6 +143,7 @@ func (m *imageFactoryMock) serve(ctx context.Context) {
 	router.POST("/schematics", m.handleSchematics)
 	router.GET("/schematics/:id", m.handleSchematicGet)
 	router.GET("/versions", m.handleVersions)
+	router.POST("/download-token", m.handleDownloadToken)
 
 	server := http.Server{
 		Handler: router,
@@ -454,7 +539,7 @@ func (suite *GrpcSuite) TestBootAssetURL() {
 			suite.Require().Equal("factory.example.org", strings.TrimPrefix(resp.ImageFactoryHost, "pxe."))
 
 			if tt.expectHeader {
-				suite.Require().Equal(map[string]string{"Authorization": "Basic dXNlcjpodW50ZXIy"}, resp.Headers)
+				suite.Require().Equal(map[string]string{"Authorization": testFactoryAuthorization}, resp.Headers)
 			} else {
 				suite.Require().Empty(resp.Headers)
 			}
@@ -519,4 +604,161 @@ func (suite *GrpcSuite) TestBootAssetURL() {
 			suite.Require().Equal(codes.InvalidArgument, status.Code(err))
 		})
 	}
+}
+
+// TestBootAssetToken covers what a caller gets when the factory Omni is configured with issues download
+// tokens: a URL that expires and only downloads, instead of the long-lived credential that works on every
+// factory route.
+//
+// TestBootAssetURL points FeaturesConfig at a factory no client is configured for, so it pins the
+// credential fallback. This points it at the mock, so ForURL finds the client and the token is issued.
+func (suite *GrpcSuite) TestBootAssetToken() {
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*30)
+	defer cancel()
+
+	const (
+		token       = "eyJhbGciOiJFUzI1NiJ9.fake.token"
+		schematicID = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+	)
+
+	features := omni.NewFeaturesConfig(omni.FeaturesConfigID)
+	features.TypedSpec().Value.ImageFactoryBaseUrl = suite.imageFactory.address
+
+	suite.Require().NoError(suite.state.Create(ctx, features))
+
+	factoryAuth := omni.NewImageFactoryAuth(suite.imageFactory.address)
+	factoryAuth.TypedSpec().Value.Username = testFactoryUsername
+	factoryAuth.TypedSpec().Value.Password = testFactoryPassword
+
+	suite.Require().NoError(suite.state.Create(ctx, factoryAuth))
+
+	client := management.NewManagementServiceClient(suite.conn)
+
+	newRequest := func() *management.BootAssetURLRequest {
+		return &management.BootAssetURLRequest{
+			TalosVersion:  "1.13.0",
+			SchematicId:   schematicID,
+			BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK,
+			Platform:      "nocloud",
+			Architecture:  "amd64",
+			Format:        "raw.xz",
+		}
+	}
+
+	assetPath := "/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz"
+
+	issuesToken := func(string) (int, string) { return http.StatusOK, token }
+
+	suite.Run("no requested lifetime takes Omni's default", func() {
+		suite.imageFactory.setDownloadToken(issuesToken)
+
+		before := time.Now()
+
+		resp, err := client.GetBootAssetURL(ctx, newRequest())
+		suite.Require().NoError(err)
+
+		suite.Require().Equal(suite.imageFactory.address+assetPath+"?token="+url.QueryEscape(token), resp.Url)
+		suite.Require().Empty(resp.Headers, "a token in the URL leaves nothing for the headers to carry")
+
+		// Sent explicitly rather than left to the factory, since the granted lifetime is the one thing the
+		// factory does not report back and the expiry has to come from somewhere.
+		suite.Require().Equal([]string{"5m0s"}, suite.imageFactory.downloadTokenTTLs())
+
+		// A token is scoped to the identity that asked for it, so an unauthenticated request would either be
+		// refused or scoped to nobody. Omni has to present its factory credentials to get one.
+		suite.Require().Equal([]string{testFactoryAuthorization}, suite.imageFactory.downloadTokenAuth())
+
+		suite.Require().NotNil(resp.ExpiresAt)
+		suite.Require().WithinRange(resp.ExpiresAt.AsTime(), before.Add(5*time.Minute), time.Now().Add(5*time.Minute))
+	})
+
+	suite.Run("a requested lifetime reaches the factory and moves the expiry", func() {
+		suite.imageFactory.setDownloadToken(issuesToken)
+
+		request := newRequest()
+		request.DownloadTokenTtl = durationpb.New(time.Hour)
+
+		before := time.Now()
+
+		resp, err := client.GetBootAssetURL(ctx, request)
+		suite.Require().NoError(err)
+
+		suite.Require().Equal([]string{"1h0m0s"}, suite.imageFactory.downloadTokenTTLs())
+		suite.Require().NotNil(resp.ExpiresAt)
+		suite.Require().WithinRange(resp.ExpiresAt.AsTime(), before.Add(time.Hour), time.Now().Add(time.Hour))
+	})
+
+	suite.Run("a standalone URL carries the token too", func() {
+		suite.imageFactory.setDownloadToken(issuesToken)
+
+		request := newRequest()
+		request.StandaloneUrl = true
+
+		resp, err := client.GetBootAssetURL(ctx, request)
+		suite.Require().NoError(err)
+
+		suite.Require().Equal(suite.imageFactory.address+assetPath+"?token="+url.QueryEscape(token), resp.Url)
+		suite.Require().NotContains(resp.Url, "hunter2", "the credential must not travel alongside the token")
+	})
+
+	suite.Run("a refused lifetime is InvalidArgument", func() {
+		// The factory answers 400 for anything outside its configured bounds. The caller chose the lifetime,
+		// so it learns its request was refused rather than quietly receiving a long-lived credential.
+		suite.imageFactory.setDownloadToken(func(string) (int, string) {
+			return http.StatusBadRequest, "ttl must be between 30s and 8h"
+		})
+
+		request := newRequest()
+		request.DownloadTokenTtl = durationpb.New(100 * time.Hour)
+
+		_, err := client.GetBootAssetURL(ctx, request)
+		suite.Require().Equal(codes.InvalidArgument, status.Code(err))
+
+		// The bounds are the whole point of passing the factory's own body on rather than summarizing it:
+		// they are what the caller needs to pick a lifetime that works.
+		suite.Require().Contains(status.Convert(err).Message(), "between 30s and 8h")
+		suite.Require().Contains(status.Convert(err).Message(), "100h0m0s")
+	})
+
+	suite.Run("a rejected token request falls back to credentials", func() {
+		// The credentials Omni requests the token with come from its startup configuration. If a factory
+		// refuses them, the resolve must still answer rather than failing a provision.
+		suite.imageFactory.setDownloadToken(func(string) (int, string) {
+			return http.StatusUnauthorized, "unauthorized"
+		})
+
+		resp, err := client.GetBootAssetURL(ctx, newRequest())
+		suite.Require().NoError(err)
+
+		suite.Require().Equal(suite.imageFactory.address+assetPath, resp.Url)
+		suite.Require().Equal(map[string]string{"Authorization": testFactoryAuthorization}, resp.Headers)
+		suite.Require().Nil(resp.ExpiresAt)
+	})
+
+	suite.Run("a negative lifetime is InvalidArgument", func() {
+		suite.imageFactory.setDownloadToken(issuesToken)
+
+		request := newRequest()
+		request.DownloadTokenTtl = durationpb.New(-time.Hour)
+
+		_, err := client.GetBootAssetURL(ctx, request)
+		suite.Require().Equal(codes.InvalidArgument, status.Code(err))
+
+		// It never reaches the factory, since the client would drop a non-positive lifetime and the factory
+		// would grant its own default instead, leaving Omni reporting an expiry in the past.
+		suite.Require().Empty(suite.imageFactory.downloadTokenTTLs())
+	})
+
+	suite.Run("a factory that does not issue tokens falls back to credentials", func() {
+		// Nil answers 404, exactly as an unregistered route does: every build below 1.5.0, every community
+		// build, and any factory with its own authentication disabled.
+		suite.imageFactory.setDownloadToken(nil)
+
+		resp, err := client.GetBootAssetURL(ctx, newRequest())
+		suite.Require().NoError(err)
+
+		suite.Require().Equal(suite.imageFactory.address+assetPath, resp.Url)
+		suite.Require().Equal(map[string]string{"Authorization": testFactoryAuthorization}, resp.Headers)
+		suite.Require().Nil(resp.ExpiresAt, "a credential does not expire, so there is nothing to report")
+	})
 }

--- a/internal/backend/runtime/omni/controllers/omni/versions_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/versions_test.go
@@ -8,7 +8,9 @@ package omni_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/siderolabs/gen/xslices"
 	"github.com/siderolabs/image-factory/pkg/client"
@@ -155,6 +157,10 @@ func (s *stubFactoryClient) SPDXBundle(context.Context, string, string, string) 
 
 func (s *stubFactoryClient) VEXDocument(context.Context, string) ([]byte, error) {
 	return nil, nil
+}
+
+func (s *stubFactoryClient) DownloadToken(context.Context, time.Duration) (string, error) {
+	return "", &client.HTTPError{Code: http.StatusNotFound, Message: "not found"}
 }
 
 // TestFetchTalosVersions verifies the two configured factories are independent: a failure fetching one

--- a/internal/backend/runtime/omni/controllers/testutils/factory.go
+++ b/internal/backend/runtime/omni/controllers/testutils/factory.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
@@ -121,6 +122,15 @@ func (i *ImageFactoryClientMock) SPDXBundle(_ context.Context, _, _, _ string) (
 
 func (i *ImageFactoryClientMock) VEXDocument(_ context.Context, _ string) ([]byte, error) {
 	return nil, nil
+}
+
+// DownloadToken answers 404, the same as a factory below 1.5.0 or one with authentication disabled.
+//
+// No controller resolves a boot asset, so nothing here depends on the answer: the method exists because
+// FactoryClient requires it. Token behavior is covered where it is actually reached, in
+// client/pkg/imagefactory and internal/backend/grpc.
+func (i *ImageFactoryClientMock) DownloadToken(_ context.Context, _ time.Duration) (string, error) {
+	return "", &client.HTTPError{Code: http.StatusNotFound, Message: "not found"}
 }
 
 // Get is a test helper for reading back what the controller uploaded.


### PR DESCRIPTION
Omni authenticates boot asset downloads for infra providers with a short-lived token from the image factory, scoped to one identity and accepted only on image downloads, so a provider holds only what the download needs. A provision step that passes the URL to something else, instead of downloading immediately, asks for the lifetime it needs with download_token_ttl and learns when the URL stops working from expires_at. PXE keeps basic auth, since the iPXE script the factory serves passes on credentials alone, and a factory that issues no tokens keeps working unchanged.

Related to: #3109