### PR TITLE
feat!: remove deprecated factory params from omni config

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -341,17 +341,6 @@ func defineRegistriesFlags(b *FlagBinder, flagConfig *config.Params) {
 	b.StringVar("registries.talos", &flagConfig.Registries.Talos)
 	b.StringVar("registries.kubernetes", &flagConfig.Registries.Kubernetes)
 
-	// Deprecated image factory flags, superseded by the --primary-factory-* flags below.
-	// These intentionally target the deprecated fields to preserve backward compatibility.
-	//nolint:staticcheck
-	b.deprecatedStringAlias("image-factory-address", "use --primary-factory-url", &flagConfig.Registries.ImageFactoryBaseURL)
-	//nolint:staticcheck
-	b.deprecatedStringAlias("image-factory-pxe-address", "use --primary-factory-pxe-url", &flagConfig.Registries.ImageFactoryPXEBaseURL)
-	//nolint:staticcheck
-	b.deprecatedStringAlias("image-factory-username", "use --primary-factory-username", &flagConfig.Registries.ImageFactoryUsername)
-	//nolint:staticcheck
-	b.deprecatedStringAlias("image-factory-password", "use --primary-factory-password", &flagConfig.Registries.ImageFactoryPassword)
-
 	primary := &flagConfig.Registries.Factories.Primary
 	b.StringVar("registries.factories.primary.url", &primary.Url)
 	b.StringVar("registries.factories.primary.pxeURL", &primary.PxeURL)

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -555,28 +555,12 @@ config:
     #talos: ghcr.io/siderolabs/installer
     # Kubernetes is the Kubernetes container registry configuration.
     #kubernetes: ghcr.io/siderolabs/kubelet
-    # ImageFactoryBaseURL is the base URL of the Image Factory service used to build custom machine images.
-    #
-    # Deprecated: use factories.primary.url instead.
-    #imageFactoryBaseURL: https://factory.talos.dev
-    # ImageFactoryPXEBaseURL is the base URL of the Image Factory PXE endpoint used to build custom PXE boot images.
-    #
-    # Deprecated: use factories.primary.pxeURL instead.
-    #imageFactoryPXEBaseURL: ""
-    # ImageFactoryUsername is the username used to authenticate against the Image Factory Enterprise service.
-    #
-    # Deprecated: use factories.primary.username instead.
-    #imageFactoryUsername: ""
-    # ImageFactoryPassword is the password used to authenticate against the Image Factory Enterprise service.
-    #
-    # Deprecated: use factories.primary.password instead.
-    #imageFactoryPassword: ""
     # Factories contains the primary and secondary Image Factory configurations.
     factories:
       # Primary is the primary Image Factory configuration.
       primary:
         # URL is the base URL of the Image Factory service used to build custom machine images.
-        #url: ""
+        #url: https://factory.talos.dev
         # PxeURL is the base URL of the Image Factory PXE endpoint used to build custom PXE boot images.
         #pxeURL: ""
         # Username is the username used to authenticate against the Image Factory Enterprise service.

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -8,6 +8,14 @@ match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 pre_release = true
 previous = "v1.9.0"
 
+[notes.aaa-upgrade-nodes]
+title = "Urgent Upgrade Notes **(No, really, you MUST read this before you upgrade)**"
+description = """\
+The deprecated flat Image Factory config fields have been removed. Please migrate to `registries.factories.primary`.
+
+Legacy `--image-factory-*` flags and `OMNI_IMAGE_FACTORY_USERNAME`/`OMNI_IMAGE_FACTORY_PASSWORD` env vars are removed; use `--primary-factory-*` and `OMNI_PRIMARY_FACTORY_USERNAME`/`OMNI_PRIMARY_FACTORY_PASSWORD`.
+"""
+
 [notes.infra-provider-boot-assets]
 title = "Infrastructure Providers Use the Image Factory Omni Is Configured With"
 description = """\

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -351,7 +351,9 @@ function prepare_omni_config() {
   local registries_body=""
 
   if [[ -n "${OMNI_IMAGE_FACTORY_BASE_URL:-}" ]]; then
-    registries_body+="  imageFactoryBaseURL: ${OMNI_IMAGE_FACTORY_BASE_URL}"$'\n'
+    registries_body+="  factories:
+    primary:
+      url: ${OMNI_IMAGE_FACTORY_BASE_URL}"$'\n'
   fi
 
   registries_body+="${REGISTRY_MIRRORS_BODY}"

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
@@ -501,9 +501,6 @@ func (helper clusterMachineConfigControllerHelper) generateConfig(clusterMachine
 	// Migration code, if the factory URL is not populated yet, use the secondary factory URL if configured
 	// As the second factory should be the old one we're migrating from
 	if installImageSpec.ImageFactoryHost == "" {
-		// Resolve the primary factory rather than reading registries.factories.primary directly: a
-		// deployment still using the deprecated flat imageFactory* config leaves that block empty, and
-		// falling back to an empty URL would yield an empty host and fail the install image build.
 		primaryFactory := helper.registries.GetPrimaryFactory()
 		fallbackURL := primaryFactory.GetUrl()
 

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -1183,50 +1183,6 @@ func (s *Posthog) SetApiKey(v string) {
 	s.ApiKey = &v
 }
 
-func (s *Registries) GetImageFactoryBaseURL() string {
-	if s == nil || s.ImageFactoryBaseURL == nil {
-		return *new(string)
-	}
-	return *s.ImageFactoryBaseURL
-}
-
-func (s *Registries) SetImageFactoryBaseURL(v string) {
-	s.ImageFactoryBaseURL = &v
-}
-
-func (s *Registries) GetImageFactoryPXEBaseURL() string {
-	if s == nil || s.ImageFactoryPXEBaseURL == nil {
-		return *new(string)
-	}
-	return *s.ImageFactoryPXEBaseURL
-}
-
-func (s *Registries) SetImageFactoryPXEBaseURL(v string) {
-	s.ImageFactoryPXEBaseURL = &v
-}
-
-func (s *Registries) GetImageFactoryPassword() string {
-	if s == nil || s.ImageFactoryPassword == nil {
-		return *new(string)
-	}
-	return *s.ImageFactoryPassword
-}
-
-func (s *Registries) SetImageFactoryPassword(v string) {
-	s.ImageFactoryPassword = &v
-}
-
-func (s *Registries) GetImageFactoryUsername() string {
-	if s == nil || s.ImageFactoryUsername == nil {
-		return *new(string)
-	}
-	return *s.ImageFactoryUsername
-}
-
-func (s *Registries) SetImageFactoryUsername(v string) {
-	s.ImageFactoryUsername = &v
-}
-
 func (s *Registries) GetKubernetes() string {
 	if s == nil || s.Kubernetes == nil {
 		return *new(string)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -230,14 +230,6 @@ func (p *Params) GetOIDCIssuerEndpoint() (string, error) {
 
 // Environment variable names that override config values after merging.
 const (
-	// EnvImageFactoryUsername and EnvImageFactoryPassword set the deprecated flat imageFactory*
-	// fields.
-	//
-	// Deprecated: use EnvPrimaryFactoryUsername/EnvPrimaryFactoryPassword instead.
-	EnvImageFactoryUsername = "OMNI_IMAGE_FACTORY_USERNAME"
-	// Deprecated: use EnvPrimaryFactoryUsername/EnvPrimaryFactoryPassword instead.
-	EnvImageFactoryPassword = "OMNI_IMAGE_FACTORY_PASSWORD"
-
 	EnvPrimaryFactoryUsername   = "OMNI_PRIMARY_FACTORY_USERNAME"
 	EnvPrimaryFactoryPassword   = "OMNI_PRIMARY_FACTORY_PASSWORD"
 	EnvSecondaryFactoryUsername = "OMNI_SECONDARY_FACTORY_USERNAME"
@@ -245,27 +237,8 @@ const (
 )
 
 // applyEnvOverrides overrides config values from environment variables, when set.
-//
-// It runs after the config file and flags have been merged, so the environment always wins over
-// the input it targets. The per-factory vars set factories.{primary,secondary}.* directly, while
-// the deprecated pair sets the flat imageFactory* fields that GetPrimaryFactory only consults as a
-// fallback. The resulting precedence for the primary factory credentials is therefore:
-//
-//	OMNI_PRIMARY_FACTORY_* > factories.primary.* > OMNI_IMAGE_FACTORY_* > flat imageFactory*
-//
-// Note that the schema requires a username and a password to be set together, so supplying only
-// one half of a pair fails validation.
+// Env overrides win over all other sources (defaults, files, flags).
 func (p *Params) applyEnvOverrides() {
-	//nolint:staticcheck
-	if v, ok := os.LookupEnv(EnvImageFactoryUsername); ok {
-		p.Registries.SetImageFactoryUsername(v)
-	}
-
-	//nolint:staticcheck
-	if v, ok := os.LookupEnv(EnvImageFactoryPassword); ok {
-		p.Registries.SetImageFactoryPassword(v)
-	}
-
 	for _, factory := range []struct {
 		target      *Factory
 		usernameEnv string

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -279,22 +279,6 @@ func TestValidateConfig(t *testing.T) {
 		},
 
 		{
-			name:   "image factory username without password",
-			config: configFull,
-			configModifyFunc: func(cfg *config.Params) {
-				cfg.Registries.SetImageFactoryUsername("user")
-			},
-			validateErr: `config value ".registries.imageFactoryPassword" or flag "--image-factory-password": is required when "imageFactoryUsername" is set`,
-		},
-		{
-			name:   "image factory password without username",
-			config: configFull,
-			configModifyFunc: func(cfg *config.Params) {
-				cfg.Registries.SetImageFactoryPassword("pass")
-			},
-			validateErr: `config value ".registries.imageFactoryUsername" or flag "--image-factory-username": is required when "imageFactoryPassword" is set`,
-		},
-		{
 			name:   "primary factory username without password",
 			config: configFull,
 			configModifyFunc: func(cfg *config.Params) {
@@ -492,7 +476,7 @@ func TestSchemaDefaults(t *testing.T) {
 	assert.Equal(t, "ghcr.io/siderolabs/kubelet", p.Registries.GetKubernetes())
 
 	// registries.factories: with nothing configured, the primary factory resolves to the
-	// deprecated field default, and there is no secondary factory.
+	// field default, and there is no secondary factory.
 	primaryFactory := p.Registries.GetPrimaryFactory()
 	assert.Equal(t, "https://factory.talos.dev", primaryFactory.GetUrl())
 
@@ -613,89 +597,6 @@ func TestSchemaDefaults(t *testing.T) {
 // TestFactories verifies the resolution of the primary/secondary factories, including the
 // "new wins, deprecated fallback" rule for the primary factory.
 func TestFactories(t *testing.T) {
-	t.Run("deprecated fields only", func(t *testing.T) {
-		p, err := config.FromBytes([]byte(`
-registries:
-  imageFactoryBaseURL: https://old.example.com
-  imageFactoryPXEBaseURL: https://pxe.old.example.com
-  imageFactoryUsername: old-user
-  imageFactoryPassword: old-pass
-`))
-		require.NoError(t, err)
-
-		primary := p.Registries.GetPrimaryFactory()
-		assert.Equal(t, "https://old.example.com", primary.GetUrl())
-		assert.Equal(t, "https://pxe.old.example.com", primary.GetPxeURL())
-		assert.Equal(t, "old-user", primary.GetUsername())
-		assert.Equal(t, "old-pass", primary.GetPassword())
-
-		_, hasSecondary := p.Registries.GetSecondaryFactory()
-		assert.False(t, hasSecondary)
-	})
-
-	t.Run("primary wins over deprecated", func(t *testing.T) {
-		p, err := config.FromBytes([]byte(`
-registries:
-  imageFactoryBaseURL: https://old.example.com
-  imageFactoryUsername: old-user
-  imageFactoryPassword: old-pass
-  factories:
-    primary:
-      url: https://new.example.com
-      username: new-user
-      password: new-pass
-`))
-		require.NoError(t, err)
-
-		primary := p.Registries.GetPrimaryFactory()
-		assert.Equal(t, "https://new.example.com", primary.GetUrl())
-		assert.Equal(t, "new-user", primary.GetUsername())
-		assert.Equal(t, "new-pass", primary.GetPassword())
-	})
-
-	t.Run("a primary factory URL ignores the deprecated credentials", func(t *testing.T) {
-		// The deprecated credentials belong to the deprecated factory URL: they must not be carried
-		// over to a different factory configured under registries.factories.primary.
-		p, err := config.FromBytes([]byte(`
-registries:
-  imageFactoryBaseURL: https://old.example.com
-  imageFactoryPXEBaseURL: https://pxe.old.example.com
-  imageFactoryUsername: old-user
-  imageFactoryPassword: old-pass
-  factories:
-    primary:
-      url: https://new.example.com
-`))
-		require.NoError(t, err)
-
-		primary := p.Registries.GetPrimaryFactory()
-		assert.Equal(t, "https://new.example.com", primary.GetUrl())
-		assert.Empty(t, primary.GetUsername())
-		assert.Empty(t, primary.GetPassword())
-		assert.Empty(t, primary.GetPxeURL(), "the deprecated PXE URL points at the deprecated factory")
-	})
-
-	t.Run("primary credentials without a primary URL still fill in over the deprecated ones", func(t *testing.T) {
-		// Only the credentials were migrated to the new-style config; the URL still comes from the
-		// deprecated field, so the two describe the same factory and may be combined.
-		p, err := config.FromBytes([]byte(`
-registries:
-  imageFactoryBaseURL: https://old.example.com
-  imageFactoryUsername: old-user
-  imageFactoryPassword: old-pass
-  factories:
-    primary:
-      username: new-user
-      password: new-pass
-`))
-		require.NoError(t, err)
-
-		primary := p.Registries.GetPrimaryFactory()
-		assert.Equal(t, "https://old.example.com", primary.GetUrl())
-		assert.Equal(t, "new-user", primary.GetUsername())
-		assert.Equal(t, "new-pass", primary.GetPassword())
-	})
-
 	t.Run("secondary factory", func(t *testing.T) {
 		p, err := config.FromBytes([]byte(`
 registries:
@@ -798,30 +699,5 @@ registries:
 		primary := cfg.Registries.GetPrimaryFactory()
 		assert.Equal(t, "env-primary-user", primary.GetUsername())
 		assert.Equal(t, "env-primary-pass", primary.GetPassword())
-	})
-
-	t.Run("configured primary credentials win over the deprecated env vars", func(t *testing.T) {
-		t.Setenv(config.EnvImageFactoryUsername, "legacy-env-user")
-		t.Setenv(config.EnvImageFactoryPassword, "legacy-env-pass")
-
-		cfg := initConfig(t, `
-registries:
-  factories:
-    primary:
-      url: https://primary.example.com
-      username: config-user
-      password: config-pass
-`)
-
-		primary := cfg.Registries.GetPrimaryFactory()
-		assert.Equal(t, "config-user", primary.GetUsername())
-		assert.Equal(t, "config-pass", primary.GetPassword())
-
-		// The deprecated env vars still drive the primary factory when nothing more specific is set.
-		cfg = initConfig(t, "registries: {}\n")
-
-		primary = cfg.Registries.GetPrimaryFactory()
-		assert.Equal(t, "legacy-env-user", primary.GetUsername())
-		assert.Equal(t, "legacy-env-pass", primary.GetPassword())
 	})
 }

--- a/internal/pkg/config/factories.go
+++ b/internal/pkg/config/factories.go
@@ -12,34 +12,12 @@ import (
 
 // GetPrimaryFactory returns the resolved primary Image Factory configuration. This is the factory
 // that Omni uses for all its Image Factory operations today.
-//
-// A registries.factories.primary block that specifies a URL is self-contained: the deprecated flat
-// imageFactory* fields are ignored entirely. Otherwise credentials configured for the old factory
-// would be sent to a newly configured one, which is both wrong and a way to leak them.
-//
-// Without a URL under registries.factories.primary, the deprecated fields are used instead (they
-// still carry the default factory URL), with any field set on the primary block winning.
 func (s *Registries) GetPrimaryFactory() Factory {
-	primary := s.Factories.Primary
-
-	if primary.GetUrl() != "" {
-		return primary
-	}
-
-	var resolved Factory
-
-	resolved.SetUrl(s.GetImageFactoryBaseURL())
-	resolved.SetPxeURL(firstNonEmpty(primary.GetPxeURL(), s.GetImageFactoryPXEBaseURL()))
-	resolved.SetUsername(firstNonEmpty(primary.GetUsername(), s.GetImageFactoryUsername()))
-	resolved.SetPassword(firstNonEmpty(primary.GetPassword(), s.GetImageFactoryPassword()))
-
-	return resolved
+	return s.Factories.Primary
 }
 
 // GetSecondaryFactory returns the configured secondary Image Factory configuration and true,
 // or a zero Factory and false when no secondary factory is configured.
-//
-// There is no deprecated fallback for the secondary factory, as it is a new concept.
 func (s *Registries) GetSecondaryFactory() (Factory, bool) {
 	secondary := s.Factories.Secondary
 	if secondary.GetUrl() == "" {
@@ -64,14 +42,4 @@ func (f Factory) PXEBaseURL() (*url.URL, error) {
 	u.Host = fmt.Sprintf("pxe.%s", u.Host)
 
 	return u, nil
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-
-	return ""
 }

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -146,13 +146,8 @@
       "required": [
         "talos",
         "kubernetes",
-        "imageFactoryBaseURL",
         "factories"
       ],
-      "dependentRequired": {
-        "imageFactoryUsername": ["imageFactoryPassword"],
-        "imageFactoryPassword": ["imageFactoryUsername"]
-      },
       "properties": {
         "talos": {
           "type": "string",
@@ -173,35 +168,6 @@
           "goJSONSchema": {
             "type": "*string"
           }
-        },
-        "imageFactoryBaseURL": {
-          "type": "string",
-          "description": "ImageFactoryBaseURL is the base URL of the Image Factory service used to build custom machine images.\n\nDeprecated: use factories.primary.url instead.",
-          "x-cli-flag": "image-factory-address",
-          "deprecated": true,
-          "minLength": 1,
-          "default": "https://factory.talos.dev",
-          "goJSONSchema": {
-            "type": "*string"
-          }
-        },
-        "imageFactoryPXEBaseURL": {
-          "description": "ImageFactoryPXEBaseURL is the base URL of the Image Factory PXE endpoint used to build custom PXE boot images.\n\nDeprecated: use factories.primary.pxeURL instead.",
-          "x-cli-flag": "image-factory-pxe-address",
-          "deprecated": true,
-          "type": "string"
-        },
-        "imageFactoryUsername": {
-          "description": "ImageFactoryUsername is the username used to authenticate against the Image Factory Enterprise service.\n\nDeprecated: use factories.primary.username instead.",
-          "x-cli-flag": "image-factory-username",
-          "deprecated": true,
-          "type": "string"
-        },
-        "imageFactoryPassword": {
-          "description": "ImageFactoryPassword is the password used to authenticate against the Image Factory Enterprise service.\n\nDeprecated: use factories.primary.password instead.",
-          "x-cli-flag": "image-factory-password",
-          "deprecated": true,
-          "type": "string"
         },
         "factories": {
           "description": "Factories contains the primary and secondary Image Factory configurations.",
@@ -232,8 +198,13 @@
         "primary": {
           "description": "Primary is the primary Image Factory configuration.",
           "$ref": "#/definitions/Factory",
+          "required": ["url"],
           "properties": {
-            "url": { "x-cli-flag": "primary-factory-url" },
+            "url": {
+              "x-cli-flag": "primary-factory-url",
+              "default": "https://factory.talos.dev",
+              "minLength": 1
+            },
             "pxeURL": { "x-cli-flag": "primary-factory-pxe-url" },
             "username": { "x-cli-flag": "primary-factory-username" },
             "password": { "x-cli-flag": "primary-factory-password" }

--- a/internal/pkg/config/testdata/backups.yaml
+++ b/internal/pkg/config/testdata/backups.yaml
@@ -34,7 +34,9 @@ logs:
 registries:
   talos: ghcr.io/siderolabs/installer
   kubernetes: ghcr.io/siderolabs/kubelet
-  imageFactoryBaseURL: https://factory.talos.dev
+  factories:
+    primary:
+      url: https://factory.talos.dev
 
 storage:
   vault:

--- a/internal/pkg/config/testdata/config-full.yaml
+++ b/internal/pkg/config/testdata/config-full.yaml
@@ -71,7 +71,6 @@ auth:
 registries:
   talos: ghcr.io/siderolabs/installer
   kubernetes: ghcr.io/siderolabs/kubelet
-  imageFactoryBaseURL: https://factory.talos.dev
   factories:
     primary:
       url: https://factory.talos.dev

--- a/internal/pkg/config/testdata/config-no-tls-certs.yaml
+++ b/internal/pkg/config/testdata/config-no-tls-certs.yaml
@@ -28,4 +28,6 @@ storage:
 registries:
   talos:  factory.talos.dev
   kubernetes:  registry.k8s.io
-  imageFactoryBaseURL:  https://factory.talos.dev
+  factories:
+    primary:
+      url: https://factory.talos.dev

--- a/internal/pkg/config/testdata/conflicting-auth.yaml
+++ b/internal/pkg/config/testdata/conflicting-auth.yaml
@@ -24,7 +24,9 @@ auth:
 registries:
   talos: ghcr.io/siderolabs/installer
   kubernetes: ghcr.io/siderolabs/kubelet
-  imageFactoryBaseURL: https://factory.talos.dev
+  factories:
+    primary:
+      url: https://factory.talos.dev
 
 storage:
   vault:

--- a/internal/pkg/config/testdata/enable-saml.yaml
+++ b/internal/pkg/config/testdata/enable-saml.yaml
@@ -26,7 +26,9 @@ auth:
 registries:
   talos: ghcr.io/siderolabs/installer
   kubernetes: ghcr.io/siderolabs/kubelet
-  imageFactoryBaseURL: https://factory.talos.dev
+  factories:
+    primary:
+      url: https://factory.talos.dev
 
 storage:
   vault:

--- a/internal/pkg/config/testdata/invalid-join-token-mode.yaml
+++ b/internal/pkg/config/testdata/invalid-join-token-mode.yaml
@@ -21,7 +21,9 @@ auth:
 registries:
   talos: ghcr.io/siderolabs/installer
   kubernetes: ghcr.io/siderolabs/kubelet
-  imageFactoryBaseURL: https://factory.talos.dev
+  factories:
+    primary:
+      url: https://factory.talos.dev
 
 storage:
   vault:

--- a/internal/pkg/config/testdata/unknown-keys.yaml
+++ b/internal/pkg/config/testdata/unknown-keys.yaml
@@ -71,7 +71,9 @@ auth:
 registries:
   talos: ghcr.io/siderolabs/installer
   kubernetes: ghcr.io/siderolabs/kubelet
-  imageFactoryBaseURL: https://factory.talos.dev
+  factories:
+    primary:
+      url: https://factory.talos.dev
 
 storage:
   vault:

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -633,30 +633,6 @@ type Registries struct {
 	// Factories contains the primary and secondary Image Factory configurations.
 	Factories Factories `json:"factories" yaml:"factories"`
 
-	// ImageFactoryBaseURL is the base URL of the Image Factory service used to build
-	// custom machine images.
-	//
-	// Deprecated: use factories.primary.url instead.
-	ImageFactoryBaseURL *string `json:"imageFactoryBaseURL" yaml:"imageFactoryBaseURL"`
-
-	// ImageFactoryPXEBaseURL is the base URL of the Image Factory PXE endpoint used
-	// to build custom PXE boot images.
-	//
-	// Deprecated: use factories.primary.pxeURL instead.
-	ImageFactoryPXEBaseURL *string `json:"imageFactoryPXEBaseURL,omitempty,omitzero" yaml:"imageFactoryPXEBaseURL,omitempty"`
-
-	// ImageFactoryPassword is the password used to authenticate against the Image
-	// Factory Enterprise service.
-	//
-	// Deprecated: use factories.primary.password instead.
-	ImageFactoryPassword *string `json:"imageFactoryPassword,omitempty,omitzero" yaml:"imageFactoryPassword,omitempty"`
-
-	// ImageFactoryUsername is the username used to authenticate against the Image
-	// Factory Enterprise service.
-	//
-	// Deprecated: use factories.primary.username instead.
-	ImageFactoryUsername *string `json:"imageFactoryUsername,omitempty,omitzero" yaml:"imageFactoryUsername,omitempty"`
-
 	// Kubernetes is the Kubernetes container registry configuration.
 	Kubernetes *string `json:"kubernetes" yaml:"kubernetes"`
 


### PR DESCRIPTION
Remove the deprecated flat config image factory parameters from Omni config. Users should now use exclusively the `registries.factories.primary` config.

Related:
- https://github.com/siderolabs/omni-controller/pull/422