### PR TITLE
fix: apply pending updates to unhealthy machines so they can recover

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/export_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/export_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package machineconfig
+
+import (
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+// UpgradeBlockedByOwnHealthForTest exposes upgradeBlockedByOwnHealth to external tests.
+func UpgradeBlockedByOwnHealthForTest(snapshot *omni.MachineStatusSnapshot) bool {
+	rc := &ReconciliationContext{machineStatusSnapshot: snapshot}
+
+	return rc.upgradeBlockedByOwnHealth()
+}

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/reconciliation_context.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/crypto/x509"
 	"github.com/siderolabs/gen/xerrors"
+	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
@@ -68,6 +69,25 @@ type ReconciliationContext struct {
 // hasPendingLifecycleOperation returns true when an upgrade/install action needs to run before config can be applied.
 func (rc *ReconciliationContext) hasPendingLifecycleOperation() bool {
 	return rc.lifecycleOp != lifecycle.OpNone
+}
+
+// upgradeBlockedByOwnHealth is true for a machine that has booted into the cluster but is not
+// ready in the sense the rollout controller subtracts from the upgrade quota. Only the booting and
+// running stages describe such a machine: a maintenance machine is not broken, just not installed
+// yet (or wiped back), so it keeps respecting the quota that holds updates back while the cluster
+// is unhealthy, and the transitional and unknown stages say nothing about health. Connectivity
+// needs no checking here: a disconnected machine never reconciles this far.
+func (rc *ReconciliationContext) upgradeBlockedByOwnHealth() bool {
+	machineStatus := rc.machineStatusSnapshot.TypedSpec().Value.GetMachineStatus()
+
+	switch machineStatus.GetStage() { //nolint:exhaustive
+	case machineapi.MachineStatusEvent_BOOTING:
+		return true
+	case machineapi.MachineStatusEvent_RUNNING:
+		return !machineStatus.GetStatus().GetReady()
+	default:
+		return false
+	}
 }
 
 func checkClusterReady(ctx context.Context, r controller.Reader, machineConfig *omni.ClusterMachineConfig) (bool, error) {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/recovery_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/recovery_test.go
@@ -1,0 +1,515 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package machineconfig_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/machineconfig"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock/options"
+)
+
+// TestUpgradeBlockedByOwnHealth pins the recovery-bypass predicate corner by corner, in particular
+// that maintenance machines never take the bypass: their not-readiness is inherent, so fresh installs
+// and machines sent back to maintenance keep respecting the cluster-health quota.
+func TestUpgradeBlockedByOwnHealth(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		status  *machine.MachineStatusEvent_MachineStatus
+		name    string
+		stage   machine.MachineStatusEvent_MachineStage
+		blocked bool
+	}{
+		{name: "runningReady", stage: machine.MachineStatusEvent_RUNNING, status: &machine.MachineStatusEvent_MachineStatus{Ready: true}, blocked: false},
+		{name: "runningNotReady", stage: machine.MachineStatusEvent_RUNNING, status: &machine.MachineStatusEvent_MachineStatus{Ready: false}, blocked: true},
+		{name: "booting", stage: machine.MachineStatusEvent_BOOTING, status: &machine.MachineStatusEvent_MachineStatus{Ready: false}, blocked: true},
+		{name: "maintenance", stage: machine.MachineStatusEvent_MAINTENANCE, blocked: false},
+		{name: "unknown", stage: machine.MachineStatusEvent_UNKNOWN, blocked: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			snapshot := omni.NewMachineStatusSnapshot("test-machine")
+			snapshot.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: tt.stage, Status: tt.status}
+
+			assert.Equal(t, tt.blocked, machineconfig.UpgradeBlockedByOwnHealthForTest(snapshot))
+		})
+	}
+}
+
+// TestClusterLifecycleRecoversUnhealthyMachine verifies that a pending update reaches a machine that is
+// itself unhealthy, which is its only way to become healthy again (siderolabs/omni#3262).
+//
+// Both checks that used to block this are exercised: the stage check (the machine is stuck in the booting
+// stage after rebooting into a bad schematic) and the rollout quota (the published quota is zero because
+// the machine's own not-readiness is subtracted from it). The recovery must go through anyway, bounded
+// only by the upgrade finalizer count.
+func TestClusterLifecycleRecoversUnhealthyMachine(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		// schematicID / talosVersion model the revert the user makes to fix the machine: a schematic
+		// change (kernel args / extensions) or a Talos version change.
+		schematicID  string
+		talosVersion string
+		stage        machine.MachineStatusEvent_MachineStage
+	}{
+		{name: "bootingSchematicRevert", stage: machine.MachineStatusEvent_BOOTING, schematicID: "bbbb"},
+		// A real cluster-wide version revert enters the Reverting phase, which publishes the quota
+		// without the not-ready subtraction; the zero quota here is synthetic. The case still proves
+		// that a booting machine no longer blocks a version operation.
+		{name: "bootingVersionChange", stage: machine.MachineStatusEvent_BOOTING, talosVersion: "1.13.6"},
+		{name: "runningNotReadySchematicRevert", stage: machine.MachineStatusEvent_RUNNING, schematicID: "bbbb"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+			t.Cleanup(cancel)
+
+			provider := &testutils.FakeKubernetesProvider{}
+
+			testutils.WithRuntime(
+				ctx, t, testutils.TestOptions{},
+				func(_ context.Context, tc testutils.TestContext) {
+					require.NoError(t, tc.Runtime.RegisterQController(
+						machineconfig.NewStatusController(testutils.NewLifecycleManager(t, tc.State, provider)),
+					))
+				},
+				func(ctx context.Context, tc testutils.TestContext) {
+					st := tc.State
+
+					clusterName := "recovery-" + tt.name
+
+					machineServices := testutils.NewMachineServices(t, st)
+
+					_, machines := createCluster(ctx, t, st, machineServices, clusterName, 1, 0)
+					id := machines[0].Metadata().ID()
+
+					// Wait for the initial config to be applied so the upgrade lock logic engages.
+					rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+						a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+					})
+
+					nodeName := "node-" + id
+
+					provider.SetClientset(testutils.NewFakeKubernetesClientset(nodeName))
+
+					rmock.Mock[*omni.ClusterMachineIdentity](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.ClusterMachineIdentity) error {
+						res.TypedSpec().Value.Nodename = nodeName
+
+						return nil
+					}))
+
+					const bootID = "boot-recovery"
+
+					// The machine is unhealthy: stuck in the booting stage, or running but not ready.
+					// Either way it stays connected to Omni.
+					rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+						res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{
+							Stage:  tt.stage,
+							Status: &machine.MachineStatusEvent_MachineStatus{Ready: false},
+						}
+						res.TypedSpec().Value.BootId = bootID
+
+						return nil
+					}))
+
+					// The rollout quota reflects the machine's own not-readiness: zero for its machine set,
+					// exactly what the upgrade rollout controller would publish for this cluster.
+					machineSetName, ok := machines[0].Metadata().Labels().Get(omni.LabelMachineSet)
+					require.True(t, ok)
+
+					rmock.Mock[*omni.UpgradeRollout](ctx, t, st, options.WithID(clusterName), options.Modify(func(res *omni.UpgradeRollout) error {
+						res.TypedSpec().Value.MachineSetsUpgradeQuota = map[string]int32{machineSetName: 0}
+
+						return nil
+					}))
+
+					// The fixing change arrives: the desired install image differs from what the machine runs.
+					rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+						if tt.schematicID != "" {
+							res.TypedSpec().Value.InstallImage.SchematicId = tt.schematicID
+						}
+
+						if tt.talosVersion != "" {
+							res.TypedSpec().Value.InstallImage.TalosVersion = tt.talosVersion
+						}
+
+						return nil
+					}))
+
+					// The machine receives the lifecycle upgrade despite being unhealthy and despite the
+					// zero quota, and the reboot is armed (the boot ID is recorded).
+					rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+						a.Equal(bootID, res.TypedSpec().Value.PreRebootBootId)
+					})
+
+					require.NotEmpty(t, machineServices.Get(id).GetLifecycleUpgradeRequests())
+					assert.Empty(t, machineServices.Get(id).GetUpgradeRequests(), "the machine must not receive a legacy MachineService.Upgrade")
+				},
+			)
+		})
+	}
+}
+
+// TestUpgradeQuotaStillBlocksHealthyMachine verifies that the recovery bypass does not weaken the rollout
+// safety for healthy machines: a ready machine with a pending update still waits when the published quota
+// is zero (some other machine in the cluster is broken).
+func TestUpgradeQuotaStillBlocksHealthyMachine(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+	t.Cleanup(cancel)
+
+	provider := &testutils.FakeKubernetesProvider{}
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterQController(
+				machineconfig.NewStatusController(testutils.NewLifecycleManager(t, tc.State, provider)),
+			))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			st := tc.State
+
+			clusterName := "quota-blocks-healthy"
+
+			machineServices := testutils.NewMachineServices(t, st)
+
+			_, machines := createCluster(ctx, t, st, machineServices, clusterName, 1, 0)
+			id := machines[0].Metadata().ID()
+
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+
+			nodeName := "node-" + id
+
+			provider.SetClientset(testutils.NewFakeKubernetesClientset(nodeName))
+
+			rmock.Mock[*omni.ClusterMachineIdentity](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.ClusterMachineIdentity) error {
+				res.TypedSpec().Value.Nodename = nodeName
+
+				return nil
+			}))
+
+			// The machine is healthy: running, ready and connected.
+			rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{
+					Stage:  machine.MachineStatusEvent_RUNNING,
+					Status: &machine.MachineStatusEvent_MachineStatus{Ready: true},
+				}
+				res.TypedSpec().Value.BootId = "boot-healthy"
+
+				return nil
+			}))
+
+			machineSetName, ok := machines[0].Metadata().Labels().Get(omni.LabelMachineSet)
+			require.True(t, ok)
+
+			// No free quota: some other machine in the cluster is not ready.
+			rmock.Mock[*omni.UpgradeRollout](ctx, t, st, options.WithID(clusterName), options.Modify(func(res *omni.UpgradeRollout) error {
+				res.TypedSpec().Value.MachineSetsUpgradeQuota = map[string]int32{machineSetName: 0}
+
+				return nil
+			}))
+
+			rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+				res.TypedSpec().Value.InstallImage.SchematicId = "bbbb"
+
+				return nil
+			}))
+
+			// From here on every pass of this machine has an upgrade due, so the barrier below pins a
+			// pass that was actually blocked, not an early one with nothing to do. Do not remove: the
+			// whole causality argument below depends on this checkpoint.
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.MachinePendingUpdates, a *assert.Assertions) {
+				a.NotNil(res.TypedSpec().Value.Upgrade)
+			})
+
+			// Force one more full pass and prove the previous one completed its slot decision: the
+			// config change below flows into the pending update's config diff, which is written at
+			// the start of every pass, before the slot decision, and the passes of one machine are
+			// serialized. Once the diff is visible, any upgrade wrongly issued under the exhausted
+			// quota has already reached the machine mock. The chain holds because nothing in this
+			// fixture can make a pass return between the diff write and the slot decision (no machine
+			// lock, no config generation error, no reboot marker, node name and install image already
+			// resolved), and the positive at the end proves the pipeline was otherwise ready.
+			rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.ClusterMachineConfig) error {
+				return res.TypedSpec().Value.SetUncompressedData([]byte("machine:\n  network:\n    kubespan:\n      enabled: true"))
+			}))
+
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.MachinePendingUpdates, a *assert.Assertions) {
+				data, err := res.TypedSpec().Value.GetUncompressedData()
+				if !a.NoError(err) {
+					return
+				}
+
+				defer data.Free()
+
+				a.Contains(string(data.Data()), "kubespan")
+			})
+
+			assert.Empty(t, machineServices.Get(id).GetLifecycleUpgradeRequests(), "a healthy machine must wait for free quota")
+
+			// Freeing the quota lets the machine proceed, proving the wait above was the quota and
+			// nothing else. A recorded pre-reboot boot ID means the lifecycle upgrade ran (the legacy
+			// path clears it).
+			rmock.Mock[*omni.UpgradeRollout](ctx, t, st, options.WithID(clusterName), options.Modify(func(res *omni.UpgradeRollout) error {
+				res.TypedSpec().Value.MachineSetsUpgradeQuota = map[string]int32{machineSetName: 1}
+
+				return nil
+			}))
+
+			rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.Equal("boot-healthy", res.TypedSpec().Value.PreRebootBootId)
+			})
+		},
+	)
+}
+
+// TestUnhealthyMachinesRecoverOneByOne verifies that the recovery bypass keeps the upgrade concurrency
+// bounded: with two unhealthy machines and parallelism 1, only one of them starts its update, the other
+// waits for the upgrade lock to be released. The absence of a second upgrade is proven with the same
+// causal barrier as in TestUpgradeQuotaStillBlocksHealthyMachine, applied to both machines: once both
+// config diffs are visible, both machines have completed a slot decision with an upgrade due, so a
+// wrongly issued second upgrade would already be in its machine mock.
+func TestUnhealthyMachinesRecoverOneByOne(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+	t.Cleanup(cancel)
+
+	provider := &testutils.FakeKubernetesProvider{}
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterQController(
+				machineconfig.NewStatusController(testutils.NewLifecycleManager(t, tc.State, provider)),
+			))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			st := tc.State
+
+			clusterName := "recovery-one-by-one"
+
+			machineServices := testutils.NewMachineServices(t, st)
+
+			_, machines := createCluster(ctx, t, st, machineServices, clusterName, 2, 0)
+
+			ids := make([]string, 0, len(machines))
+			nodeNames := make([]string, 0, len(machines))
+
+			for _, m := range machines {
+				ids = append(ids, m.Metadata().ID())
+				nodeNames = append(nodeNames, "node-"+m.Metadata().ID())
+			}
+
+			rtestutils.AssertResources(ctx, t, st, ids, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+				a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+			})
+
+			provider.SetClientset(testutils.NewFakeKubernetesClientset(nodeNames...))
+
+			machineSetName, ok := machines[0].Metadata().Labels().Get(omni.LabelMachineSet)
+			require.True(t, ok)
+
+			// Both machines are broken, and the quota reflects that: zero for the machine set.
+			rmock.Mock[*omni.UpgradeRollout](ctx, t, st, options.WithID(clusterName), options.Modify(func(res *omni.UpgradeRollout) error {
+				res.TypedSpec().Value.MachineSetsUpgradeQuota = map[string]int32{machineSetName: 0}
+
+				return nil
+			}))
+
+			for i, id := range ids {
+				rmock.Mock[*omni.ClusterMachineIdentity](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.ClusterMachineIdentity) error {
+					res.TypedSpec().Value.Nodename = nodeNames[i]
+
+					return nil
+				}))
+
+				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{
+						Stage:  machine.MachineStatusEvent_BOOTING,
+						Status: &machine.MachineStatusEvent_MachineStatus{Ready: false},
+					}
+					res.TypedSpec().Value.BootId = "boot-" + id
+
+					return nil
+				}))
+
+				rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+					res.TypedSpec().Value.InstallImage.SchematicId = "bbbb"
+
+					return nil
+				}))
+			}
+
+			countUpgrading := func() int {
+				count := 0
+
+				for _, id := range ids {
+					if len(machineServices.Get(id).GetLifecycleUpgradeRequests()) > 0 {
+						count++
+					}
+				}
+
+				return count
+			}
+
+			// From here on every pass of either machine has an upgrade due (see the same checkpoint in
+			// TestUpgradeQuotaStillBlocksHealthyMachine).
+			rtestutils.AssertResources(ctx, t, st, ids, func(res *omni.MachinePendingUpdates, a *assert.Assertions) {
+				a.NotNil(res.TypedSpec().Value.Upgrade)
+			})
+
+			// The causal barrier, for both machines: once both config diffs are visible, both machines
+			// have completed a pass that decided on an upgrade slot, so whichever upgrades were going
+			// to be issued are already in the machine mocks. The winner never finishes its reboot in
+			// this test, so its upgrade lock stays held and there is nothing left to wait for.
+			for _, id := range ids {
+				rmock.Mock[*omni.ClusterMachineConfig](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.ClusterMachineConfig) error {
+					return res.TypedSpec().Value.SetUncompressedData([]byte("machine:\n  network:\n    kubespan:\n      enabled: true"))
+				}))
+			}
+
+			rtestutils.AssertResources(ctx, t, st, ids, func(res *omni.MachinePendingUpdates, a *assert.Assertions) {
+				data, err := res.TypedSpec().Value.GetUncompressedData()
+				if !a.NoError(err) {
+					return
+				}
+
+				defer data.Free()
+
+				a.Contains(string(data.Data()), "kubespan")
+			})
+
+			assert.Equal(t, 1, countUpgrading(), "exactly one unhealthy machine may upgrade at a time")
+		},
+	)
+}
+
+// TestLegacyRecoveryStagesUpgradeAndReboots verifies the recovery path for machines older than the
+// LifecycleService (Talos < 1.13). The regular upgrade sequence on such a machine drains the node
+// through the Kubernetes API, which an unhealthy machine may not have at all, so the recovery uses a
+// staged upgrade followed by an explicit reboot instead. A healthy machine must keep the regular
+// upgrade with the node-side drain: no staging, no reboot request.
+func TestLegacyRecoveryStagesUpgradeAndReboots(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		unhealthy bool
+	}{
+		{name: "unhealthyMachineGetsStagedUpgradeAndReboot", unhealthy: true},
+		{name: "healthyMachineKeepsRegularUpgrade", unhealthy: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
+			t.Cleanup(cancel)
+
+			testutils.WithRuntime(
+				ctx, t, testutils.TestOptions{},
+				func(_ context.Context, tc testutils.TestContext) {
+					require.NoError(t, tc.Runtime.RegisterQController(
+						machineconfig.NewStatusController(testutils.NewLifecycleManager(t, tc.State, nil)),
+					))
+				},
+				func(ctx context.Context, tc testutils.TestContext) {
+					st := tc.State
+
+					const targetVersion = "1.11.9"
+
+					clusterName := "legacy-recovery-" + tt.name
+
+					machineServices := testutils.NewMachineServices(t, st)
+
+					_, machines := createCluster(ctx, t, st, machineServices, clusterName, 1, 0,
+						withClusterMockOption(options.WithTalosVersion("1.11.6")))
+					id := machines[0].Metadata().ID()
+
+					// The mock machine reports the target version once upgraded, as a real one would after the reboot.
+					machineServices.Get(id).OnUpdate = func(ctx context.Context, _ *machine.UpgradeRequest, st state.State, id string) (*machine.UpgradeResponse, error) {
+						if err := safe.StateModify(ctx, st, omni.NewMachineStatus(id), func(res *omni.MachineStatus) error {
+							res.TypedSpec().Value.TalosVersion = targetVersion
+
+							return nil
+						}); err != nil {
+							return nil, err
+						}
+
+						return &machine.UpgradeResponse{}, nil
+					}
+
+					// Wait for the initial config to be applied before changing the target.
+					rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+						a.NotEmpty(res.TypedSpec().Value.ClusterMachineConfigSha256)
+					})
+
+					if tt.unhealthy {
+						// The machine is stuck in the booting stage. Talos versions this old report no boot ID.
+						rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
+							res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{
+								Stage:  machine.MachineStatusEvent_BOOTING,
+								Status: &machine.MachineStatusEvent_MachineStatus{Ready: false},
+							}
+
+							return nil
+						}))
+					}
+
+					// The fixing change arrives: a new target Talos version.
+					rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+						res.TypedSpec().Value.InstallImage.TalosVersion = targetVersion
+
+						return nil
+					}))
+
+					// Once the applied version is recorded back, the pass that issued the upgrade has fully
+					// completed: reconciles of one machine are serialized, so by now the reboot request of
+					// that pass has been sent, or provably never will be.
+					rtestutils.AssertResource(ctx, t, st, id, func(res *omni.ClusterMachineConfigStatus, a *assert.Assertions) {
+						a.Equal(targetVersion, res.TypedSpec().Value.TalosVersion)
+					})
+
+					requests := machineServices.Get(id).GetUpgradeRequests()
+					require.NotEmpty(t, requests)
+
+					for _, request := range requests {
+						assert.Equal(t, tt.unhealthy, request.Stage)
+					}
+
+					assert.Empty(t, machineServices.Get(id).GetLifecycleUpgradeRequests(), "a pre-1.13 machine must not receive a lifecycle upgrade")
+
+					if tt.unhealthy {
+						assert.Positive(t, machineServices.Get(id).GetRebootCount(), "the staged upgrade needs an explicit reboot to apply")
+					} else {
+						assert.Zero(t, machineServices.Get(id).GetRebootCount(), "a healthy machine reboots through its own upgrade sequence")
+					}
+				},
+			)
+		})
+	}
+}

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -583,6 +583,15 @@ func (ctrl *StatusController) legacyUpgrade(inputCtx context.Context, logger *za
 		return false, err
 	}
 
+	// An unhealthy machine also gets a staged upgrade. The regular upgrade sequence on the node
+	// drains the node first, and the drain waits for the node to be cordoned through the Kubernetes
+	// API. An unhealthy machine may have no reachable Kubernetes API at all, e.g. a single control
+	// plane whose kubelet is crashlooping. The drain then times out, the whole upgrade sequence
+	// fails, and the machine reboots into the same broken image over and over. A staged upgrade
+	// skips the drain and applies the new image on the next boot instead.
+	recovering := rc.upgradeBlockedByOwnHealth()
+	stageUpgrade = stageUpgrade || recovering
+
 	nodeClient, err := ctrl.lifecycleManager.GetForMachine(upgradeCtx, rc.ID())
 	if err != nil {
 		return false, fmt.Errorf("failed to get talos client: %w", err)
@@ -600,6 +609,19 @@ func (ctrl *StatusController) legacyUpgrade(inputCtx context.Context, logger *za
 	// If upgrade is not implemented, it means that we run older Talos that doesn't support upgrades in maintenance mode.
 	if status.Code(err) == codes.Unimplemented {
 		return true, nil
+	}
+
+	if err == nil && recovering {
+		// A machine stuck mid-boot cannot run the staged upgrade sequence at all: the sequencer
+		// refuses to start it while the boot sequence is running, and only a reboot is allowed to
+		// take over a stuck boot. The staged image is already recorded on the machine at this
+		// point, so an explicit reboot applies it. Talos acknowledges the reboot request before
+		// running the sequence, so an error here only means the request did not reach the machine.
+		// The next reconcile then stages and reboots again.
+		if rebootErr := nodeClient.Reboot(upgradeCtx); rebootErr != nil {
+			logger.Warn("reboot request after staged upgrade failed, retrying on the next reconcile",
+				zap.String("machine", rc.ID()), zap.Error(rebootErr))
+		}
 	}
 
 	return false, err
@@ -724,8 +746,11 @@ func (ctrl *StatusController) runClusterLifecycle(
 		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("waiting for machine boot ID before upgrade: %s", machineID)
 	}
 
-	if stage := rc.machineStatusSnapshot.TypedSpec().Value.GetMachineStatus().GetStage(); stage != machineapi.MachineStatusEvent_RUNNING {
-		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine %s is not running (%s), skipping upgrade", machineID, stage)
+	// Booting machines are eligible too: a machine stuck in the booting stage may need this very
+	// upgrade to become healthy again (e.g. reverting a kernel args change that broke it), and the
+	// legacy upgrade path and the config apply path both accept booting machines already.
+	if stage := rc.machineStatusSnapshot.TypedSpec().Value.GetMachineStatus().GetStage(); stage != machineapi.MachineStatusEvent_RUNNING && stage != machineapi.MachineStatusEvent_BOOTING {
+		return false, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine %s is not running or booting (%s), skipping upgrade", machineID, stage)
 	}
 
 	clusterName, ok := rc.clusterMachine.Metadata().Labels().Get(omni.LabelCluster)
@@ -771,7 +796,7 @@ func (ctrl *StatusController) runClusterLifecycle(
 		lifecycle.WithProgress(func(msg string) {
 			logger.Debug("upgrade progress", zap.String("machine", machineID), zap.String("message", msg))
 		}),
-		lifecycle.WithCordonDrain(clusterName, nodeName),
+		lifecycle.WithCordonDrain(clusterName, nodeName, rc.upgradeBlockedByOwnHealth()),
 	}
 
 	clusterMachines, err := ctrl.listClusterMachines(ctx, r, clusterName)
@@ -945,9 +970,9 @@ func (ctrl *StatusController) getNodeName(ctx context.Context, r controller.Read
 	return identity.TypedSpec().Value.Nodename, nil
 }
 
-// stageUpgrade decides if the upgrade should be staged.
+// stageUpgrade decides if the upgrade should be staged based on the Talos version.
 //
-// Currently, it is only required as a workaround for this bug affecting Talos 1.9.0-1.9.2:
+// It is required as a workaround for this bug affecting Talos 1.9.0-1.9.2:
 // https://github.com/siderolabs/talos/issues/10163.
 func (ctrl *StatusController) stageUpgrade(actualTalosVersion string) (bool, error) {
 	version, err := semver.ParseTolerant(actualTalosVersion)
@@ -1432,6 +1457,18 @@ func (ctrl *StatusController) acquireUpgradeLock(ctx context.Context, r controll
 	}
 
 	quota := rollout.TypedSpec().Value.MachineSetsUpgradeQuota[machineSetName]
+
+	// The published quota subtracts every not-ready machine in the cluster and disappears entirely
+	// while control planes are updating, both to protect healthy machines from a rollout that would
+	// degrade the cluster further. A machine that is itself not ready needs no such protection: the
+	// pending update is its recovery path (e.g. reverting a kernel args change that broke it), and
+	// blocking on its own unhealthiness would leave it stuck forever. Guarantee it one upgrade slot;
+	// the finalizer count below still bounds the concurrency cluster-wide, so broken machines
+	// recover one by one, and a recovery may also have to wait out an upgrade already in flight.
+	if quota < 1 && rc.upgradeBlockedByOwnHealth() {
+		quota = 1
+	}
+
 	if quota == 0 {
 		return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("%w: waiting for free quota for upgrade", errAcquireUpgradeLock)
 	}

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status_test.go
@@ -1726,7 +1726,7 @@ func TestMachineConfigStatusController(t *testing.T) {
 					return nil
 				}))
 				rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
-					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING}
+					res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING, Status: &machine.MachineStatusEvent_MachineStatus{Ready: true}}
 					res.TypedSpec().Value.BootId = "boot-after-reboot"
 
 					return nil
@@ -2533,7 +2533,7 @@ func TestClusterLifecycleUpgrade(t *testing.T) {
 
 			// The machine is up and running with a known boot ID.
 			rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
-				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING}
+				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING, Status: &machine.MachineStatusEvent_MachineStatus{Ready: true}}
 				res.TypedSpec().Value.BootId = bootID
 
 				return nil
@@ -2633,7 +2633,7 @@ func TestClusterLifecycleConvergesOnLiveVersion(t *testing.T) {
 			})
 
 			rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
-				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING}
+				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING, Status: &machine.MachineStatusEvent_MachineStatus{Ready: true}}
 				res.TypedSpec().Value.BootId = "boot-converged"
 
 				return nil
@@ -2728,7 +2728,7 @@ func TestClusterLifecycleHoldsUpgradeLockUntilFinalized(t *testing.T) {
 			}))
 
 			rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
-				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING}
+				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING, Status: &machine.MachineStatusEvent_MachineStatus{Ready: true}}
 				res.TypedSpec().Value.BootId = "boot-before"
 
 				return nil
@@ -2776,7 +2776,7 @@ func TestClusterLifecycleHoldsUpgradeLockUntilFinalized(t *testing.T) {
 			})
 
 			rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
-				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING}
+				res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING, Status: &machine.MachineStatusEvent_MachineStatus{Ready: true}}
 				res.TypedSpec().Value.BootId = "boot-after"
 
 				return nil
@@ -2801,7 +2801,7 @@ func TestClusterLifecycleHoldsUpgradeLockUntilFinalized(t *testing.T) {
 // upgrade quota, so the controller runs the cluster-lifecycle upgrade for it.
 func triggerClusterUpgrade(ctx context.Context, t *testing.T, st state.State, clusterName, id, nodeName, targetVersion string) {
 	rmock.Mock[*omni.MachineStatusSnapshot](ctx, t, st, options.WithID(id), options.Modify(func(res *omni.MachineStatusSnapshot) error {
-		res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING}
+		res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{Stage: machine.MachineStatusEvent_RUNNING, Status: &machine.MachineStatusEvent_MachineStatus{Ready: true}}
 		res.TypedSpec().Value.BootId = "boot-" + id
 
 		return nil

--- a/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
+++ b/internal/backend/runtime/omni/controllers/testutils/rmock/rmock.go
@@ -435,7 +435,8 @@ func init() {
 
 	addDefaults(func(ctx context.Context, st state.State, res *omni.MachineStatusSnapshot) error {
 		res.TypedSpec().Value.MachineStatus = &machine.MachineStatusEvent{
-			Stage: machine.MachineStatusEvent_RUNNING,
+			Stage:  machine.MachineStatusEvent_RUNNING,
+			Status: &machine.MachineStatusEvent_MachineStatus{Ready: true},
 		}
 
 		return nil

--- a/internal/backend/talos/lifecycle/drain_test.go
+++ b/internal/backend/talos/lifecycle/drain_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package lifecycle_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/siderolabs/omni/client/pkg/imagefactory"
+	"github.com/siderolabs/omni/internal/backend/talos/lifecycle"
+)
+
+// fixedClientsetProvider returns the same clientset for any cluster.
+type fixedClientsetProvider struct {
+	clientset k8s.Interface
+}
+
+func (p fixedClientsetProvider) GetKubernetesClientset(context.Context, string) (k8s.Interface, error) {
+	return p.clientset, nil
+}
+
+func newDrainTestManager(t *testing.T, clientset k8s.Interface) *lifecycle.Manager {
+	t.Helper()
+
+	c, err := imagefactory.NewClient("factory.talos.dev", "", "")
+	require.NoError(t, err)
+
+	return lifecycle.NewManager(zapNop(t), imagefactory.NewClients(
+		state.WrapCore(namespaced.NewState(inmem.Build)),
+		c,
+	), "ghcr.io/siderolabs/installer", fixedClientsetProvider{clientset: clientset}, nil, nil)
+}
+
+// TestCordonAndDrain verifies the two cordon/drain modes: the normal mode cordons and drains with
+// failures aborting the operation as always, while the best-effort mode (a recovery of an unhealthy
+// machine) only cordons, tolerates every failure, and never blocks the reboot.
+func TestCordonAndDrain(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	const nodeName = "node-1"
+
+	progressCollector := func(messages *[]string) func(string) {
+		return func(msg string) { *messages = append(*messages, msg) }
+	}
+
+	joined := func(messages []string) string { return strings.Join(messages, "\n") }
+
+	newNodeClientset := func() *fake.Clientset {
+		return fake.NewSimpleClientset([]k8sruntime.Object{&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}}...)
+	}
+
+	t.Run("normalModeDrains", func(t *testing.T) {
+		t.Parallel()
+
+		clientset := newNodeClientset()
+
+		var messages []string
+
+		err := newDrainTestManager(t, clientset).RunCordonAndDrainForTest(ctx, "cluster-1", nodeName, false, progressCollector(&messages))
+		require.NoError(t, err)
+
+		assert.Contains(t, joined(messages), "drained")
+
+		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.True(t, node.Spec.Unschedulable, "the node must be cordoned")
+	})
+
+	t.Run("normalModeAbortsOnCordonFailure", func(t *testing.T) {
+		t.Parallel()
+
+		clientset := newNodeClientset()
+		clientset.PrependReactor("patch", "nodes", func(ktesting.Action) (bool, k8sruntime.Object, error) {
+			return true, nil, errors.New("api server unreachable")
+		})
+
+		var messages []string
+
+		err := newDrainTestManager(t, clientset).RunCordonAndDrainForTest(ctx, "cluster-1", nodeName, false, progressCollector(&messages))
+		require.Error(t, err, "a cordon failure must abort a normal operation, the machine is healthy and can wait")
+	})
+
+	t.Run("bestEffortDrains", func(t *testing.T) {
+		t.Parallel()
+
+		clientset := newNodeClientset()
+
+		var messages []string
+
+		err := newDrainTestManager(t, clientset).RunCordonAndDrainForTest(ctx, "cluster-1", nodeName, true, progressCollector(&messages))
+		require.NoError(t, err)
+
+		assert.Contains(t, joined(messages), "drained", "an evictable node must still be drained on a recovery")
+
+		node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.True(t, node.Spec.Unschedulable, "the node must be cordoned")
+	})
+
+	t.Run("bestEffortToleratesDrainFailure", func(t *testing.T) {
+		t.Parallel()
+
+		clientset := newNodeClientset()
+		clientset.PrependReactor("list", "pods", func(ktesting.Action) (bool, k8sruntime.Object, error) {
+			return true, nil, errors.New("pod listing broken")
+		})
+
+		var messages []string
+
+		err := newDrainTestManager(t, clientset).RunCordonAndDrainForTest(ctx, "cluster-1", nodeName, true, progressCollector(&messages))
+		require.NoError(t, err, "a failing drain must not abort a recovery operation")
+
+		assert.Contains(t, joined(messages), "failed to drain")
+	})
+
+	t.Run("bestEffortToleratesUnreachableAPI", func(t *testing.T) {
+		t.Parallel()
+
+		// Every node read and write fails, as when the machine being recovered hosts the only
+		// control plane and its API server is down along with it.
+		clientset := fake.NewSimpleClientset()
+		clientset.PrependReactor("*", "nodes", func(ktesting.Action) (bool, k8sruntime.Object, error) {
+			return true, nil, errors.New("api server unreachable")
+		})
+
+		var messages []string
+
+		err := newDrainTestManager(t, clientset).RunCordonAndDrainForTest(ctx, "cluster-1", nodeName, true, progressCollector(&messages))
+		require.NoError(t, err, "nothing may abort a recovery operation")
+
+		assert.Contains(t, joined(messages), "failed to cordon")
+	})
+}

--- a/internal/backend/talos/lifecycle/export_test.go
+++ b/internal/backend/talos/lifecycle/export_test.go
@@ -35,6 +35,14 @@ func (m *Manager) AcquireForTest(machineID string) bool {
 	return m.acquire(machineID)
 }
 
+// RunCordonAndDrainForTest exposes runCordonAndDrain to external tests.
+func (m *Manager) RunCordonAndDrainForTest(ctx context.Context, clusterName, nodeName string, bestEffort bool, progress func(string)) error {
+	return m.runCordonAndDrain(ctx, runConfig{
+		cordonDrain: &nodeRef{clusterName: clusterName, nodeName: nodeName, bestEffort: bestEffort},
+		progress:    progress,
+	})
+}
+
 // ReleaseForTest exposes release to external tests.
 func (m *Manager) ReleaseForTest(machineID string) {
 	m.release(machineID)

--- a/internal/backend/talos/lifecycle/manager.go
+++ b/internal/backend/talos/lifecycle/manager.go
@@ -89,10 +89,11 @@ func (m *Manager) clientset(ctx context.Context, cluster string) (k8s.Interface,
 // PreRebootHook runs before the node is drained. An error aborts the Run.
 type PreRebootHook func(ctx context.Context, talosClient *talosclient.Client) error
 
-// nodeRef names a cluster node.
+// nodeRef names a cluster node. With bestEffort, cordon/drain failures do not abort the operation.
 type nodeRef struct {
 	clusterName string
 	nodeName    string
+	bestEffort  bool
 }
 
 // runConfig holds the per-call options resolved from Option values.
@@ -108,10 +109,18 @@ type runConfig struct {
 type Option func(*runConfig)
 
 // WithCordonDrain makes Run cordon and drain the node before reboot. Set for cluster members.
-func WithCordonDrain(clusterName, nodeName string) Option {
+//
+// With bestEffort, cordon and drain failures do not abort the operation. Set it when the operation
+// is the recovery path of a machine that is itself unhealthy: nothing may block its reboot then,
+// and the workload Kubernetes API may be served by the very machine being recovered. The drain is
+// still attempted, because an unhealthy machine does not imply an unhealthy node: a machine can
+// stay Talos-not-ready (e.g. an extension service missing its configuration) while its node keeps
+// serving pods, and those deserve an eviction before the reboot. On a node that cannot finish
+// evictions the attempt costs at most the drain timeout, acceptable for a recovery.
+func WithCordonDrain(clusterName, nodeName string, bestEffort bool) Option {
 	return func(cfg *runConfig) {
 		if clusterName != "" && nodeName != "" {
-			cfg.cordonDrain = &nodeRef{clusterName: clusterName, nodeName: nodeName}
+			cfg.cordonDrain = &nodeRef{clusterName: clusterName, nodeName: nodeName, bestEffort: bestEffort}
 		}
 	}
 }
@@ -283,7 +292,15 @@ func (m *Manager) runCordonAndDrain(ctx context.Context, cfg runConfig) error {
 
 	clientset, err := m.clientset(ctx, target.clusterName)
 	if err != nil {
-		return WrapErr(err, "failed to get kubernetes client to cordon/drain node")
+		err = WrapErr(err, "failed to get kubernetes client to cordon/drain node")
+
+		if target.bestEffort {
+			emitf(cfg.progress, "[omni] skipping cordon and drain of node %s: %s", target.nodeName, err)
+
+			return nil
+		}
+
+		return err
 	}
 
 	cordonCtx, cancel := context.WithTimeout(ctx, CordonTimeout)
@@ -292,19 +309,40 @@ func (m *Manager) runCordonAndDrain(ctx context.Context, cfg runConfig) error {
 	emitf(cfg.progress, "[omni] cordoning node %s", target.nodeName)
 
 	if err = nodedrain.Cordon(cordonCtx, clientset, target.nodeName); err != nil {
+		if target.bestEffort {
+			emitf(cfg.progress, "[omni] failed to cordon node %s, proceeding to reboot: %s", target.nodeName, err)
+
+			return nil
+		}
+
 		return err
 	}
 
-	emitf(cfg.progress, "[omni] draining node %s", target.nodeName)
+	if err = drain(ctx, clientset, cfg, target.nodeName); err != nil {
+		// See WithCordonDrain for why a best-effort operation tolerates a failed drain.
+		if target.bestEffort {
+			emitf(cfg.progress, "[omni] failed to drain node %s, proceeding to reboot: %s", target.nodeName, err)
 
-	// Drain bounds itself with its own DefaultDrainTimeout.
-	if err = nodedrain.Drain(ctx, clientset, target.nodeName, nodedrain.DrainOptions{
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// drain evicts the node's pods, bounding itself with nodedrain's own drain timeout.
+func drain(ctx context.Context, clientset k8s.Interface, cfg runConfig, nodeName string) error {
+	emitf(cfg.progress, "[omni] draining node %s", nodeName)
+
+	if err := nodedrain.Drain(ctx, clientset, nodeName, nodedrain.DrainOptions{
 		Progress: func(msg string) { cfg.progress("[omni] " + msg) },
 	}); err != nil {
 		return err
 	}
 
-	emitf(cfg.progress, "[omni] node %s drained", target.nodeName)
+	emitf(cfg.progress, "[omni] node %s drained", nodeName)
 
 	return nil
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -251,6 +251,7 @@ func TestIntegration(t *testing.T) {
 		t.Run("OmniUpgradeVerify", testOmniUpgradeVerify(testOptions))
 		t.Run("ClusterImport", func(t *testing.T) { testClusterImport(t, testOptions) })
 		t.Run("KernelArgsUpdate", func(t *testing.T) { testKernelArgsUpdate(t, testOptions) })
+		t.Run("KernelArgsBreakAndRevert", func(t *testing.T) { testKernelArgsBreakAndRevert(t, testOptions) })
 		t.Run("RotateCA", func(t *testing.T) { testRotateCA(t, testOptions) })
 		t.Run("DrainTerminationGracePeriod", func(t *testing.T) { testDrainTerminationGracePeriod(t, testOptions) })
 	})

--- a/internal/integration/kernelargs_recovery_test.go
+++ b/internal/integration/kernelargs_recovery_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+)
+
+// kubeletReservedCPUsPatch pins kubelet system-reserved CPUs to cores 1 and 2. It is valid on the
+// 3-CPU test machines, and becomes invalid once the maxcpus=2 kernel arg leaves only CPUs 0-1 online:
+// kubelet then fails validation with "reserved-cpus is not a subset of online-cpus" and crashloops,
+// exactly the failure mode of siderolabs/omni#3262.
+const kubeletReservedCPUsPatch = `machine:
+  kubelet:
+    extraArgs:
+      reserved-cpus: "1,2"`
+
+// testKernelArgsBreakAndRevert breaks a machine through a kernel args change and verifies that reverting
+// the change recovers it (siderolabs/omni#3262). The broken machine stays connected to Omni but is not
+// healthy, so before the fix neither the revert nor anything else could reach it, and the machine was
+// stuck until manual bootloader intervention or a reprovision.
+//
+// On emulated (talemu) machines the breakage is the talemu.stuck=booting magic arg. On QEMU machines it
+// is the real thing: a kubelet reserved-cpus setting that a maxcpus kernel arg invalidates.
+func testKernelArgsBreakAndRevert(t *testing.T, options *TestOptions) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Minute)
+	defer cancel()
+
+	options.claimMachines(t, 2)
+
+	clusterName := "integration-kernel-args-revert"
+
+	t.Run(
+		"ClusterShouldBeCreated",
+		CreateCluster(t.Context(), options, ClusterOptions{
+			Name:          clusterName,
+			ControlPlanes: 1,
+			Workers:       1,
+
+			MachineOptions: options.MachineOptions,
+			ScalingTimeout: options.ScalingTimeout,
+
+			SkipExtensionCheckOnCreate: options.SkipExtensionsCheckOnCreate,
+		}),
+	)
+
+	assertClusterAndAPIReady(t, clusterName, options)
+
+	omniState := options.omniClient.Omni().State()
+
+	workerIDs := rtestutils.ResourceIDs[*omni.ClusterMachine](ctx, t, omniState, state.WithLabelQuery(
+		resource.LabelEqual(omni.LabelCluster, clusterName),
+		resource.LabelExists(omni.LabelWorkerRole),
+	))
+	require.Len(t, workerIDs, 1)
+
+	machineID := workerIDs[0]
+
+	t.Logf("breaking and reverting machine ID: %s", machineID)
+
+	// Mirrors StuckBootingKernelArg in talemu's internal/pkg/constants.
+	breakingArg := "talemu.stuck=booting"
+
+	if !clusterUsesEmulatedMachines(ctx, t, omniState, clusterName) {
+		breakingArg = "maxcpus=2"
+
+		// The kubelet patch must be fully applied and kubelet healthy again BEFORE the kernel args
+		// change: the pending kernel args upgrade would otherwise block the config apply, and the
+		// breakage would never arm.
+		t.Run("KubeletReservedCPUsPatchShouldBeApplied", func(t *testing.T) {
+			patch := omni.NewConfigPatch("500-" + clusterName + "-kubelet-reserved-cpus")
+
+			createOrUpdate(ctx, t, omniState, patch, func(cps *omni.ConfigPatch) error {
+				cps.Metadata().Labels().Set(omni.LabelCluster, clusterName)
+				cps.Metadata().Labels().Set(omni.LabelClusterMachine, machineID)
+
+				return cps.TypedSpec().Value.SetUncompressedData([]byte(kubeletReservedCPUsPatch))
+			})
+
+			// The patch is provably part of the applied config, not merely created: asserting only
+			// on ConfigUpToDate could pass before the patch propagates into the desired config.
+			rtestutils.AssertResource(ctx, t, omniState, machineID, func(res *omni.ClusterMachineConfigStatus, assert *assert.Assertions) {
+				data, err := res.TypedSpec().Value.GetUncompressedData()
+				if !assert.NoError(err) {
+					return
+				}
+
+				defer data.Free()
+
+				assert.Contains(string(data.Data()), "reserved-cpus")
+			})
+
+			rtestutils.AssertResource(ctx, t, omniState, machineID, func(res *omni.ClusterMachineStatus, assert *assert.Assertions) {
+				assert.True(res.TypedSpec().Value.ConfigUpToDate, resourceDetails(res))
+				assert.True(res.TypedSpec().Value.Ready, resourceDetails(res))
+			})
+		})
+	}
+
+	t.Run("BreakingKernelArgsShouldMakeMachineUnhealthy", func(t *testing.T) {
+		_, err := safe.StateModifyWithResult(ctx, omniState, omni.NewKernelArgs(machineID), func(res *omni.KernelArgs) error {
+			res.TypedSpec().Value.Args = []string{breakingArg}
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		// The machine reboots into the new schematic and comes back broken: connected but not ready.
+		rtestutils.AssertResource(ctx, t, omniState, machineID, func(res *omni.MachineStatus, assert *assert.Assertions) {
+			assert.Contains(res.TypedSpec().Value.KernelCmdline, breakingArg, resourceDetails(res))
+		})
+
+		rtestutils.AssertResource(ctx, t, omniState, machineID, func(res *omni.ClusterMachineStatus, assert *assert.Assertions) {
+			assert.False(res.TypedSpec().Value.Ready, resourceDetails(res))
+		})
+
+		clusterMachineStatus, err := safe.StateGetByID[*omni.ClusterMachineStatus](ctx, omniState, machineID)
+		require.NoError(t, err)
+
+		// The stage the breakage lands in is informational: booting and running-but-not-ready are both
+		// covered by the fix, and a real kubelet crashloop can present as either.
+		t.Logf("broken machine stage: %s", clusterMachineStatus.TypedSpec().Value.Stage)
+	})
+
+	t.Run("RevertedKernelArgsShouldRecoverMachine", func(t *testing.T) {
+		_, err := safe.StateModifyWithResult(ctx, omniState, omni.NewKernelArgs(machineID), func(res *omni.KernelArgs) error {
+			res.TypedSpec().Value.Args = nil
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		// Before the fix this hangs forever: the machine is not healthy, so Omni never applies the
+		// reverted args to it.
+		rtestutils.AssertResource(ctx, t, omniState, machineID, func(res *omni.MachineStatus, assert *assert.Assertions) {
+			assert.NotContains(res.TypedSpec().Value.KernelCmdline, breakingArg, resourceDetails(res))
+		})
+
+		rtestutils.AssertResource(ctx, t, omniState, machineID, func(res *omni.ClusterMachineStatus, assert *assert.Assertions) {
+			assert.True(res.TypedSpec().Value.Ready, resourceDetails(res))
+		})
+	})
+
+	t.Run("ClusterShouldBeDestroyed", AssertDestroyCluster(t.Context(), options.omniClient.Omni().State(), clusterName, false, false))
+}


### PR DESCRIPTION
When a kernel args or extensions change broke a machine, reverting it had no effect: updates run through the upgrade flow, which skipped machines that are not healthy. The machine could not become healthy without the update, and the update never ran while it was unhealthy, so the only way out was the bootloader console or a reprovision.

A machine's own unhealthiness no longer blocks its own pending update: a booting machine is now eligible for the upgrade like it already was for config apply, a not-ready machine is guaranteed one upgrade slot, and the cordon and drain of a recovery are best-effort. Healthy machines still wait while the cluster is degraded, broken machines recover one at a time, and Talos version reverts on booting machines are unblocked the same way.

On machines older than Talos 1.13, the regular upgrade drains the node first, and a broken machine may have no working Kubernetes API to drain through. The upgrade then failed before installing anything, and the machine rebooted into the same broken image over and over. Recovery on these machines now uses a staged upgrade followed by an explicit reboot, which skips the drain and applies the new image on the next boot.

Closes siderolabs/omni#3262.
