### PR TITLE
fix: mark a cluster as bootstrapped only once etcd is running on the node

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -3883,10 +3883,13 @@ func (x *MachinePendingUpdatesSpec) GetCompressedConfigDiff() []byte {
 
 // ClusterBootstrapStatusSpec keeps track of bootstrap calls for a cluster.
 type ClusterBootstrapStatusSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Bootstrapped  bool                   `protobuf:"varint,1,opt,name=bootstrapped,proto3" json:"bootstrapped,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Bootstrapped is set once etcd is confirmed to be running on the bootstrapped node.
+	Bootstrapped bool `protobuf:"varint,1,opt,name=bootstrapped,proto3" json:"bootstrapped,omitempty"`
+	// LastBootstrapAttempt is the time the bootstrap request was last sent to the cluster.
+	LastBootstrapAttempt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_bootstrap_attempt,json=lastBootstrapAttempt,proto3" json:"last_bootstrap_attempt,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ClusterBootstrapStatusSpec) Reset() {
@@ -3924,6 +3927,13 @@ func (x *ClusterBootstrapStatusSpec) GetBootstrapped() bool {
 		return x.Bootstrapped
 	}
 	return false
+}
+
+func (x *ClusterBootstrapStatusSpec) GetLastBootstrapAttempt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastBootstrapAttempt
+	}
+	return nil
 }
 
 // ClusterSecretsSpec describes cluster secrets.
@@ -12377,9 +12387,10 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\fto_schematic\x18\x02 \x01(\tR\vtoSchematic\x12!\n" +
 	"\ffrom_version\x18\x03 \x01(\tR\vfromVersion\x12\x1d\n" +
 	"\n" +
-	"to_version\x18\x04 \x01(\tR\ttoVersion\"@\n" +
+	"to_version\x18\x04 \x01(\tR\ttoVersion\"\x92\x01\n" +
 	"\x1aClusterBootstrapStatusSpec\x12\"\n" +
-	"\fbootstrapped\x18\x01 \x01(\bR\fbootstrapped\"\xa4\x02\n" +
+	"\fbootstrapped\x18\x01 \x01(\bR\fbootstrapped\x12P\n" +
+	"\x16last_bootstrap_attempt\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x14lastBootstrapAttempt\"\xa4\x02\n" +
 	"\x12ClusterSecretsSpec\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\fR\x04data\x12\x1a\n" +
 	"\bimported\x18\x02 \x01(\bR\bimported\x12@\n" +
@@ -13284,122 +13295,123 @@ var file_omni_specs_omni_proto_depIdxs = []int32{
 	56,  // 23: specs.ClusterStatusSpec.machines:type_name -> specs.Machines
 	9,   // 24: specs.ClusterStatusSpec.phase:type_name -> specs.ClusterStatusSpec.Phase
 	157, // 25: specs.MachinePendingUpdatesSpec.upgrade:type_name -> specs.MachinePendingUpdatesSpec.Upgrade
-	158, // 26: specs.ClusterSecretsSpec.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
-	10,  // 27: specs.MachineSetSpec.update_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	161, // 28: specs.MachineSetSpec.machine_class:type_name -> specs.MachineSetSpec.MachineAllocation
-	162, // 29: specs.MachineSetSpec.bootstrap_spec:type_name -> specs.MachineSetSpec.BootstrapSpec
-	10,  // 30: specs.MachineSetSpec.delete_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	164, // 31: specs.MachineSetSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	164, // 32: specs.MachineSetSpec.delete_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	161, // 33: specs.MachineSetSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
-	10,  // 34: specs.MachineSetSpec.upgrade_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	164, // 35: specs.MachineSetSpec.upgrade_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	13,  // 36: specs.TalosUpgradeStatusSpec.phase:type_name -> specs.TalosUpgradeStatusSpec.Phase
-	1,   // 37: specs.MachineSetStatusSpec.phase:type_name -> specs.MachineSetPhase
-	56,  // 38: specs.MachineSetStatusSpec.machines:type_name -> specs.Machines
-	161, // 39: specs.MachineSetStatusSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
-	10,  // 40: specs.MachineSetConfigStatusSpec.update_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
-	164, // 41: specs.MachineSetConfigStatusSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
-	197, // 42: specs.MachineStatusSnapshotSpec.machine_status:type_name -> machine.MachineStatusEvent
-	14,  // 43: specs.MachineStatusSnapshotSpec.power_stage:type_name -> specs.MachineStatusSnapshotSpec.PowerStage
-	165, // 44: specs.ControlPlaneStatusSpec.conditions:type_name -> specs.ControlPlaneStatusSpec.Condition
-	166, // 45: specs.KubernetesStatusSpec.nodes:type_name -> specs.KubernetesStatusSpec.NodeStatus
-	168, // 46: specs.KubernetesStatusSpec.static_pods:type_name -> specs.KubernetesStatusSpec.NodeStaticPods
-	17,  // 47: specs.KubernetesUpgradeStatusSpec.phase:type_name -> specs.KubernetesUpgradeStatusSpec.Phase
-	72,  // 48: specs.OngoingTaskSpec.talos_upgrade:type_name -> specs.TalosUpgradeStatusSpec
-	81,  // 49: specs.OngoingTaskSpec.kubernetes_upgrade:type_name -> specs.KubernetesUpgradeStatusSpec
-	83,  // 50: specs.OngoingTaskSpec.destroy:type_name -> specs.DestroyStatusSpec
-	107, // 51: specs.OngoingTaskSpec.machine_upgrade:type_name -> specs.MachineUpgradeStatusSpec
-	130, // 52: specs.OngoingTaskSpec.secrets_rotation:type_name -> specs.ClusterSecretsRotationStatusSpec
-	93,  // 53: specs.FeaturesConfigSpec.etcd_backup_settings:type_name -> specs.EtcdBackupSettings
-	89,  // 54: specs.FeaturesConfigSpec.user_pilot_settings:type_name -> specs.UserPilotSettings
-	91,  // 55: specs.FeaturesConfigSpec.stripe_settings:type_name -> specs.StripeSettings
-	92,  // 56: specs.FeaturesConfigSpec.account:type_name -> specs.Account
-	90,  // 57: specs.FeaturesConfigSpec.posthog_settings:type_name -> specs.PosthogSettings
-	195, // 58: specs.EtcdBackupSettings.tick_interval:type_name -> google.protobuf.Duration
-	195, // 59: specs.EtcdBackupSettings.min_interval:type_name -> google.protobuf.Duration
-	195, // 60: specs.EtcdBackupSettings.max_interval:type_name -> google.protobuf.Duration
-	169, // 61: specs.MachineClassSpec.auto_provision:type_name -> specs.MachineClassSpec.Provision
-	170, // 62: specs.MachineConfigGenOptionsSpec.install_image:type_name -> specs.MachineConfigGenOptionsSpec.InstallImage
-	171, // 63: specs.KubernetesUsageSpec.cpu:type_name -> specs.KubernetesUsageSpec.Quantity
-	171, // 64: specs.KubernetesUsageSpec.mem:type_name -> specs.KubernetesUsageSpec.Quantity
-	171, // 65: specs.KubernetesUsageSpec.storage:type_name -> specs.KubernetesUsageSpec.Quantity
-	172, // 66: specs.KubernetesUsageSpec.pods:type_name -> specs.KubernetesUsageSpec.Pod
-	173, // 67: specs.ImagePullRequestSpec.node_image_list:type_name -> specs.ImagePullRequestSpec.NodeImageList
-	174, // 68: specs.TalosExtensionsSpec.items:type_name -> specs.TalosExtensionsSpec.Info
-	18,  // 69: specs.MachineUpgradeStatusSpec.phase:type_name -> specs.MachineUpgradeStatusSpec.Phase
-	175, // 70: specs.MachineExtensionsStatusSpec.extensions:type_name -> specs.MachineExtensionsStatusSpec.Item
-	176, // 71: specs.MachineStatusMetricsSpec.platforms:type_name -> specs.MachineStatusMetricsSpec.PlatformsEntry
-	177, // 72: specs.MachineStatusMetricsSpec.secure_boot_status:type_name -> specs.MachineStatusMetricsSpec.SecureBootStatusEntry
-	178, // 73: specs.MachineStatusMetricsSpec.uki_status:type_name -> specs.MachineStatusMetricsSpec.UkiStatusEntry
-	179, // 74: specs.ClusterMetricsSpec.features:type_name -> specs.ClusterMetricsSpec.FeaturesEntry
-	180, // 75: specs.ClusterStatusMetricsSpec.phases:type_name -> specs.ClusterStatusMetricsSpec.PhasesEntry
-	34,  // 76: specs.MachineRequestSetSpec.meta_values:type_name -> specs.MetaValue
-	3,   // 77: specs.MachineRequestSetSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	181, // 78: specs.ClusterDiagnosticsSpec.nodes:type_name -> specs.ClusterDiagnosticsSpec.Node
-	20,  // 79: specs.ClusterMachineRequestStatusSpec.stage:type_name -> specs.ClusterMachineRequestStatusSpec.Stage
-	22,  // 80: specs.InfraMachineConfigSpec.power_state:type_name -> specs.InfraMachineConfigSpec.MachinePowerState
-	21,  // 81: specs.InfraMachineConfigSpec.acceptance_status:type_name -> specs.InfraMachineConfigSpec.AcceptanceStatus
-	182, // 82: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
-	183, // 83: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
-	184, // 84: specs.InfraProviderCombinedStatusSpec.health:type_name -> specs.InfraProviderCombinedStatusSpec.Health
-	198, // 85: specs.InstallationMediaConfigSpec.architecture:type_name -> specs.PlatformConfigSpec.Arch
-	185, // 86: specs.InstallationMediaConfigSpec.cloud:type_name -> specs.InstallationMediaConfigSpec.Cloud
-	186, // 87: specs.InstallationMediaConfigSpec.sbc:type_name -> specs.InstallationMediaConfigSpec.SBC
-	3,   // 88: specs.InstallationMediaConfigSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	187, // 89: specs.InstallationMediaConfigSpec.machine_labels:type_name -> specs.InstallationMediaConfigSpec.MachineLabelsEntry
-	199, // 90: specs.InstallationMediaConfigSpec.bootloader:type_name -> management.SchematicBootloader
-	23,  // 91: specs.SecretRotationSpec.status:type_name -> specs.SecretRotationSpec.Status
-	24,  // 92: specs.SecretRotationSpec.phase:type_name -> specs.SecretRotationSpec.Phase
-	25,  // 93: specs.SecretRotationSpec.component:type_name -> specs.SecretRotationSpec.Component
-	158, // 94: specs.SecretRotationSpec.certs:type_name -> specs.ClusterSecretsSpec.Certs
-	158, // 95: specs.SecretRotationSpec.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
-	159, // 96: specs.SecretRotationSpec.backup_certs_os:type_name -> specs.ClusterSecretsSpec.Certs.CA
-	159, // 97: specs.SecretRotationSpec.backup_certs_k8s:type_name -> specs.ClusterSecretsSpec.Certs.CA
-	24,  // 98: specs.ClusterSecretsRotationStatusSpec.phase:type_name -> specs.SecretRotationSpec.Phase
-	25,  // 99: specs.ClusterSecretsRotationStatusSpec.component:type_name -> specs.SecretRotationSpec.Component
-	188, // 100: specs.ClusterMachineSecretsSpec.rotation:type_name -> specs.ClusterMachineSecretsSpec.Rotation
-	189, // 101: specs.UpgradeRolloutSpec.machine_sets_upgrade_quota:type_name -> specs.UpgradeRolloutSpec.MachineSetsUpgradeQuotaEntry
-	26,  // 102: specs.NotificationSpec.type:type_name -> specs.NotificationSpec.Type
-	27,  // 103: specs.KubernetesManifestGroupSpec.mode:type_name -> specs.KubernetesManifestGroupSpec.Mode
-	192, // 104: specs.ClusterKubernetesManifestsStatusSpec.groups:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry
-	195, // 105: specs.KubernetesHealthCheckSpec.interval:type_name -> google.protobuf.Duration
-	30,  // 106: specs.KubernetesHealthCheckStatusSpec.state:type_name -> specs.KubernetesHealthCheckStatusSpec.State
-	194, // 107: specs.MachineInstallDiskStatusSpec.disks:type_name -> specs.MachineInstallDiskStatusSpec.Disk
-	149, // 108: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
-	150, // 109: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
-	151, // 110: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
-	152, // 111: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
-	153, // 112: specs.MachineStatusSpec.PlatformMetadata.tags:type_name -> specs.MachineStatusSpec.PlatformMetadata.TagsEntry
-	154, // 113: specs.MachineStatusSpec.Schematic.initial_state:type_name -> specs.MachineStatusSpec.Schematic.InitialState
-	159, // 114: specs.ClusterSecretsSpec.Certs.os:type_name -> specs.ClusterSecretsSpec.Certs.CA
-	159, // 115: specs.ClusterSecretsSpec.Certs.k8s:type_name -> specs.ClusterSecretsSpec.Certs.CA
-	11,  // 116: specs.MachineSetSpec.MachineClass.allocation_type:type_name -> specs.MachineSetSpec.MachineClass.Type
-	12,  // 117: specs.MachineSetSpec.MachineAllocation.allocation_type:type_name -> specs.MachineSetSpec.MachineAllocation.Type
-	163, // 118: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
-	2,   // 119: specs.ControlPlaneStatusSpec.Condition.type:type_name -> specs.ConditionType
-	15,  // 120: specs.ControlPlaneStatusSpec.Condition.status:type_name -> specs.ControlPlaneStatusSpec.Condition.Status
-	16,  // 121: specs.ControlPlaneStatusSpec.Condition.severity:type_name -> specs.ControlPlaneStatusSpec.Condition.Severity
-	167, // 122: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
-	34,  // 123: specs.MachineClassSpec.Provision.meta_values:type_name -> specs.MetaValue
-	3,   // 124: specs.MachineClassSpec.Provision.grpc_tunnel:type_name -> specs.GrpcTunnelMode
-	32,  // 125: specs.MachineConfigGenOptionsSpec.InstallImage.security_state:type_name -> specs.SecurityState
-	19,  // 126: specs.MachineExtensionsStatusSpec.Item.phase:type_name -> specs.MachineExtensionsStatusSpec.Item.Phase
-	23,  // 127: specs.ClusterMachineSecretsSpec.Rotation.status:type_name -> specs.SecretRotationSpec.Status
-	24,  // 128: specs.ClusterMachineSecretsSpec.Rotation.phase:type_name -> specs.SecretRotationSpec.Phase
-	25,  // 129: specs.ClusterMachineSecretsSpec.Rotation.component:type_name -> specs.SecretRotationSpec.Component
-	158, // 130: specs.ClusterMachineSecretsSpec.Rotation.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
-	28,  // 131: specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus.phase:type_name -> specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus.Phase
-	29,  // 132: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.phase:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.Phase
-	27,  // 133: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.mode:type_name -> specs.KubernetesManifestGroupSpec.Mode
-	193, // 134: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.manifests:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry
-	191, // 135: specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry.value:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus
-	190, // 136: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry.value:type_name -> specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus
-	137, // [137:137] is the sub-list for method output_type
-	137, // [137:137] is the sub-list for method input_type
-	137, // [137:137] is the sub-list for extension type_name
-	137, // [137:137] is the sub-list for extension extendee
-	0,   // [0:137] is the sub-list for field type_name
+	196, // 26: specs.ClusterBootstrapStatusSpec.last_bootstrap_attempt:type_name -> google.protobuf.Timestamp
+	158, // 27: specs.ClusterSecretsSpec.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
+	10,  // 28: specs.MachineSetSpec.update_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
+	161, // 29: specs.MachineSetSpec.machine_class:type_name -> specs.MachineSetSpec.MachineAllocation
+	162, // 30: specs.MachineSetSpec.bootstrap_spec:type_name -> specs.MachineSetSpec.BootstrapSpec
+	10,  // 31: specs.MachineSetSpec.delete_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
+	164, // 32: specs.MachineSetSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	164, // 33: specs.MachineSetSpec.delete_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	161, // 34: specs.MachineSetSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
+	10,  // 35: specs.MachineSetSpec.upgrade_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
+	164, // 36: specs.MachineSetSpec.upgrade_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	13,  // 37: specs.TalosUpgradeStatusSpec.phase:type_name -> specs.TalosUpgradeStatusSpec.Phase
+	1,   // 38: specs.MachineSetStatusSpec.phase:type_name -> specs.MachineSetPhase
+	56,  // 39: specs.MachineSetStatusSpec.machines:type_name -> specs.Machines
+	161, // 40: specs.MachineSetStatusSpec.machine_allocation:type_name -> specs.MachineSetSpec.MachineAllocation
+	10,  // 41: specs.MachineSetConfigStatusSpec.update_strategy:type_name -> specs.MachineSetSpec.UpdateStrategy
+	164, // 42: specs.MachineSetConfigStatusSpec.update_strategy_config:type_name -> specs.MachineSetSpec.UpdateStrategyConfig
+	197, // 43: specs.MachineStatusSnapshotSpec.machine_status:type_name -> machine.MachineStatusEvent
+	14,  // 44: specs.MachineStatusSnapshotSpec.power_stage:type_name -> specs.MachineStatusSnapshotSpec.PowerStage
+	165, // 45: specs.ControlPlaneStatusSpec.conditions:type_name -> specs.ControlPlaneStatusSpec.Condition
+	166, // 46: specs.KubernetesStatusSpec.nodes:type_name -> specs.KubernetesStatusSpec.NodeStatus
+	168, // 47: specs.KubernetesStatusSpec.static_pods:type_name -> specs.KubernetesStatusSpec.NodeStaticPods
+	17,  // 48: specs.KubernetesUpgradeStatusSpec.phase:type_name -> specs.KubernetesUpgradeStatusSpec.Phase
+	72,  // 49: specs.OngoingTaskSpec.talos_upgrade:type_name -> specs.TalosUpgradeStatusSpec
+	81,  // 50: specs.OngoingTaskSpec.kubernetes_upgrade:type_name -> specs.KubernetesUpgradeStatusSpec
+	83,  // 51: specs.OngoingTaskSpec.destroy:type_name -> specs.DestroyStatusSpec
+	107, // 52: specs.OngoingTaskSpec.machine_upgrade:type_name -> specs.MachineUpgradeStatusSpec
+	130, // 53: specs.OngoingTaskSpec.secrets_rotation:type_name -> specs.ClusterSecretsRotationStatusSpec
+	93,  // 54: specs.FeaturesConfigSpec.etcd_backup_settings:type_name -> specs.EtcdBackupSettings
+	89,  // 55: specs.FeaturesConfigSpec.user_pilot_settings:type_name -> specs.UserPilotSettings
+	91,  // 56: specs.FeaturesConfigSpec.stripe_settings:type_name -> specs.StripeSettings
+	92,  // 57: specs.FeaturesConfigSpec.account:type_name -> specs.Account
+	90,  // 58: specs.FeaturesConfigSpec.posthog_settings:type_name -> specs.PosthogSettings
+	195, // 59: specs.EtcdBackupSettings.tick_interval:type_name -> google.protobuf.Duration
+	195, // 60: specs.EtcdBackupSettings.min_interval:type_name -> google.protobuf.Duration
+	195, // 61: specs.EtcdBackupSettings.max_interval:type_name -> google.protobuf.Duration
+	169, // 62: specs.MachineClassSpec.auto_provision:type_name -> specs.MachineClassSpec.Provision
+	170, // 63: specs.MachineConfigGenOptionsSpec.install_image:type_name -> specs.MachineConfigGenOptionsSpec.InstallImage
+	171, // 64: specs.KubernetesUsageSpec.cpu:type_name -> specs.KubernetesUsageSpec.Quantity
+	171, // 65: specs.KubernetesUsageSpec.mem:type_name -> specs.KubernetesUsageSpec.Quantity
+	171, // 66: specs.KubernetesUsageSpec.storage:type_name -> specs.KubernetesUsageSpec.Quantity
+	172, // 67: specs.KubernetesUsageSpec.pods:type_name -> specs.KubernetesUsageSpec.Pod
+	173, // 68: specs.ImagePullRequestSpec.node_image_list:type_name -> specs.ImagePullRequestSpec.NodeImageList
+	174, // 69: specs.TalosExtensionsSpec.items:type_name -> specs.TalosExtensionsSpec.Info
+	18,  // 70: specs.MachineUpgradeStatusSpec.phase:type_name -> specs.MachineUpgradeStatusSpec.Phase
+	175, // 71: specs.MachineExtensionsStatusSpec.extensions:type_name -> specs.MachineExtensionsStatusSpec.Item
+	176, // 72: specs.MachineStatusMetricsSpec.platforms:type_name -> specs.MachineStatusMetricsSpec.PlatformsEntry
+	177, // 73: specs.MachineStatusMetricsSpec.secure_boot_status:type_name -> specs.MachineStatusMetricsSpec.SecureBootStatusEntry
+	178, // 74: specs.MachineStatusMetricsSpec.uki_status:type_name -> specs.MachineStatusMetricsSpec.UkiStatusEntry
+	179, // 75: specs.ClusterMetricsSpec.features:type_name -> specs.ClusterMetricsSpec.FeaturesEntry
+	180, // 76: specs.ClusterStatusMetricsSpec.phases:type_name -> specs.ClusterStatusMetricsSpec.PhasesEntry
+	34,  // 77: specs.MachineRequestSetSpec.meta_values:type_name -> specs.MetaValue
+	3,   // 78: specs.MachineRequestSetSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
+	181, // 79: specs.ClusterDiagnosticsSpec.nodes:type_name -> specs.ClusterDiagnosticsSpec.Node
+	20,  // 80: specs.ClusterMachineRequestStatusSpec.stage:type_name -> specs.ClusterMachineRequestStatusSpec.Stage
+	22,  // 81: specs.InfraMachineConfigSpec.power_state:type_name -> specs.InfraMachineConfigSpec.MachinePowerState
+	21,  // 82: specs.InfraMachineConfigSpec.acceptance_status:type_name -> specs.InfraMachineConfigSpec.AcceptanceStatus
+	182, // 83: specs.InfraMachineBMCConfigSpec.ipmi:type_name -> specs.InfraMachineBMCConfigSpec.IPMI
+	183, // 84: specs.InfraMachineBMCConfigSpec.api:type_name -> specs.InfraMachineBMCConfigSpec.API
+	184, // 85: specs.InfraProviderCombinedStatusSpec.health:type_name -> specs.InfraProviderCombinedStatusSpec.Health
+	198, // 86: specs.InstallationMediaConfigSpec.architecture:type_name -> specs.PlatformConfigSpec.Arch
+	185, // 87: specs.InstallationMediaConfigSpec.cloud:type_name -> specs.InstallationMediaConfigSpec.Cloud
+	186, // 88: specs.InstallationMediaConfigSpec.sbc:type_name -> specs.InstallationMediaConfigSpec.SBC
+	3,   // 89: specs.InstallationMediaConfigSpec.grpc_tunnel:type_name -> specs.GrpcTunnelMode
+	187, // 90: specs.InstallationMediaConfigSpec.machine_labels:type_name -> specs.InstallationMediaConfigSpec.MachineLabelsEntry
+	199, // 91: specs.InstallationMediaConfigSpec.bootloader:type_name -> management.SchematicBootloader
+	23,  // 92: specs.SecretRotationSpec.status:type_name -> specs.SecretRotationSpec.Status
+	24,  // 93: specs.SecretRotationSpec.phase:type_name -> specs.SecretRotationSpec.Phase
+	25,  // 94: specs.SecretRotationSpec.component:type_name -> specs.SecretRotationSpec.Component
+	158, // 95: specs.SecretRotationSpec.certs:type_name -> specs.ClusterSecretsSpec.Certs
+	158, // 96: specs.SecretRotationSpec.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
+	159, // 97: specs.SecretRotationSpec.backup_certs_os:type_name -> specs.ClusterSecretsSpec.Certs.CA
+	159, // 98: specs.SecretRotationSpec.backup_certs_k8s:type_name -> specs.ClusterSecretsSpec.Certs.CA
+	24,  // 99: specs.ClusterSecretsRotationStatusSpec.phase:type_name -> specs.SecretRotationSpec.Phase
+	25,  // 100: specs.ClusterSecretsRotationStatusSpec.component:type_name -> specs.SecretRotationSpec.Component
+	188, // 101: specs.ClusterMachineSecretsSpec.rotation:type_name -> specs.ClusterMachineSecretsSpec.Rotation
+	189, // 102: specs.UpgradeRolloutSpec.machine_sets_upgrade_quota:type_name -> specs.UpgradeRolloutSpec.MachineSetsUpgradeQuotaEntry
+	26,  // 103: specs.NotificationSpec.type:type_name -> specs.NotificationSpec.Type
+	27,  // 104: specs.KubernetesManifestGroupSpec.mode:type_name -> specs.KubernetesManifestGroupSpec.Mode
+	192, // 105: specs.ClusterKubernetesManifestsStatusSpec.groups:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry
+	195, // 106: specs.KubernetesHealthCheckSpec.interval:type_name -> google.protobuf.Duration
+	30,  // 107: specs.KubernetesHealthCheckStatusSpec.state:type_name -> specs.KubernetesHealthCheckStatusSpec.State
+	194, // 108: specs.MachineInstallDiskStatusSpec.disks:type_name -> specs.MachineInstallDiskStatusSpec.Disk
+	149, // 109: specs.MachineStatusSpec.HardwareStatus.processors:type_name -> specs.MachineStatusSpec.HardwareStatus.Processor
+	150, // 110: specs.MachineStatusSpec.HardwareStatus.memory_modules:type_name -> specs.MachineStatusSpec.HardwareStatus.MemoryModule
+	151, // 111: specs.MachineStatusSpec.HardwareStatus.blockdevices:type_name -> specs.MachineStatusSpec.HardwareStatus.BlockDevice
+	152, // 112: specs.MachineStatusSpec.NetworkStatus.network_links:type_name -> specs.MachineStatusSpec.NetworkStatus.NetworkLinkStatus
+	153, // 113: specs.MachineStatusSpec.PlatformMetadata.tags:type_name -> specs.MachineStatusSpec.PlatformMetadata.TagsEntry
+	154, // 114: specs.MachineStatusSpec.Schematic.initial_state:type_name -> specs.MachineStatusSpec.Schematic.InitialState
+	159, // 115: specs.ClusterSecretsSpec.Certs.os:type_name -> specs.ClusterSecretsSpec.Certs.CA
+	159, // 116: specs.ClusterSecretsSpec.Certs.k8s:type_name -> specs.ClusterSecretsSpec.Certs.CA
+	11,  // 117: specs.MachineSetSpec.MachineClass.allocation_type:type_name -> specs.MachineSetSpec.MachineClass.Type
+	12,  // 118: specs.MachineSetSpec.MachineAllocation.allocation_type:type_name -> specs.MachineSetSpec.MachineAllocation.Type
+	163, // 119: specs.MachineSetSpec.UpdateStrategyConfig.rolling:type_name -> specs.MachineSetSpec.RollingUpdateStrategyConfig
+	2,   // 120: specs.ControlPlaneStatusSpec.Condition.type:type_name -> specs.ConditionType
+	15,  // 121: specs.ControlPlaneStatusSpec.Condition.status:type_name -> specs.ControlPlaneStatusSpec.Condition.Status
+	16,  // 122: specs.ControlPlaneStatusSpec.Condition.severity:type_name -> specs.ControlPlaneStatusSpec.Condition.Severity
+	167, // 123: specs.KubernetesStatusSpec.NodeStaticPods.static_pods:type_name -> specs.KubernetesStatusSpec.StaticPodStatus
+	34,  // 124: specs.MachineClassSpec.Provision.meta_values:type_name -> specs.MetaValue
+	3,   // 125: specs.MachineClassSpec.Provision.grpc_tunnel:type_name -> specs.GrpcTunnelMode
+	32,  // 126: specs.MachineConfigGenOptionsSpec.InstallImage.security_state:type_name -> specs.SecurityState
+	19,  // 127: specs.MachineExtensionsStatusSpec.Item.phase:type_name -> specs.MachineExtensionsStatusSpec.Item.Phase
+	23,  // 128: specs.ClusterMachineSecretsSpec.Rotation.status:type_name -> specs.SecretRotationSpec.Status
+	24,  // 129: specs.ClusterMachineSecretsSpec.Rotation.phase:type_name -> specs.SecretRotationSpec.Phase
+	25,  // 130: specs.ClusterMachineSecretsSpec.Rotation.component:type_name -> specs.SecretRotationSpec.Component
+	158, // 131: specs.ClusterMachineSecretsSpec.Rotation.extra_certs:type_name -> specs.ClusterSecretsSpec.Certs
+	28,  // 132: specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus.phase:type_name -> specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus.Phase
+	29,  // 133: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.phase:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.Phase
+	27,  // 134: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.mode:type_name -> specs.KubernetesManifestGroupSpec.Mode
+	193, // 135: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.manifests:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry
+	191, // 136: specs.ClusterKubernetesManifestsStatusSpec.GroupsEntry.value:type_name -> specs.ClusterKubernetesManifestsStatusSpec.GroupStatus
+	190, // 137: specs.ClusterKubernetesManifestsStatusSpec.GroupStatus.ManifestsEntry.value:type_name -> specs.ClusterKubernetesManifestsStatusSpec.ManifestStatus
+	138, // [138:138] is the sub-list for method output_type
+	138, // [138:138] is the sub-list for method input_type
+	138, // [138:138] is the sub-list for extension type_name
+	138, // [138:138] is the sub-list for extension extendee
+	0,   // [0:138] is the sub-list for field type_name
 }
 
 func init() { file_omni_specs_omni_proto_init() }

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -726,7 +726,10 @@ message MachinePendingUpdatesSpec {
 
 // ClusterBootstrapStatusSpec keeps track of bootstrap calls for a cluster.
 message ClusterBootstrapStatusSpec {
+  // Bootstrapped is set once etcd is confirmed to be running on the bootstrapped node.
   bool bootstrapped = 1;
+  // LastBootstrapAttempt is the time the bootstrap request was last sent to the cluster.
+  google.protobuf.Timestamp last_bootstrap_attempt = 2;
 }
 
 // ClusterSecretsSpec describes cluster secrets.

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -1058,6 +1058,7 @@ func (m *ClusterBootstrapStatusSpec) CloneVT() *ClusterBootstrapStatusSpec {
 	}
 	r := new(ClusterBootstrapStatusSpec)
 	r.Bootstrapped = m.Bootstrapped
+	r.LastBootstrapAttempt = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.LastBootstrapAttempt).CloneVT())
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -4913,6 +4914,9 @@ func (this *ClusterBootstrapStatusSpec) EqualVT(that *ClusterBootstrapStatusSpec
 		return false
 	}
 	if this.Bootstrapped != that.Bootstrapped {
+		return false
+	}
+	if !(*timestamppb1.Timestamp)(this.LastBootstrapAttempt).EqualVT((*timestamppb1.Timestamp)(that.LastBootstrapAttempt)) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -11288,6 +11292,16 @@ func (m *ClusterBootstrapStatusSpec) MarshalToSizedBufferVT(dAtA []byte) (int, e
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.LastBootstrapAttempt != nil {
+		size, err := (*timestamppb1.Timestamp)(m.LastBootstrapAttempt).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
 	}
 	if m.Bootstrapped {
 		i--
@@ -18856,6 +18870,10 @@ func (m *ClusterBootstrapStatusSpec) SizeVT() (n int) {
 	_ = l
 	if m.Bootstrapped {
 		n += 2
+	}
+	if m.LastBootstrapAttempt != nil {
+		l = (*timestamppb1.Timestamp)(m.LastBootstrapAttempt).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -29574,6 +29592,42 @@ func (m *ClusterBootstrapStatusSpec) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Bootstrapped = bool(v != 0)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastBootstrapAttempt", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LastBootstrapAttempt == nil {
+				m.LastBootstrapAttempt = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.LastBootstrapAttempt).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/frontend/src/api/omni/specs/omni.pb.ts
+++ b/frontend/src/api/omni/specs/omni.pb.ts
@@ -565,6 +565,7 @@ export type MachinePendingUpdatesSpec = {
 
 export type ClusterBootstrapStatusSpec = {
   bootstrapped?: boolean
+  last_bootstrap_attempt?: GoogleProtobufTimestamp.Timestamp
 }
 
 export type ClusterSecretsSpecCertsCA = {

--- a/internal/backend/resourcelogger/resourcelogger_test.go
+++ b/internal/backend/resourcelogger/resourcelogger_test.go
@@ -140,7 +140,7 @@ func TestResourceLogger(t *testing.T) {
 				resource: "ClusterBootstrapStatuses.omni.sidero.dev(default/test@2)",
 				diff: `--- ClusterBootstrapStatuses.omni.sidero.dev(default/test)
 +++ ClusterBootstrapStatuses.omni.sidero.dev(default/test)
-@@ -2,10 +2,10 @@
+@@ -2,11 +2,11 @@
      namespace: default
      type: ClusterBootstrapStatuses.omni.sidero.dev
      id: test
@@ -154,6 +154,7 @@ func TestResourceLogger(t *testing.T) {
  spec:
 -    bootstrapped: false
 +    bootstrapped: true
+     lastbootstrapattempt: null
 `,
 			},
 			{

--- a/internal/backend/runtime/omni/controllers/omni/cluster/bootstrap_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster/bootstrap_status.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
@@ -18,6 +19,9 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
@@ -35,6 +39,19 @@ type BootstrapStatusController struct {
 
 // BootstrapStatusControllerName is the name of the BootstrapStatusController.
 const BootstrapStatusControllerName = "ClusterBootstrapStatusController"
+
+const (
+	// bootstrapCheckInterval is how often etcd is checked on the bootstrapped node after a bootstrap request was sent.
+	bootstrapCheckInterval = 5 * time.Second
+
+	// bootstrapRetryInterval is how long to wait before sending another bootstrap request.
+	//
+	// It is long on purpose: a bootstrap with a snapshot restore runs on the node long after the request
+	// has returned, and a request sent while that restore is still running interrupts it and can leave
+	// a broken etcd data directory behind, from which the cluster does not recover on its own. Waiting
+	// too long only delays the recovery from a lost request.
+	bootstrapRetryInterval = 5 * time.Minute
+)
 
 // NewBootstrapStatusController initializes BootstrapStatusController.
 func NewBootstrapStatusController(etcdBackupStoreFactory store.Factory) *BootstrapStatusController {
@@ -88,6 +105,7 @@ func (ctrl *BootstrapStatusController) reconcile(
 	if err != nil {
 		if state.IsNotFoundError(err) { // missing control-plane, mark the cluster as non-bootstrapped
 			bootstrapStatus.TypedSpec().Value.Bootstrapped = false
+			bootstrapStatus.TypedSpec().Value.LastBootstrapAttempt = nil
 
 			return nil
 		}
@@ -97,6 +115,7 @@ func (ctrl *BootstrapStatusController) reconcile(
 
 	if cpMachineSet.Metadata().Phase() == resource.PhaseTearingDown {
 		bootstrapStatus.TypedSpec().Value.Bootstrapped = false
+		bootstrapStatus.TypedSpec().Value.LastBootstrapAttempt = nil
 
 		return r.RemoveFinalizer(ctx, cpMachineSet.Metadata(), BootstrapStatusControllerName)
 	}
@@ -128,59 +147,6 @@ func (ctrl *BootstrapStatusController) reconcile(
 	}
 
 	return ctrl.bootstrapCluster(ctx, r, logger, cpMachineSet, bootstrapStatus)
-}
-
-func (ctrl *BootstrapStatusController) bootstrapCluster(
-	ctx context.Context,
-	r controller.Reader,
-	logger *zap.Logger,
-	cpMachineSet *omni.MachineSet,
-	bootstrapStatus *omni.ClusterBootstrapStatus,
-) error {
-	clusterID := bootstrapStatus.Metadata().ID()
-
-	talosCli, err := ctrl.getTalosClient(ctx, r, clusterID)
-	if err != nil {
-		if talos.IsClientNotReadyError(err) {
-			return nil
-		}
-
-		return fmt.Errorf("error getting talos client for cluster '%s': %w", clusterID, err)
-	}
-
-	defer func() {
-		if e := talosCli.Close(); e != nil {
-			logger.Error("failed to close talos client", zap.Error(e))
-		}
-	}()
-
-	bootstrapSpec := cpMachineSet.TypedSpec().Value.GetBootstrapSpec()
-	recoverEtcd := bootstrapSpec != nil
-
-	if recoverEtcd {
-		logger.Info(
-			"recovering etcd from backup",
-			zap.String("cluster_id", clusterID),
-			zap.String("cluster_uuid", bootstrapSpec.GetClusterUuid()),
-			zap.String("snapshot", bootstrapSpec.GetSnapshot()),
-		)
-
-		if err = ctrl.recoverEtcdFromBackup(ctx, r, talosCli, bootstrapSpec); err != nil {
-			return err
-		}
-	}
-
-	if err = talosCli.Bootstrap(ctx, &machine.BootstrapRequest{
-		RecoverEtcd: recoverEtcd,
-	}); err != nil {
-		return fmt.Errorf("error bootstrapping cluster '%s': %w", clusterID, err)
-	}
-
-	logger.Info("bootstrapping cluster", zap.String("cluster_id", clusterID))
-
-	bootstrapStatus.TypedSpec().Value.Bootstrapped = true
-
-	return nil
 }
 
 func (ctrl *BootstrapStatusController) finalizerRemoval(ctx context.Context, r controller.ReaderWriter, _ *zap.Logger, clusterStatus *omni.ClusterStatus) error {
@@ -244,6 +210,119 @@ func (ctrl *BootstrapStatusController) recoverEtcdFromBackup(
 	}
 
 	return nil
+}
+
+// bootstrapCluster sends the bootstrap request to the cluster and marks the cluster as bootstrapped once etcd is
+// confirmed to be running on the node.
+//
+// The bootstrap API returns as soon as the etcd service is started on the node, before the bootstrap (and the
+// snapshot restore, if requested) has actually happened. The node only keeps that intent in memory, so a reboot
+// in that window loses it. This is why the cluster is marked as bootstrapped only once etcd is running.
+func (ctrl *BootstrapStatusController) bootstrapCluster(
+	ctx context.Context,
+	r controller.Reader,
+	logger *zap.Logger,
+	cpMachineSet *omni.MachineSet,
+	bootstrapStatus *omni.ClusterBootstrapStatus,
+) error {
+	clusterID := bootstrapStatus.Metadata().ID()
+
+	talosCli, err := ctrl.getTalosClient(ctx, r, clusterID)
+	if err != nil {
+		if talos.IsClientNotReadyError(err) {
+			return nil
+		}
+
+		return fmt.Errorf("error getting talos client for cluster '%s': %w", clusterID, err)
+	}
+
+	defer func() {
+		if e := talosCli.Close(); e != nil {
+			logger.Error("failed to close talos client", zap.Error(e))
+		}
+	}()
+
+	etcdRunning, err := ctrl.isEtcdRunning(ctx, talosCli)
+	if err != nil {
+		return fmt.Errorf("error checking etcd on cluster '%s': %w", clusterID, err)
+	}
+
+	if etcdRunning {
+		logger.Info("etcd is running, cluster is bootstrapped", zap.String("cluster_id", clusterID))
+
+		bootstrapStatus.TypedSpec().Value.Bootstrapped = true
+
+		return nil
+	}
+
+	// A request sent recently might still be in progress on the node. Sending another one would interrupt it, so
+	// only keep checking etcd until enough time has passed to send again.
+	lastAttempt := bootstrapStatus.TypedSpec().Value.GetLastBootstrapAttempt()
+	if lastAttempt != nil && time.Since(lastAttempt.AsTime()) < bootstrapRetryInterval {
+		return controller.NewRequeueInterval(bootstrapCheckInterval)
+	}
+
+	bootstrapSpec := cpMachineSet.TypedSpec().Value.GetBootstrapSpec()
+	recoverEtcd := bootstrapSpec != nil
+
+	if recoverEtcd {
+		logger.Info(
+			"recovering etcd from backup",
+			zap.String("cluster_id", clusterID),
+			zap.String("cluster_uuid", bootstrapSpec.GetClusterUuid()),
+			zap.String("snapshot", bootstrapSpec.GetSnapshot()),
+		)
+
+		if err = ctrl.recoverEtcdFromBackup(ctx, r, talosCli, bootstrapSpec); err != nil {
+			return err
+		}
+	}
+
+	bootstrapStatus.TypedSpec().Value.LastBootstrapAttempt = timestamppb.Now()
+
+	if err = talosCli.Bootstrap(ctx, &machine.BootstrapRequest{
+		RecoverEtcd: recoverEtcd,
+	}); err != nil {
+		// The node already has etcd data, e.g. from a bootstrap that was not confirmed yet: there is nothing to
+		// send, keep checking etcd instead.
+		if status.Code(err) == codes.AlreadyExists {
+			logger.Warn("the node has etcd data but etcd is not running, waiting for it", zap.String("cluster_id", clusterID))
+
+			return controller.NewRequeueInterval(bootstrapCheckInterval)
+		}
+
+		// The request might have been accepted by the node even though the call failed, e.g. on a timeout. Do not
+		// fail the reconcile, as that would discard the attempt time and re-send the request right away.
+		logger.Error("error bootstrapping cluster", zap.String("cluster_id", clusterID), zap.Error(err))
+
+		return controller.NewRequeueInterval(bootstrapCheckInterval)
+	}
+
+	logger.Info("bootstrapping cluster", zap.String("cluster_id", clusterID))
+
+	return controller.NewRequeueInterval(bootstrapCheckInterval)
+}
+
+// isEtcdRunning checks whether the etcd service is running and healthy on the node.
+//
+// The etcd service gets there only after its preparation is done, which includes the snapshot restore
+// when one was requested, so this confirms that the bootstrap has happened.
+func (ctrl *BootstrapStatusController) isEtcdRunning(ctx context.Context, talosCli *client.Client) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	services, err := talosCli.ServiceInfo(ctx, "etcd")
+	if err != nil {
+		return false, err
+	}
+
+	for _, svc := range services {
+		if svc.Service.GetState() == "Running" && svc.Service.GetHealth().GetHealthy() {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (ctrl *BootstrapStatusController) getTalosClient(ctx context.Context, r controller.Reader, clusterName string) (*client.Client, error) {

--- a/internal/backend/runtime/omni/controllers/omni/cluster/bootstrap_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster/bootstrap_status_test.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -39,29 +41,24 @@ var testBackupData = etcdbackup.BackupData{
 	SecretboxEncryptionSecret: "test-secretbox-secret",
 }
 
-// TestBootstrap checks the bootstrap flow: a cluster with a connected control plane is bootstrapped, the
-// bootstrapped state is dropped when the control plane machine set goes away, and a new control plane with a
-// bootstrap spec gets its etcd restored from the backup.
+// TestBootstrap checks the normal flow: the cluster is marked as bootstrapped only once etcd is running on the
+// node, the bootstrapped state is dropped when the control plane machine set goes away, and a new control plane
+// with a bootstrap spec gets its etcd restored from the backup.
 func TestBootstrap(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
 	defer cancel()
 
-	store := &mockEtcdBackupStore{}
+	withBootstrapController(ctx, t, func(ctx context.Context, tc testutils.TestContext, ms *testutils.MachineServiceMock) {
+		ms.SetEtcdRunning(false)
 
-	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(_ context.Context, tc testutils.TestContext) {
-		require.NoError(t, tc.Runtime.RegisterQController(cluster.NewBootstrapStatusController(&mockStoreFactory{store: store})))
-	}, func(ctx context.Context, tc testutils.TestContext) {
-		ms := testutils.NewMachineServiceMock(ctx, t, "", tc.State)
+		// an accepted bootstrap request brings etcd up some time later, never right away
+		ms.SetBootstrapHandler(func(context.Context, *machine.BootstrapRequest) (*machine.BootstrapResponse, error) {
+			time.AfterFunc(500*time.Millisecond, func() { ms.SetEtcdRunning(true) })
 
-		require.NoError(t, store.Upload(ctx, etcdbackup.Description{
-			ClusterUUID: testClusterUUID,
-			EncryptionData: etcdbackup.EncryptionData{
-				AESCBCEncryptionSecret:    testBackupData.AESCBCEncryptionSecret,
-				SecretboxEncryptionSecret: testBackupData.SecretboxEncryptionSecret,
-			},
-		}, strings.NewReader("data")))
+			return &machine.BootstrapResponse{}, nil
+		})
 
 		clusterName := createCluster(ctx, t, tc.State, ms.SocketConnectionString)
 
@@ -71,24 +68,149 @@ func TestBootstrap(t *testing.T) {
 
 		require.Len(t, ms.GetBootstrapRequests(), 1)
 
+		// the control plane machine set goes away: the cluster is not bootstrapped anymore, the machine is wiped
+		cpMachineSetID := omni.ControlPlanesResourceID(clusterName)
+
+		cpMachineSet, err := safe.StateGetByID[*omni.MachineSet](ctx, tc.State, cpMachineSetID)
+		require.NoError(t, err)
+
+		rtestutils.Destroy[*omni.MachineSet](ctx, t, tc.State, []string{cpMachineSetID})
+		ms.SetEtcdRunning(false)
+
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.False(r.TypedSpec().Value.Bootstrapped)
+			assertion.Nil(r.TypedSpec().Value.LastBootstrapAttempt)
+		})
+
+		// a new control plane machine set with a bootstrap spec restores etcd from the backup
+		backupData := omni.NewBackupData(clusterName)
+		backupData.TypedSpec().Value.EncryptionKey = []byte("test-key")
+		backupData.TypedSpec().Value.AesCbcEncryptionSecret = testBackupData.AESCBCEncryptionSecret
+		backupData.TypedSpec().Value.SecretboxEncryptionSecret = testBackupData.SecretboxEncryptionSecret
+
+		require.NoError(t, tc.State.Create(ctx, backupData))
+
+		cpMachineSet.TypedSpec().Value.BootstrapSpec = &specs.MachineSetSpec_BootstrapSpec{
+			ClusterUuid: testClusterUUID,
+			Snapshot:    testSnapshot,
+		}
+
+		require.NoError(t, tc.State.Create(ctx, cpMachineSet))
+
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.True(r.TypedSpec().Value.Bootstrapped)
+		})
+
+		// the snapshot is uploaded and the bootstrap request is sent once, nothing is re-sent while etcd is coming up
+		require.EqualValues(t, 1, ms.GetEtcdRecoverRequestCount())
+		require.Len(t, ms.GetBootstrapRequests(), 2)
+		require.True(t, ms.GetBootstrapRequests()[1].RecoverEtcd)
+
 		// the cluster goes away while its control plane machine set is still there: the finalizer is released
 		rtestutils.Destroy[*omni.ClusterStatus](ctx, t, tc.State, []string{clusterName})
 		rtestutils.AssertNoResource[*omni.ClusterBootstrapStatus](ctx, t, tc.State, clusterName)
 
-		rtestutils.AssertResources(ctx, t, tc.State, []string{omni.ControlPlanesResourceID(clusterName)}, func(r *omni.MachineSet, assertion *assert.Assertions) {
+		rtestutils.AssertResources(ctx, t, tc.State, []string{cpMachineSetID}, func(r *omni.MachineSet, assertion *assert.Assertions) {
 			assertion.False(r.Metadata().Finalizers().Has(cluster.BootstrapStatusControllerName))
 		})
 	})
 }
 
-// TestRestore checks that a control plane machine set with a bootstrap spec restores etcd from the backup before
-// bootstrapping.
-func TestRestore(t *testing.T) {
+// TestBootstrapConfirmedByEtcd checks that the cluster is not marked as bootstrapped on the bootstrap request result
+// alone, but only once etcd is confirmed running on the node. This is what a node looks like after it rebooted before
+// the bootstrap was done and lost it.
+func TestBootstrapConfirmedByEtcd(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
 	defer cancel()
 
+	withBootstrapController(ctx, t, func(ctx context.Context, tc testutils.TestContext, ms *testutils.MachineServiceMock) {
+		ms.SetEtcdRunning(false)
+
+		ms.SetBootstrapHandler(func(context.Context, *machine.BootstrapRequest) (*machine.BootstrapResponse, error) {
+			return &machine.BootstrapResponse{}, nil
+		})
+
+		clusterName := createCluster(ctx, t, tc.State, ms.SocketConnectionString)
+
+		// the request was sent, but the cluster is not marked as bootstrapped on its result alone while etcd is down.
+		// the attempt time being recorded on the output resource means the reconcile ran to completion.
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.NotNil(r.TypedSpec().Value.LastBootstrapAttempt)
+			assertion.False(r.TypedSpec().Value.Bootstrapped, "the cluster must not be marked as bootstrapped before etcd is running")
+		})
+
+		ms.SetEtcdRunning(true)
+
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.True(r.TypedSpec().Value.Bootstrapped, "the cluster must be marked as bootstrapped once etcd is running")
+		})
+
+		// a single request was sent across the whole flow: it was not re-sent while etcd was being waited for
+		require.Len(t, ms.GetBootstrapRequests(), 1, "the bootstrap request must not be re-sent while etcd is being waited for")
+	})
+}
+
+// TestBootstrapAlreadyExists checks that a node which already has etcd data does not get the controller stuck: the
+// cluster is marked as bootstrapped once etcd is running, without another bootstrap request having to succeed.
+func TestBootstrapAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	withBootstrapController(ctx, t, func(ctx context.Context, tc testutils.TestContext, ms *testutils.MachineServiceMock) {
+		ms.SetEtcdRunning(false)
+
+		ms.SetBootstrapHandler(func(context.Context, *machine.BootstrapRequest) (*machine.BootstrapResponse, error) {
+			return nil, status.Error(codes.AlreadyExists, "etcd data directory is not empty")
+		})
+
+		clusterName := createCluster(ctx, t, tc.State, ms.SocketConnectionString)
+
+		// the request came back with AlreadyExists while etcd is down: the controller records the attempt and keeps
+		// going instead of getting stuck, and does not mark the cluster as bootstrapped yet.
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.NotNil(r.TypedSpec().Value.LastBootstrapAttempt)
+			assertion.False(r.TypedSpec().Value.Bootstrapped)
+		})
+
+		ms.SetEtcdRunning(true)
+
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.True(r.TypedSpec().Value.Bootstrapped)
+		})
+	})
+}
+
+// TestBootstrapErrorSavesAttempt checks that a bootstrap request which fails with an error is still counted as sent,
+// as the node might have accepted it, so it is not re-sent right away.
+func TestBootstrapErrorSavesAttempt(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	withBootstrapController(ctx, t, func(ctx context.Context, tc testutils.TestContext, ms *testutils.MachineServiceMock) {
+		ms.SetEtcdRunning(false)
+
+		ms.SetBootstrapHandler(func(context.Context, *machine.BootstrapRequest) (*machine.BootstrapResponse, error) {
+			return nil, status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+		})
+
+		clusterName := createCluster(ctx, t, tc.State, ms.SocketConnectionString)
+
+		// the request failed, but the attempt time is still recorded so the request is not re-sent right away
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.NotNil(r.TypedSpec().Value.LastBootstrapAttempt, "the attempt must be saved even though the request failed")
+		})
+	})
+}
+
+// withBootstrapController runs the test with the bootstrap controller registered and a Talos machine mock which has a
+// backup for the test cluster.
+func withBootstrapController(ctx context.Context, t *testing.T, test func(ctx context.Context, tc testutils.TestContext, ms *testutils.MachineServiceMock)) {
 	store := &mockEtcdBackupStore{}
 
 	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(_ context.Context, tc testutils.TestContext) {
@@ -104,46 +226,7 @@ func TestRestore(t *testing.T) {
 			},
 		}, strings.NewReader("data")))
 
-		clusterName := "test-restore"
-
-		clusterUUID := omni.NewClusterUUID(clusterName)
-		clusterUUID.TypedSpec().Value.Uuid = testClusterUUID
-		clusterUUID.Metadata().Labels().Set(omni.LabelClusterUUID, testClusterUUID)
-		require.NoError(t, tc.State.Create(ctx, clusterUUID))
-
-		backupData := omni.NewBackupData(clusterName)
-		backupData.TypedSpec().Value.EncryptionKey = []byte("test-key")
-		backupData.TypedSpec().Value.AesCbcEncryptionSecret = testBackupData.AESCBCEncryptionSecret
-		backupData.TypedSpec().Value.SecretboxEncryptionSecret = testBackupData.SecretboxEncryptionSecret
-		require.NoError(t, tc.State.Create(ctx, backupData))
-
-		cpMachineSet := omni.NewMachineSet(omni.ControlPlanesResourceID(clusterName))
-		cpMachineSet.Metadata().Labels().Set(omni.LabelCluster, clusterName)
-		cpMachineSet.Metadata().Labels().Set(omni.LabelControlPlaneRole, "")
-		cpMachineSet.TypedSpec().Value.BootstrapSpec = &specs.MachineSetSpec_BootstrapSpec{
-			ClusterUuid: testClusterUUID,
-			Snapshot:    testSnapshot,
-		}
-		require.NoError(t, tc.State.Create(ctx, cpMachineSet))
-
-		require.NoError(t, tc.State.Create(ctx, omni.NewTalosConfig(clusterName)))
-
-		clusterEndpoint := omni.NewClusterEndpoint(clusterName)
-		clusterEndpoint.TypedSpec().Value.ManagementAddresses = []string{ms.SocketConnectionString}
-		require.NoError(t, tc.State.Create(ctx, clusterEndpoint))
-
-		clusterStatus := omni.NewClusterStatus(clusterName)
-		clusterStatus.TypedSpec().Value.Available = true
-		clusterStatus.TypedSpec().Value.HasConnectedControlPlanes = true
-		require.NoError(t, tc.State.Create(ctx, clusterStatus))
-
-		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
-			assertion.True(r.TypedSpec().Value.Bootstrapped)
-		})
-
-		require.EqualValues(t, 1, ms.GetEtcdRecoverRequestCount())
-		require.Len(t, ms.GetBootstrapRequests(), 1)
-		require.True(t, ms.GetBootstrapRequests()[0].RecoverEtcd)
+		test(ctx, tc, ms)
 	})
 }
 
@@ -156,6 +239,10 @@ func createCluster(ctx context.Context, t *testing.T, st state.State, address st
 	cpMachineSet.Metadata().Labels().Set(omni.LabelCluster, clusterName)
 	cpMachineSet.Metadata().Labels().Set(omni.LabelControlPlaneRole, "")
 
+	clusterUUID := omni.NewClusterUUID(clusterName)
+	clusterUUID.TypedSpec().Value.Uuid = testClusterUUID
+	clusterUUID.Metadata().Labels().Set(omni.LabelClusterUUID, testClusterUUID)
+
 	clusterEndpoint := omni.NewClusterEndpoint(clusterName)
 	clusterEndpoint.TypedSpec().Value.ManagementAddresses = []string{address}
 
@@ -165,6 +252,7 @@ func createCluster(ctx context.Context, t *testing.T, st state.State, address st
 
 	for _, res := range []resource.Resource{
 		cpMachineSet,
+		clusterUUID,
 		clusterEndpoint,
 		omni.NewTalosConfig(clusterName),
 		clusterStatus,

--- a/internal/backend/runtime/omni/controllers/testutils/machine_service.go
+++ b/internal/backend/runtime/omni/controllers/testutils/machine_service.go
@@ -176,6 +176,7 @@ type MachineServiceMock struct {
 	files                   map[string][]string
 	serviceList             *machine.ServiceListResponse
 	etcdLeaveClusterHandler func(context.Context, *machine.EtcdLeaveClusterRequest) (*machine.EtcdLeaveClusterResponse, error)
+	bootstrapHandler        func(context.Context, *machine.BootstrapRequest) (*machine.BootstrapResponse, error)
 	versionHandler          func(ctx context.Context, _ *emptypb.Empty) (*machine.VersionResponse, error)
 	readHandler             func(*machine.ReadRequest, grpc.ServerStreamingServer[common.Data]) error
 
@@ -290,13 +291,52 @@ func (ms *MachineServiceMock) GetApplyRequests() []*machine.ApplyConfigurationRe
 	return ms.applyRequests
 }
 
-func (ms *MachineServiceMock) Bootstrap(_ context.Context, req *machine.BootstrapRequest) (*machine.BootstrapResponse, error) {
+func (ms *MachineServiceMock) Bootstrap(ctx context.Context, req *machine.BootstrapRequest) (*machine.BootstrapResponse, error) {
+	ms.lock.Lock()
+	ms.bootstrapRequests = append(ms.bootstrapRequests, req)
+	handler := ms.bootstrapHandler
+	ms.lock.Unlock()
+
+	if handler != nil {
+		return handler(ctx, req)
+	}
+
+	return &machine.BootstrapResponse{}, nil
+}
+
+// SetBootstrapHandler overrides the response to the bootstrap requests.
+func (ms *MachineServiceMock) SetBootstrapHandler(handler func(context.Context, *machine.BootstrapRequest) (*machine.BootstrapResponse, error)) {
 	ms.lock.Lock()
 	defer ms.lock.Unlock()
 
-	ms.bootstrapRequests = append(ms.bootstrapRequests, req)
+	ms.bootstrapHandler = handler
+}
 
-	return &machine.BootstrapResponse{}, nil
+// SetEtcdRunning makes the etcd service report as running and healthy, or as still preparing.
+func (ms *MachineServiceMock) SetEtcdRunning(running bool) {
+	svc := &machine.ServiceInfo{
+		Id:     "etcd",
+		State:  "Preparing",
+		Health: &machine.ServiceHealth{Unknown: true},
+	}
+
+	if running {
+		svc.State = "Running"
+		svc.Health = &machine.ServiceHealth{Healthy: true}
+	}
+
+	ms.SetServiceList(&machine.ServiceListResponse{
+		Messages: []*machine.ServiceList{
+			{
+				Services: []*machine.ServiceInfo{svc},
+			},
+		},
+	})
+}
+
+// GetEtcdRecoverRequestCount returns the number of etcd recover requests received.
+func (ms *MachineServiceMock) GetEtcdRecoverRequestCount() uint64 {
+	return ms.etcdRecoverRequestCount.Load()
 }
 
 func (ms *MachineServiceMock) GetBootstrapRequests() []*machine.BootstrapRequest {
@@ -304,11 +344,6 @@ func (ms *MachineServiceMock) GetBootstrapRequests() []*machine.BootstrapRequest
 	defer ms.lock.Unlock()
 
 	return ms.bootstrapRequests
-}
-
-// GetEtcdRecoverRequestCount returns the number of etcd recover requests received.
-func (ms *MachineServiceMock) GetEtcdRecoverRequestCount() uint64 {
-	return ms.etcdRecoverRequestCount.Load()
 }
 
 func (ms *MachineServiceMock) Reset(ctx context.Context, req *machine.ResetRequest) (*machine.ResetResponse, error) {


### PR DESCRIPTION
The Talos bootstrap API returns as soon as the etcd service is started on the node, before the bootstrap itself, and the snapshot restore when one was requested, have actually happened. The node keeps that intent only in memory, so a reboot in that window loses it, and etcd ends up waiting to join a cluster that was never bootstrapped. Omni recorded the cluster as bootstrapped when the API call returned and never checked again, so it never sent another request and the cluster stayed broken.

Mark the cluster as bootstrapped only once the etcd service is confirmed to be running and healthy on the node, which happens only after the restore is done. Until then:

- check the etcd service on the node periodically
- send the bootstrap request again if enough time has passed since the last one

The wait between requests is not short (5m) on purpose: a request sent while a restore is still running might interrupt it. The time of the last request is kept on the bootstrap status resource.

Related to siderolabs/omni#3300.