### PR TITLE
refactor: rename the boot asset API to installation media URL

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -402,60 +402,60 @@ func (CreateSchematicRequest_SiderolinkGRPCTunnelMode) EnumDescriptor() ([]byte,
 	return file_omni_management_management_proto_rawDescGZIP(), []int{18, 0}
 }
 
-// BootAssetKind is one of the asset kinds the image factory serves. The comments show the shape of
-// the name the factory serves the asset under, which Omni assembles from the fields below.
-type BootAssetURLRequest_BootAssetKind int32
+// InstallationMediaKind is one of the kinds the image factory serves. The comments show the shape of
+// the filename the factory serves each kind under, which Omni assembles from the fields below.
+type InstallationMediaURLRequest_InstallationMediaKind int32
 
 const (
-	BootAssetURLRequest_BOOT_ASSET_KIND_UNSET BootAssetURLRequest_BootAssetKind = 0
+	InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_UNSET InstallationMediaURLRequest_InstallationMediaKind = 0
 	// <platform>-<arch>[-secureboot], served from the factory's PXE endpoint.
-	BootAssetURLRequest_BOOT_ASSET_KIND_PXE BootAssetURLRequest_BootAssetKind = 1
+	InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_PXE InstallationMediaURLRequest_InstallationMediaKind = 1
 	// <platform>-<arch>[-secureboot].iso
-	BootAssetURLRequest_BOOT_ASSET_KIND_ISO BootAssetURLRequest_BootAssetKind = 2
+	InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_ISO InstallationMediaURLRequest_InstallationMediaKind = 2
 	// <platform>-<arch>[-secureboot].<format>
-	BootAssetURLRequest_BOOT_ASSET_KIND_DISK BootAssetURLRequest_BootAssetKind = 3
+	InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_DISK InstallationMediaURLRequest_InstallationMediaKind = 3
 )
 
-// Enum value maps for BootAssetURLRequest_BootAssetKind.
+// Enum value maps for InstallationMediaURLRequest_InstallationMediaKind.
 var (
-	BootAssetURLRequest_BootAssetKind_name = map[int32]string{
-		0: "BOOT_ASSET_KIND_UNSET",
-		1: "BOOT_ASSET_KIND_PXE",
-		2: "BOOT_ASSET_KIND_ISO",
-		3: "BOOT_ASSET_KIND_DISK",
+	InstallationMediaURLRequest_InstallationMediaKind_name = map[int32]string{
+		0: "INSTALLATION_MEDIA_KIND_UNSET",
+		1: "INSTALLATION_MEDIA_KIND_PXE",
+		2: "INSTALLATION_MEDIA_KIND_ISO",
+		3: "INSTALLATION_MEDIA_KIND_DISK",
 	}
-	BootAssetURLRequest_BootAssetKind_value = map[string]int32{
-		"BOOT_ASSET_KIND_UNSET": 0,
-		"BOOT_ASSET_KIND_PXE":   1,
-		"BOOT_ASSET_KIND_ISO":   2,
-		"BOOT_ASSET_KIND_DISK":  3,
+	InstallationMediaURLRequest_InstallationMediaKind_value = map[string]int32{
+		"INSTALLATION_MEDIA_KIND_UNSET": 0,
+		"INSTALLATION_MEDIA_KIND_PXE":   1,
+		"INSTALLATION_MEDIA_KIND_ISO":   2,
+		"INSTALLATION_MEDIA_KIND_DISK":  3,
 	}
 )
 
-func (x BootAssetURLRequest_BootAssetKind) Enum() *BootAssetURLRequest_BootAssetKind {
-	p := new(BootAssetURLRequest_BootAssetKind)
+func (x InstallationMediaURLRequest_InstallationMediaKind) Enum() *InstallationMediaURLRequest_InstallationMediaKind {
+	p := new(InstallationMediaURLRequest_InstallationMediaKind)
 	*p = x
 	return p
 }
 
-func (x BootAssetURLRequest_BootAssetKind) String() string {
+func (x InstallationMediaURLRequest_InstallationMediaKind) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (BootAssetURLRequest_BootAssetKind) Descriptor() protoreflect.EnumDescriptor {
+func (InstallationMediaURLRequest_InstallationMediaKind) Descriptor() protoreflect.EnumDescriptor {
 	return file_omni_management_management_proto_enumTypes[7].Descriptor()
 }
 
-func (BootAssetURLRequest_BootAssetKind) Type() protoreflect.EnumType {
+func (InstallationMediaURLRequest_InstallationMediaKind) Type() protoreflect.EnumType {
 	return &file_omni_management_management_proto_enumTypes[7]
 }
 
-func (x BootAssetURLRequest_BootAssetKind) Number() protoreflect.EnumNumber {
+func (x InstallationMediaURLRequest_InstallationMediaKind) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use BootAssetURLRequest_BootAssetKind.Descriptor instead.
-func (BootAssetURLRequest_BootAssetKind) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use InstallationMediaURLRequest_InstallationMediaKind.Descriptor instead.
+func (InstallationMediaURLRequest_InstallationMediaKind) EnumDescriptor() ([]byte, []int) {
 	return file_omni_management_management_proto_rawDescGZIP(), []int{21, 0}
 }
 
@@ -1741,9 +1741,9 @@ func (x *CreateSchematicResponse) GetSchematicYml() string {
 	return ""
 }
 
-type BootAssetURLRequest struct {
+type InstallationMediaURLRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// TalosVersion selects the image factory the same way asset URLs do.
+	// TalosVersion selects the image factory the same way the media URLs do.
 	TalosVersion string `protobuf:"bytes,1,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
 	// SchematicId is the ID the image factory returned for a schematic, e.g. from CreateSchematicFromRaw.
 	SchematicId string `protobuf:"bytes,2,opt,name=schematic_id,json=schematicId,proto3" json:"schematic_id,omitempty"`
@@ -1753,15 +1753,15 @@ type BootAssetURLRequest struct {
 	// Such a URL is as sensitive as the credentials it carries. Anything it is written into, like an
 	// iPXE script or a task log, exposes them to whoever can read it.
 	//
-	// When this is set, Headers on the response will be empty. It is implied for PXE assets, which are
+	// When this is set, Headers on the response will be empty. It is implied for the PXE kind, which is
 	// fetched by firmware that cannot send headers.
 	//
 	// Leaving it unset does not promise headers: a factory that authenticates downloads with a token puts it
 	// in the URL for every caller. Send Headers whenever it is not empty, instead of deciding from this field.
-	StandaloneUrl bool                              `protobuf:"varint,3,opt,name=standalone_url,json=standaloneUrl,proto3" json:"standalone_url,omitempty"`
-	BootAssetKind BootAssetURLRequest_BootAssetKind `protobuf:"varint,4,opt,name=boot_asset_kind,json=bootAssetKind,proto3,enum=management.BootAssetURLRequest_BootAssetKind" json:"boot_asset_kind,omitempty"`
-	// Platform, Architecture, Format and SecureBoot name the asset. Omni assembles the image factory
-	// filename out of them, so callers never encode the naming convention themselves.
+	StandaloneUrl         bool                                              `protobuf:"varint,3,opt,name=standalone_url,json=standaloneUrl,proto3" json:"standalone_url,omitempty"`
+	InstallationMediaKind InstallationMediaURLRequest_InstallationMediaKind `protobuf:"varint,4,opt,name=installation_media_kind,json=installationMediaKind,proto3,enum=management.InstallationMediaURLRequest_InstallationMediaKind" json:"installation_media_kind,omitempty"`
+	// Platform, Architecture, Format and SecureBoot identify which medium is wanted. Omni assembles the
+	// image factory filename out of them, so callers never encode the naming convention themselves.
 	//
 	// Platform is the Talos platform, e.g. "metal" or "nocloud".
 	Platform     string `protobuf:"bytes,5,opt,name=platform,proto3" json:"platform,omitempty"`
@@ -1781,20 +1781,20 @@ type BootAssetURLRequest struct {
 	sizeCache        protoimpl.SizeCache
 }
 
-func (x *BootAssetURLRequest) Reset() {
-	*x = BootAssetURLRequest{}
+func (x *InstallationMediaURLRequest) Reset() {
+	*x = InstallationMediaURLRequest{}
 	mi := &file_omni_management_management_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *BootAssetURLRequest) String() string {
+func (x *InstallationMediaURLRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*BootAssetURLRequest) ProtoMessage() {}
+func (*InstallationMediaURLRequest) ProtoMessage() {}
 
-func (x *BootAssetURLRequest) ProtoReflect() protoreflect.Message {
+func (x *InstallationMediaURLRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_omni_management_management_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1806,89 +1806,89 @@ func (x *BootAssetURLRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use BootAssetURLRequest.ProtoReflect.Descriptor instead.
-func (*BootAssetURLRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use InstallationMediaURLRequest.ProtoReflect.Descriptor instead.
+func (*InstallationMediaURLRequest) Descriptor() ([]byte, []int) {
 	return file_omni_management_management_proto_rawDescGZIP(), []int{21}
 }
 
-func (x *BootAssetURLRequest) GetTalosVersion() string {
+func (x *InstallationMediaURLRequest) GetTalosVersion() string {
 	if x != nil {
 		return x.TalosVersion
 	}
 	return ""
 }
 
-func (x *BootAssetURLRequest) GetSchematicId() string {
+func (x *InstallationMediaURLRequest) GetSchematicId() string {
 	if x != nil {
 		return x.SchematicId
 	}
 	return ""
 }
 
-func (x *BootAssetURLRequest) GetStandaloneUrl() bool {
+func (x *InstallationMediaURLRequest) GetStandaloneUrl() bool {
 	if x != nil {
 		return x.StandaloneUrl
 	}
 	return false
 }
 
-func (x *BootAssetURLRequest) GetBootAssetKind() BootAssetURLRequest_BootAssetKind {
+func (x *InstallationMediaURLRequest) GetInstallationMediaKind() InstallationMediaURLRequest_InstallationMediaKind {
 	if x != nil {
-		return x.BootAssetKind
+		return x.InstallationMediaKind
 	}
-	return BootAssetURLRequest_BOOT_ASSET_KIND_UNSET
+	return InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_UNSET
 }
 
-func (x *BootAssetURLRequest) GetPlatform() string {
+func (x *InstallationMediaURLRequest) GetPlatform() string {
 	if x != nil {
 		return x.Platform
 	}
 	return ""
 }
 
-func (x *BootAssetURLRequest) GetArchitecture() string {
+func (x *InstallationMediaURLRequest) GetArchitecture() string {
 	if x != nil {
 		return x.Architecture
 	}
 	return ""
 }
 
-func (x *BootAssetURLRequest) GetFormat() string {
+func (x *InstallationMediaURLRequest) GetFormat() string {
 	if x != nil {
 		return x.Format
 	}
 	return ""
 }
 
-func (x *BootAssetURLRequest) GetSecureBoot() bool {
+func (x *InstallationMediaURLRequest) GetSecureBoot() bool {
 	if x != nil {
 		return x.SecureBoot
 	}
 	return false
 }
 
-func (x *BootAssetURLRequest) GetDownloadTokenTtl() *durationpb.Duration {
+func (x *InstallationMediaURLRequest) GetDownloadTokenTtl() *durationpb.Duration {
 	if x != nil {
 		return x.DownloadTokenTtl
 	}
 	return nil
 }
 
-type BootAssetURLResponse struct {
+type InstallationMediaURLResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Url   string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
 	// Headers must be sent with the request fetching the URL. Empty when the image factory needs no
 	// authentication, or when it travels inside the URL instead.
 	Headers map[string]string `protobuf:"bytes,2,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// ImageFactoryHost is the same host as in the URL. Purely informative: to fetch the asset, only the
+	// ImageFactoryHost is the same host as in the URL. Purely informative: to fetch the medium, only the
 	// URL and the headers should be used.
 	ImageFactoryHost string `protobuf:"bytes,3,opt,name=image_factory_host,json=imageFactoryHost,proto3" json:"image_factory_host,omitempty"`
-	// StorageKey identifies the asset the URL points at, for callers that store what they download. It
-	// changes only when the asset itself does, so it is stable across credential rotation, unlike the URL,
+	// StorageKey identifies the medium the URL points at, for callers that store what they download. It
+	// changes only when the medium itself does, so it is stable across credential rotation, unlike the URL,
 	// which can carry credentials or a token.
 	//
 	// Treat it as opaque. Omni may change how it is derived, which costs a caller one re-download of the
-	// assets it already holds.
+	// media it already holds.
 	StorageKey string `protobuf:"bytes,4,opt,name=storage_key,json=storageKey,proto3" json:"storage_key,omitempty"`
 	// ExpiresAt is when the URL stops working, for a caller that does not perform the fetch itself, such as
 	// one handing the URL to a hypervisor download API. Unset when the URL does not expire.
@@ -1900,20 +1900,20 @@ type BootAssetURLResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *BootAssetURLResponse) Reset() {
-	*x = BootAssetURLResponse{}
+func (x *InstallationMediaURLResponse) Reset() {
+	*x = InstallationMediaURLResponse{}
 	mi := &file_omni_management_management_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *BootAssetURLResponse) String() string {
+func (x *InstallationMediaURLResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*BootAssetURLResponse) ProtoMessage() {}
+func (*InstallationMediaURLResponse) ProtoMessage() {}
 
-func (x *BootAssetURLResponse) ProtoReflect() protoreflect.Message {
+func (x *InstallationMediaURLResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_omni_management_management_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1925,40 +1925,40 @@ func (x *BootAssetURLResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use BootAssetURLResponse.ProtoReflect.Descriptor instead.
-func (*BootAssetURLResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use InstallationMediaURLResponse.ProtoReflect.Descriptor instead.
+func (*InstallationMediaURLResponse) Descriptor() ([]byte, []int) {
 	return file_omni_management_management_proto_rawDescGZIP(), []int{22}
 }
 
-func (x *BootAssetURLResponse) GetUrl() string {
+func (x *InstallationMediaURLResponse) GetUrl() string {
 	if x != nil {
 		return x.Url
 	}
 	return ""
 }
 
-func (x *BootAssetURLResponse) GetHeaders() map[string]string {
+func (x *InstallationMediaURLResponse) GetHeaders() map[string]string {
 	if x != nil {
 		return x.Headers
 	}
 	return nil
 }
 
-func (x *BootAssetURLResponse) GetImageFactoryHost() string {
+func (x *InstallationMediaURLResponse) GetImageFactoryHost() string {
 	if x != nil {
 		return x.ImageFactoryHost
 	}
 	return ""
 }
 
-func (x *BootAssetURLResponse) GetStorageKey() string {
+func (x *InstallationMediaURLResponse) GetStorageKey() string {
 	if x != nil {
 		return x.StorageKey
 	}
 	return ""
 }
 
-func (x *BootAssetURLResponse) GetExpiresAt() *timestamppb.Timestamp {
+func (x *InstallationMediaURLResponse) GetExpiresAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.ExpiresAt
 	}
@@ -3894,26 +3894,26 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\fschematic_id\x18\x01 \x01(\tR\vschematicId\x12\x17\n" +
 	"\apxe_url\x18\x02 \x01(\tR\x06pxeUrl\x12.\n" +
 	"\x13grpc_tunnel_enabled\x18\x03 \x01(\bR\x11grpcTunnelEnabled\x12#\n" +
-	"\rschematic_yml\x18\x04 \x01(\tR\fschematicYml\"\x95\x04\n" +
-	"\x13BootAssetURLRequest\x12#\n" +
+	"\rschematic_yml\x18\x04 \x01(\tR\fschematicYml\"\xe6\x04\n" +
+	"\x1bInstallationMediaURLRequest\x12#\n" +
 	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12!\n" +
 	"\fschematic_id\x18\x02 \x01(\tR\vschematicId\x12%\n" +
-	"\x0estandalone_url\x18\x03 \x01(\bR\rstandaloneUrl\x12U\n" +
-	"\x0fboot_asset_kind\x18\x04 \x01(\x0e2-.management.BootAssetURLRequest.BootAssetKindR\rbootAssetKind\x12\x1a\n" +
+	"\x0estandalone_url\x18\x03 \x01(\bR\rstandaloneUrl\x12u\n" +
+	"\x17installation_media_kind\x18\x04 \x01(\x0e2=.management.InstallationMediaURLRequest.InstallationMediaKindR\x15installationMediaKind\x12\x1a\n" +
 	"\bplatform\x18\x05 \x01(\tR\bplatform\x12\"\n" +
 	"\farchitecture\x18\x06 \x01(\tR\farchitecture\x12\x16\n" +
 	"\x06format\x18\a \x01(\tR\x06format\x12\x1f\n" +
 	"\vsecure_boot\x18\b \x01(\bR\n" +
 	"secureBoot\x12G\n" +
-	"\x12download_token_ttl\x18\t \x01(\v2\x19.google.protobuf.DurationR\x10downloadTokenTtl\"v\n" +
-	"\rBootAssetKind\x12\x19\n" +
-	"\x15BOOT_ASSET_KIND_UNSET\x10\x00\x12\x17\n" +
-	"\x13BOOT_ASSET_KIND_PXE\x10\x01\x12\x17\n" +
-	"\x13BOOT_ASSET_KIND_ISO\x10\x02\x12\x18\n" +
-	"\x14BOOT_ASSET_KIND_DISK\x10\x03\"\xb7\x02\n" +
-	"\x14BootAssetURLResponse\x12\x10\n" +
-	"\x03url\x18\x01 \x01(\tR\x03url\x12G\n" +
-	"\aheaders\x18\x02 \x03(\v2-.management.BootAssetURLResponse.HeadersEntryR\aheaders\x12,\n" +
+	"\x12download_token_ttl\x18\t \x01(\v2\x19.google.protobuf.DurationR\x10downloadTokenTtl\"\x9e\x01\n" +
+	"\x15InstallationMediaKind\x12!\n" +
+	"\x1dINSTALLATION_MEDIA_KIND_UNSET\x10\x00\x12\x1f\n" +
+	"\x1bINSTALLATION_MEDIA_KIND_PXE\x10\x01\x12\x1f\n" +
+	"\x1bINSTALLATION_MEDIA_KIND_ISO\x10\x02\x12 \n" +
+	"\x1cINSTALLATION_MEDIA_KIND_DISK\x10\x03\"\xc7\x02\n" +
+	"\x1cInstallationMediaURLResponse\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12O\n" +
+	"\aheaders\x18\x02 \x03(\v25.management.InstallationMediaURLResponse.HeadersEntryR\aheaders\x12,\n" +
 	"\x12image_factory_host\x18\x03 \x01(\tR\x10imageFactoryHost\x12\x1f\n" +
 	"\vstorage_key\x18\x04 \x01(\tR\n" +
 	"storageKey\x129\n" +
@@ -4064,7 +4064,7 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x12AuditLogOrderByDir\x12&\n" +
 	"\"AUDIT_LOG_ORDER_BY_DIR_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aAUDIT_LOG_ORDER_BY_DIR_ASC\x10\x01\x12\x1f\n" +
-	"\x1bAUDIT_LOG_ORDER_BY_DIR_DESC\x10\x022\x86\x14\n" +
+	"\x1bAUDIT_LOG_ORDER_BY_DIR_DESC\x10\x022\x9e\x14\n" +
 	"\x11ManagementService\x12K\n" +
 	"\n" +
 	"Kubeconfig\x12\x1d.management.KubeconfigRequest\x1a\x1e.management.KubeconfigResponse\x12N\n" +
@@ -4081,8 +4081,8 @@ const file_omni_management_management_proto_rawDesc = "" +
 	"\x1aKubernetesUpgradePreChecks\x12-.management.KubernetesUpgradePreChecksRequest\x1a..management.KubernetesUpgradePreChecksResponse\x12r\n" +
 	"\x17KubernetesSyncManifests\x12).management.KubernetesSyncManifestRequest\x1a*.management.KubernetesSyncManifestResponse0\x01\x12Z\n" +
 	"\x0fCreateSchematic\x12\".management.CreateSchematicRequest\x1a#.management.CreateSchematicResponse\x12h\n" +
-	"\x16CreateSchematicFromRaw\x12).management.CreateSchematicFromRawRequest\x1a#.management.CreateSchematicResponse\x12T\n" +
-	"\x0fGetBootAssetURL\x12\x1f.management.BootAssetURLRequest\x1a .management.BootAssetURLResponse\x12_\n" +
+	"\x16CreateSchematicFromRaw\x12).management.CreateSchematicFromRawRequest\x1a#.management.CreateSchematicResponse\x12l\n" +
+	"\x17GetInstallationMediaURL\x12'.management.InstallationMediaURLRequest\x1a(.management.InstallationMediaURLResponse\x12_\n" +
 	"\x10GetSupportBundle\x12#.management.GetSupportBundleRequest\x1a$.management.GetSupportBundleResponse0\x01\x12S\n" +
 	"\fReadAuditLog\x12\x1f.management.ReadAuditLogRequest\x1a .management.ReadAuditLogResponse0\x01\x12c\n" +
 	"\x12MaintenanceUpgrade\x12%.management.MaintenanceUpgradeRequest\x1a&.management.MaintenanceUpgradeResponse\x12k\n" +
@@ -4121,7 +4121,7 @@ var file_omni_management_management_proto_goTypes = []any{
 	(KubernetesSSAOptions_InventoryPolicy)(0),                       // 4: management.KubernetesSSAOptions.InventoryPolicy
 	(KubernetesSyncManifestResponse_ResponseType)(0),                // 5: management.KubernetesSyncManifestResponse.ResponseType
 	(CreateSchematicRequest_SiderolinkGRPCTunnelMode)(0),            // 6: management.CreateSchematicRequest.SiderolinkGRPCTunnelMode
-	(BootAssetURLRequest_BootAssetKind)(0),                          // 7: management.BootAssetURLRequest.BootAssetKind
+	(InstallationMediaURLRequest_InstallationMediaKind)(0),          // 7: management.InstallationMediaURLRequest.InstallationMediaKind
 	(MaintenanceLifecycleRequest_Operation)(0),                      // 8: management.MaintenanceLifecycleRequest.Operation
 	(*KubeconfigResponse)(nil),                                      // 9: management.KubeconfigResponse
 	(*TalosconfigResponse)(nil),                                     // 10: management.TalosconfigResponse
@@ -4144,8 +4144,8 @@ var file_omni_management_management_proto_goTypes = []any{
 	(*CreateSchematicRequest)(nil),                                  // 27: management.CreateSchematicRequest
 	(*CreateSchematicFromRawRequest)(nil),                           // 28: management.CreateSchematicFromRawRequest
 	(*CreateSchematicResponse)(nil),                                 // 29: management.CreateSchematicResponse
-	(*BootAssetURLRequest)(nil),                                     // 30: management.BootAssetURLRequest
-	(*BootAssetURLResponse)(nil),                                    // 31: management.BootAssetURLResponse
+	(*InstallationMediaURLRequest)(nil),                             // 30: management.InstallationMediaURLRequest
+	(*InstallationMediaURLResponse)(nil),                            // 31: management.InstallationMediaURLResponse
 	(*GetSupportBundleRequest)(nil),                                 // 32: management.GetSupportBundleRequest
 	(*GetSupportBundleResponse)(nil),                                // 33: management.GetSupportBundleResponse
 	(*ReadAuditLogRequest)(nil),                                     // 34: management.ReadAuditLogRequest
@@ -4176,7 +4176,7 @@ var file_omni_management_management_proto_goTypes = []any{
 	(*ListServiceAccountsResponse_ServiceAccount_PgpPublicKey)(nil), // 59: management.ListServiceAccountsResponse.ServiceAccount.PgpPublicKey
 	(*CreateSchematicRequest_Overlay)(nil),                          // 60: management.CreateSchematicRequest.Overlay
 	nil,                                                             // 61: management.CreateSchematicRequest.MetaValuesEntry
-	nil,                                                             // 62: management.BootAssetURLResponse.HeadersEntry
+	nil,                                                             // 62: management.InstallationMediaURLResponse.HeadersEntry
 	(*GetSupportBundleResponse_Progress)(nil),                       // 63: management.GetSupportBundleResponse.Progress
 	(*ValidateJsonSchemaResponse_Error)(nil),                        // 64: management.ValidateJsonSchemaResponse.Error
 	(*ListUsersResponse_User)(nil),                                  // 65: management.ListUsersResponse.User
@@ -4197,10 +4197,10 @@ var file_omni_management_management_proto_depIdxs = []int32{
 	6,  // 7: management.CreateSchematicRequest.siderolink_grpc_tunnel_mode:type_name -> management.CreateSchematicRequest.SiderolinkGRPCTunnelMode
 	60, // 8: management.CreateSchematicRequest.overlay:type_name -> management.CreateSchematicRequest.Overlay
 	0,  // 9: management.CreateSchematicRequest.bootloader:type_name -> management.SchematicBootloader
-	7,  // 10: management.BootAssetURLRequest.boot_asset_kind:type_name -> management.BootAssetURLRequest.BootAssetKind
-	67, // 11: management.BootAssetURLRequest.download_token_ttl:type_name -> google.protobuf.Duration
-	62, // 12: management.BootAssetURLResponse.headers:type_name -> management.BootAssetURLResponse.HeadersEntry
-	68, // 13: management.BootAssetURLResponse.expires_at:type_name -> google.protobuf.Timestamp
+	7,  // 10: management.InstallationMediaURLRequest.installation_media_kind:type_name -> management.InstallationMediaURLRequest.InstallationMediaKind
+	67, // 11: management.InstallationMediaURLRequest.download_token_ttl:type_name -> google.protobuf.Duration
+	62, // 12: management.InstallationMediaURLResponse.headers:type_name -> management.InstallationMediaURLResponse.HeadersEntry
+	68, // 13: management.InstallationMediaURLResponse.expires_at:type_name -> google.protobuf.Timestamp
 	63, // 14: management.GetSupportBundleResponse.progress:type_name -> management.GetSupportBundleResponse.Progress
 	2,  // 15: management.ReadAuditLogRequest.order_by_field:type_name -> management.AuditLogOrderByField
 	3,  // 16: management.ReadAuditLogRequest.order_by_dir:type_name -> management.AuditLogOrderByDir
@@ -4229,7 +4229,7 @@ var file_omni_management_management_proto_depIdxs = []int32{
 	25, // 39: management.ManagementService.KubernetesSyncManifests:input_type -> management.KubernetesSyncManifestRequest
 	27, // 40: management.ManagementService.CreateSchematic:input_type -> management.CreateSchematicRequest
 	28, // 41: management.ManagementService.CreateSchematicFromRaw:input_type -> management.CreateSchematicFromRawRequest
-	30, // 42: management.ManagementService.GetBootAssetURL:input_type -> management.BootAssetURLRequest
+	30, // 42: management.ManagementService.GetInstallationMediaURL:input_type -> management.InstallationMediaURLRequest
 	32, // 43: management.ManagementService.GetSupportBundle:input_type -> management.GetSupportBundleRequest
 	34, // 44: management.ManagementService.ReadAuditLog:input_type -> management.ReadAuditLogRequest
 	38, // 45: management.ManagementService.MaintenanceUpgrade:input_type -> management.MaintenanceUpgradeRequest
@@ -4257,7 +4257,7 @@ var file_omni_management_management_proto_depIdxs = []int32{
 	26, // 67: management.ManagementService.KubernetesSyncManifests:output_type -> management.KubernetesSyncManifestResponse
 	29, // 68: management.ManagementService.CreateSchematic:output_type -> management.CreateSchematicResponse
 	29, // 69: management.ManagementService.CreateSchematicFromRaw:output_type -> management.CreateSchematicResponse
-	31, // 70: management.ManagementService.GetBootAssetURL:output_type -> management.BootAssetURLResponse
+	31, // 70: management.ManagementService.GetInstallationMediaURL:output_type -> management.InstallationMediaURLResponse
 	33, // 71: management.ManagementService.GetSupportBundle:output_type -> management.GetSupportBundleResponse
 	35, // 72: management.ManagementService.ReadAuditLog:output_type -> management.ReadAuditLogResponse
 	39, // 73: management.ManagementService.MaintenanceUpgrade:output_type -> management.MaintenanceUpgradeResponse

--- a/client/api/omni/management/management.pb.gw.go
+++ b/client/api/omni/management/management.pb.gw.go
@@ -406,9 +406,9 @@ func local_request_ManagementService_CreateSchematicFromRaw_0(ctx context.Contex
 	return msg, metadata, err
 }
 
-func request_ManagementService_GetBootAssetURL_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func request_ManagementService_GetInstallationMediaURL_0(ctx context.Context, marshaler runtime.Marshaler, client ManagementServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq BootAssetURLRequest
+		protoReq InstallationMediaURLRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
@@ -417,19 +417,19 @@ func request_ManagementService_GetBootAssetURL_0(ctx context.Context, marshaler 
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
 	}
-	msg, err := client.GetBootAssetURL(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.GetInstallationMediaURL(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 }
 
-func local_request_ManagementService_GetBootAssetURL_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+func local_request_ManagementService_GetInstallationMediaURL_0(ctx context.Context, marshaler runtime.Marshaler, server ManagementServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq BootAssetURLRequest
+		protoReq InstallationMediaURLRequest
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	msg, err := server.GetBootAssetURL(ctx, &protoReq)
+	msg, err := server.GetInstallationMediaURL(ctx, &protoReq)
 	return msg, metadata, err
 }
 
@@ -1032,25 +1032,25 @@ func RegisterManagementServiceHandlerServer(ctx context.Context, mux *runtime.Se
 		}
 		forward_ManagementService_CreateSchematicFromRaw_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_ManagementService_GetBootAssetURL_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_ManagementService_GetInstallationMediaURL_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/GetBootAssetURL", runtime.WithHTTPPathPattern("/management.ManagementService/GetBootAssetURL"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/management.ManagementService/GetInstallationMediaURL", runtime.WithHTTPPathPattern("/management.ManagementService/GetInstallationMediaURL"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_ManagementService_GetBootAssetURL_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_ManagementService_GetInstallationMediaURL_0(annotatedContext, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_ManagementService_GetBootAssetURL_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_ManagementService_GetInstallationMediaURL_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	mux.Handle(http.MethodPost, pattern_ManagementService_GetSupportBundle_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1551,22 +1551,22 @@ func RegisterManagementServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_ManagementService_CreateSchematicFromRaw_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPost, pattern_ManagementService_GetBootAssetURL_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_ManagementService_GetInstallationMediaURL_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/GetBootAssetURL", runtime.WithHTTPPathPattern("/management.ManagementService/GetBootAssetURL"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/management.ManagementService/GetInstallationMediaURL", runtime.WithHTTPPathPattern("/management.ManagementService/GetInstallationMediaURL"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_ManagementService_GetBootAssetURL_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_ManagementService_GetInstallationMediaURL_0(annotatedContext, inboundMarshaler, client, req, pathParams)
 		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		forward_ManagementService_GetBootAssetURL_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_ManagementService_GetInstallationMediaURL_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 	mux.Handle(http.MethodPost, pattern_ManagementService_GetSupportBundle_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
@@ -1807,7 +1807,7 @@ var (
 	pattern_ManagementService_KubernetesSyncManifests_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "KubernetesSyncManifests"}, ""))
 	pattern_ManagementService_CreateSchematic_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "CreateSchematic"}, ""))
 	pattern_ManagementService_CreateSchematicFromRaw_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "CreateSchematicFromRaw"}, ""))
-	pattern_ManagementService_GetBootAssetURL_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "GetBootAssetURL"}, ""))
+	pattern_ManagementService_GetInstallationMediaURL_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "GetInstallationMediaURL"}, ""))
 	pattern_ManagementService_GetSupportBundle_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "GetSupportBundle"}, ""))
 	pattern_ManagementService_ReadAuditLog_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "ReadAuditLog"}, ""))
 	pattern_ManagementService_MaintenanceUpgrade_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"management.ManagementService", "MaintenanceUpgrade"}, ""))
@@ -1838,7 +1838,7 @@ var (
 	forward_ManagementService_KubernetesSyncManifests_0    = runtime.ForwardResponseStream
 	forward_ManagementService_CreateSchematic_0            = runtime.ForwardResponseMessage
 	forward_ManagementService_CreateSchematicFromRaw_0     = runtime.ForwardResponseMessage
-	forward_ManagementService_GetBootAssetURL_0            = runtime.ForwardResponseMessage
+	forward_ManagementService_GetInstallationMediaURL_0    = runtime.ForwardResponseMessage
 	forward_ManagementService_GetSupportBundle_0           = runtime.ForwardResponseStream
 	forward_ManagementService_ReadAuditLog_0               = runtime.ForwardResponseStream
 	forward_ManagementService_MaintenanceUpgrade_0         = runtime.ForwardResponseMessage

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -189,20 +189,20 @@ message CreateSchematicResponse {
   string schematic_yml = 4;
 }
 
-message BootAssetURLRequest {
-  // BootAssetKind is one of the asset kinds the image factory serves. The comments show the shape of
-  // the name the factory serves the asset under, which Omni assembles from the fields below.
-  enum BootAssetKind {
-    BOOT_ASSET_KIND_UNSET = 0;
+message InstallationMediaURLRequest {
+  // InstallationMediaKind is one of the kinds the image factory serves. The comments show the shape of
+  // the filename the factory serves each kind under, which Omni assembles from the fields below.
+  enum InstallationMediaKind {
+    INSTALLATION_MEDIA_KIND_UNSET = 0;
     // <platform>-<arch>[-secureboot], served from the factory's PXE endpoint.
-    BOOT_ASSET_KIND_PXE = 1;
+    INSTALLATION_MEDIA_KIND_PXE = 1;
     // <platform>-<arch>[-secureboot].iso
-    BOOT_ASSET_KIND_ISO = 2;
+    INSTALLATION_MEDIA_KIND_ISO = 2;
     // <platform>-<arch>[-secureboot].<format>
-    BOOT_ASSET_KIND_DISK = 3;
+    INSTALLATION_MEDIA_KIND_DISK = 3;
   }
 
-  // TalosVersion selects the image factory the same way asset URLs do.
+  // TalosVersion selects the image factory the same way the media URLs do.
   string talos_version = 1;
   // SchematicId is the ID the image factory returned for a schematic, e.g. from CreateSchematicFromRaw.
   string schematic_id = 2;
@@ -212,16 +212,16 @@ message BootAssetURLRequest {
   // Such a URL is as sensitive as the credentials it carries. Anything it is written into, like an
   // iPXE script or a task log, exposes them to whoever can read it.
   //
-  // When this is set, Headers on the response will be empty. It is implied for PXE assets, which are
+  // When this is set, Headers on the response will be empty. It is implied for the PXE kind, which is
   // fetched by firmware that cannot send headers.
   //
   // Leaving it unset does not promise headers: a factory that authenticates downloads with a token puts it
   // in the URL for every caller. Send Headers whenever it is not empty, instead of deciding from this field.
   bool standalone_url = 3;
-  BootAssetKind boot_asset_kind = 4;
+  InstallationMediaKind installation_media_kind = 4;
 
-  // Platform, Architecture, Format and SecureBoot name the asset. Omni assembles the image factory
-  // filename out of them, so callers never encode the naming convention themselves.
+  // Platform, Architecture, Format and SecureBoot identify which medium is wanted. Omni assembles the
+  // image factory filename out of them, so callers never encode the naming convention themselves.
   //
   // Platform is the Talos platform, e.g. "metal" or "nocloud".
   string platform = 5;
@@ -240,20 +240,20 @@ message BootAssetURLRequest {
   google.protobuf.Duration download_token_ttl = 9;
 }
 
-message BootAssetURLResponse {
+message InstallationMediaURLResponse {
   string url = 1;
   // Headers must be sent with the request fetching the URL. Empty when the image factory needs no
   // authentication, or when it travels inside the URL instead.
   map<string, string> headers = 2;
-  // ImageFactoryHost is the same host as in the URL. Purely informative: to fetch the asset, only the
+  // ImageFactoryHost is the same host as in the URL. Purely informative: to fetch the medium, only the
   // URL and the headers should be used.
   string image_factory_host = 3;
-  // StorageKey identifies the asset the URL points at, for callers that store what they download. It
-  // changes only when the asset itself does, so it is stable across credential rotation, unlike the URL,
+  // StorageKey identifies the medium the URL points at, for callers that store what they download. It
+  // changes only when the medium itself does, so it is stable across credential rotation, unlike the URL,
   // which can carry credentials or a token.
   //
   // Treat it as opaque. Omni may change how it is derived, which costs a caller one re-download of the
-  // assets it already holds.
+  // media it already holds.
   string storage_key = 4;
 
   // ExpiresAt is when the URL stops working, for a caller that does not perform the fetch itself, such as
@@ -499,7 +499,7 @@ service ManagementService {
   rpc KubernetesSyncManifests(KubernetesSyncManifestRequest) returns (stream KubernetesSyncManifestResponse);
   rpc CreateSchematic(CreateSchematicRequest) returns (CreateSchematicResponse);
   rpc CreateSchematicFromRaw(CreateSchematicFromRawRequest) returns (CreateSchematicResponse);
-  rpc GetBootAssetURL(BootAssetURLRequest) returns (BootAssetURLResponse);
+  rpc GetInstallationMediaURL(InstallationMediaURLRequest) returns (InstallationMediaURLResponse);
   rpc GetSupportBundle(GetSupportBundleRequest) returns (stream GetSupportBundleResponse);
   rpc ReadAuditLog(ReadAuditLogRequest) returns (stream ReadAuditLogResponse);
   rpc MaintenanceUpgrade(MaintenanceUpgradeRequest) returns (MaintenanceUpgradeResponse);

--- a/client/api/omni/management/management_grpc.pb.go
+++ b/client/api/omni/management/management_grpc.pb.go
@@ -36,7 +36,7 @@ const (
 	ManagementService_KubernetesSyncManifests_FullMethodName    = "/management.ManagementService/KubernetesSyncManifests"
 	ManagementService_CreateSchematic_FullMethodName            = "/management.ManagementService/CreateSchematic"
 	ManagementService_CreateSchematicFromRaw_FullMethodName     = "/management.ManagementService/CreateSchematicFromRaw"
-	ManagementService_GetBootAssetURL_FullMethodName            = "/management.ManagementService/GetBootAssetURL"
+	ManagementService_GetInstallationMediaURL_FullMethodName    = "/management.ManagementService/GetInstallationMediaURL"
 	ManagementService_GetSupportBundle_FullMethodName           = "/management.ManagementService/GetSupportBundle"
 	ManagementService_ReadAuditLog_FullMethodName               = "/management.ManagementService/ReadAuditLog"
 	ManagementService_MaintenanceUpgrade_FullMethodName         = "/management.ManagementService/MaintenanceUpgrade"
@@ -70,7 +70,7 @@ type ManagementServiceClient interface {
 	KubernetesSyncManifests(ctx context.Context, in *KubernetesSyncManifestRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[KubernetesSyncManifestResponse], error)
 	CreateSchematic(ctx context.Context, in *CreateSchematicRequest, opts ...grpc.CallOption) (*CreateSchematicResponse, error)
 	CreateSchematicFromRaw(ctx context.Context, in *CreateSchematicFromRawRequest, opts ...grpc.CallOption) (*CreateSchematicResponse, error)
-	GetBootAssetURL(ctx context.Context, in *BootAssetURLRequest, opts ...grpc.CallOption) (*BootAssetURLResponse, error)
+	GetInstallationMediaURL(ctx context.Context, in *InstallationMediaURLRequest, opts ...grpc.CallOption) (*InstallationMediaURLResponse, error)
 	GetSupportBundle(ctx context.Context, in *GetSupportBundleRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetSupportBundleResponse], error)
 	ReadAuditLog(ctx context.Context, in *ReadAuditLogRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ReadAuditLogResponse], error)
 	MaintenanceUpgrade(ctx context.Context, in *MaintenanceUpgradeRequest, opts ...grpc.CallOption) (*MaintenanceUpgradeResponse, error)
@@ -252,10 +252,10 @@ func (c *managementServiceClient) CreateSchematicFromRaw(ctx context.Context, in
 	return out, nil
 }
 
-func (c *managementServiceClient) GetBootAssetURL(ctx context.Context, in *BootAssetURLRequest, opts ...grpc.CallOption) (*BootAssetURLResponse, error) {
+func (c *managementServiceClient) GetInstallationMediaURL(ctx context.Context, in *InstallationMediaURLRequest, opts ...grpc.CallOption) (*InstallationMediaURLResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(BootAssetURLResponse)
-	err := c.cc.Invoke(ctx, ManagementService_GetBootAssetURL_FullMethodName, in, out, cOpts...)
+	out := new(InstallationMediaURLResponse)
+	err := c.cc.Invoke(ctx, ManagementService_GetInstallationMediaURL_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +437,7 @@ type ManagementServiceServer interface {
 	KubernetesSyncManifests(*KubernetesSyncManifestRequest, grpc.ServerStreamingServer[KubernetesSyncManifestResponse]) error
 	CreateSchematic(context.Context, *CreateSchematicRequest) (*CreateSchematicResponse, error)
 	CreateSchematicFromRaw(context.Context, *CreateSchematicFromRawRequest) (*CreateSchematicResponse, error)
-	GetBootAssetURL(context.Context, *BootAssetURLRequest) (*BootAssetURLResponse, error)
+	GetInstallationMediaURL(context.Context, *InstallationMediaURLRequest) (*InstallationMediaURLResponse, error)
 	GetSupportBundle(*GetSupportBundleRequest, grpc.ServerStreamingServer[GetSupportBundleResponse]) error
 	ReadAuditLog(*ReadAuditLogRequest, grpc.ServerStreamingServer[ReadAuditLogResponse]) error
 	MaintenanceUpgrade(context.Context, *MaintenanceUpgradeRequest) (*MaintenanceUpgradeResponse, error)
@@ -503,8 +503,8 @@ func (UnimplementedManagementServiceServer) CreateSchematic(context.Context, *Cr
 func (UnimplementedManagementServiceServer) CreateSchematicFromRaw(context.Context, *CreateSchematicFromRawRequest) (*CreateSchematicResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateSchematicFromRaw not implemented")
 }
-func (UnimplementedManagementServiceServer) GetBootAssetURL(context.Context, *BootAssetURLRequest) (*BootAssetURLResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method GetBootAssetURL not implemented")
+func (UnimplementedManagementServiceServer) GetInstallationMediaURL(context.Context, *InstallationMediaURLRequest) (*InstallationMediaURLResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetInstallationMediaURL not implemented")
 }
 func (UnimplementedManagementServiceServer) GetSupportBundle(*GetSupportBundleRequest, grpc.ServerStreamingServer[GetSupportBundleResponse]) error {
 	return status.Error(codes.Unimplemented, "method GetSupportBundle not implemented")
@@ -804,20 +804,20 @@ func _ManagementService_CreateSchematicFromRaw_Handler(srv interface{}, ctx cont
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ManagementService_GetBootAssetURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(BootAssetURLRequest)
+func _ManagementService_GetInstallationMediaURL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InstallationMediaURLRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ManagementServiceServer).GetBootAssetURL(ctx, in)
+		return srv.(ManagementServiceServer).GetInstallationMediaURL(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: ManagementService_GetBootAssetURL_FullMethodName,
+		FullMethod: ManagementService_GetInstallationMediaURL_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ManagementServiceServer).GetBootAssetURL(ctx, req.(*BootAssetURLRequest))
+		return srv.(ManagementServiceServer).GetInstallationMediaURL(ctx, req.(*InstallationMediaURLRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1091,8 +1091,8 @@ var ManagementService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _ManagementService_CreateSchematicFromRaw_Handler,
 		},
 		{
-			MethodName: "GetBootAssetURL",
-			Handler:    _ManagementService_GetBootAssetURL_Handler,
+			MethodName: "GetInstallationMediaURL",
+			Handler:    _ManagementService_GetInstallationMediaURL_Handler,
 		},
 		{
 			MethodName: "MaintenanceUpgrade",

--- a/client/api/omni/management/management_vtproto.pb.go
+++ b/client/api/omni/management/management_vtproto.pb.go
@@ -528,15 +528,15 @@ func (m *CreateSchematicResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
-func (m *BootAssetURLRequest) CloneVT() *BootAssetURLRequest {
+func (m *InstallationMediaURLRequest) CloneVT() *InstallationMediaURLRequest {
 	if m == nil {
-		return (*BootAssetURLRequest)(nil)
+		return (*InstallationMediaURLRequest)(nil)
 	}
-	r := new(BootAssetURLRequest)
+	r := new(InstallationMediaURLRequest)
 	r.TalosVersion = m.TalosVersion
 	r.SchematicId = m.SchematicId
 	r.StandaloneUrl = m.StandaloneUrl
-	r.BootAssetKind = m.BootAssetKind
+	r.InstallationMediaKind = m.InstallationMediaKind
 	r.Platform = m.Platform
 	r.Architecture = m.Architecture
 	r.Format = m.Format
@@ -549,15 +549,15 @@ func (m *BootAssetURLRequest) CloneVT() *BootAssetURLRequest {
 	return r
 }
 
-func (m *BootAssetURLRequest) CloneMessageVT() proto.Message {
+func (m *InstallationMediaURLRequest) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
-func (m *BootAssetURLResponse) CloneVT() *BootAssetURLResponse {
+func (m *InstallationMediaURLResponse) CloneVT() *InstallationMediaURLResponse {
 	if m == nil {
-		return (*BootAssetURLResponse)(nil)
+		return (*InstallationMediaURLResponse)(nil)
 	}
-	r := new(BootAssetURLResponse)
+	r := new(InstallationMediaURLResponse)
 	r.Url = m.Url
 	r.ImageFactoryHost = m.ImageFactoryHost
 	r.StorageKey = m.StorageKey
@@ -576,7 +576,7 @@ func (m *BootAssetURLResponse) CloneVT() *BootAssetURLResponse {
 	return r
 }
 
-func (m *BootAssetURLResponse) CloneMessageVT() proto.Message {
+func (m *InstallationMediaURLResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -1801,7 +1801,7 @@ func (this *CreateSchematicResponse) EqualMessageVT(thatMsg proto.Message) bool 
 	}
 	return this.EqualVT(that)
 }
-func (this *BootAssetURLRequest) EqualVT(that *BootAssetURLRequest) bool {
+func (this *InstallationMediaURLRequest) EqualVT(that *InstallationMediaURLRequest) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
@@ -1816,7 +1816,7 @@ func (this *BootAssetURLRequest) EqualVT(that *BootAssetURLRequest) bool {
 	if this.StandaloneUrl != that.StandaloneUrl {
 		return false
 	}
-	if this.BootAssetKind != that.BootAssetKind {
+	if this.InstallationMediaKind != that.InstallationMediaKind {
 		return false
 	}
 	if this.Platform != that.Platform {
@@ -1837,14 +1837,14 @@ func (this *BootAssetURLRequest) EqualVT(that *BootAssetURLRequest) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
-func (this *BootAssetURLRequest) EqualMessageVT(thatMsg proto.Message) bool {
-	that, ok := thatMsg.(*BootAssetURLRequest)
+func (this *InstallationMediaURLRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*InstallationMediaURLRequest)
 	if !ok {
 		return false
 	}
 	return this.EqualVT(that)
 }
-func (this *BootAssetURLResponse) EqualVT(that *BootAssetURLResponse) bool {
+func (this *InstallationMediaURLResponse) EqualVT(that *InstallationMediaURLResponse) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
@@ -1877,8 +1877,8 @@ func (this *BootAssetURLResponse) EqualVT(that *BootAssetURLResponse) bool {
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
-func (this *BootAssetURLResponse) EqualMessageVT(thatMsg proto.Message) bool {
-	that, ok := thatMsg.(*BootAssetURLResponse)
+func (this *InstallationMediaURLResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*InstallationMediaURLResponse)
 	if !ok {
 		return false
 	}
@@ -3967,7 +3967,7 @@ func (m *CreateSchematicResponse) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
-func (m *BootAssetURLRequest) MarshalVT() (dAtA []byte, err error) {
+func (m *InstallationMediaURLRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -3980,12 +3980,12 @@ func (m *BootAssetURLRequest) MarshalVT() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *BootAssetURLRequest) MarshalToVT(dAtA []byte) (int, error) {
+func (m *InstallationMediaURLRequest) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *BootAssetURLRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *InstallationMediaURLRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -4038,8 +4038,8 @@ func (m *BootAssetURLRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x2a
 	}
-	if m.BootAssetKind != 0 {
-		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.BootAssetKind))
+	if m.InstallationMediaKind != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.InstallationMediaKind))
 		i--
 		dAtA[i] = 0x20
 	}
@@ -4070,7 +4070,7 @@ func (m *BootAssetURLRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *BootAssetURLResponse) MarshalVT() (dAtA []byte, err error) {
+func (m *InstallationMediaURLResponse) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -4083,12 +4083,12 @@ func (m *BootAssetURLResponse) MarshalVT() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *BootAssetURLResponse) MarshalToVT(dAtA []byte) (int, error) {
+func (m *InstallationMediaURLResponse) MarshalToVT(dAtA []byte) (int, error) {
 	size := m.SizeVT()
 	return m.MarshalToSizedBufferVT(dAtA[:size])
 }
 
-func (m *BootAssetURLResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+func (m *InstallationMediaURLResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -6107,7 +6107,7 @@ func (m *CreateSchematicResponse) SizeVT() (n int) {
 	return n
 }
 
-func (m *BootAssetURLRequest) SizeVT() (n int) {
+func (m *InstallationMediaURLRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -6124,8 +6124,8 @@ func (m *BootAssetURLRequest) SizeVT() (n int) {
 	if m.StandaloneUrl {
 		n += 2
 	}
-	if m.BootAssetKind != 0 {
-		n += 1 + protohelpers.SizeOfVarint(uint64(m.BootAssetKind))
+	if m.InstallationMediaKind != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.InstallationMediaKind))
 	}
 	l = len(m.Platform)
 	if l > 0 {
@@ -6150,7 +6150,7 @@ func (m *BootAssetURLRequest) SizeVT() (n int) {
 	return n
 }
 
-func (m *BootAssetURLResponse) SizeVT() (n int) {
+func (m *InstallationMediaURLResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -10099,7 +10099,7 @@ func (m *CreateSchematicResponse) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *BootAssetURLRequest) UnmarshalVT(dAtA []byte) error {
+func (m *InstallationMediaURLRequest) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -10122,10 +10122,10 @@ func (m *BootAssetURLRequest) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: BootAssetURLRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: InstallationMediaURLRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: BootAssetURLRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: InstallationMediaURLRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -10214,9 +10214,9 @@ func (m *BootAssetURLRequest) UnmarshalVT(dAtA []byte) error {
 			m.StandaloneUrl = bool(v != 0)
 		case 4:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field BootAssetKind", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field InstallationMediaKind", wireType)
 			}
-			m.BootAssetKind = 0
+			m.InstallationMediaKind = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -10226,7 +10226,7 @@ func (m *BootAssetURLRequest) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.BootAssetKind |= BootAssetURLRequest_BootAssetKind(b&0x7F) << shift
+				m.InstallationMediaKind |= InstallationMediaURLRequest_InstallationMediaKind(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -10405,7 +10405,7 @@ func (m *BootAssetURLRequest) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *BootAssetURLResponse) UnmarshalVT(dAtA []byte) error {
+func (m *InstallationMediaURLResponse) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -10428,10 +10428,10 @@ func (m *BootAssetURLResponse) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: BootAssetURLResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: InstallationMediaURLResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: BootAssetURLResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: InstallationMediaURLResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/client/pkg/client/management/management.go
+++ b/client/pkg/client/management/management.go
@@ -167,10 +167,10 @@ func (client *Client) CreateSchematicFromRaw(ctx context.Context, schematic []by
 	return client.conn.CreateSchematicFromRaw(ctx, req)
 }
 
-// GetBootAssetURL returns the URL of a boot asset, served by whichever image factory Omni uses for the
+// GetInstallationMediaURL returns the URL of an installation medium, served by whichever image factory Omni uses for the
 // given Talos version, with the authentication the fetch must carry.
-func (client *Client) GetBootAssetURL(ctx context.Context, request *management.BootAssetURLRequest) (*management.BootAssetURLResponse, error) {
-	return client.conn.GetBootAssetURL(ctx, request)
+func (client *Client) GetInstallationMediaURL(ctx context.Context, request *management.InstallationMediaURLRequest) (*management.InstallationMediaURLResponse, error) {
+	return client.conn.GetInstallationMediaURL(ctx, request)
 }
 
 // CreateServiceAccount creates a service account and returns the public key ID.

--- a/client/pkg/imagefactory/installationmedia.go
+++ b/client/pkg/imagefactory/installationmedia.go
@@ -27,27 +27,27 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
-// BootAssetKind selects one of the asset kinds the image factory serves.
-type BootAssetKind string
+// InstallationMediaKind selects one of the kinds the image factory serves.
+type InstallationMediaKind string
 
 const (
-	// BootAssetKindPXE is an iPXE script, served from the factory's PXE endpoint.
-	BootAssetKindPXE BootAssetKind = "pxe"
+	// InstallationMediaKindPXE is an iPXE script, served from the factory's PXE endpoint.
+	InstallationMediaKindPXE InstallationMediaKind = "pxe"
 
-	// BootAssetKindISO is a bootable ISO image.
-	BootAssetKindISO BootAssetKind = "iso"
+	// InstallationMediaKindISO is a bootable ISO image.
+	InstallationMediaKindISO InstallationMediaKind = "iso"
 
-	// BootAssetKindDisk is a bootable disk image, in the disk format named by AssetSpec.Format.
-	BootAssetKindDisk BootAssetKind = "disk"
+	// InstallationMediaKindDisk is a bootable disk image, in the disk format named by MediaSpec.Format.
+	InstallationMediaKindDisk InstallationMediaKind = "disk"
 )
 
 // ErrInvalidInput marks the arguments a caller got wrong, as opposed to a misconfigured image factory.
 // A server turning these into a response should answer InvalidArgument for them and not for the rest.
-var ErrInvalidInput = errors.New("invalid boot asset request")
+var ErrInvalidInput = errors.New("invalid installation media request")
 
-// AssetSpec names a boot asset, without saying how the image factory spells it.
-type AssetSpec struct {
-	Kind BootAssetKind
+// MediaSpec identifies an installation medium, without saying how the image factory spells it.
+type MediaSpec struct {
+	Kind InstallationMediaKind
 
 	// Platform is the Talos platform, such as "metal" or "nocloud".
 	Platform string
@@ -59,7 +59,7 @@ type AssetSpec struct {
 	// unused by every other kind, whose format the kind itself implies.
 	Format string
 
-	// SecureBoot selects the secure boot variant of the asset.
+	// SecureBoot selects the secure boot variant.
 	SecureBoot bool
 }
 
@@ -81,14 +81,14 @@ func validPathSegment(value string) bool {
 	}) == -1 && value != "." && value != ".."
 }
 
-// Validate reports whether the spec names an asset the image factory can serve.
-func (s AssetSpec) Validate() error {
+// Validate reports whether the spec identifies a medium the image factory can serve.
+func (s MediaSpec) Validate() error {
 	switch s.Kind {
-	case BootAssetKindPXE, BootAssetKindISO, BootAssetKindDisk:
+	case InstallationMediaKindPXE, InstallationMediaKindISO, InstallationMediaKindDisk:
 	case "":
-		return fmt.Errorf("%w: boot asset kind is not set", ErrInvalidInput)
+		return fmt.Errorf("%w: installation media kind is not set", ErrInvalidInput)
 	default:
-		return fmt.Errorf("%w: unknown boot asset kind %q", ErrInvalidInput, s.Kind)
+		return fmt.Errorf("%w: unknown installation media kind %q", ErrInvalidInput, s.Kind)
 	}
 
 	if !validPathSegment(s.Platform) {
@@ -99,31 +99,31 @@ func (s AssetSpec) Validate() error {
 		return fmt.Errorf("%w: invalid architecture %q", ErrInvalidInput, s.Architecture)
 	}
 
-	if s.Kind == BootAssetKindDisk && !validPathSegment(s.Format) {
+	if s.Kind == InstallationMediaKindDisk && !validPathSegment(s.Format) {
 		return fmt.Errorf("%w: invalid disk image format %q", ErrInvalidInput, s.Format)
 	}
 
 	return nil
 }
 
-// Filename returns the name the image factory serves this asset under.
-func (s AssetSpec) Filename() string {
+// Filename returns the filename the image factory serves this medium under.
+func (s MediaSpec) Filename() string {
 	platform := platforms.Platform{Name: s.Platform}
 
 	switch s.Kind {
-	case BootAssetKindPXE:
+	case InstallationMediaKindPXE:
 		if s.SecureBoot {
 			return platform.SecureBootPXEScriptPath(s.Architecture)
 		}
 
 		return platform.PXEScriptPath(s.Architecture)
-	case BootAssetKindISO:
+	case InstallationMediaKindISO:
 		if s.SecureBoot {
 			return platform.SecureBootISOPath(s.Architecture)
 		}
 
 		return platform.ISOPath(s.Architecture)
-	case BootAssetKindDisk:
+	case InstallationMediaKindDisk:
 		if s.SecureBoot {
 			return platform.SecureBootDiskImagePath(s.Architecture, s.Format)
 		}
@@ -134,11 +134,11 @@ func (s AssetSpec) Filename() string {
 	return ""
 }
 
-// BootAsset is a fetchable boot asset.
+// InstallationMedia is a fetchable installation medium.
 //
 // Fetch URL, sending Headers when they are not empty. The URL is opaque and can carry secrets, whether
 // as credentials or as a factory token, so it does not belong in a log line.
-type BootAsset struct {
+type InstallationMedia struct {
 	// Headers must be sent with the request fetching URL. Empty when the factory needs no
 	// authentication, or when it travels inside the URL instead.
 	Headers http.Header
@@ -152,47 +152,47 @@ type BootAsset struct {
 	// the earliest moment the URL may stop working.
 	ExpiresAt time.Time
 
-	// URL of the boot asset.
+	// URL of the installation medium.
 	URL string
 
-	// SchematicID is the ID the image factory gave the schematic this asset is built from.
+	// SchematicID is the ID the image factory gave the schematic this medium is built from.
 	SchematicID string
 
-	// StorageKey identifies this asset, for callers that store what they download. It changes only when
-	// the asset itself does, so it survives a credential rotation, which the URL does not: a name derived
+	// StorageKey identifies this medium, for callers that store what they download. It changes only when
+	// the medium itself does, so it survives a credential rotation, which the URL does not: a name derived
 	// from the URL would change with the credentials in it and orphan whatever was stored under the old
 	// one.
 	//
 	// Treat it as opaque. Omni may change how it is derived, which costs a caller one re-download of the
-	// assets it already holds.
+	// media it already holds.
 	StorageKey string
 
-	// ImageFactoryHost is the host serving the asset, the same one in the URL. Purely informative: to
-	// fetch the asset, use the URL and the headers.
+	// ImageFactoryHost is the host serving the medium, the same one in the URL. Purely informative: to
+	// fetch it, use the URL and the headers.
 	ImageFactoryHost string
 }
 
-// String returns a representation of the asset that is safe to log.
+// String returns a representation that is safe to log.
 //
 // The URL is left out on purpose: it can carry credentials as userinfo or a token in the query, so a
-// logged BootAsset would leak them. What remains identifies the asset just as well. This covers %v and
+// logged InstallationMedia would leak them. What remains identifies the medium just as well. This covers %v and
 // zap.Any, which prefer a Stringer, but not reflection or json.Marshal.
-func (a BootAsset) String() string {
+func (a InstallationMedia) String() string {
 	var expires string
 
 	if !a.ExpiresAt.IsZero() {
 		expires = ", expires: " + a.ExpiresAt.Format(time.RFC3339)
 	}
 
-	return fmt.Sprintf("BootAsset{host: %q, schematic: %q, key: %q%s}", a.ImageFactoryHost, a.SchematicID, a.StorageKey, expires)
+	return fmt.Sprintf("InstallationMedia{host: %q, schematic: %q, key: %q%s}", a.ImageFactoryHost, a.SchematicID, a.StorageKey, expires)
 }
 
-// storageKey derives the identity of an asset from everything that decides its content: the factory
+// storageKey derives the identity of a medium from everything that decides its content: the factory
 // serving it, the schematic, the Talos version and the name the factory serves it under.
 //
 // Deliberately not the URL, which also carries the credentials and so changes when they rotate.
 //
-// **Important:** New inputs must be appended only when they are set, so that every asset hashed
+// **Important:** New inputs must be appended only when they are set, so that every medium hashed
 // before the input existed keeps its key. A changed key makes the providers
 // re-download everything they already store.
 func storageKey(factoryBaseURL, pathPrefix, schematicID, version, filename string) string {
@@ -203,7 +203,7 @@ func storageKey(factoryBaseURL, pathPrefix, schematicID, version, filename strin
 	return hex.EncodeToString(digest[:])
 }
 
-// ResolveOption configures how an asset is resolved. With no options, the download is authenticated with
+// ResolveOption configures how a medium is resolved. With no options, the download is authenticated with
 // the basic auth credentials Omni holds.
 type ResolveOption func(*resolveOptions)
 
@@ -256,7 +256,7 @@ func requestDownloadToken(ctx context.Context, baseURL string, opts *DownloadTok
 
 	factory := opts.Factories.ForURL(baseURL)
 	if factory == nil {
-		logger.Warn("no image factory client is configured for the factory serving this asset, so no download token was requested",
+		logger.Warn("no image factory client is configured for the factory serving this medium, so no download token was requested",
 			zap.String("factory_url", baseURL))
 
 		return "", time.Time{}, false, nil
@@ -308,7 +308,7 @@ func requestDownloadToken(ctx context.Context, baseURL string, opts *DownloadTok
 	}
 }
 
-// ResolveBootAsset returns the boot asset the given schematic produces, served by whichever image
+// ResolveInstallationMedia returns the installation medium the given schematic produces, served by whichever image
 // factory Omni uses for the given Talos version. An empty version means the default Talos version.
 //
 // Set standalone when the fetch cannot carry headers, such as a hypervisor download API handed a bare
@@ -318,9 +318,9 @@ func requestDownloadToken(ctx context.Context, baseURL string, opts *DownloadTok
 // Headers can come back empty without standalone too, since a factory issuing download tokens
 // authenticates the download inside the URL for every caller. Send Headers whenever it is not empty,
 // instead of deciding from what was asked for.
-func ResolveBootAsset(
-	ctx context.Context, st state.State, talosVersion string, spec AssetSpec, schematicID string, standalone bool, opts ...ResolveOption,
-) (BootAsset, error) {
+func ResolveInstallationMedia(
+	ctx context.Context, st state.State, talosVersion string, spec MediaSpec, schematicID string, standalone bool, opts ...ResolveOption,
+) (InstallationMedia, error) {
 	var options resolveOptions
 
 	for _, opt := range opts {
@@ -328,11 +328,11 @@ func ResolveBootAsset(
 	}
 
 	if err := spec.Validate(); err != nil {
-		return BootAsset{}, err
+		return InstallationMedia{}, err
 	}
 
 	if options.downloadTokens != nil && options.downloadTokens.TTL < 0 {
-		return BootAsset{}, fmt.Errorf("%w: download token lifetime %s is negative", ErrInvalidInput, options.downloadTokens.TTL)
+		return InstallationMedia{}, fmt.Errorf("%w: download token lifetime %s is negative", ErrInvalidInput, options.downloadTokens.TTL)
 	}
 
 	if talosVersion == "" {
@@ -340,74 +340,74 @@ func ResolveBootAsset(
 	}
 
 	if _, err := semver.ParseTolerant(talosVersion); err != nil {
-		return BootAsset{}, fmt.Errorf("%w: invalid Talos version %q: %w", ErrInvalidInput, talosVersion, err)
+		return InstallationMedia{}, fmt.Errorf("%w: invalid Talos version %q: %w", ErrInvalidInput, talosVersion, err)
 	}
 
 	version := "v" + strings.TrimLeft(talosVersion, "v")
 
 	if !validPathSegment(schematicID) {
-		return BootAsset{}, fmt.Errorf("%w: invalid schematic ID %q", ErrInvalidInput, schematicID)
+		return InstallationMedia{}, fmt.Errorf("%w: invalid schematic ID %q", ErrInvalidInput, schematicID)
 	}
 
 	resolved, err := resolveEndpoint(ctx, st, talosVersion)
 	if err != nil {
-		return BootAsset{}, err
+		return InstallationMedia{}, err
 	}
 
 	baseURL, pathPrefix := resolved.baseURL, "image"
-	if spec.Kind == BootAssetKindPXE {
+	if spec.Kind == InstallationMediaKindPXE {
 		baseURL, pathPrefix = resolved.pxeBaseURL, "pxe"
 	}
 
 	parsed, err := parseFactoryURL(baseURL)
 	if err != nil {
-		return BootAsset{}, err
+		return InstallationMedia{}, err
 	}
 
 	filename := spec.Filename()
-	assetURL := parsed.JoinPath(pathPrefix, schematicID, version, filename)
+	mediaURL := parsed.JoinPath(pathPrefix, schematicID, version, filename)
 
-	asset := BootAsset{
+	media := InstallationMedia{
 		SchematicID:      schematicID,
 		StorageKey:       storageKey(baseURL, pathPrefix, schematicID, version, filename),
-		ImageFactoryHost: assetURL.Host,
+		ImageFactoryHost: mediaURL.Host,
 	}
 
 	switch {
 	case resolved.username == "" || resolved.password == "":
 		// The factory serves this anonymously, so there is nothing to place.
-	case spec.Kind == BootAssetKindPXE:
-		assetURL.User = url.UserPassword(resolved.username, resolved.password)
+	case spec.Kind == InstallationMediaKindPXE:
+		mediaURL.User = url.UserPassword(resolved.username, resolved.password)
 	default:
 		token, expiresAt, ok, err := requestDownloadToken(ctx, resolved.baseURL, options.downloadTokens)
 
 		switch {
 		case err != nil:
-			return BootAsset{}, err
+			return InstallationMedia{}, err
 		case ok:
-			query := assetURL.Query()
+			query := mediaURL.Query()
 			query.Set("token", token)
-			assetURL.RawQuery = query.Encode()
+			mediaURL.RawQuery = query.Encode()
 
-			asset.ExpiresAt = expiresAt
+			media.ExpiresAt = expiresAt
 		case standalone:
-			assetURL.User = url.UserPassword(resolved.username, resolved.password)
+			mediaURL.User = url.UserPassword(resolved.username, resolved.password)
 
-			options.downloadTokens.logger().Debug("authenticating the boot asset download with credentials in the URL",
+			options.downloadTokens.logger().Debug("authenticating the installation media download with credentials in the URL",
 				zap.String("factory_url", resolved.baseURL))
 		default:
-			asset.Headers = http.Header{
+			media.Headers = http.Header{
 				"Authorization": []string{"Basic " + base64.StdEncoding.EncodeToString([]byte(resolved.username+":"+resolved.password))},
 			}
 
-			options.downloadTokens.logger().Debug("authenticating the boot asset download with a credentials header",
+			options.downloadTokens.logger().Debug("authenticating the installation media download with a credentials header",
 				zap.String("factory_url", resolved.baseURL))
 		}
 	}
 
-	asset.URL = assetURL.String()
+	media.URL = mediaURL.String()
 
-	return asset, nil
+	return media, nil
 }
 
 // parseFactoryURL parses a factory URL and rejects anything that is not absolute.
@@ -470,7 +470,7 @@ func resolveEndpoint(ctx context.Context, st state.State, talosVersion string) (
 	// Check the base URL before deriving anything from it, so the error names what Omni was given rather
 	// than the mangled host derivePXEBaseURL would build out of it.
 	//
-	// A configured PXE URL is deliberately left to the PXE asset build. Resolving also serves callers
+	// A configured PXE URL is deliberately left to the PXE build. Resolving also serves callers
 	// that only download images, and a malformed PXE URL is no reason to deny them.
 	parsedBaseURL, err := parseFactoryURL(baseURL)
 	if err != nil {

--- a/client/pkg/imagefactory/installationmedia_test.go
+++ b/client/pkg/imagefactory/installationmedia_test.go
@@ -39,19 +39,19 @@ const (
 	schematicID = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
 )
 
-// diskSpec is the asset most providers ask for.
-func diskSpec() imagefactory.AssetSpec {
-	return imagefactory.AssetSpec{
-		Kind:         imagefactory.BootAssetKindDisk,
+// diskSpec is the medium most providers ask for.
+func diskSpec() imagefactory.MediaSpec {
+	return imagefactory.MediaSpec{
+		Kind:         imagefactory.InstallationMediaKindDisk,
 		Platform:     "nocloud",
 		Architecture: "amd64",
 		Format:       "raw.xz",
 	}
 }
 
-func pxeSpec() imagefactory.AssetSpec {
-	return imagefactory.AssetSpec{
-		Kind:         imagefactory.BootAssetKindPXE,
+func pxeSpec() imagefactory.MediaSpec {
+	return imagefactory.MediaSpec{
+		Kind:         imagefactory.InstallationMediaKindPXE,
 		Platform:     "metal",
 		Architecture: "amd64",
 	}
@@ -105,41 +105,41 @@ func (s deniedAuthState) Get(ctx context.Context, ptr resource.Pointer, opts ...
 	return s.State.Get(ctx, ptr, opts...)
 }
 
-// TestAssetSpecFilename pins the filename of every asset kind the image factory serves, in the forms
+// TestMediaSpecFilename pins the filename of every kind the image factory serves, in the forms
 // its own path parser accepts.
-func TestAssetSpecFilename(t *testing.T) {
+func TestMediaSpecFilename(t *testing.T) {
 	t.Parallel()
 
 	for name, tt := range map[string]struct {
 		expected string
-		spec     imagefactory.AssetSpec
+		spec     imagefactory.MediaSpec
 	}{
 		"pxe": {
-			spec:     imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindPXE, Platform: "metal", Architecture: "amd64"},
+			spec:     imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindPXE, Platform: "metal", Architecture: "amd64"},
 			expected: "metal-amd64",
 		},
 		"pxe secure boot": {
-			spec:     imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindPXE, Platform: "metal", Architecture: "amd64", SecureBoot: true},
+			spec:     imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindPXE, Platform: "metal", Architecture: "amd64", SecureBoot: true},
 			expected: "metal-amd64-secureboot",
 		},
 		"iso": {
-			spec:     imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindISO, Platform: "metal", Architecture: "arm64"},
+			spec:     imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindISO, Platform: "metal", Architecture: "arm64"},
 			expected: "metal-arm64.iso",
 		},
 		"iso secure boot": {
-			spec:     imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindISO, Platform: "metal", Architecture: "amd64", SecureBoot: true},
+			spec:     imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindISO, Platform: "metal", Architecture: "amd64", SecureBoot: true},
 			expected: "metal-amd64-secureboot.iso",
 		},
 		"disk raw xz": {
-			spec:     imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindDisk, Platform: "nocloud", Architecture: "amd64", Format: "raw.xz"},
+			spec:     imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindDisk, Platform: "nocloud", Architecture: "amd64", Format: "raw.xz"},
 			expected: "nocloud-amd64.raw.xz",
 		},
 		"disk qcow2": {
-			spec:     imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindDisk, Platform: "nocloud", Architecture: "amd64", Format: "qcow2"},
+			spec:     imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindDisk, Platform: "nocloud", Architecture: "amd64", Format: "qcow2"},
 			expected: "nocloud-amd64.qcow2",
 		},
 		"disk compressed with secure boot": {
-			spec:     imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindDisk, Platform: "nocloud", Architecture: "amd64", Format: "qcow2.gz", SecureBoot: true},
+			spec:     imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindDisk, Platform: "nocloud", Architecture: "amd64", Format: "qcow2.gz", SecureBoot: true},
 			expected: "nocloud-amd64-secureboot.qcow2.gz",
 		},
 	} {
@@ -152,50 +152,50 @@ func TestAssetSpecFilename(t *testing.T) {
 	}
 }
 
-// TestAssetSpecValidate covers what must not reach the factory as a URL path, and the per-kind
+// TestMediaSpecValidate covers what must not reach the factory as a URL path, and the per-kind
 // requirements. The traversal cases are the ones that matter: these fields become path segments and
 // generally come from a provider's own configuration.
-func TestAssetSpecValidate(t *testing.T) {
+func TestMediaSpecValidate(t *testing.T) {
 	t.Parallel()
 
 	for name, tt := range map[string]struct {
 		errContains string
-		spec        imagefactory.AssetSpec
+		spec        imagefactory.MediaSpec
 	}{
 		"kind unset": {
-			spec:        imagefactory.AssetSpec{Platform: "metal", Architecture: "amd64"},
-			errContains: "boot asset kind is not set",
+			spec:        imagefactory.MediaSpec{Platform: "metal", Architecture: "amd64"},
+			errContains: "installation media kind is not set",
 		},
 		"unknown kind": {
-			spec:        imagefactory.AssetSpec{Kind: "raw", Platform: "metal", Architecture: "amd64"},
-			errContains: `unknown boot asset kind "raw"`,
+			spec:        imagefactory.MediaSpec{Kind: "raw", Platform: "metal", Architecture: "amd64"},
+			errContains: `unknown installation media kind "raw"`,
 		},
 		"missing architecture": {
-			spec:        imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindISO, Platform: "metal"},
+			spec:        imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindISO, Platform: "metal"},
 			errContains: "invalid architecture",
 		},
 		"missing platform": {
-			spec:        imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindISO, Architecture: "amd64"},
+			spec:        imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindISO, Architecture: "amd64"},
 			errContains: "invalid platform",
 		},
 		"platform traversal": {
-			spec:        imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindISO, Platform: "../../secret", Architecture: "amd64"},
+			spec:        imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindISO, Platform: "../../secret", Architecture: "amd64"},
 			errContains: "invalid platform",
 		},
 		"architecture with a slash": {
-			spec:        imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindISO, Platform: "metal", Architecture: "amd64/../.."},
+			spec:        imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindISO, Platform: "metal", Architecture: "amd64/../.."},
 			errContains: "invalid architecture",
 		},
 		"format traversal": {
-			spec:        imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindDisk, Platform: "nocloud", Architecture: "amd64", Format: "../../etc/passwd"},
+			spec:        imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindDisk, Platform: "nocloud", Architecture: "amd64", Format: "../../etc/passwd"},
 			errContains: "invalid disk image format",
 		},
 		"disk without a format": {
-			spec:        imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindDisk, Platform: "nocloud", Architecture: "amd64"},
+			spec:        imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindDisk, Platform: "nocloud", Architecture: "amd64"},
 			errContains: "invalid disk image format",
 		},
 		"parent directory as a platform": {
-			spec:        imagefactory.AssetSpec{Kind: imagefactory.BootAssetKindISO, Platform: "..", Architecture: "amd64"},
+			spec:        imagefactory.MediaSpec{Kind: imagefactory.InstallationMediaKindISO, Platform: "..", Architecture: "amd64"},
 			errContains: "invalid platform",
 		},
 	} {
@@ -207,10 +207,10 @@ func TestAssetSpecValidate(t *testing.T) {
 	}
 }
 
-// TestResolveBootAssetRouting pins which factory serves each Talos version, and that the version
+// TestResolveInstallationMediaRouting pins which factory serves each Talos version, and that the version
 // segment lands in the URL in the factory's canonical v-prefixed form regardless of how the caller
 // spells it. The PXE kind goes to the PXE endpoint, everything else to the image endpoint.
-func TestResolveBootAssetRouting(t *testing.T) {
+func TestResolveInstallationMediaRouting(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -283,21 +283,21 @@ func TestResolveBootAssetRouting(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			disk, err := imagefactory.ResolveBootAsset(ctx, st, tt.version, diskSpec(), schematicID, false)
+			disk, err := imagefactory.ResolveInstallationMedia(ctx, st, tt.version, diskSpec(), schematicID, false)
 			require.NoError(t, err)
 			require.Equal(t, tt.base+"/image/"+schematicID+"/"+tt.pathVersion+"/nocloud-amd64.raw.xz", disk.URL)
 			require.Empty(t, disk.Headers)
 
-			pxe, err := imagefactory.ResolveBootAsset(ctx, st, tt.version, pxeSpec(), schematicID, false)
+			pxe, err := imagefactory.ResolveInstallationMedia(ctx, st, tt.version, pxeSpec(), schematicID, false)
 			require.NoError(t, err)
 			require.Equal(t, tt.pxeBase+"/pxe/"+schematicID+"/"+tt.pathVersion+"/metal-amd64", pxe.URL)
 		})
 	}
 }
 
-// TestResolveBootAssetDefaults covers an Omni that reports no factory URLs at all: the public factory
+// TestResolveInstallationMediaDefaults covers an Omni that reports no factory URLs at all: the public factory
 // fills in, and the PXE endpoint is derived from it the way Omni itself derives an unconfigured one.
-func TestResolveBootAssetDefaults(t *testing.T) {
+func TestResolveInstallationMediaDefaults(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -308,37 +308,37 @@ func TestResolveBootAssetDefaults(t *testing.T) {
 		config.TypedSpec().Value.ImageFactoryPxeBaseUrl = ""
 	})
 
-	disk, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+	disk, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 	require.NoError(t, err)
 	require.Equal(t, constants.ImageFactoryBaseURL+"/image/"+schematicID+"/v1.13.0/nocloud-amd64.raw.xz", disk.URL)
 	require.Equal(t, "factory.talos.dev", disk.ImageFactoryHost)
 
-	pxe, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", pxeSpec(), schematicID, false)
+	pxe, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false)
 	require.NoError(t, err)
 	require.Equal(t, "https://pxe.factory.talos.dev/pxe/"+schematicID+"/v1.13.0/metal-amd64", pxe.URL)
 	require.Equal(t, "pxe.factory.talos.dev", pxe.ImageFactoryHost)
 }
 
-// TestResolveBootAssetStorageKey pins the property a provider storing what it downloads depends on: the
-// key follows the asset, not the credentials in its URL. Hashing the URL instead would rename everything
+// TestResolveInstallationMediaStorageKey pins the property a provider storing what it downloads depends on: the
+// key follows the medium, not the credentials in its URL. Hashing the URL instead would rename everything
 // stored on every password rotation and orphan the old copies.
-func TestResolveBootAssetStorageKey(t *testing.T) {
+func TestResolveInstallationMediaStorageKey(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 
-	keyFor := func(t *testing.T, configure func(*omni.FeaturesConfig), version string, spec imagefactory.AssetSpec, schematic string) string {
+	keyFor := func(t *testing.T, configure func(*omni.FeaturesConfig), version string, spec imagefactory.MediaSpec, schematic string) string {
 		t.Helper()
 
 		st := newTestState(t)
 
 		createFeaturesConfig(ctx, t, st, configure)
 
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, version, spec, schematic, false)
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, version, spec, schematic, false)
 		require.NoError(t, err)
-		require.NotEmpty(t, asset.StorageKey)
+		require.NotEmpty(t, media.StorageKey)
 
-		return asset.StorageKey
+		return media.StorageKey
 	}
 
 	base := keyFor(t, nil, "1.13.0", diskSpec(), schematicID)
@@ -346,18 +346,18 @@ func TestResolveBootAssetStorageKey(t *testing.T) {
 	t.Run("stable across credential rotation", func(t *testing.T) {
 		t.Parallel()
 
-		// The same asset behind an authenticated factory, and behind one whose password then changes.
+		// The same medium behind an authenticated factory, and behind one whose password then changes.
 		first := func(password string) string {
 			st := newTestState(t)
 
 			createFeaturesConfig(ctx, t, st, nil)
 			createFactoryAuth(ctx, t, st, primaryURL, "user", password)
 
-			asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true)
+			media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true)
 			require.NoError(t, err)
-			require.Contains(t, asset.URL, password, "the standalone URL is expected to carry the password")
+			require.Contains(t, media.URL, password, "the standalone URL is expected to carry the password")
 
-			return asset.StorageKey
+			return media.StorageKey
 		}
 
 		require.Equal(t, first("secret1"), first("secret2"))
@@ -372,16 +372,16 @@ func TestResolveBootAssetStorageKey(t *testing.T) {
 		createFeaturesConfig(ctx, t, st, nil)
 		createFactoryAuth(ctx, t, st, primaryURL, "user", "hunter2")
 
-		headers, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		headers, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 		require.NoError(t, err)
 
-		standalone, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true)
+		standalone, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true)
 		require.NoError(t, err)
 
 		require.Equal(t, headers.StorageKey, standalone.StorageKey)
 	})
 
-	t.Run("changes with the asset", func(t *testing.T) {
+	t.Run("changes with the medium", func(t *testing.T) {
 		t.Parallel()
 
 		otherSchematic := "0000000000000000000000000000000000000000000000000000000000000000"
@@ -421,9 +421,9 @@ func TestResolveBootAssetStorageKey(t *testing.T) {
 	})
 }
 
-// TestBootAssetStringOmitsURL is what keeps a logged asset from leaking its credentials, since the URL
+// TestInstallationMediaStringOmitsURL is what keeps a logged medium from leaking its credentials, since the URL
 // can carry them as userinfo or, later, as a token in the query.
-func TestBootAssetStringOmitsURL(t *testing.T) {
+func TestInstallationMediaStringOmitsURL(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -432,26 +432,26 @@ func TestBootAssetStringOmitsURL(t *testing.T) {
 	createFeaturesConfig(ctx, t, st, nil)
 	createFactoryAuth(ctx, t, st, primaryURL, "user", "hunter2")
 
-	asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true)
+	media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true)
 	require.NoError(t, err)
-	require.Contains(t, asset.URL, "hunter2", "the standalone URL is expected to carry the password")
+	require.Contains(t, media.URL, "hunter2", "the standalone URL is expected to carry the password")
 
 	for _, rendered := range []string{
-		asset.String(),
-		// The accident this guards against: an asset handed to a formatter or a logger.
-		fmt.Sprintf("%v", asset),
+		media.String(),
+		// The accident this guards against: a medium handed to a formatter or a logger.
+		fmt.Sprintf("%v", media),
 	} {
 		require.NotContains(t, rendered, "hunter2")
-		require.NotContains(t, rendered, asset.URL)
-		require.Contains(t, rendered, asset.SchematicID)
-		require.Contains(t, rendered, asset.StorageKey)
-		require.Contains(t, rendered, asset.ImageFactoryHost)
+		require.NotContains(t, rendered, media.URL)
+		require.Contains(t, rendered, media.SchematicID)
+		require.Contains(t, rendered, media.StorageKey)
+		require.Contains(t, rendered, media.ImageFactoryHost)
 	}
 }
 
-// TestResolveBootAssetAuth is the contract providers rely on: fetch the URL sending the headers, and a
+// TestResolveInstallationMediaAuth is the contract providers rely on: fetch the URL sending the headers, and a
 // standalone URL works on its own.
-func TestResolveBootAssetAuth(t *testing.T) {
+func TestResolveInstallationMediaAuth(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -466,18 +466,18 @@ func TestResolveBootAssetAuth(t *testing.T) {
 		createFeaturesConfig(ctx, t, st, nil)
 		createFactoryAuth(ctx, t, st, primaryURL, "user", "hunter2")
 
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 		require.NoError(t, err)
 
-		require.NotEmpty(t, asset.StorageKey)
+		require.NotEmpty(t, media.StorageKey)
 
-		asset.StorageKey = ""
-		require.Equal(t, imagefactory.BootAsset{
+		media.StorageKey = ""
+		require.Equal(t, imagefactory.InstallationMedia{
 			URL:              primaryURL + "/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz",
 			Headers:          http.Header{"Authorization": []string{authorization}},
 			SchematicID:      schematicID,
 			ImageFactoryHost: "factory.example.org",
-		}, asset)
+		}, media)
 	})
 
 	t.Run("standalone puts the credentials in the URL and returns no headers", func(t *testing.T) {
@@ -488,17 +488,17 @@ func TestResolveBootAssetAuth(t *testing.T) {
 		createFeaturesConfig(ctx, t, st, nil)
 		createFactoryAuth(ctx, t, st, primaryURL, "user", "hunter2")
 
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true)
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true)
 		require.NoError(t, err)
 
-		require.NotEmpty(t, asset.StorageKey)
+		require.NotEmpty(t, media.StorageKey)
 
-		asset.StorageKey = ""
-		require.Equal(t, imagefactory.BootAsset{
+		media.StorageKey = ""
+		require.Equal(t, imagefactory.InstallationMedia{
 			URL:              "https://user:hunter2@factory.example.org/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz",
 			SchematicID:      schematicID,
 			ImageFactoryHost: "factory.example.org",
-		}, asset)
+		}, media)
 	})
 
 	t.Run("PXE is always standalone", func(t *testing.T) {
@@ -510,17 +510,17 @@ func TestResolveBootAssetAuth(t *testing.T) {
 		createFactoryAuth(ctx, t, st, primaryURL, "user", "hunter2")
 
 		// Not requested as standalone: PXE firmware cannot send headers, so the URL has to carry them.
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", pxeSpec(), schematicID, false)
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false)
 		require.NoError(t, err)
 
-		require.NotEmpty(t, asset.StorageKey)
+		require.NotEmpty(t, media.StorageKey)
 
-		asset.StorageKey = ""
-		require.Equal(t, imagefactory.BootAsset{
+		media.StorageKey = ""
+		require.Equal(t, imagefactory.InstallationMedia{
 			URL:              "https://user:hunter2@pxe.factory.example.org/pxe/" + schematicID + "/v1.13.0/metal-amd64",
 			SchematicID:      schematicID,
 			ImageFactoryHost: "pxe.factory.example.org",
-		}, asset)
+		}, media)
 	})
 
 	t.Run("each factory gets its own credentials", func(t *testing.T) {
@@ -537,14 +537,14 @@ func TestResolveBootAssetAuth(t *testing.T) {
 		createFactoryAuth(ctx, t, st, secondaryURL, "secondary-user", "secondary-pass")
 
 		// The primary has no credentials, so a version it serves resolves anonymously.
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.14.0", diskSpec(), schematicID, false)
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.14.0", diskSpec(), schematicID, false)
 		require.NoError(t, err)
-		require.Empty(t, asset.Headers)
+		require.Empty(t, media.Headers)
 
-		asset, err = imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		media, err = imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 		require.NoError(t, err)
-		require.Equal(t, secondaryURL+"/image/"+schematicID+"/v1.13.0/nocloud-amd64.raw.xz", asset.URL)
-		require.NotEmpty(t, asset.Headers.Get("Authorization"))
+		require.Equal(t, secondaryURL+"/image/"+schematicID+"/v1.13.0/nocloud-amd64.raw.xz", media.URL)
+		require.NotEmpty(t, media.Headers.Get("Authorization"))
 	})
 
 	t.Run("special characters survive both forms", func(t *testing.T) {
@@ -557,7 +557,7 @@ func TestResolveBootAssetAuth(t *testing.T) {
 		createFeaturesConfig(ctx, t, st, nil)
 		createFactoryAuth(ctx, t, st, primaryURL, "user", password)
 
-		withHeaders, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		withHeaders, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 		require.NoError(t, err)
 
 		encoded, ok := strings.CutPrefix(withHeaders.Headers.Get("Authorization"), "Basic ")
@@ -567,7 +567,7 @@ func TestResolveBootAssetAuth(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "user:"+password, string(decoded))
 
-		standalone, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true)
+		standalone, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true)
 		require.NoError(t, err)
 
 		parsed, err := url.Parse(standalone.URL)
@@ -587,17 +587,17 @@ func TestResolveBootAssetAuth(t *testing.T) {
 		createFeaturesConfig(ctx, t, st, nil)
 		createFactoryAuth(ctx, t, st, primaryURL, "user", "")
 
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true)
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true)
 		require.NoError(t, err)
-		require.Empty(t, asset.Headers)
-		require.NotContains(t, asset.URL, "user")
+		require.Empty(t, media.Headers)
+		require.NotContains(t, media.URL, "user")
 	})
 }
 
-// TestResolveBootAssetDeniedCredentials covers an Omni that refuses the ImageFactoryAuth read: either it
-// predates the resource, or it predates infra providers being allowed to read it. The asset comes back
-// anonymous, since a factory serving assets anonymously has nothing to lose by it.
-func TestResolveBootAssetDeniedCredentials(t *testing.T) {
+// TestResolveInstallationMediaDeniedCredentials covers an Omni that refuses the ImageFactoryAuth read: either it
+// predates the resource, or it predates infra providers being allowed to read it. The media comes back
+// anonymous, since a factory serving media anonymously has nothing to lose by it.
+func TestResolveInstallationMediaDeniedCredentials(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -605,20 +605,20 @@ func TestResolveBootAssetDeniedCredentials(t *testing.T) {
 
 	createFeaturesConfig(ctx, t, st, nil)
 
-	asset, err := imagefactory.ResolveBootAsset(ctx, deniedAuthState{State: st}, "1.13.0", diskSpec(), schematicID, false)
+	media, err := imagefactory.ResolveInstallationMedia(ctx, deniedAuthState{State: st}, "1.13.0", diskSpec(), schematicID, false)
 	require.NoError(t, err)
-	require.Equal(t, primaryURL+"/image/"+schematicID+"/v1.13.0/nocloud-amd64.raw.xz", asset.URL)
-	require.Empty(t, asset.Headers)
+	require.Equal(t, primaryURL+"/image/"+schematicID+"/v1.13.0/nocloud-amd64.raw.xz", media.URL)
+	require.Empty(t, media.Headers)
 }
 
-func TestResolveBootAssetNoFeaturesConfig(t *testing.T) {
+func TestResolveInstallationMediaNoFeaturesConfig(t *testing.T) {
 	t.Parallel()
 
-	_, err := imagefactory.ResolveBootAsset(t.Context(), newTestState(t), "1.13.0", diskSpec(), schematicID, false)
+	_, err := imagefactory.ResolveInstallationMedia(t.Context(), newTestState(t), "1.13.0", diskSpec(), schematicID, false)
 	require.ErrorContains(t, err, "failed to get features config")
 }
 
-func TestResolveBootAssetRejectsInvalidSpec(t *testing.T) {
+func TestResolveInstallationMediaRejectsInvalidSpec(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -629,14 +629,14 @@ func TestResolveBootAssetRejectsInvalidSpec(t *testing.T) {
 	spec := diskSpec()
 	spec.Platform = "../../secret"
 
-	_, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", spec, schematicID, false)
+	_, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", spec, schematicID, false)
 	require.ErrorContains(t, err, "invalid platform")
 }
 
-// TestResolveBootAssetRejectsInvalidTalosVersion covers a version that is a safe path segment but not a
+// TestResolveInstallationMediaRejectsInvalidTalosVersion covers a version that is a safe path segment but not a
 // version. Without the check it resolves against the wrong factory and yields a URL that can only 404,
 // so the error would surface at download or PXE boot time rather than here.
-func TestResolveBootAssetRejectsInvalidTalosVersion(t *testing.T) {
+func TestResolveInstallationMediaRejectsInvalidTalosVersion(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -649,7 +649,7 @@ func TestResolveBootAssetRejectsInvalidTalosVersion(t *testing.T) {
 
 			createFeaturesConfig(ctx, t, st, nil)
 
-			_, err := imagefactory.ResolveBootAsset(ctx, st, version, diskSpec(), schematicID, false)
+			_, err := imagefactory.ResolveInstallationMedia(ctx, st, version, diskSpec(), schematicID, false)
 			require.ErrorIs(t, err, imagefactory.ErrInvalidInput)
 			require.ErrorContains(t, err, "invalid Talos version")
 		})
@@ -664,18 +664,18 @@ func TestResolveBootAssetRejectsInvalidTalosVersion(t *testing.T) {
 
 			createFeaturesConfig(ctx, t, st, nil)
 
-			asset, err := imagefactory.ResolveBootAsset(ctx, st, version, diskSpec(), schematicID, false)
+			media, err := imagefactory.ResolveInstallationMedia(ctx, st, version, diskSpec(), schematicID, false)
 			require.NoError(t, err)
-			require.Contains(t, asset.URL, "/v"+strings.TrimLeft(version, "v")+"/")
+			require.Contains(t, media.URL, "/v"+strings.TrimLeft(version, "v")+"/")
 		})
 	}
 }
 
-// TestResolveBootAssetRejectsRelativeConfig fails a build rather than handing back a URL nothing can
+// TestResolveInstallationMediaRejectsRelativeConfig fails a build rather than handing back a URL nothing can
 // fetch. url.Parse accepts these and JoinPath extends them, so without the check the missing scheme
 // would only surface at download time as "unsupported protocol scheme". A malformed PXE URL fails the
 // PXE kind alone: callers that only download images still get theirs.
-func TestResolveBootAssetRejectsRelativeConfig(t *testing.T) {
+func TestResolveInstallationMediaRejectsRelativeConfig(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -690,10 +690,10 @@ func TestResolveBootAssetRejectsRelativeConfig(t *testing.T) {
 			config.TypedSpec().Value.ImageFactoryPxeBaseUrl = ""
 		})
 
-		_, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		_, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 		require.ErrorContains(t, err, `image factory URL "factory.example.org" is not absolute`)
 
-		_, err = imagefactory.ResolveBootAsset(ctx, st, "1.13.0", pxeSpec(), schematicID, false)
+		_, err = imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false)
 		require.ErrorContains(t, err, `image factory URL "factory.example.org" is not absolute`)
 	})
 
@@ -706,18 +706,18 @@ func TestResolveBootAssetRejectsRelativeConfig(t *testing.T) {
 			config.TypedSpec().Value.ImageFactoryPxeBaseUrl = "pxe.factory.example.org"
 		})
 
-		disk, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		disk, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 		require.NoError(t, err)
 		require.Equal(t, primaryURL+"/image/"+schematicID+"/v1.13.0/nocloud-amd64.raw.xz", disk.URL)
 
-		_, err = imagefactory.ResolveBootAsset(ctx, st, "1.13.0", pxeSpec(), schematicID, false)
+		_, err = imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false)
 		require.ErrorContains(t, err, `image factory URL "pxe.factory.example.org" is not absolute`)
 	})
 }
 
-// TestResolveBootAssetPathShapes pins JoinPath behavior on the base URL shapes Omni can be configured
+// TestResolveInstallationMediaPathShapes pins JoinPath behavior on the base URL shapes Omni can be configured
 // with.
-func TestResolveBootAssetPathShapes(t *testing.T) {
+func TestResolveInstallationMediaPathShapes(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -747,18 +747,18 @@ func TestResolveBootAssetPathShapes(t *testing.T) {
 				config.TypedSpec().Value.ImageFactoryBaseUrl = tt.baseURL
 			})
 
-			asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+			media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, asset.URL)
+			require.Equal(t, tt.expected, media.URL)
 		})
 	}
 }
 
-// TestResolveBootAssetRejectsInvalidPathSegments covers the inputs that are not part of the spec but
+// TestResolveInstallationMediaRejectsInvalidPathSegments covers the inputs that are not part of the spec but
 // still become URL path segments. JoinPath resolves "..", so an unchecked one would silently point the
 // URL at another path on the factory, taking any credentials with it, and it drops the error from a
 // malformed percent escape, leaving nothing but the base URL.
-func TestResolveBootAssetRejectsInvalidPathSegments(t *testing.T) {
+func TestResolveInstallationMediaRejectsInvalidPathSegments(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -801,18 +801,18 @@ func TestResolveBootAssetRejectsInvalidPathSegments(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := imagefactory.ResolveBootAsset(ctx, st, tt.version, diskSpec(), tt.schematicID, true)
+			_, err := imagefactory.ResolveInstallationMedia(ctx, st, tt.version, diskSpec(), tt.schematicID, true)
 			require.ErrorContains(t, err, tt.errContains)
 		})
 	}
 
 	// A pre-release version is a legitimate segment and has to keep working.
-	asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.14.0-alpha.0", diskSpec(), schematicID, false)
+	media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.14.0-alpha.0", diskSpec(), schematicID, false)
 	require.NoError(t, err)
-	require.Contains(t, asset.URL, "/v1.14.0-alpha.0/")
+	require.Contains(t, media.URL, "/v1.14.0-alpha.0/")
 }
 
-// fakeFactoryClient is an imagefactory.FactoryClient that does only the two things resolving a boot asset
+// fakeFactoryClient is an imagefactory.FactoryClient that does only the two things resolving an installation medium media
 // asks of one: report the URL it serves, so ForURL can find it, and issue a download token.
 type fakeFactoryClient struct {
 	imagefactory.FactoryClient
@@ -893,9 +893,9 @@ func authenticatedState(ctx context.Context, t *testing.T) state.State {
 	return st
 }
 
-// TestResolveBootAssetDownloadTokenRequest covers the deadline the token request runs under, and what a
+// TestResolveInstallationMediaDownloadTokenRequest covers the deadline the token request runs under, and what a
 // caller gets when its own context ends first.
-func TestResolveBootAssetDownloadTokenRequest(t *testing.T) {
+func TestResolveInstallationMediaDownloadTokenRequest(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -915,7 +915,7 @@ func TestResolveBootAssetDownloadTokenRequest(t *testing.T) {
 
 		before := time.Now()
 
-		_, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		_, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
 		require.NoError(t, err)
 
 		// Without one, a factory that accepts the connection and never answers holds the resolve for the factory
@@ -937,14 +937,14 @@ func TestResolveBootAssetDownloadTokenRequest(t *testing.T) {
 		issuer := newIssuer("", errors.New("connection reset"))
 		issuer.onRequest = cancel
 
-		_, err := imagefactory.ResolveBootAsset(callerCtx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, issuer, 0))
+		_, err := imagefactory.ResolveInstallationMedia(callerCtx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, issuer, 0))
 		require.ErrorIs(t, err, context.Canceled)
 	})
 }
 
-// TestResolveBootAssetDownloadToken covers the authentication a caller gets for an asset under /image/
+// TestResolveInstallationMediaDownloadToken covers the authentication a caller gets for a medium under /image/
 // when the factory issues download tokens, and the credential fallback for every factory that does not.
-func TestResolveBootAssetDownloadToken(t *testing.T) {
+func TestResolveInstallationMediaDownloadToken(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -958,7 +958,7 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 		defaultTTL = 5 * time.Minute
 	)
 
-	assetPath := "/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz"
+	mediaPath := "/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz"
 
 	t.Run("a token replaces the userinfo on a standalone image", func(t *testing.T) {
 		t.Parallel()
@@ -966,12 +966,12 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 		st := authenticatedState(ctx, t)
 		issuer := newIssuer(token, nil)
 
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, issuer, 0))
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, issuer, 0))
 		require.NoError(t, err)
 
-		require.Equal(t, primaryURL+assetPath+"?token="+url.QueryEscape(token), asset.URL)
-		require.Empty(t, asset.Headers)
-		require.NotContains(t, asset.URL, "hunter2", "the credential must not travel alongside the token")
+		require.Equal(t, primaryURL+mediaPath+"?token="+url.QueryEscape(token), media.URL)
+		require.Empty(t, media.Headers)
+		require.NotContains(t, media.URL, "hunter2", "the credential must not travel alongside the token")
 	})
 
 	t.Run("a token replaces the header on a non-standalone image", func(t *testing.T) {
@@ -980,11 +980,11 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 		st := authenticatedState(ctx, t)
 		issuer := newIssuer(token, nil)
 
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
 		require.NoError(t, err)
 
-		require.Equal(t, primaryURL+assetPath+"?token="+url.QueryEscape(token), asset.URL)
-		require.Empty(t, asset.Headers, "a token in the URL leaves nothing for the headers to carry")
+		require.Equal(t, primaryURL+mediaPath+"?token="+url.QueryEscape(token), media.URL)
+		require.Empty(t, media.Headers, "a token in the URL leaves nothing for the headers to carry")
 	})
 
 	t.Run("PXE keeps its credentials and never asks for a token", func(t *testing.T) {
@@ -995,12 +995,12 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 		// The factory reads ?token= only under /image/, and its iPXE script propagates basic auth alone, so
 		// a token would authenticate neither the script nor what it boots.
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", pxeSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
 		require.NoError(t, err)
 
-		require.Equal(t, "https://user:hunter2@pxe.factory.example.org/pxe/"+schematicID+"/v1.13.0/metal-amd64", asset.URL)
+		require.Equal(t, "https://user:hunter2@pxe.factory.example.org/pxe/"+schematicID+"/v1.13.0/metal-amd64", media.URL)
 		require.Empty(t, issuer.calls(), "a token that cannot be used must not be requested")
-		require.Zero(t, asset.ExpiresAt)
+		require.Zero(t, media.ExpiresAt)
 	})
 
 	t.Run("an anonymous factory never asks for a token", func(t *testing.T) {
@@ -1011,13 +1011,13 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 		issuer := newIssuer(token, nil)
 
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
 		require.NoError(t, err)
 
-		require.Equal(t, primaryURL+assetPath, asset.URL)
-		require.Empty(t, asset.Headers)
+		require.Equal(t, primaryURL+mediaPath, media.URL)
+		require.Empty(t, media.Headers)
 		require.Empty(t, issuer.calls(), "there is nothing to authenticate")
-		require.Zero(t, asset.ExpiresAt)
+		require.Zero(t, media.ExpiresAt)
 	})
 
 	t.Run("the lifetime asked for reaches the factory and comes back as the expiry", func(t *testing.T) {
@@ -1039,11 +1039,11 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 				before := time.Now()
 
-				asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, tt.requested))
+				media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, tt.requested))
 				require.NoError(t, err)
 
 				require.Equal(t, []time.Duration{tt.expected}, issuer.calls())
-				require.WithinRange(t, asset.ExpiresAt, before.Add(tt.expected), time.Now().Add(tt.expected))
+				require.WithinRange(t, media.ExpiresAt, before.Add(tt.expected), time.Now().Add(tt.expected))
 			})
 		}
 	})
@@ -1065,14 +1065,14 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 				st := authenticatedState(ctx, t)
 
-				standalone, resolveErr := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, newIssuer("", err), 0))
+				standalone, resolveErr := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, newIssuer("", err), 0))
 				require.NoError(t, resolveErr)
-				require.Equal(t, "https://user:hunter2@factory.example.org"+assetPath, standalone.URL)
+				require.Equal(t, "https://user:hunter2@factory.example.org"+mediaPath, standalone.URL)
 				require.Zero(t, standalone.ExpiresAt)
 
-				withHeaders, resolveErr := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, newIssuer("", err), 0))
+				withHeaders, resolveErr := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, newIssuer("", err), 0))
 				require.NoError(t, resolveErr)
-				require.Equal(t, primaryURL+assetPath, withHeaders.URL)
+				require.Equal(t, primaryURL+mediaPath, withHeaders.URL)
 				require.Equal(t, authorization, withHeaders.Headers.Get("Authorization"))
 				require.Zero(t, withHeaders.ExpiresAt)
 			})
@@ -1086,7 +1086,7 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 		// The factory refuses anything outside its configured bounds with a 400. Silently handing back a
 		// long-lived credential instead would answer a request the caller did not make.
-		_, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false,
+		_, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false,
 			withIssuer(t, st, newIssuer("", &client.InvalidSchematicError{}), 100*time.Hour))
 
 		require.ErrorIs(t, err, imagefactory.ErrInvalidInput)
@@ -1100,12 +1100,12 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 		// Omni's own guess is not the caller's request, so a factory whose bounds exclude it falls back
 		// rather than failing a provision over a value the caller never chose.
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false,
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false,
 			withIssuer(t, st, newIssuer("", &client.InvalidSchematicError{}), 0))
 
 		require.NoError(t, err)
-		require.Equal(t, authorization, asset.Headers.Get("Authorization"))
-		require.Zero(t, asset.ExpiresAt)
+		require.Equal(t, authorization, media.Headers.Get("Authorization"))
+		require.Zero(t, media.ExpiresAt)
 	})
 
 	t.Run("a 200 carrying no token falls back", func(t *testing.T) {
@@ -1115,12 +1115,12 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 		// Placing an empty token would build a URL with no credentials anywhere, which only fails at the
 		// download, with nothing in Omni's logs pointing at the token.
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, newIssuer("", nil), 0))
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, true, withIssuer(t, st, newIssuer("", nil), 0))
 		require.NoError(t, err)
 
-		require.Equal(t, "https://user:hunter2@factory.example.org"+assetPath, asset.URL)
-		require.NotContains(t, asset.URL, "token=")
-		require.Zero(t, asset.ExpiresAt)
+		require.Equal(t, "https://user:hunter2@factory.example.org"+mediaPath, media.URL)
+		require.NotContains(t, media.URL, "token=")
+		require.Zero(t, media.ExpiresAt)
 	})
 
 	t.Run("an unroutable factory falls back", func(t *testing.T) {
@@ -1128,14 +1128,14 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 		st := authenticatedState(ctx, t)
 
-		// A token must come from the factory serving the asset and no other, so a client set with nothing
+		// A token must come from the factory serving the medium and no other, so a client set with nothing
 		// configured for it issues nothing at all.
 		issuer := &fakeFactoryClient{url: "https://other.example.org", token: token}
 
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
 		require.NoError(t, err)
 
-		require.Equal(t, authorization, asset.Headers.Get("Authorization"))
+		require.Equal(t, authorization, media.Headers.Get("Authorization"))
 		require.Empty(t, issuer.calls())
 	})
 
@@ -1144,12 +1144,12 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 
 		st := authenticatedState(ctx, t)
 
-		// This is the provider-side fallback against an Omni that predates the boot asset API.
-		asset, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		// This is the provider-side fallback against an Omni that predates the installation media API.
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 		require.NoError(t, err)
 
-		require.Equal(t, authorization, asset.Headers.Get("Authorization"))
-		require.Zero(t, asset.ExpiresAt)
+		require.Equal(t, authorization, media.Headers.Get("Authorization"))
+		require.Zero(t, media.ExpiresAt)
 	})
 
 	t.Run("the storage key and the log line are unaffected", func(t *testing.T) {
@@ -1158,16 +1158,16 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 		st := authenticatedState(ctx, t)
 
 		// The key must not move when a token appears, or every provider re-downloads everything it stores.
-		withToken, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, newIssuer(token, nil), 0))
+		withToken, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false, withIssuer(t, st, newIssuer(token, nil), 0))
 		require.NoError(t, err)
 
-		withCredentials, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", diskSpec(), schematicID, false)
+		withCredentials, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", diskSpec(), schematicID, false)
 		require.NoError(t, err)
 
 		require.Equal(t, withCredentials.StorageKey, withToken.StorageKey)
 
 		for _, rendered := range []string{withToken.String(), fmt.Sprintf("%v", withToken)} {
-			require.NotContains(t, rendered, token, "a logged asset must not leak the token")
+			require.NotContains(t, rendered, token, "a logged medium must not leak the token")
 			require.NotContains(t, rendered, withToken.URL)
 			require.Contains(t, rendered, withToken.StorageKey)
 			require.Contains(t, rendered, "expires", "the expiry explains a download failing later, and is not a secret")
@@ -1175,10 +1175,10 @@ func TestResolveBootAssetDownloadToken(t *testing.T) {
 	})
 }
 
-// TestResolveBootAssetNegativeTokenLifetime covers a lifetime the caller got wrong. It is refused the same
-// way for every asset kind, not only for the ones that would have requested a token, so that a bad value
+// TestResolveInstallationMediaNegativeTokenLifetime covers a lifetime the caller got wrong. It is refused the same
+// way for every kind, not only for the ones that would have requested a token, so that a bad value
 // cannot pass unnoticed against the public factory and fail only against an authenticated one.
-func TestResolveBootAssetNegativeTokenLifetime(t *testing.T) {
+func TestResolveInstallationMediaNegativeTokenLifetime(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -1190,7 +1190,7 @@ func TestResolveBootAssetNegativeTokenLifetime(t *testing.T) {
 	// for every kind, including the two that never request a token: accepting it there would let a bad
 	// value through against the public factory and fail only against an authenticated one.
 	for name, tt := range map[string]struct {
-		spec      imagefactory.AssetSpec
+		spec      imagefactory.MediaSpec
 		anonymous bool
 	}{
 		"disk, which would have requested one": {spec: diskSpec()},
@@ -1209,7 +1209,7 @@ func TestResolveBootAssetNegativeTokenLifetime(t *testing.T) {
 
 			issuer := newIssuer(token, nil)
 
-			_, err := imagefactory.ResolveBootAsset(ctx, st, "1.13.0", tt.spec, schematicID, false, withIssuer(t, st, issuer, -time.Hour))
+			_, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", tt.spec, schematicID, false, withIssuer(t, st, issuer, -time.Hour))
 
 			require.ErrorIs(t, err, imagefactory.ErrInvalidInput)
 			require.Empty(t, issuer.calls(), "a lifetime that cannot be honored must not reach the factory")

--- a/client/pkg/infra/controllers/provision.go
+++ b/client/pkg/infra/controllers/provision.go
@@ -39,7 +39,7 @@ const currentStepAnnotation = "infra." + omni.SystemLabelPrefix + "step"
 type ProvisionController[T generic.ResourceWithRD] struct {
 	generic.NamedController
 	provisioner                provision.Provisioner[T]
-	bootAssetResolver          provision.BootAssetResolver
+	installationMediaResolver  provision.InstallationMediaResolver
 	providerID                 string
 	concurrency                uint
 	encodeRequestIDsIntoTokens bool
@@ -49,7 +49,7 @@ type ProvisionController[T generic.ResourceWithRD] struct {
 // NewProvisionController creates new ProvisionController.
 func NewProvisionController[T generic.ResourceWithRD](providerID string, provisioner provision.Provisioner[T], concurrency uint,
 	encodeRequestIDsIntoTokens bool,
-	resourceDefinitions map[string]struct{}, bootAssetResolver provision.BootAssetResolver,
+	resourceDefinitions map[string]struct{}, installationMediaResolver provision.InstallationMediaResolver,
 ) *ProvisionController[T] {
 	_, providerJoinConfigRegistered := resourceDefinitions[strings.ToLower(siderolinkres.ProviderJoinConfigType)]
 
@@ -62,7 +62,7 @@ func NewProvisionController[T generic.ResourceWithRD](providerID string, provisi
 		concurrency:                concurrency,
 		encodeRequestIDsIntoTokens: encodeRequestIDsIntoTokens,
 		useV2Tokens:                providerJoinConfigRegistered,
-		bootAssetResolver:          bootAssetResolver,
+		installationMediaResolver:  installationMediaResolver,
 	}
 }
 
@@ -331,7 +331,7 @@ func (ctrl *ProvisionController[T]) reconcileRunning(ctx context.Context, r cont
 				st,
 				connectionParams,
 				r,
-				ctrl.bootAssetResolver,
+				ctrl.installationMediaResolver,
 			))
 
 			st.Metadata().Annotations().Set(currentStepAnnotation, step.Name())

--- a/client/pkg/infra/export_test.go
+++ b/client/pkg/infra/export_test.go
@@ -7,6 +7,6 @@ package infra
 // Exported for testing: the two conversions between a provision step's spec and the management API, so
 // they can be checked without standing up a management service to answer the RPC.
 var (
-	BootAssetRequest      = bootAssetRequest
-	BootAssetFromResponse = bootAssetFromResponse
+	InstallationMediaRequest      = installationMediaRequest
+	InstallationMediaFromResponse = installationMediaFromResponse
 )

--- a/client/pkg/infra/infra.go
+++ b/client/pkg/infra/infra.go
@@ -139,12 +139,12 @@ func (provider *Provider[T]) Run(ctx context.Context, logger *zap.Logger, opts .
 		return fmt.Errorf("invalid infra provider configuration: either WithOmniEndpoint or WithState option should be used")
 	}
 
-	// Boot assets are resolved through Omni, so a provider given only a state has no way to reach one:
+	// Installation media are resolved through Omni, so a provider given only a state has no way to reach one:
 	// such a setup has to supply its own resolver.
-	bootAssetResolver := options.bootAssetResolver
-	if bootAssetResolver == nil && c != nil {
-		bootAssetResolver = func(ctx context.Context, talosVersion string, schematic schematic.Schematic, spec provision.BootAssetSpec) (imagefactory.BootAsset, error) {
-			return EnsureBootAsset(ctx, c, talosVersion, schematic, spec)
+	installationMediaResolver := options.installationMediaResolver
+	if installationMediaResolver == nil && c != nil {
+		installationMediaResolver = func(ctx context.Context, talosVersion string, schematic schematic.Schematic, spec provision.MediaSpec) (imagefactory.InstallationMedia, error) {
+			return EnsureInstallationMedia(ctx, c, talosVersion, schematic, spec)
 		}
 	}
 
@@ -164,7 +164,7 @@ func (provider *Provider[T]) Run(ctx context.Context, logger *zap.Logger, opts .
 		options.concurrency,
 		options.encodeRequestIDsIntoTokens,
 		rds,
-		bootAssetResolver,
+		installationMediaResolver,
 	)); err != nil {
 		return err
 	}
@@ -235,86 +235,86 @@ func schematicError(err error) error {
 	return fmt.Errorf("failed to create the schematic through Omni: %w", err)
 }
 
-// EnsureBootAsset ensures the schematic exists on the image factory Omni is configured with, and
-// returns the boot asset the given spec names, built from it.
+// EnsureInstallationMedia ensures the schematic exists on the image factory Omni is configured with, and
+// returns the installation medium the given spec identifies, built from it.
 //
-// Providers that run a provision step should call Context.EnsureBootAsset instead, which builds the
+// Providers that run a provision step should call Context.EnsureInstallationMedia instead, which builds the
 // schematic out of the machine request for them. This is for the ones that never build a provision
 // context, such as a provider serving its own iPXE endpoint.
 //
-// Fetch BootAsset.URL, sending BootAsset.Headers when they are not empty. See imagefactory.BootAsset
+// Fetch InstallationMedia.URL, sending InstallationMedia.Headers when they are not empty. See imagefactory.InstallationMedia
 // for the full contract.
-func EnsureBootAsset(
+func EnsureInstallationMedia(
 	ctx context.Context,
 	c *client.Client,
 	talosVersion string,
 	schematic schematic.Schematic,
-	spec provision.BootAssetSpec,
-) (imagefactory.BootAsset, error) {
+	spec provision.MediaSpec,
+) (imagefactory.InstallationMedia, error) {
 	schematicID, err := EnsureSchematic(ctx, c, talosVersion, schematic)
 	if err != nil {
-		return imagefactory.BootAsset{}, err
+		return imagefactory.InstallationMedia{}, err
 	}
 
-	return resolveBootAsset(ctx, c, talosVersion, spec, schematicID)
+	return resolveInstallationMedia(ctx, c, talosVersion, spec, schematicID)
 }
 
-// bootAssetKinds maps the kinds this library names onto the wire enum.
-var bootAssetKinds = map[imagefactory.BootAssetKind]management.BootAssetURLRequest_BootAssetKind{
-	imagefactory.BootAssetKindPXE:  management.BootAssetURLRequest_BOOT_ASSET_KIND_PXE,
-	imagefactory.BootAssetKindISO:  management.BootAssetURLRequest_BOOT_ASSET_KIND_ISO,
-	imagefactory.BootAssetKindDisk: management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK,
+// installationMediaKinds maps the kinds this library names onto the wire enum.
+var installationMediaKinds = map[imagefactory.InstallationMediaKind]management.InstallationMediaURLRequest_InstallationMediaKind{
+	imagefactory.InstallationMediaKindPXE:  management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_PXE,
+	imagefactory.InstallationMediaKindISO:  management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_ISO,
+	imagefactory.InstallationMediaKindDisk: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_DISK,
 }
 
-// resolveBootAsset asks Omni to name and locate the asset, where the server decides how it is
+// resolveInstallationMedia asks Omni to locate the medium, where the server decides how it is
 // authenticated. That is what lets factory auth schemes evolve without updating this library: the
 // caller applies whatever the server returns.
 //
-// A server that predates the boot asset API answers Unimplemented, and the asset is built here instead
+// A server that predates the installation media API answers Unimplemented, and it is built here instead
 // from the image factory configuration in Omni's state, which every version exposes.
-func resolveBootAsset(
+func resolveInstallationMedia(
 	ctx context.Context,
 	c *client.Client,
 	talosVersion string,
-	spec provision.BootAssetSpec,
+	spec provision.MediaSpec,
 	schematicID string,
-) (imagefactory.BootAsset, error) {
-	request, err := bootAssetRequest(talosVersion, schematicID, spec)
+) (imagefactory.InstallationMedia, error) {
+	request, err := installationMediaRequest(talosVersion, schematicID, spec)
 	if err != nil {
-		return imagefactory.BootAsset{}, err
+		return imagefactory.InstallationMedia{}, err
 	}
 
-	resp, err := c.Management().GetBootAssetURL(ctx, request)
+	resp, err := c.Management().GetInstallationMediaURL(ctx, request)
 	if err != nil {
 		if status.Code(err) != codes.Unimplemented {
-			return imagefactory.BootAsset{}, fmt.Errorf("failed to get the boot asset URL from Omni: %w", err)
+			return imagefactory.InstallationMedia{}, fmt.Errorf("failed to get the installation media URL from Omni: %w", err)
 		}
 
-		return imagefactory.ResolveBootAsset(ctx, c.Omni().State(), talosVersion, spec.AssetSpec, schematicID, spec.StandaloneURL)
+		return imagefactory.ResolveInstallationMedia(ctx, c.Omni().State(), talosVersion, spec.MediaSpec, schematicID, spec.StandaloneURL)
 	}
 
-	asset := bootAssetFromResponse(resp)
-	asset.SchematicID = schematicID
+	media := installationMediaFromResponse(resp)
+	media.SchematicID = schematicID
 
-	return asset, nil
+	return media, nil
 }
 
-// bootAssetRequest converts a provision step's spec into the management API request.
-func bootAssetRequest(talosVersion, schematicID string, spec provision.BootAssetSpec) (*management.BootAssetURLRequest, error) {
-	kind, ok := bootAssetKinds[spec.Kind]
+// installationMediaRequest converts a provision step's spec into the management API request.
+func installationMediaRequest(talosVersion, schematicID string, spec provision.MediaSpec) (*management.InstallationMediaURLRequest, error) {
+	kind, ok := installationMediaKinds[spec.Kind]
 	if !ok {
-		return nil, fmt.Errorf("unknown boot asset kind %q", spec.Kind)
+		return nil, fmt.Errorf("unknown installation media kind %q", spec.Kind)
 	}
 
-	request := &management.BootAssetURLRequest{
-		TalosVersion:  talosVersion,
-		SchematicId:   schematicID,
-		StandaloneUrl: spec.StandaloneURL,
-		BootAssetKind: kind,
-		Platform:      spec.Platform,
-		Architecture:  spec.Architecture,
-		Format:        spec.Format,
-		SecureBoot:    spec.SecureBoot,
+	request := &management.InstallationMediaURLRequest{
+		TalosVersion:          talosVersion,
+		SchematicId:           schematicID,
+		StandaloneUrl:         spec.StandaloneURL,
+		InstallationMediaKind: kind,
+		Platform:              spec.Platform,
+		Architecture:          spec.Architecture,
+		Format:                spec.Format,
+		SecureBoot:            spec.SecureBoot,
 	}
 
 	// A zero duration on the wire would look like a request for no lifetime at all, so it stays unset and
@@ -326,8 +326,8 @@ func bootAssetRequest(talosVersion, schematicID string, spec provision.BootAsset
 	return request, nil
 }
 
-// bootAssetFromResponse converts the management API response into the client-side type.
-func bootAssetFromResponse(resp *management.BootAssetURLResponse) imagefactory.BootAsset {
+// installationMediaFromResponse converts the management API response into the client-side type.
+func installationMediaFromResponse(resp *management.InstallationMediaURLResponse) imagefactory.InstallationMedia {
 	var headers http.Header
 
 	if len(resp.Headers) > 0 {
@@ -346,7 +346,7 @@ func bootAssetFromResponse(resp *management.BootAssetURLResponse) imagefactory.B
 		expiresAt = resp.ExpiresAt.AsTime()
 	}
 
-	return imagefactory.BootAsset{
+	return imagefactory.InstallationMedia{
 		URL:              resp.Url,
 		Headers:          headers,
 		StorageKey:       resp.StorageKey,

--- a/client/pkg/infra/infra_test.go
+++ b/client/pkg/infra/infra_test.go
@@ -56,10 +56,10 @@ const (
 	testFactoryPassword = "pass"
 )
 
-// testBootAssetSpec is the asset the steps below ask for when only the schematic behind it matters.
-var testBootAssetSpec = provision.BootAssetSpec{
-	AssetSpec: imagefactory.AssetSpec{
-		Kind:         imagefactory.BootAssetKindDisk,
+// testMediaSpec is the medium the steps below ask for when only the schematic behind it matters.
+var testMediaSpec = provision.MediaSpec{
+	MediaSpec: imagefactory.MediaSpec{
+		Kind:         imagefactory.InstallationMediaKindDisk,
 		Platform:     "nocloud",
 		Architecture: "amd64",
 		Format:       "raw.xz",
@@ -175,40 +175,40 @@ func validateConnectionParams(_ context.Context, _ *zap.Logger, pctx provision.C
 	return nil
 }
 
-// genSchematic pins the schematic the machine request generates, which EnsureBootAsset reports back as
+// genSchematic pins the schematic the machine request generates, which EnsureInstallationMedia reports back as
 // the ID of the schematic it ensured.
 func genSchematic(ctx context.Context, logger *zap.Logger, pctx provision.Context[*TestResource]) error {
 	if pctx.ConnectionParams.CustomDataEncoded {
-		_, err := pctx.EnsureBootAsset(ctx, logger, testBootAssetSpec)
+		_, err := pctx.EnsureInstallationMedia(ctx, logger, testMediaSpec)
 		if err == nil {
 			return errors.New("generating schematics with the connection params must be not allowed")
 		}
 	} else {
-		asset, err := pctx.EnsureBootAsset(ctx, logger, testBootAssetSpec)
+		media, err := pctx.EnsureInstallationMedia(ctx, logger, testMediaSpec)
 		if err != nil {
 			return err
 		}
 
 		expectedSchematic := "4e2a2ec4368100c1b21d4fa7be47f3d38ddab9185f34fc187f82400b1e20da17"
 
-		if asset.SchematicID != expectedSchematic {
-			return fmt.Errorf("expected schematic id to be %s got %s", expectedSchematic, asset.SchematicID)
+		if media.SchematicID != expectedSchematic {
+			return fmt.Errorf("expected schematic id to be %s got %s", expectedSchematic, media.SchematicID)
 		}
 	}
 
-	asset, err := pctx.EnsureBootAsset(ctx, logger, testBootAssetSpec, provision.WithoutConnectionParams())
+	media, err := pctx.EnsureInstallationMedia(ctx, logger, testMediaSpec, provision.WithoutConnectionParams())
 	if err != nil {
 		return err
 	}
 
 	expectedSchematic := "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
 
-	if asset.SchematicID != expectedSchematic {
-		return fmt.Errorf("expected schematic id to be %s got %s", expectedSchematic, asset.SchematicID)
+	if media.SchematicID != expectedSchematic {
+		return fmt.Errorf("expected schematic id to be %s got %s", expectedSchematic, media.SchematicID)
 	}
 
-	embedded, err := pctx.EnsureBootAsset(
-		ctx, logger, testBootAssetSpec,
+	embedded, err := pctx.EnsureInstallationMedia(
+		ctx, logger, testMediaSpec,
 		provision.WithoutConnectionParams(),
 		provision.WithEmbeddedMachineConfig("version: v1alpha1\nmachine: {}\n"),
 	)
@@ -426,16 +426,16 @@ func setupInfra(ctx context.Context, t *testing.T, p provision.Provisioner[*Test
 
 	eg, ctx := errgroup.WithContext(ctx)
 
-	// Stands in for Omni: ensuring the schematic is local to the test, and the asset is built from the
+	// Stands in for Omni: ensuring the schematic is local to the test, and the medium is built from the
 	// image factory configuration in the state, exactly as an older server's fallback would.
-	opts = append(opts, infra.WithState(state), infra.WithBootAssetResolver(
-		func(ctx context.Context, talosVersion string, schematic schematic.Schematic, spec provision.BootAssetSpec) (imagefactory.BootAsset, error) {
+	opts = append(opts, infra.WithState(state), infra.WithInstallationMediaResolver(
+		func(ctx context.Context, talosVersion string, schematic schematic.Schematic, spec provision.MediaSpec) (imagefactory.InstallationMedia, error) {
 			schematicID, err := schematic.ID()
 			if err != nil {
-				return imagefactory.BootAsset{}, err
+				return imagefactory.InstallationMedia{}, err
 			}
 
-			return imagefactory.ResolveBootAsset(ctx, state, talosVersion, imagefactory.AssetSpec{
+			return imagefactory.ResolveInstallationMedia(ctx, state, talosVersion, imagefactory.MediaSpec{
 				Kind:         spec.Kind,
 				Platform:     spec.Platform,
 				Architecture: spec.Architecture,
@@ -497,19 +497,19 @@ func TestProvisionStepImageFactory(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	type bootAssets struct {
-		disk imagefactory.BootAsset
-		pxe  imagefactory.BootAsset
+	type installationMedia struct {
+		disk imagefactory.InstallationMedia
+		pxe  imagefactory.InstallationMedia
 	}
 
-	resolved := make(chan bootAssets, 1)
+	resolved := make(chan installationMedia, 1)
 
 	p := &stepProvisioner{
 		steps: []provision.Step[*TestResource]{
 			provision.NewStep("resolveFactory", func(ctx context.Context, logger *zap.Logger, pctx provision.Context[*TestResource]) error {
-				disk, err := pctx.EnsureBootAsset(ctx, logger, provision.BootAssetSpec{
-					AssetSpec: imagefactory.AssetSpec{
-						Kind:         imagefactory.BootAssetKindDisk,
+				disk, err := pctx.EnsureInstallationMedia(ctx, logger, provision.MediaSpec{
+					MediaSpec: imagefactory.MediaSpec{
+						Kind:         imagefactory.InstallationMediaKindDisk,
 						Platform:     "nocloud",
 						Architecture: "amd64",
 						Format:       "raw.xz",
@@ -519,9 +519,9 @@ func TestProvisionStepImageFactory(t *testing.T) {
 					return err
 				}
 
-				pxe, err := pctx.EnsureBootAsset(ctx, logger, provision.BootAssetSpec{
-					AssetSpec: imagefactory.AssetSpec{
-						Kind:         imagefactory.BootAssetKindPXE,
+				pxe, err := pctx.EnsureInstallationMedia(ctx, logger, provision.MediaSpec{
+					MediaSpec: imagefactory.MediaSpec{
+						Kind:         imagefactory.InstallationMediaKindPXE,
 						Platform:     "metal",
 						Architecture: "amd64",
 					},
@@ -533,7 +533,7 @@ func TestProvisionStepImageFactory(t *testing.T) {
 				// The controller resumes at the recorded step, so this can run more than once for the same
 				// request. Only the first resolution is asserted, and a re-run must not block on it.
 				select {
-				case resolved <- bootAssets{disk: disk, pxe: pxe}:
+				case resolved <- installationMedia{disk: disk, pxe: pxe}:
 				default:
 				}
 
@@ -555,30 +555,30 @@ func TestProvisionStepImageFactory(t *testing.T) {
 		assert.Equal(specs.MachineRequestStatusSpec_PROVISIONED, mrs.TypedSpec().Value.Stage)
 	})
 
-	var assets bootAssets
+	var media installationMedia
 
 	select {
-	case assets = <-resolved:
+	case media = <-resolved:
 	case <-ctx.Done():
-		require.Fail(t, "the provision step did not report the boot assets")
+		require.Fail(t, "the provision step did not report the installation media")
 	}
 
 	// The mock factory client returns the schematic's own ID, so the URL carries whatever the step's
 	// machine request generated.
-	require.Contains(t, assets.disk.URL, "https://factory.example.org/image/")
-	require.Contains(t, assets.disk.URL, "/v1.13.0/nocloud-amd64.raw.xz")
+	require.Contains(t, media.disk.URL, "https://factory.example.org/image/")
+	require.Contains(t, media.disk.URL, "/v1.13.0/nocloud-amd64.raw.xz")
 
 	// A disk image is fetched by the provider itself, so the credentials come back as a header and the
 	// URL stays clean.
 	require.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte(testFactoryUsername+":"+testFactoryPassword)),
-		assets.disk.Headers.Get("Authorization"))
-	require.NotContains(t, assets.disk.URL, testFactoryPassword)
+		media.disk.Headers.Get("Authorization"))
+	require.NotContains(t, media.disk.URL, testFactoryPassword)
 
 	// PXE firmware cannot send headers, so those credentials have to ride in the URL instead.
-	require.Contains(t, assets.pxe.URL,
+	require.Contains(t, media.pxe.URL,
 		"https://"+testFactoryUsername+":"+testFactoryPassword+"@pxe.factory.example.org/pxe/")
-	require.Contains(t, assets.pxe.URL, "/v1.13.0/metal-amd64")
-	require.Empty(t, assets.pxe.Headers)
+	require.Contains(t, media.pxe.URL, "/v1.13.0/metal-amd64")
+	require.Empty(t, media.pxe.Headers)
 }
 
 // TestProvisionContextWithoutResolver pins the error a hand-built Context reports, since provider step
@@ -598,15 +598,15 @@ func TestProvisionContextWithoutResolver(t *testing.T) {
 		nil,
 	)
 
-	_, err := pctx.EnsureBootAsset(t.Context(), zaptest.NewLogger(t), provision.BootAssetSpec{
-		AssetSpec: imagefactory.AssetSpec{
-			Kind:         imagefactory.BootAssetKindDisk,
+	_, err := pctx.EnsureInstallationMedia(t.Context(), zaptest.NewLogger(t), provision.MediaSpec{
+		MediaSpec: imagefactory.MediaSpec{
+			Kind:         imagefactory.InstallationMediaKindDisk,
 			Platform:     "nocloud",
 			Architecture: "amd64",
 			Format:       "raw.xz",
 		},
 	})
-	require.ErrorContains(t, err, "provision context has no boot asset resolver")
+	require.ErrorContains(t, err, "provision context has no installation media resolver")
 }
 
 func TestProvisionStepFailurePersistsError(t *testing.T) {
@@ -741,17 +741,17 @@ func TestProvisionStepMutationsRestricted(t *testing.T) {
 	})
 }
 
-// TestBootAssetWireConversion covers the two conversions between a provision step's spec and the
+// TestInstallationMediaWireConversion covers the two conversions between a provision step's spec and the
 // management API, since a provider only ever gets what these two carry across.
-func TestBootAssetWireConversion(t *testing.T) {
+func TestInstallationMediaWireConversion(t *testing.T) {
 	t.Parallel()
 
 	const schematicID = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
 
-	diskSpec := func() provision.BootAssetSpec {
-		return provision.BootAssetSpec{
-			AssetSpec: imagefactory.AssetSpec{
-				Kind:         imagefactory.BootAssetKindDisk,
+	diskSpec := func() provision.MediaSpec {
+		return provision.MediaSpec{
+			MediaSpec: imagefactory.MediaSpec{
+				Kind:         imagefactory.InstallationMediaKindDisk,
 				Platform:     "nocloud",
 				Architecture: "amd64",
 				Format:       "raw.xz",
@@ -765,18 +765,18 @@ func TestBootAssetWireConversion(t *testing.T) {
 		spec := diskSpec()
 		spec.DownloadTokenTTL = 90 * time.Minute
 
-		request, err := infra.BootAssetRequest("v1.13.0", schematicID, spec)
+		request, err := infra.InstallationMediaRequest("v1.13.0", schematicID, spec)
 		require.NoError(t, err)
 
 		require.Equal(t, 90*time.Minute, request.DownloadTokenTtl.AsDuration())
-		require.Equal(t, management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK, request.BootAssetKind)
+		require.Equal(t, management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_DISK, request.InstallationMediaKind)
 		require.Equal(t, schematicID, request.SchematicId)
 	})
 
 	t.Run("a step that asks for no lifetime sends none", func(t *testing.T) {
 		t.Parallel()
 
-		request, err := infra.BootAssetRequest("v1.13.0", schematicID, diskSpec())
+		request, err := infra.InstallationMediaRequest("v1.13.0", schematicID, diskSpec())
 		require.NoError(t, err)
 
 		// Unset rather than zero, so Omni can tell "no preference" from a lifetime and apply its default.
@@ -786,7 +786,7 @@ func TestBootAssetWireConversion(t *testing.T) {
 	t.Run("an unknown kind is refused", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := infra.BootAssetRequest("v1.13.0", schematicID, provision.BootAssetSpec{})
+		_, err := infra.InstallationMediaRequest("v1.13.0", schematicID, provision.MediaSpec{})
 		require.Error(t, err)
 	})
 
@@ -795,15 +795,15 @@ func TestBootAssetWireConversion(t *testing.T) {
 
 		expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
 
-		asset := infra.BootAssetFromResponse(&management.BootAssetURLResponse{
+		media := infra.InstallationMediaFromResponse(&management.InstallationMediaURLResponse{
 			Url:              "https://factory.example.org/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz?token=abcd",
 			ImageFactoryHost: "factory.example.org",
 			StorageKey:       "key",
 			ExpiresAt:        timestamppb.New(expiresAt),
 		})
 
-		require.Equal(t, expiresAt, asset.ExpiresAt)
-		require.Empty(t, asset.Headers)
+		require.Equal(t, expiresAt, media.ExpiresAt)
+		require.Empty(t, media.Headers)
 	})
 
 	t.Run("a response without an expiry leaves it zero", func(t *testing.T) {
@@ -811,12 +811,12 @@ func TestBootAssetWireConversion(t *testing.T) {
 
 		// An Omni that predates the field, or a factory authenticating with credentials, sends nothing.
 		// Reading that as the Unix epoch would look like a URL that expired in 1970.
-		asset := infra.BootAssetFromResponse(&management.BootAssetURLResponse{
+		media := infra.InstallationMediaFromResponse(&management.InstallationMediaURLResponse{
 			Url:     "https://factory.example.org/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz",
 			Headers: map[string]string{"Authorization": "Basic dXNlcjpwYXNz"},
 		})
 
-		require.Zero(t, asset.ExpiresAt)
-		require.Equal(t, "Basic dXNlcjpwYXNz", asset.Headers.Get("Authorization"))
+		require.Zero(t, media.ExpiresAt)
+		require.Equal(t, "Basic dXNlcjpwYXNz", media.Headers.Get("Authorization"))
 	})
 }

--- a/client/pkg/infra/options.go
+++ b/client/pkg/infra/options.go
@@ -20,7 +20,7 @@ type HealthCheckFunc func(context.Context) error
 // Options defines additional infra provider options.
 type Options struct {
 	state                      state.State
-	bootAssetResolver          provision.BootAssetResolver
+	installationMediaResolver  provision.InstallationMediaResolver
 	healthCheckFunc            HealthCheckFunc
 	omniEndpoint               string
 	version                    string
@@ -40,13 +40,13 @@ func WithClientOptions(options ...client.Option) Option {
 	}
 }
 
-// WithBootAssetResolver sets up the boot asset resolver explicitly.
+// WithInstallationMediaResolver sets up the installation media resolver explicitly.
 //
 // The infra provider builds one over its Omni API client, so this is for the setups that have no such
 // client, such as one configured with WithState, and for tests.
-func WithBootAssetResolver(resolver provision.BootAssetResolver) Option {
+func WithInstallationMediaResolver(resolver provision.InstallationMediaResolver) Option {
 	return func(o *Options) {
-		o.bootAssetResolver = resolver
+		o.installationMediaResolver = resolver
 	}
 }
 

--- a/client/pkg/infra/provision/context.go
+++ b/client/pkg/infra/provision/context.go
@@ -92,12 +92,12 @@ type ConnectionParams struct {
 	CustomDataEncoded bool
 }
 
-// BootAssetSpec names the boot asset a provision step wants, without saying how the image factory
+// MediaSpec identifies the installation medium a provision step wants, without saying how the image factory
 // spells it, and says how the provider intends to fetch it.
-type BootAssetSpec struct {
-	// AssetSpec names the asset. It is embedded rather than restated so that a field added to it reaches
-	// every caller, instead of being dropped by one of the conversions along the way.
-	imagefactory.AssetSpec
+type MediaSpec struct {
+	// Embedded rather than restated so that a field added to it reaches every caller, instead of being
+	// dropped by one of the conversions along the way.
+	imagefactory.MediaSpec
 
 	// DownloadTokenTTL is how long this provider needs the URL to keep working for a factory that
 	// authenticates downloads with a token. Zero takes Omni's default, which assumes the fetch happens
@@ -113,11 +113,11 @@ type BootAssetSpec struct {
 	StandaloneURL bool
 }
 
-// BootAssetResolver ensures the schematic exists and returns the boot asset built from it.
+// InstallationMediaResolver ensures the schematic exists and returns the installation medium built from it.
 //
 // The infra library wires one that goes through Omni's management API, so that newer Omni versions can
 // apply image factory changes this library predates.
-type BootAssetResolver func(ctx context.Context, talosVersion string, schematic schematic.Schematic, spec BootAssetSpec) (imagefactory.BootAsset, error)
+type InstallationMediaResolver func(ctx context.Context, talosVersion string, schematic schematic.Schematic, spec MediaSpec) (imagefactory.InstallationMedia, error)
 
 // NewContext creates a new provision context.
 func NewContext[T resource.Resource](
@@ -126,54 +126,54 @@ func NewContext[T resource.Resource](
 	providerState T,
 	connectionParams ConnectionParams,
 	runtime controller.QRuntime,
-	bootAssetResolver BootAssetResolver,
+	installationMediaResolver InstallationMediaResolver,
 ) Context[T] {
 	return Context[T]{
-		machineRequest:       machineRequest,
-		MachineRequestStatus: machineRequestStatus,
-		State:                providerState,
-		ConnectionParams:     connectionParams,
-		runtime:              runtime,
-		bootAssetResolver:    bootAssetResolver,
+		machineRequest:            machineRequest,
+		MachineRequestStatus:      machineRequestStatus,
+		State:                     providerState,
+		ConnectionParams:          connectionParams,
+		runtime:                   runtime,
+		installationMediaResolver: installationMediaResolver,
 	}
 }
 
 // Context keeps all context which might be required for the provision calls.
 type Context[T resource.Resource] struct {
-	machineRequest       *infra.MachineRequest
-	MachineRequestStatus *infra.MachineRequestStatus
-	runtime              controller.QRuntime
-	bootAssetResolver    BootAssetResolver
-	State                T
-	ConnectionParams     ConnectionParams
+	machineRequest            *infra.MachineRequest
+	MachineRequestStatus      *infra.MachineRequestStatus
+	runtime                   controller.QRuntime
+	installationMediaResolver InstallationMediaResolver
+	State                     T
+	ConnectionParams          ConnectionParams
 }
 
-// EnsureBootAsset returns the boot asset named by the spec, for the machine request's Talos version and
+// EnsureInstallationMedia returns the installation medium the spec identifies, for the machine request's Talos version and
 // the schematic generated from the machine request and the given options.
 //
 // It ensures the schematic exists on the image factory Omni is configured with and then resolves the
-// asset, so a provision step never handles a schematic ID, a factory URL, or a filename convention.
+// medium, so a provision step never handles a schematic ID, a factory URL, or a filename convention.
 //
-// Fetch BootAsset.URL, sending BootAsset.Headers when they are not empty. See imagefactory.BootAsset
+// Fetch InstallationMedia.URL, sending InstallationMedia.Headers when they are not empty. See imagefactory.InstallationMedia
 // for the full contract: the URL is opaque and can carry secrets, so it does not belong in a log line
 // verbatim, it is not a stable input for a persisted name, and it can be short-lived, so use it
-// promptly rather than storing it. BootAsset.ExpiresAt says when it stops working, for a provider that
-// hands it on rather than fetching it, and BootAssetSpec.DownloadTokenTTL asks for a longer one.
-func (context *Context[T]) EnsureBootAsset(ctx context.Context, logger *zap.Logger, spec BootAssetSpec, opts ...SchematicOption) (imagefactory.BootAsset, error) {
+// promptly rather than storing it. InstallationMedia.ExpiresAt says when it stops working, for a provider that
+// hands it on rather than fetching it, and MediaSpec.DownloadTokenTTL asks for a longer one.
+func (context *Context[T]) EnsureInstallationMedia(ctx context.Context, logger *zap.Logger, spec MediaSpec, opts ...SchematicOption) (imagefactory.InstallationMedia, error) {
 	// Built before the resolver is checked, so that a schematic the options cannot produce is reported as
 	// such rather than as a missing resolver.
 	schematic, err := context.buildSchematic(logger, opts...)
 	if err != nil {
-		return imagefactory.BootAsset{}, err
+		return imagefactory.InstallationMedia{}, err
 	}
 
 	// The resolver goes through Omni, which owns the schematic upload as well as naming and locating the
-	// asset. A provider given only a COSI state has no way to reach it and has to supply its own.
-	if context.bootAssetResolver == nil {
-		return imagefactory.BootAsset{}, errors.New("provision context has no boot asset resolver, the infra provider needs an Omni API client")
+	// medium. A provider given only a COSI state has no way to reach it and has to supply its own.
+	if context.installationMediaResolver == nil {
+		return imagefactory.InstallationMedia{}, errors.New("provision context has no installation media resolver, the infra provider needs an Omni API client")
 	}
 
-	return context.bootAssetResolver(ctx, context.GetTalosVersion(), schematic, spec)
+	return context.installationMediaResolver(ctx, context.GetTalosVersion(), schematic, spec)
 }
 
 // GetRequestID returns machine request id.

--- a/frontend/src/api/omni/management/management.pb.ts
+++ b/frontend/src/api/omni/management/management.pb.ts
@@ -63,11 +63,11 @@ export enum CreateSchematicRequestSiderolinkGRPCTunnelMode {
   ENABLED = 2,
 }
 
-export enum BootAssetURLRequestBootAssetKind {
-  BOOT_ASSET_KIND_UNSET = 0,
-  BOOT_ASSET_KIND_PXE = 1,
-  BOOT_ASSET_KIND_ISO = 2,
-  BOOT_ASSET_KIND_DISK = 3,
+export enum InstallationMediaURLRequestInstallationMediaKind {
+  INSTALLATION_MEDIA_KIND_UNSET = 0,
+  INSTALLATION_MEDIA_KIND_PXE = 1,
+  INSTALLATION_MEDIA_KIND_ISO = 2,
+  INSTALLATION_MEDIA_KIND_DISK = 3,
 }
 
 export enum MaintenanceLifecycleRequestOperation {
@@ -218,11 +218,11 @@ export type CreateSchematicResponse = {
   schematic_yml?: string
 }
 
-export type BootAssetURLRequest = {
+export type InstallationMediaURLRequest = {
   talos_version?: string
   schematic_id?: string
   standalone_url?: boolean
-  boot_asset_kind?: BootAssetURLRequestBootAssetKind
+  installation_media_kind?: InstallationMediaURLRequestInstallationMediaKind
   platform?: string
   architecture?: string
   format?: string
@@ -230,7 +230,7 @@ export type BootAssetURLRequest = {
   download_token_ttl?: GoogleProtobufDuration.Duration
 }
 
-export type BootAssetURLResponse = {
+export type InstallationMediaURLResponse = {
   url?: string
   headers?: {[key: string]: string}
   image_factory_host?: string
@@ -432,8 +432,8 @@ export class ManagementService {
   static CreateSchematicFromRaw(req: CreateSchematicFromRawRequest, ...options: fm.fetchOption[]): Promise<CreateSchematicResponse> {
     return fm.fetchReq<CreateSchematicFromRawRequest, CreateSchematicResponse>("POST", `/management.ManagementService/CreateSchematicFromRaw`, req, ...options)
   }
-  static GetBootAssetURL(req: BootAssetURLRequest, ...options: fm.fetchOption[]): Promise<BootAssetURLResponse> {
-    return fm.fetchReq<BootAssetURLRequest, BootAssetURLResponse>("POST", `/management.ManagementService/GetBootAssetURL`, req, ...options)
+  static GetInstallationMediaURL(req: InstallationMediaURLRequest, ...options: fm.fetchOption[]): Promise<InstallationMediaURLResponse> {
+    return fm.fetchReq<InstallationMediaURLRequest, InstallationMediaURLResponse>("POST", `/management.ManagementService/GetInstallationMediaURL`, req, ...options)
   }
   static GetSupportBundle(req: GetSupportBundleRequest, entityNotifier: fm.NotifyStreamEntityArrival<GetSupportBundleResponse>, ...options: fm.fetchOption[]): Promise<void> {
     return fm.fetchStreamingRequest<GetSupportBundleRequest, GetSupportBundleResponse>("POST", `/management.ManagementService/GetSupportBundle`, req, entityNotifier, ...options)

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -8,21 +8,22 @@ match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 pre_release = true
 previous = "v1.9.0"
 
-[notes.infra-provider-boot-assets]
+[notes.infra-provider-installation-media]
 title = "Infrastructure Providers Use the Image Factory Omni Is Configured With"
 description = """\
 Infrastructure providers used to reach the image factory themselves, at the hardcoded public URL, so an on-prem or authenticated factory was out of \
-reach, and every provider carried its own copy of the factory's URL layout and file naming. A provision step now names the asset it wants by kind, \
-platform, architecture and format. Omni creates the schematic, picks the factory that serves the machine's Talos version, works out the filename \
-including the secure boot variant, and answers with a URL and whatever headers the fetch has to carry. A provider that cannot attach a header, because \
-PXE firmware or a hypervisor download API performs the fetch, asks for a self-contained URL instead. Carrying this through the Omni client library for \
-infrastructure providers meant breaking changes, so a provider has to be updated to the new API, and once it is, it needs Omni 1.8 or newer.
+reach, and every provider carried its own copy of the factory's URL layout and file naming. A provision step now states which medium it wants by kind, \
+platform, architecture and format through Context.EnsureInstallationMedia. Omni creates the schematic, picks the factory that serves the machine's \
+Talos version, works out the filename including the secure boot variant, and answers with a URL and whatever headers the fetch has to carry. A provider \
+that cannot attach a header, because PXE firmware or a hypervisor download API performs the fetch, asks for a self-contained URL instead. Carrying this \
+through the Omni client library for infrastructure providers meant breaking changes, so a provider has to be updated to the new API, and once it is, it \
+needs Omni 1.8 or newer.
 
 Image downloads are now authenticated with a short-lived download token issued by the factory rather than with the factory credentials, so a provider \
 receives something that expires and that only downloads, instead of a credential valid on every factory route until someone rotates it. A provision \
 step that hands the URL to something else, such as a hypervisor import queue that starts later, asks for the lifetime it needs and is told when the \
 URL stops working. A factory that does not issue tokens keeps working unchanged, and so does PXE: the factory accepts a token only on image downloads, \
-and the iPXE script it serves passes on the credentials it was fetched with, so a PXE asset still carries them. Two things change for provider authors. \
-A URL is no longer stable for a given asset, since each one carries a fresh token, so compare the storage key rather than the URL when deciding whether \
-something has already been fetched. And a URL now expires, so fetch it promptly or ask for a lifetime that covers the delay.
+and the iPXE script it serves passes on the credentials it was fetched with, so a PXE script still carries them. Two things change for provider authors. \
+A URL is no longer stable for a given medium, since each one carries a fresh token, so compare the storage key rather than the URL when deciding \
+whether something has already been fetched. And a URL now expires, so fetch it promptly or ask for a lifetime that covers the delay.
 """

--- a/internal/backend/grpc/schematics.go
+++ b/internal/backend/grpc/schematics.go
@@ -179,27 +179,27 @@ func (s *managementServer) CreateSchematicFromRaw(ctx context.Context, request *
 	}, nil
 }
 
-// bootAssetKinds maps the wire enum onto the kinds the image factory serves.
-var bootAssetKinds = map[management.BootAssetURLRequest_BootAssetKind]imagefactory.BootAssetKind{
-	management.BootAssetURLRequest_BOOT_ASSET_KIND_PXE:  imagefactory.BootAssetKindPXE,
-	management.BootAssetURLRequest_BOOT_ASSET_KIND_ISO:  imagefactory.BootAssetKindISO,
-	management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK: imagefactory.BootAssetKindDisk,
+// installationMediaKinds maps the wire enum onto the kinds the image factory serves.
+var installationMediaKinds = map[management.InstallationMediaURLRequest_InstallationMediaKind]imagefactory.InstallationMediaKind{
+	management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_PXE:  imagefactory.InstallationMediaKindPXE,
+	management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_ISO:  imagefactory.InstallationMediaKindISO,
+	management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_DISK: imagefactory.InstallationMediaKindDisk,
 }
 
-// GetBootAssetURL implements managementServer.
-func (s *managementServer) GetBootAssetURL(ctx context.Context, request *management.BootAssetURLRequest) (*management.BootAssetURLResponse, error) {
+// GetInstallationMediaURL implements managementServer.
+func (s *managementServer) GetInstallationMediaURL(ctx context.Context, request *management.InstallationMediaURLRequest) (*management.InstallationMediaURLResponse, error) {
 	if _, err := auth.CheckGRPC(ctx, auth.WithExactRoles(role.InfraProvider, role.Operator, role.Admin)); err != nil {
 		return nil, err
 	}
 
 	ctx = actor.MarkContextAsInternalActor(ctx)
 
-	kind, ok := bootAssetKinds[request.BootAssetKind]
+	kind, ok := installationMediaKinds[request.InstallationMediaKind]
 	if !ok {
-		return nil, status.Errorf(codes.InvalidArgument, "unknown boot asset kind %s", request.BootAssetKind)
+		return nil, status.Errorf(codes.InvalidArgument, "unknown installation media kind %s", request.InstallationMediaKind)
 	}
 
-	spec := imagefactory.AssetSpec{
+	spec := imagefactory.MediaSpec{
 		Kind:         kind,
 		Platform:     request.Platform,
 		Architecture: request.Architecture,
@@ -213,30 +213,30 @@ func (s *managementServer) GetBootAssetURL(ctx context.Context, request *managem
 		TTL:       request.DownloadTokenTtl.AsDuration(),
 	})
 
-	asset, err := imagefactory.ResolveBootAsset(ctx, s.omniState, request.TalosVersion, spec, request.SchematicId, request.StandaloneUrl, downloadTokens)
+	media, err := imagefactory.ResolveInstallationMedia(ctx, s.omniState, request.TalosVersion, spec, request.SchematicId, request.StandaloneUrl, downloadTokens)
 	if err != nil {
 		if errors.Is(err, imagefactory.ErrInvalidInput) {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 
-		return nil, status.Errorf(codes.Internal, "failed to resolve the boot asset: %s", err)
+		return nil, status.Errorf(codes.Internal, "failed to resolve the installation media: %s", err)
 	}
 
-	headers := make(map[string]string, len(asset.Headers))
+	headers := make(map[string]string, len(media.Headers))
 
-	for name := range asset.Headers {
-		headers[name] = asset.Headers.Get(name)
+	for name := range media.Headers {
+		headers[name] = media.Headers.Get(name)
 	}
 
-	response := &management.BootAssetURLResponse{
-		Url:              asset.URL,
+	response := &management.InstallationMediaURLResponse{
+		Url:              media.URL,
 		Headers:          headers,
-		ImageFactoryHost: asset.ImageFactoryHost,
-		StorageKey:       asset.StorageKey,
+		ImageFactoryHost: media.ImageFactoryHost,
+		StorageKey:       media.StorageKey,
 	}
 
-	if !asset.ExpiresAt.IsZero() {
-		response.ExpiresAt = timestamppb.New(asset.ExpiresAt)
+	if !media.ExpiresAt.IsZero() {
+		response.ExpiresAt = timestamppb.New(media.ExpiresAt)
 	}
 
 	return response, nil

--- a/internal/backend/grpc/schematics_test.go
+++ b/internal/backend/grpc/schematics_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/siderolink"
 )
 
-// The credentials the boot asset tests configure on both sides: the ImageFactoryAuth resource Omni reads
+// The credentials the installation media tests configure on both sides: the ImageFactoryAuth resource Omni reads
 // for the fallback, and the factory client Omni requests a download token with.
 const (
 	testFactoryUsername = "user"
@@ -455,10 +455,10 @@ func (suite *GrpcSuite) TestSchematicCreate() {
 	}
 }
 
-// TestBootAssetURL pins the server-side boot asset build: Omni assembles the image factory filename
-// from the asset spec, picks the factory serving that Talos version, and places the credentials where
+// TestMediaURL pins the server-side installation media build: Omni assembles the image factory filename
+// from the media spec, picks the factory serving that Talos version, and places the credentials where
 // the caller can use them.
-func (suite *GrpcSuite) TestBootAssetURL() {
+func (suite *GrpcSuite) TestMediaURL() {
 	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
 	defer cancel()
 
@@ -480,39 +480,39 @@ func (suite *GrpcSuite) TestBootAssetURL() {
 
 	for _, tt := range []struct {
 		name         string
-		request      *management.BootAssetURLRequest
+		request      *management.InstallationMediaURLRequest
 		expectedURL  string
 		expectHeader bool
 	}{
 		{
 			name: "disk image with credentials in the headers",
-			request: &management.BootAssetURLRequest{
-				BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK,
-				Platform:      "nocloud",
-				Architecture:  "amd64",
-				Format:        "raw.xz",
+			request: &management.InstallationMediaURLRequest{
+				InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_DISK,
+				Platform:              "nocloud",
+				Architecture:          "amd64",
+				Format:                "raw.xz",
 			},
 			expectedURL:  "https://factory.example.org/image/" + schematicID + "/v1.13.0/nocloud-amd64.raw.xz",
 			expectHeader: true,
 		},
 		{
 			name: "standalone disk image carries them in the URL",
-			request: &management.BootAssetURLRequest{
-				BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK,
-				Platform:      "nocloud",
-				Architecture:  "amd64",
-				Format:        "qcow2",
-				StandaloneUrl: true,
+			request: &management.InstallationMediaURLRequest{
+				InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_DISK,
+				Platform:              "nocloud",
+				Architecture:          "amd64",
+				Format:                "qcow2",
+				StandaloneUrl:         true,
 			},
 			expectedURL: "https://user:hunter2@factory.example.org/image/" + schematicID + "/v1.13.0/nocloud-amd64.qcow2",
 		},
 		{
 			name: "secure boot ISO",
-			request: &management.BootAssetURLRequest{
-				BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_ISO,
-				Platform:      "metal",
-				Architecture:  "amd64",
-				SecureBoot:    true,
+			request: &management.InstallationMediaURLRequest{
+				InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_ISO,
+				Platform:              "metal",
+				Architecture:          "amd64",
+				SecureBoot:            true,
 			},
 			expectedURL:  "https://factory.example.org/image/" + schematicID + "/v1.13.0/metal-amd64-secureboot.iso",
 			expectHeader: true,
@@ -520,10 +520,10 @@ func (suite *GrpcSuite) TestBootAssetURL() {
 		{
 			// PXE firmware cannot send headers, so the URL carries the credentials even unasked.
 			name: "PXE is always standalone",
-			request: &management.BootAssetURLRequest{
-				BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_PXE,
-				Platform:      "metal",
-				Architecture:  "amd64",
+			request: &management.InstallationMediaURLRequest{
+				InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_PXE,
+				Platform:              "metal",
+				Architecture:          "amd64",
 			},
 			expectedURL: "https://user:hunter2@pxe.factory.example.org/pxe/" + schematicID + "/v1.13.0/metal-amd64",
 		},
@@ -532,7 +532,7 @@ func (suite *GrpcSuite) TestBootAssetURL() {
 			tt.request.TalosVersion = "1.13.0"
 			tt.request.SchematicId = schematicID
 
-			resp, err := client.GetBootAssetURL(ctx, tt.request)
+			resp, err := client.GetInstallationMediaURL(ctx, tt.request)
 			suite.Require().NoError(err)
 
 			suite.Require().Equal(tt.expectedURL, resp.Url)
@@ -547,47 +547,47 @@ func (suite *GrpcSuite) TestBootAssetURL() {
 	}
 
 	for _, tt := range []struct {
-		request *management.BootAssetURLRequest
+		request *management.InstallationMediaURLRequest
 		name    string
 	}{
 		{
 			name:    "kind unset",
-			request: &management.BootAssetURLRequest{Platform: "metal", Architecture: "amd64"},
+			request: &management.InstallationMediaURLRequest{Platform: "metal", Architecture: "amd64"},
 		},
 		{
 			// These fields become URL path segments, so traversal has to be refused outright.
 			name: "platform traversal",
-			request: &management.BootAssetURLRequest{
-				BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_ISO,
-				Platform:      "../../secret",
-				Architecture:  "amd64",
+			request: &management.InstallationMediaURLRequest{
+				InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_ISO,
+				Platform:              "../../secret",
+				Architecture:          "amd64",
 			},
 		},
 		{
 			name: "disk without a format",
-			request: &management.BootAssetURLRequest{
-				BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK,
-				Platform:      "nocloud",
-				Architecture:  "amd64",
+			request: &management.InstallationMediaURLRequest{
+				InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_DISK,
+				Platform:              "nocloud",
+				Architecture:          "amd64",
 			},
 		},
 		{
 			// The schematic ID and the Talos version become path segments too.
 			name: "schematic ID traversal",
-			request: &management.BootAssetURLRequest{
-				BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_ISO,
-				Platform:      "metal",
-				Architecture:  "amd64",
-				SchematicId:   "../../..",
+			request: &management.InstallationMediaURLRequest{
+				InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_ISO,
+				Platform:              "metal",
+				Architecture:          "amd64",
+				SchematicId:           "../../..",
 			},
 		},
 		{
 			name: "Talos version traversal",
-			request: &management.BootAssetURLRequest{
-				BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_ISO,
-				Platform:      "metal",
-				Architecture:  "amd64",
-				TalosVersion:  "1.13.0/../..",
+			request: &management.InstallationMediaURLRequest{
+				InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_ISO,
+				Platform:              "metal",
+				Architecture:          "amd64",
+				TalosVersion:          "1.13.0/../..",
 			},
 		},
 	} {
@@ -600,19 +600,19 @@ func (suite *GrpcSuite) TestBootAssetURL() {
 				tt.request.SchematicId = schematicID
 			}
 
-			_, err := client.GetBootAssetURL(ctx, tt.request)
+			_, err := client.GetInstallationMediaURL(ctx, tt.request)
 			suite.Require().Equal(codes.InvalidArgument, status.Code(err))
 		})
 	}
 }
 
-// TestBootAssetToken covers what a caller gets when the factory Omni is configured with issues download
+// TestMediaToken covers what a caller gets when the factory Omni is configured with issues download
 // tokens: a URL that expires and only downloads, instead of the long-lived credential that works on every
 // factory route.
 //
-// TestBootAssetURL points FeaturesConfig at a factory no client is configured for, so it pins the
+// TestMediaURL points FeaturesConfig at a factory no client is configured for, so it pins the
 // credential fallback. This points it at the mock, so ForURL finds the client and the token is issued.
-func (suite *GrpcSuite) TestBootAssetToken() {
+func (suite *GrpcSuite) TestMediaToken() {
 	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*30)
 	defer cancel()
 
@@ -634,14 +634,14 @@ func (suite *GrpcSuite) TestBootAssetToken() {
 
 	client := management.NewManagementServiceClient(suite.conn)
 
-	newRequest := func() *management.BootAssetURLRequest {
-		return &management.BootAssetURLRequest{
-			TalosVersion:  "1.13.0",
-			SchematicId:   schematicID,
-			BootAssetKind: management.BootAssetURLRequest_BOOT_ASSET_KIND_DISK,
-			Platform:      "nocloud",
-			Architecture:  "amd64",
-			Format:        "raw.xz",
+	newRequest := func() *management.InstallationMediaURLRequest {
+		return &management.InstallationMediaURLRequest{
+			TalosVersion:          "1.13.0",
+			SchematicId:           schematicID,
+			InstallationMediaKind: management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_DISK,
+			Platform:              "nocloud",
+			Architecture:          "amd64",
+			Format:                "raw.xz",
 		}
 	}
 
@@ -654,7 +654,7 @@ func (suite *GrpcSuite) TestBootAssetToken() {
 
 		before := time.Now()
 
-		resp, err := client.GetBootAssetURL(ctx, newRequest())
+		resp, err := client.GetInstallationMediaURL(ctx, newRequest())
 		suite.Require().NoError(err)
 
 		suite.Require().Equal(suite.imageFactory.address+assetPath+"?token="+url.QueryEscape(token), resp.Url)
@@ -680,7 +680,7 @@ func (suite *GrpcSuite) TestBootAssetToken() {
 
 		before := time.Now()
 
-		resp, err := client.GetBootAssetURL(ctx, request)
+		resp, err := client.GetInstallationMediaURL(ctx, request)
 		suite.Require().NoError(err)
 
 		suite.Require().Equal([]string{"1h0m0s"}, suite.imageFactory.downloadTokenTTLs())
@@ -694,7 +694,7 @@ func (suite *GrpcSuite) TestBootAssetToken() {
 		request := newRequest()
 		request.StandaloneUrl = true
 
-		resp, err := client.GetBootAssetURL(ctx, request)
+		resp, err := client.GetInstallationMediaURL(ctx, request)
 		suite.Require().NoError(err)
 
 		suite.Require().Equal(suite.imageFactory.address+assetPath+"?token="+url.QueryEscape(token), resp.Url)
@@ -711,7 +711,7 @@ func (suite *GrpcSuite) TestBootAssetToken() {
 		request := newRequest()
 		request.DownloadTokenTtl = durationpb.New(100 * time.Hour)
 
-		_, err := client.GetBootAssetURL(ctx, request)
+		_, err := client.GetInstallationMediaURL(ctx, request)
 		suite.Require().Equal(codes.InvalidArgument, status.Code(err))
 
 		// The bounds are the whole point of passing the factory's own body on rather than summarizing it:
@@ -727,7 +727,7 @@ func (suite *GrpcSuite) TestBootAssetToken() {
 			return http.StatusUnauthorized, "unauthorized"
 		})
 
-		resp, err := client.GetBootAssetURL(ctx, newRequest())
+		resp, err := client.GetInstallationMediaURL(ctx, newRequest())
 		suite.Require().NoError(err)
 
 		suite.Require().Equal(suite.imageFactory.address+assetPath, resp.Url)
@@ -741,7 +741,7 @@ func (suite *GrpcSuite) TestBootAssetToken() {
 		request := newRequest()
 		request.DownloadTokenTtl = durationpb.New(-time.Hour)
 
-		_, err := client.GetBootAssetURL(ctx, request)
+		_, err := client.GetInstallationMediaURL(ctx, request)
 		suite.Require().Equal(codes.InvalidArgument, status.Code(err))
 
 		// It never reaches the factory, since the client would drop a non-positive lifetime and the factory
@@ -754,7 +754,7 @@ func (suite *GrpcSuite) TestBootAssetToken() {
 		// build, and any factory with its own authentication disabled.
 		suite.imageFactory.setDownloadToken(nil)
 
-		resp, err := client.GetBootAssetURL(ctx, newRequest())
+		resp, err := client.GetInstallationMediaURL(ctx, newRequest())
 		suite.Require().NoError(err)
 
 		suite.Require().Equal(suite.imageFactory.address+assetPath, resp.Url)

--- a/internal/backend/runtime/omni/controllers/testutils/factory.go
+++ b/internal/backend/runtime/omni/controllers/testutils/factory.go
@@ -126,7 +126,7 @@ func (i *ImageFactoryClientMock) VEXDocument(_ context.Context, _ string) ([]byt
 
 // DownloadToken answers 404, the same as a factory below 1.5.0 or one with authentication disabled.
 //
-// No controller resolves a boot asset, so nothing here depends on the answer: the method exists because
+// No controller resolves installation media, so nothing here depends on the answer: the method exists because
 // FactoryClient requires it. Token behavior is covered where it is actually reached, in
 // client/pkg/imagefactory and internal/backend/grpc.
 func (i *ImageFactoryClientMock) DownloadToken(_ context.Context, _ time.Duration) (string, error) {


### PR DESCRIPTION
The management endpoint that tells a caller where to fetch a Talos image was introduced as GetBootAssetURL, which gave a second vocabulary to something Omni already models as InstallationMedia and InstallationMediaConfig. It is now GetInstallationMediaURL, and the types around it in the client library for infrastructure providers follow, so a provision step calls EnsureInstallationMedia and gets back an imagefactory.InstallationMedia.