### PR TITLE
feat: use tokens for authenticating with factory

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/siderolabs/go-api-signature v0.3.13
 	github.com/siderolabs/go-kubeconfig v0.1.2
 	github.com/siderolabs/go-talos-support v0.3.1
-	github.com/siderolabs/image-factory v1.5.1
+	github.com/siderolabs/image-factory v1.5.2-0.20260827204513-4691e0156da8
 	github.com/siderolabs/proto-codec v0.1.4
 	github.com/siderolabs/siderolink v0.3.17
 	github.com/siderolabs/talos/pkg/machinery v1.14.0-rc.2.0.20260825161121-322de8bf2974

--- a/client/go.sum
+++ b/client/go.sum
@@ -238,8 +238,8 @@ github.com/siderolabs/go-retry v0.3.3 h1:zKV+S1vumtO72E6sYsLlmIdV/G/GcYSBLiEx/c9
 github.com/siderolabs/go-retry v0.3.3/go.mod h1:Ff/VGc7v7un4uQg3DybgrmOWHEmJ8BzZds/XNn/BqMI=
 github.com/siderolabs/go-talos-support v0.3.1 h1:2cIct5nxGby8B7NNALO5WL3WbCe9S1se/3/nT0H/x7Q=
 github.com/siderolabs/go-talos-support v0.3.1/go.mod h1:3fljgD3YQGB2+nJfWLLt482/C8epdqge70fWH+VtuiU=
-github.com/siderolabs/image-factory v1.5.1 h1:VYz9CQcFuzD2of6tw1YCIiNdchPawKFVptT1q4skD/Y=
-github.com/siderolabs/image-factory v1.5.1/go.mod h1:usi+gZen80PnprOrlF9S85wwpqehG48fsWSDjMverMs=
+github.com/siderolabs/image-factory v1.5.2-0.20260827204513-4691e0156da8 h1:OemFX0FhkU2dneZHvcIiH5QC2EF2gpagteAIl/N0rN4=
+github.com/siderolabs/image-factory v1.5.2-0.20260827204513-4691e0156da8/go.mod h1:cbFXaZBOMcfT0vxOQ/GU8Pep9vmoyI9vWnAT8yeS3m8=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=
 github.com/siderolabs/net v0.4.0/go.mod h1:/ibG+Hm9HU27agp5r9Q3eZicEfjquzNzQNux5uEk0kM=
 github.com/siderolabs/proto-codec v0.1.4 h1:AcrLot/251qAa35GYhSqDeEKF3bygOlNaYJSrl7MPNQ=

--- a/client/pkg/imagefactory/client.go
+++ b/client/pkg/imagefactory/client.go
@@ -75,7 +75,7 @@ type Client struct {
 // The base URL is canonicalized by stripping any trailing slash, so that the URL reported by
 // [Client.URL] can be compared to a factory URL from any other source (a configured factory, a
 // TalosVersion resource, a client request) without each comparison having to normalize first.
-func NewClient(imageFactoryBaseURL, username, password string) (*Client, error) {
+func NewClient(imageFactoryBaseURL, username, password string, extraOpts ...client.Option) (*Client, error) {
 	imageFactoryBaseURL = normalizeFactoryURL(imageFactoryBaseURL)
 
 	sniffer := &serverSnifferTransport{wrapped: http.DefaultTransport}
@@ -87,6 +87,8 @@ func NewClient(imageFactoryBaseURL, username, password string) (*Client, error) 
 	if username != "" && password != "" {
 		clientOptions = append(clientOptions, client.WithBasicAuth(username, password))
 	}
+
+	clientOptions = append(clientOptions, extraOpts...)
 
 	factoryClient, err := client.New(imageFactoryBaseURL, clientOptions...)
 	if err != nil {

--- a/client/pkg/imagefactory/clients.go
+++ b/client/pkg/imagefactory/clients.go
@@ -84,7 +84,7 @@ func NewClientsFromState(ctx context.Context, st state.State) (*Clients, error) 
 		return nil, err
 	}
 
-	primaryClient, err := NewClient(baseURL, username, password)
+	primaryClient, err := NewClient(baseURL, username, password, client.WithTokenSource(TokenSource(st, baseURL)))
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,10 @@ func NewClientsFromState(ctx context.Context, st state.State) (*Clients, error) 
 			return nil, err
 		}
 
-		secondaryClient, err := NewClient(config.TypedSpec().Value.SecondaryImageFactoryBaseUrl, secondaryUsername, secondaryPassword)
+		secondaryClient, err := NewClient(
+			config.TypedSpec().Value.SecondaryImageFactoryBaseUrl, secondaryUsername, secondaryPassword,
+			client.WithTokenSource(TokenSource(st, config.TypedSpec().Value.SecondaryImageFactoryBaseUrl)),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +137,32 @@ func Credentials(ctx context.Context, st state.State, factoryURL string) (userna
 		return "", "", fmt.Errorf("failed to get image factory auth: %w", err)
 	}
 
+	token := auth.TypedSpec().Value.GetToken().GetToken()
+	if token != "" {
+		return "token", token, nil
+	}
+
 	return auth.TypedSpec().Value.GetUsername(), auth.TypedSpec().Value.GetPassword(), nil
+}
+
+// TokenSource returns a client.TokenSource that reads the bearer token reconciled into
+// ImageFactoryAuth for the factory at the given URL. The token is looked up fresh on every
+// request, so it stays current as AuthController rotates it.
+func TokenSource(st state.State, factoryURL string) client.TokenSource {
+	factoryURL = normalizeFactoryURL(factoryURL)
+
+	return func(ctx context.Context) (string, error) {
+		auth, err := safe.ReaderGetByID[*omni.ImageFactoryAuth](ctx, st, factoryURL)
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				return "", nil
+			}
+
+			return "", fmt.Errorf("failed to get image factory auth: %w", err)
+		}
+
+		return auth.TypedSpec().Value.GetToken().GetToken(), nil
+	}
 }
 
 // SetSecondary configures the secondary image factory client.

--- a/cmd/omni/pkg/app/app.go
+++ b/cmd/omni/pkg/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/zapr"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
+	imagefactoryclient "github.com/siderolabs/image-factory/pkg/client"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/klog/v2"
@@ -279,6 +280,7 @@ func setupImageFactoryClients(cfg *config.Params, state *omni.State) (*imagefact
 		primaryFactory.GetUrl(),
 		primaryFactory.GetUsername(),
 		primaryFactory.GetPassword(),
+		imagefactoryclient.WithTokenSource(imagefactory.TokenSource(state.Default(), primaryFactory.GetUrl())),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up image factory client: %w", err)
@@ -296,6 +298,7 @@ func setupImageFactoryClients(cfg *config.Params, state *omni.State) (*imagefact
 			secondaryFactory.GetUrl(),
 			secondaryFactory.GetUsername(),
 			secondaryFactory.GetPassword(),
+			imagefactoryclient.WithTokenSource(imagefactory.TokenSource(state.Default(), secondaryFactory.GetUrl())),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set up secondary image factory client: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/go-talos-support v0.3.1
 	github.com/siderolabs/grpc-proxy v0.5.2
-	github.com/siderolabs/image-factory v1.5.1
+	github.com/siderolabs/image-factory v1.5.2-0.20260827204513-4691e0156da8
 	github.com/siderolabs/kms-client v0.2.0
 	github.com/siderolabs/omni/client v1.9.3
 	github.com/siderolabs/proto-codec v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,8 @@ github.com/siderolabs/go-talos-support v0.3.1 h1:2cIct5nxGby8B7NNALO5WL3WbCe9S1s
 github.com/siderolabs/go-talos-support v0.3.1/go.mod h1:3fljgD3YQGB2+nJfWLLt482/C8epdqge70fWH+VtuiU=
 github.com/siderolabs/grpc-proxy v0.5.2 h1:o34tS02IxbX3qeXe0MM99zE2XhfWHuvdBtSWWRD9HNI=
 github.com/siderolabs/grpc-proxy v0.5.2/go.mod h1:ygf+gqFxWdymAXuP4qMHTa+j6SvasdcFg3XkhpvUvDw=
-github.com/siderolabs/image-factory v1.5.1 h1:VYz9CQcFuzD2of6tw1YCIiNdchPawKFVptT1q4skD/Y=
-github.com/siderolabs/image-factory v1.5.1/go.mod h1:usi+gZen80PnprOrlF9S85wwpqehG48fsWSDjMverMs=
+github.com/siderolabs/image-factory v1.5.2-0.20260827204513-4691e0156da8 h1:OemFX0FhkU2dneZHvcIiH5QC2EF2gpagteAIl/N0rN4=
+github.com/siderolabs/image-factory v1.5.2-0.20260827204513-4691e0156da8/go.mod h1:cbFXaZBOMcfT0vxOQ/GU8Pep9vmoyI9vWnAT8yeS3m8=
 github.com/siderolabs/kms-client v0.2.0 h1:8RniCStUI75RTZO8qkhHOSVOnEU1AvvsKqJ7FqW/8NA=
 github.com/siderolabs/kms-client v0.2.0/go.mod h1:qq6dwcLPO0gaUyfkrhWi/37g/ZyZJzOHzvHrilLz48E=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=

--- a/internal/backend/runtime/omni/controllers/omni/internal/imagefactoryauth/imagefactoryauth.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/imagefactoryauth/imagefactoryauth.go
@@ -17,10 +17,11 @@ import (
 )
 
 func buildDoc(auth *omni.ImageFactoryAuth) (*cri.RegistryAuthConfigV1Alpha1, error) {
+	token := auth.TypedSpec().Value.GetToken().GetToken()
 	username := auth.TypedSpec().Value.Username
 	password := auth.TypedSpec().Value.Password
 
-	if username == "" || password == "" {
+	if token == "" && (username == "" || password == "") {
 		return nil, nil //nolint:nilnil
 	}
 
@@ -30,8 +31,13 @@ func buildDoc(auth *omni.ImageFactoryAuth) (*cri.RegistryAuthConfigV1Alpha1, err
 	}
 
 	doc := cri.NewRegistryAuthConfigV1Alpha1(u.Host)
-	doc.RegistryUsername = username
-	doc.RegistryPassword = password
+	if token != "" {
+		doc.RegistryUsername = "token"
+		doc.RegistryPassword = token
+	} else {
+		doc.RegistryUsername = username
+		doc.RegistryPassword = password
+	}
 
 	return doc, nil
 }

--- a/internal/backend/runtime/omni/controllers/omni/internal/imagefactoryauth/imagefactoryauth_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/imagefactoryauth/imagefactoryauth_test.go
@@ -30,6 +30,15 @@ func newImageFactoryAuth(id, username, password string) *omni.ImageFactoryAuth {
 	)
 }
 
+func newImageFactoryAuthToken(id, token string) *omni.ImageFactoryAuth {
+	return typed.NewResource[omni.ImageFactoryAuthSpec, omni.ImageFactoryAuthExtension](
+		resource.NewMetadata(resources.DefaultNamespace, omni.ImageFactoryAuthType, id, resource.VersionUndefined),
+		protobuf.NewResourceSpec(&specs.ImageFactoryAuthSpec{
+			Token: &specs.ImageFactoryAuthSpec_AccessToken{Token: token},
+		}),
+	)
+}
+
 func TestBuildDocs(t *testing.T) {
 	t.Parallel()
 
@@ -91,5 +100,21 @@ func TestBuildDocs(t *testing.T) {
 		require.Len(t, docs, 1)
 
 		assert.Equal(t, "factory.example.org", docs[0].Name())
+	})
+
+	t.Run("token credentials are used as the registry password", func(t *testing.T) {
+		t.Parallel()
+
+		creds := []*omni.ImageFactoryAuth{
+			newImageFactoryAuthToken("https://factory.example.org", "the-token"),
+		}
+
+		docs, err := imagefactoryauth.BuildDocs(creds)
+		require.NoError(t, err)
+		require.Len(t, docs, 1)
+
+		assert.Equal(t, "factory.example.org", docs[0].Name())
+		assert.Equal(t, "token", docs[0].Username())
+		assert.Equal(t, "the-token", docs[0].Password())
 	})
 }

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -870,10 +870,8 @@ func makeMux(
 		))
 	}
 
-	primaryFactory := cfg.Registries.GetPrimaryFactory()
-
 	frontendHandler := compress.Handler(
-		frontend.NewStaticHandler(7200, primaryFactory.GetUrl()),
+		frontend.NewStaticHandler(7200, &cfg.Registries),
 		gzip.BestCompression,
 	)
 

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/jxskiss/base62"
+
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
 

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -21,23 +21,24 @@ import (
 	"time"
 
 	"github.com/jxskiss/base62"
+	"github.com/siderolabs/omni/internal/pkg/config"
 )
 
 const index = "/index.html"
 
 // StaticHandler serves embedded frontend files.
 type StaticHandler struct {
-	modTime             time.Time
-	imageFactoryBaseURL string
-	maxAgeSec           int
+	modTime    time.Time
+	registries *config.Registries
+	maxAgeSec  int
 }
 
 // NewStaticHandler creates new static handler.
-func NewStaticHandler(maxAgeSec int, imageFactoryBaseURL string) *StaticHandler {
+func NewStaticHandler(maxAgeSec int, registries *config.Registries) *StaticHandler {
 	return &StaticHandler{
-		modTime:             time.Now(),
-		imageFactoryBaseURL: imageFactoryBaseURL,
-		maxAgeSec:           maxAgeSec,
+		modTime:    time.Now(),
+		registries: registries,
+		maxAgeSec:  maxAgeSec,
 	}
 }
 
@@ -130,6 +131,13 @@ func (handler *StaticHandler) serveFile(w http.ResponseWriter, r *http.Request, 
 
 			nonce := base62.EncodeToString(b)
 
+			allFactories := handler.registries.AllFactories()
+			factoryUrls := make([]string, 0, len(allFactories))
+
+			for _, factory := range allFactories {
+				factoryUrls = append(factoryUrls, factory.GetUrl())
+			}
+
 			// If at all possible, when updating the CSP, please also update it for the dev server.
 			// This can be done in frontend/vite.config.ts and will ensure CSP issues are reproducible
 			// on both dev and prod.
@@ -140,7 +148,7 @@ func (handler *StaticHandler) serveFile(w http.ResponseWriter, r *http.Request, 
 					fmt.Sprintf(";script-src 'self' 'nonce-%s' https://*.userpilot.io https://*.posthog.com", nonce)+
 					";media-src 'self' https://js.userpilot.io"+
 					";img-src * data:"+
-					fmt.Sprintf(";connect-src 'self' %s https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io https://*.posthog.com", handler.imageFactoryBaseURL)+
+					fmt.Sprintf(";connect-src 'self' %s https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io https://*.posthog.com", strings.Join(factoryUrls, " "))+
 					";font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.userpilot.io"+
 					// We are forced to use unsafe-inline for style-src due to monaco-editor https://github.com/microsoft/monaco-editor/issues/271
 					";style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com"+

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -774,6 +774,27 @@ registries:
 		assert.Equal(t, "new-pass", primary.GetPassword())
 	})
 
+	t.Run("primary OAuth2 without a primary URL is carried over as-is", func(t *testing.T) {
+		p, err := config.FromBytes([]byte(`
+registries:
+  imageFactoryBaseURL: https://old.example.com
+  factories:
+    primary:
+      oAuth2:
+        domain: tenant.example.com
+        audience: https://image-factory.example.com
+        clientID: client_id
+        clientSecret: client_secret
+`))
+		require.NoError(t, err)
+
+		primary := p.Registries.GetPrimaryFactory()
+		assert.Equal(t, "tenant.example.com", primary.OAuth2.GetDomain())
+		assert.Equal(t, "https://image-factory.example.com", primary.OAuth2.GetAudience())
+		assert.Equal(t, "client_id", primary.OAuth2.GetClientID())
+		assert.Equal(t, "client_secret", primary.OAuth2.GetClientSecret())
+	})
+
 	t.Run("secondary factory", func(t *testing.T) {
 		p, err := config.FromBytes([]byte(`
 registries:

--- a/internal/pkg/config/factories.go
+++ b/internal/pkg/config/factories.go
@@ -32,6 +32,10 @@ func (s *Registries) GetPrimaryFactory() Factory {
 	resolved.SetPxeURL(firstNonEmpty(primary.GetPxeURL(), s.GetImageFactoryPXEBaseURL()))
 	resolved.SetUsername(firstNonEmpty(primary.GetUsername(), s.GetImageFactoryUsername()))
 	resolved.SetPassword(firstNonEmpty(primary.GetPassword(), s.GetImageFactoryPassword()))
+	resolved.OAuth2.SetDomain(primary.OAuth2.GetDomain())
+	resolved.OAuth2.SetAudience(primary.OAuth2.GetAudience())
+	resolved.OAuth2.SetClientID(primary.OAuth2.GetClientID())
+	resolved.OAuth2.SetClientSecret(primary.OAuth2.GetClientSecret())
 
 	return resolved
 }


### PR DESCRIPTION
Use the stored access tokens for authenticating Omni with factory. Also noticed secondary factory was missing from CSP so added it there.