### PR TITLE
test: fix a race in the preserve-features machine config test

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster/cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster/cleanup.go
@@ -18,13 +18,13 @@ import (
 	customcleanup "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/cleanup"
 )
 
-// Controller manages Cluster resource lifecycle.
-//
-// Controller plays the role of machine discovery.
-type Controller = cleanup.Controller[*omni.Cluster]
+// CleanupController removes the resources associated with a cluster when the cluster is destroyed.
+type CleanupController = cleanup.Controller[*omni.Cluster]
 
-// ControllerName is the name of the cluster controller.
-const ControllerName = "ClusterController"
+// CleanupControllerName is the name of the cluster cleanup controller.
+//
+// The value keeps the old name of the controller, as it is persisted in the state, e.g., in the finalizers.
+const CleanupControllerName = "ClusterController"
 
 // KubernetesRuntime is the subset of the Kubernetes runtime the cluster cleanup needs.
 type KubernetesRuntime interface {
@@ -56,14 +56,14 @@ func (c handler) Outputs() []controller.Output {
 	return c.handler.Outputs()
 }
 
-// NewController creates new cluster Controller.
-func NewController(kubernetesRuntime KubernetesRuntime) *Controller {
+// NewCleanupController creates a new cluster cleanup controller.
+func NewCleanupController(kubernetesRuntime KubernetesRuntime) *CleanupController {
 	return cleanup.NewController(
 		cleanup.Settings[*omni.Cluster]{
-			Name: ControllerName,
+			Name: CleanupControllerName,
 			Handler: handler{
 				kubernetesRuntime: kubernetesRuntime,
-				finalizer:         ControllerName,
+				finalizer:         CleanupControllerName,
 				handler: cleanup.Combine(
 					cleanup.RemoveOutputs[*omni.MachineSet](func(cluster *omni.Cluster) state.ListOption {
 						return state.WithLabelQuery(

--- a/internal/backend/runtime/omni/controllers/omni/cluster/uuid.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster/uuid.go
@@ -39,7 +39,7 @@ func NewUUIDController() *UUIDController {
 			},
 			TransformFunc: ctrl.transform,
 		},
-		qtransform.WithIgnoreTeardownWhile(ControllerName),
+		qtransform.WithIgnoreTeardownWhile(CleanupControllerName),
 	)
 
 	return ctrl

--- a/internal/backend/runtime/omni/controllers/omni/cluster_endpoint_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_endpoint_test.go
@@ -24,7 +24,7 @@ type ClusterEndpointSuite struct {
 func (suite *ClusterEndpointSuite) TestReconcile() {
 	suite.startRuntime()
 
-	suite.Require().NoError(suite.runtime.RegisterController(clusterctrl.NewController(suite.kubernetesRuntime)))
+	suite.Require().NoError(suite.runtime.RegisterController(clusterctrl.NewCleanupController(suite.kubernetesRuntime)))
 	suite.Require().NoError(suite.runtime.RegisterController(omnictrl.NewMachineSetController()))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewClusterMachineStatusController()))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewClusterEndpointController()))

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
@@ -272,6 +272,9 @@ func reconcileClusterMachineConfig(
 		return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("install disk is not resolved yet: %s", installDiskStatus.TypedSpec().Value.Message)
 	}
 
+	// clusterMachine is not on this list on purpose. Everything read from it to generate the
+	// config is set when it is created and is never updated in place. Because of this, a new
+	// version of it alone never changes the generated config.
 	inputs := []resource.Resource{
 		clusterMachineSecrets,
 		loadBalancerConfig,

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_test.go
@@ -57,8 +57,8 @@ func registerClusterMachineConfigControllers(t *testing.T) testutils.TestFunc {
 
 // createConfigTestCluster creates everything the ClusterMachineConfigController reads for a cluster
 // of one control plane and the requested number of workers. The control plane comes first in the
-// returned machines.
-func createConfigTestCluster(ctx context.Context, t *testing.T, st state.State, clusterName string, workers int, talosVersion string) (
+// returned machines. The extra machine options are applied to every created ClusterMachine.
+func createConfigTestCluster(ctx context.Context, t *testing.T, st state.State, clusterName string, workers int, talosVersion string, machineOptions ...options.MockOption) (
 	*omni.Cluster, []*omni.ClusterMachine,
 ) {
 	const controlPlanes = 1
@@ -117,11 +117,13 @@ func createConfigTestCluster(ctx context.Context, t *testing.T, st state.State, 
 		ctx, t, st,
 		options.IDs(ids),
 		options.ItemOptions(
-			options.Modify(func(res *omni.ClusterMachine) error {
-				res.TypedSpec().Value.KubernetesVersion = cluster.TypedSpec().Value.KubernetesVersion
+			append([]options.MockOption{
+				options.Modify(func(res *omni.ClusterMachine) error {
+					res.TypedSpec().Value.KubernetesVersion = cluster.TypedSpec().Value.KubernetesVersion
 
-				return nil
-			}),
+					return nil
+				}),
+			}, machineOptions...)...,
 		),
 	)
 
@@ -269,15 +271,19 @@ func TestClusterMachineConfigGeneratePreserveFeatures(t *testing.T) {
 	testutils.WithRuntime(
 		ctx, t, testutils.TestOptions{}, registerClusterMachineConfigControllers(t),
 		func(ctx context.Context, tc testutils.TestContext) {
-			_, machines := createConfigTestCluster(ctx, t, tc.State, "talos-default-old", 1, "1.2.0")
+			// The annotations are set when the machines are created. If they were set with a
+			// later update, they would sporadically be missed: the controller does not
+			// re-generate the config when the cluster machine itself is updated, because in
+			// production, it is never updated in place after it is created.
+			_, machines := createConfigTestCluster(
+				ctx, t, tc.State, "talos-default-old", 1, "1.2.0",
+				options.Modify(func(res *omni.ClusterMachine) error {
+					res.Metadata().Annotations().Set(omni.PreserveApidCheckExtKeyUsage, "")
+					res.Metadata().Annotations().Set(omni.PreserveDiskQuotaSupport, "")
 
-			_, err := safe.StateUpdateWithConflicts(ctx, tc.State, machines[0].Metadata(), func(res *omni.ClusterMachine) error {
-				res.Metadata().Annotations().Set(omni.PreserveApidCheckExtKeyUsage, "")
-				res.Metadata().Annotations().Set(omni.PreserveDiskQuotaSupport, "")
-
-				return nil
-			}, state.WithUpdateOwner(rmock.GetOwner[*omni.ClusterMachine]()))
-			require.NoError(t, err)
+					return nil
+				}),
+			)
 
 			rtestutils.AssertResource(ctx, t, tc.State, machines[0].Metadata().ID(), func(res *omni.ClusterMachineConfig, assertions *assert.Assertions) {
 				assertions.True(machineConfigOf(t, res).Machine().Features().DiskQuotaSupportEnabled())

--- a/internal/backend/runtime/omni/controllers/omni/cluster_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_test.go
@@ -26,7 +26,7 @@ type ClusterSuite struct {
 func (suite *ClusterSuite) TestReconcile() {
 	suite.startRuntime()
 
-	suite.Require().NoError(suite.runtime.RegisterController(clusterctrl.NewController(suite.kubernetesRuntime)))
+	suite.Require().NoError(suite.runtime.RegisterController(clusterctrl.NewCleanupController(suite.kubernetesRuntime)))
 	suite.Require().NoError(suite.runtime.RegisterController(omnictrl.NewMachineSetController()))
 	suite.Require().NoError(suite.runtime.RegisterQController(clusterctrl.NewConfigVersionController()))
 

--- a/internal/backend/runtime/omni/controllers/omni/etcd_backup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcd_backup_test.go
@@ -62,7 +62,7 @@ func beforeStart(st state.State, t *testing.T, rt *runtime.Runtime) {
 	logger := zaptest.NewLogger(t)
 	kubernetesRuntime := kubernetes.NewWithTTL(st, 0, logger, "", "", "")
 
-	require.NoError(t, rt.RegisterController(clusterctrl.NewController(kubernetesRuntime)))
+	require.NoError(t, rt.RegisterController(clusterctrl.NewCleanupController(kubernetesRuntime)))
 	require.NoError(t, rt.RegisterQController(clusterctrl.NewUUIDController()))
 	require.NoError(t, rt.RegisterQController(omnictrl.NewEtcdBackupEncryptionController()))
 	require.NoError(t, rt.RegisterQController(omnictrl.NewBackupDataController()))

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -157,7 +157,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 	controllers := []controller.Controller{
 		&metricsctrl.UserMetricsController{},
 		omnictrl.NewCertRefreshTickController(constants.CertificateValidityTime / 10), // issue ticks at 10% of the validity, as we refresh certificates at 50% of the validity
-		cluster.NewController(kubernetesRuntime),
+		cluster.NewCleanupController(kubernetesRuntime),
 		omnictrl.NewMachineSetController(),
 		&omnictrl.ClusterMachineIdentityController{},
 		&metricsctrl.ClusterMachineStatusMetricsController{},


### PR DESCRIPTION
The test set the annotations that force the preserved machine features by updating the cluster machine after creating it. This sporadically failed:

1. The controller generates the machine config before the annotations are set.
2. The annotations are set on the cluster machine.
3. The controller does not re-generate the config. It only reacts when its other inputs change, not when the cluster machine itself changes. This is because in production, the cluster machine is never updated in place after it is created.
4. The test times out waiting for the preserved features to appear in the config.

Fix this by setting the annotations when the cluster machine is created.

Additionally, document this behavior with a comment on the controller.

Also rename the cluster controller to the cluster cleanup controller. It was named as if it managed the whole cluster, but it only cleans up the resources of a cluster when the cluster is destroyed. The registered controller name is kept unchanged, as it is persisted in the state, e.g., in the finalizers.