### PR TITLE
fix: record the image factory host for machines already at target

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -451,8 +451,10 @@ func (ctrl *StatusController) reconcileUpgrade(
 
 			if rc.machineStatus.TypedSpec().Value.GetSchematic().GetInvalid() {
 				rc.machineConfigStatus.TypedSpec().Value.SchematicId = ""
+				rc.machineConfigStatus.TypedSpec().Value.ImageFactoryHost = ""
 			} else {
 				rc.machineConfigStatus.TypedSpec().Value.SchematicId = rc.installImage.SchematicId
+				rc.machineConfigStatus.TypedSpec().Value.ImageFactoryHost = rc.installImage.ImageFactoryHost
 			}
 		}
 	}

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -484,9 +484,12 @@ func TestMachineConfigStatusController(t *testing.T) {
 
 			awaitAllMachinesConfigured(ctx, t, testContext.State, clusterName)
 
-			// Schematic ID should be set after initial config apply
+			// Schematic ID should be set after initial config apply, and so should the
+			// image factory host: they describe the same installed image and are
+			// recorded together everywhere else.
 			rtestutils.AssertResource(ctx, t, testContext.State, id, func(res *omni.ClusterMachineConfigStatus, assert *assert.Assertions) {
 				assert.NotEmpty(res.TypedSpec().Value.SchematicId)
+				assert.NotEmpty(res.TypedSpec().Value.ImageFactoryHost)
 			})
 
 			// Mark the machine as having an invalid schematic


### PR DESCRIPTION
A machine that reaches its target version without an upgrade records the version and the schematic but not the image factory host, so the field stays empty for good while every other path that records an installed image writes all three together.