### PR TITLE
feat(frontend): hide machine creation commands not supported by enterprise

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -60,12 +60,8 @@ included in the LICENSE file.
     @apply bg-naturals-n0 text-naturals-n11 antialiased;
   }
 
-  *::-webkit-scrollbar {
-    @apply h-1.5 w-1.5 bg-transparent;
-  }
-
-  *::-webkit-scrollbar-thumb {
-    @apply h-1.5 w-1.5 rounded-sm border border-naturals-n4 bg-naturals-n5;
+  * {
+    @apply scrollbar-thin scrollbar-thumb-naturals-n5 scrollbar-track-transparent;
   }
 
   button:not(:disabled),

--- a/frontend/src/views/Clusters/Management/MachineSetPicker.vue
+++ b/frontend/src/views/Clusters/Management/MachineSetPicker.vue
@@ -92,7 +92,7 @@ function toggleOption(option: PickerOption, index: number, checked: boolean) {
           <RadioGroup
             ref="optionsView"
             v-model="machineSetIndex"
-            class="no-scrollbar scroll flex h-30 flex-col items-center gap-0.5 overflow-y-auto"
+            class="flex h-30 scrollbar-none flex-col items-center gap-0.5 overflow-y-auto"
             @scroll.stop
           >
             <RadioGroupOption
@@ -138,15 +138,3 @@ function toggleOption(option: PickerOption, index: number, checked: boolean) {
     </PopoverRoot>
   </div>
 </template>
-
-<style scoped>
-.no-scrollbar::-webkit-scrollbar {
-  display: none;
-}
-
-/* Hide scrollbar for IE, Edge and Firefox */
-.no-scrollbar {
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-}
-</style>

--- a/frontend/src/views/InstallationMedia/Confirmation.vue
+++ b/frontend/src/views/InstallationMedia/Confirmation.vue
@@ -5,7 +5,6 @@ Use of this software is governed by the Business Source License
 included in the LICENSE file.
 -->
 <script setup lang="ts">
-import { gte } from 'semver'
 import { computed } from 'vue'
 
 import { Runtime } from '@/api/common/omni.pb'
@@ -75,9 +74,7 @@ const { data: talosVersion } = useResourceGet<TalosVersionSpec>(() => ({
   },
 }))
 
-const { url: factoryUrl, credentials: imageFactoryAuth } = useResolvedFactory(
-  () => talosVersion.value?.spec.image_factory_url,
-)
+const { url: factoryUrl } = useResolvedFactory(() => talosVersion.value?.spec.image_factory_url)
 
 const isEnterpriseFactory = computed(() => talosVersion.value?.spec.is_enterprise)
 
@@ -153,38 +150,6 @@ const installerImage = computed(() => {
   return supportsUnifiedInstaller.value
     ? `${factoryHost.value}/${formState.value.hardwareType}-installer${secureBootSuffix.value}/${schematicId.value}:${resolvedTalosVersion.value}`
     : `${factoryHost.value}/installer/${schematicId.value}:${resolvedTalosVersion.value}`
-})
-
-const quote = (input: string) => {
-  if (/["\s\\]/.test(input) && !/'/.test(input)) {
-    return "'" + input.replace(/(['])/g, '\\$1') + "'"
-  }
-
-  if (/["'\s]/.test(input)) {
-    return '"' + input.replace(/(["\\$`!])/g, '\\$1') + '"'
-  }
-
-  return String(input).replace(/([A-Za-z]:)?([#!"$&'()*,:;<=>?@[\\\]^`{|}])/g, '$1\\$2')
-}
-
-const clusterCreateCommand = computed(() => {
-  if (!factoryUrl.value) return
-
-  const parts = [
-    'talosctl cluster create qemu',
-    `--image-factory-url=${factoryUrl.value}`,
-    `--schematic-id=${schematicId.value}`,
-    `--talos-version=v${resolvedTalosVersion.value}`,
-  ]
-
-  // The local cluster pulls the installer from the factory that serves this version, so it must
-  // authenticate with that factory's credentials.
-  const { username, password } = imageFactoryAuth.value ?? {}
-  if (username && password) {
-    parts.push(`--image-factory-auth=${quote(`${username}:${password}`)}`)
-  }
-
-  return parts.join(' ')
 })
 </script>
 
@@ -313,18 +278,6 @@ const clusterCreateCommand = computed(() => {
       <CodeBlock
         :button-attrs="{ 'aria-label': 'Copy create Talos test cluster command' }"
         :code="installerImage"
-      />
-    </template>
-
-    <template v-if="gte(resolvedTalosVersion, '1.12.0-alpha.2') && clusterCreateCommand">
-      <h3 class="text-sm text-naturals-n14">Local Test Cluster</h3>
-      <p>
-        To create a local Talos Linux test cluster from this schematic on macOS (Apple Silicon) or
-        Linux, run:
-      </p>
-      <CodeBlock
-        :button-attrs="{ 'aria-label': 'Copy create Talos test cluster command' }"
-        :code="clusterCreateCommand"
       />
     </template>
 

--- a/frontend/src/views/Machines/components/AddingMachinesTutorial.stories.ts
+++ b/frontend/src/views/Machines/components/AddingMachinesTutorial.stories.ts
@@ -2,7 +2,11 @@
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
+import { createWatchStreamHandler } from '@msw/helpers.ts'
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+
+import type { FeaturesConfigSpec } from '@/api/omni/specs/omni.pb.ts'
+import { DefaultNamespace, FeaturesConfigID, FeaturesConfigType } from '@/api/resources.ts'
 
 import AddingMachinesTutorial from './AddingMachinesTutorial.vue'
 
@@ -13,4 +17,55 @@ const meta: Meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  beforeEach({ msw }) {
+    msw.use(
+      createWatchStreamHandler<FeaturesConfigSpec>({
+        expectedOptions: {
+          namespace: DefaultNamespace,
+          type: FeaturesConfigType,
+          id: FeaturesConfigID,
+        },
+        initialResources: [
+          {
+            metadata: {
+              namespace: DefaultNamespace,
+              type: FeaturesConfigType,
+              id: FeaturesConfigID,
+            },
+            spec: {
+              is_enterprise_image_factory: false,
+            },
+          },
+        ],
+      }).handler,
+    )
+  },
+}
+
+export const Enterprise: Story = {
+  beforeEach({ msw }) {
+    msw.use(
+      createWatchStreamHandler<FeaturesConfigSpec>({
+        expectedOptions: {
+          namespace: DefaultNamespace,
+          type: FeaturesConfigType,
+          id: FeaturesConfigID,
+        },
+        initialResources: [
+          {
+            metadata: {
+              namespace: DefaultNamespace,
+              type: FeaturesConfigType,
+              id: FeaturesConfigID,
+            },
+            spec: {
+              is_enterprise_image_factory: true,
+              image_factory_base_url: 'https://factory-enterprise.talos.dev',
+            },
+          },
+        ],
+      }).handler,
+    )
+  },
+}

--- a/frontend/src/views/Machines/components/AddingMachinesTutorial.vue
+++ b/frontend/src/views/Machines/components/AddingMachinesTutorial.vue
@@ -63,15 +63,16 @@ const pxeBootCode =
       <p>To add your first machine create Installation Media and put it onto your machine.</p>
 
       <div class="space-y-2">
-        <p>Local testing</p>
-        <CodeBlock
-          code="talosctl cluster create qemu --omni-api-endpoint $(omnictl jointoken omni-endpoint) --workers 0 --controlplanes 3"
-        ></CodeBlock>
-
-        <p>AWS</p>
-        <CodeBlock :code="awsCode"></CodeBlock>
-
+        <!-- TODO: Update these commands for enterprise support -->
         <template v-if="!isEnterpriseFactory">
+          <p>Local testing</p>
+          <CodeBlock
+            code="talosctl cluster create qemu --omni-api-endpoint $(omnictl jointoken omni-endpoint) --workers 0 --controlplanes 3"
+          ></CodeBlock>
+
+          <p>AWS</p>
+          <CodeBlock :code="awsCode"></CodeBlock>
+
           <p>PXE boot</p>
           <CodeBlock :code="pxeBootCode"></CodeBlock>
         </template>


### PR DESCRIPTION
When using enterprise image factory, the commands in the machine quick start do not currently work, and need changes in other areas for them to work. Will hide them from frontend until support is added. With regards to the installation media talosctl cluster create command in particular, it won't work at all regardless of enterprise or not currently.

Unrelated: Update scrollbar styling with cross-browser versions added in tailwindcss 4.3

Closes #3139 

