### PR TITLE
feat: authenticate PXE installation media with a download token

### DIFF
--- a/client/api/omni/management/management.pb.go
+++ b/client/api/omni/management/management.pb.go
@@ -1772,7 +1772,8 @@ type InstallationMediaURLRequest struct {
 	SecureBoot bool   `protobuf:"varint,8,opt,name=secure_boot,json=secureBoot,proto3" json:"secure_boot,omitempty"`
 	// DownloadTokenTtl is how long the caller needs the URL to keep working, for a factory that
 	// authenticates downloads with a token. Unset takes Omni's default, which suits a fetch performed right
-	// away. Ask for more when something else performs it later, such as a hypervisor import queue.
+	// away, or for the PXE kind one that also covers writing the script into a boot configuration. Ask for
+	// more when something else performs the fetch later, such as a hypervisor import queue.
 	//
 	// The factory refuses a lifetime outside its configured bounds, which comes back as InvalidArgument.
 	// Ignored by a factory that authenticates downloads with credentials instead.

--- a/client/api/omni/management/management.proto
+++ b/client/api/omni/management/management.proto
@@ -233,7 +233,8 @@ message InstallationMediaURLRequest {
 
   // DownloadTokenTtl is how long the caller needs the URL to keep working, for a factory that
   // authenticates downloads with a token. Unset takes Omni's default, which suits a fetch performed right
-  // away. Ask for more when something else performs it later, such as a hypervisor import queue.
+  // away, or for the PXE kind one that also covers writing the script into a boot configuration. Ask for
+  // more when something else performs the fetch later, such as a hypervisor import queue.
   //
   // The factory refuses a lifetime outside its configured bounds, which comes back as InvalidArgument.
   // Ignored by a factory that authenticates downloads with credentials instead.

--- a/client/go.mod
+++ b/client/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/siderolabs/go-api-signature v0.3.13
 	github.com/siderolabs/go-kubeconfig v0.1.2
 	github.com/siderolabs/go-talos-support v0.3.1
-	github.com/siderolabs/image-factory v1.5.1
+	github.com/siderolabs/image-factory v1.6.0
 	github.com/siderolabs/proto-codec v0.1.4
 	github.com/siderolabs/siderolink v0.3.17
 	github.com/siderolabs/talos/pkg/machinery v1.14.0-rc.2.0.20260825161121-322de8bf2974

--- a/client/go.sum
+++ b/client/go.sum
@@ -238,8 +238,8 @@ github.com/siderolabs/go-retry v0.3.3 h1:zKV+S1vumtO72E6sYsLlmIdV/G/GcYSBLiEx/c9
 github.com/siderolabs/go-retry v0.3.3/go.mod h1:Ff/VGc7v7un4uQg3DybgrmOWHEmJ8BzZds/XNn/BqMI=
 github.com/siderolabs/go-talos-support v0.3.1 h1:2cIct5nxGby8B7NNALO5WL3WbCe9S1se/3/nT0H/x7Q=
 github.com/siderolabs/go-talos-support v0.3.1/go.mod h1:3fljgD3YQGB2+nJfWLLt482/C8epdqge70fWH+VtuiU=
-github.com/siderolabs/image-factory v1.5.1 h1:VYz9CQcFuzD2of6tw1YCIiNdchPawKFVptT1q4skD/Y=
-github.com/siderolabs/image-factory v1.5.1/go.mod h1:usi+gZen80PnprOrlF9S85wwpqehG48fsWSDjMverMs=
+github.com/siderolabs/image-factory v1.6.0 h1:nzx28i+g24kTUiD8O6MfSYahQRYuuaunqJZNHdln3Rg=
+github.com/siderolabs/image-factory v1.6.0/go.mod h1:EA4pVNZOH8BvtvywCYcfOtItWd1adXPUuk3d/rUALpQ=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=
 github.com/siderolabs/net v0.4.0/go.mod h1:/ibG+Hm9HU27agp5r9Q3eZicEfjquzNzQNux5uEk0kM=
 github.com/siderolabs/proto-codec v0.1.4 h1:AcrLot/251qAa35GYhSqDeEKF3bygOlNaYJSrl7MPNQ=

--- a/client/pkg/imagefactory/installationmedia.go
+++ b/client/pkg/imagefactory/installationmedia.go
@@ -228,15 +228,23 @@ func (o *DownloadTokenOptions) logger() *zap.Logger {
 	return o.Logger
 }
 
-// defaultDownloadTokenTTL is what Omni asks for when the caller asks for nothing.
-const defaultDownloadTokenTTL = 5 * time.Minute
+// defaultDownloadTokenTTL is what Omni asks for when the caller asks for nothing. An image is fetched as
+// soon as it is resolved, while a PXE script is written into a boot configuration first and has to
+// outlive being set up, so the two are worth different lifetimes.
+func defaultDownloadTokenTTL(kind InstallationMediaKind) time.Duration {
+	if kind == InstallationMediaKindPXE {
+		return 2 * time.Hour
+	}
+
+	return 5 * time.Minute
+}
 
 // downloadTokenRequestTimeout bounds the token request on its own, since the factory client's timeout is
 // sized for the slowest thing it does.
 const downloadTokenRequestTimeout = 30 * time.Second
 
-// WithDownloadTokens authenticates an image download with a short-lived token issued by the factory
-// instead of the basic auth credentials Omni holds.
+// WithDownloadTokens authenticates an installation media download with a short-lived token issued by
+// the factory instead of the basic auth credentials Omni holds.
 func WithDownloadTokens(opts DownloadTokenOptions) ResolveOption {
 	return func(o *resolveOptions) {
 		o.downloadTokens = &opts
@@ -245,7 +253,7 @@ func WithDownloadTokens(opts DownloadTokenOptions) ResolveOption {
 
 // requestDownloadToken returns a token authenticating a download from the factory at baseURL and the
 // moment it stops working.
-func requestDownloadToken(ctx context.Context, baseURL string, opts *DownloadTokenOptions) (string, time.Time, bool, error) {
+func requestDownloadToken(ctx context.Context, baseURL string, kind InstallationMediaKind, opts *DownloadTokenOptions) (string, time.Time, bool, error) {
 	// A caller that cannot ask for a token, such as the provider-side fallback against an older Omni,
 	// passes nothing.
 	if opts == nil || opts.Factories == nil {
@@ -264,7 +272,7 @@ func requestDownloadToken(ctx context.Context, baseURL string, opts *DownloadTok
 
 	ttl := opts.TTL
 	if ttl == 0 {
-		ttl = defaultDownloadTokenTTL
+		ttl = defaultDownloadTokenTTL(kind)
 	}
 
 	tokenCtx, cancel := context.WithTimeout(ctx, downloadTokenRequestTimeout)
@@ -373,13 +381,12 @@ func ResolveInstallationMedia(
 		ImageFactoryHost: mediaURL.Host,
 	}
 
-	switch {
-	case resolved.username == "" || resolved.password == "":
-		// The factory serves this anonymously, so there is nothing to place.
-	case spec.Kind == InstallationMediaKindPXE:
-		mediaURL.User = url.UserPassword(resolved.username, resolved.password)
-	default:
-		token, expiresAt, ok, err := requestDownloadToken(ctx, resolved.baseURL, options.downloadTokens)
+	// The firmware fetching an iPXE script cannot send a header, and neither can the boot that follows it,
+	// so PXE authentication always travels inside the URL.
+	standalone = standalone || spec.Kind == InstallationMediaKindPXE
+
+	if resolved.username != "" && resolved.password != "" {
+		token, expiresAt, ok, err := requestDownloadToken(ctx, resolved.baseURL, spec.Kind, options.downloadTokens)
 
 		switch {
 		case err != nil:

--- a/client/pkg/imagefactory/installationmedia_test.go
+++ b/client/pkg/imagefactory/installationmedia_test.go
@@ -942,6 +942,70 @@ func TestResolveInstallationMediaDownloadTokenRequest(t *testing.T) {
 	})
 }
 
+// TestResolveInstallationMediaPXEDownloadToken covers the authentication a caller gets for a PXE script.
+// The factory forwards the token that fetched the script into the kernel and initramfs URLs it points at,
+// so the token authenticates the whole boot and the credentials never leave Omni.
+func TestResolveInstallationMediaPXEDownloadToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	const (
+		token = "eyJhbGciOiJFUzI1NiJ9.fake.token"
+
+		// defaultPXETTL pins imagefactory's unexported PXE default, which is longer than the image one
+		// because a PXE URL is written into a boot configuration before anything boots from it.
+		defaultPXETTL = 2 * time.Hour
+	)
+
+	t.Run("a token replaces the userinfo", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+		issuer := newIssuer(token, nil)
+
+		before := time.Now()
+
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		require.NoError(t, err)
+
+		require.Equal(t, primaryPXEURL+"/pxe/"+schematicID+"/v1.13.0/metal-amd64?token="+url.QueryEscape(token), media.URL)
+		require.Empty(t, media.Headers, "PXE firmware cannot send a header")
+		require.NotContains(t, media.URL, "hunter2", "the credential must not travel alongside the token")
+
+		require.Equal(t, []time.Duration{defaultPXETTL}, issuer.calls())
+		require.WithinRange(t, media.ExpiresAt, before.Add(defaultPXETTL), time.Now().Add(defaultPXETTL))
+	})
+
+	t.Run("a requested lifetime overrides the PXE default", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+		issuer := newIssuer(token, nil)
+
+		_, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false, withIssuer(t, st, issuer, 30*time.Minute))
+		require.NoError(t, err)
+
+		require.Equal(t, []time.Duration{30 * time.Minute}, issuer.calls())
+	})
+
+	t.Run("a factory that issues no token falls back to credentials", func(t *testing.T) {
+		t.Parallel()
+
+		st := authenticatedState(ctx, t)
+		issuer := newIssuer("", &client.HTTPError{Code: http.StatusNotFound, Message: "not found"})
+
+		// An image factory below 1.6.0 rejects a token on /pxe/, and one below 1.5.0 or with its own
+		// authentication disabled issues none at all. Both answer 404 here.
+		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
+		require.NoError(t, err)
+
+		require.Equal(t, "https://user:hunter2@pxe.factory.example.org/pxe/"+schematicID+"/v1.13.0/metal-amd64", media.URL)
+		require.Empty(t, media.Headers)
+		require.Zero(t, media.ExpiresAt)
+	})
+}
+
 // TestResolveInstallationMediaDownloadToken covers the authentication a caller gets for a medium under /image/
 // when the factory issues download tokens, and the credential fallback for every factory that does not.
 func TestResolveInstallationMediaDownloadToken(t *testing.T) {
@@ -953,7 +1017,7 @@ func TestResolveInstallationMediaDownloadToken(t *testing.T) {
 		token         = "eyJhbGciOiJFUzI1NiJ9.fake.token"
 		authorization = "Basic dXNlcjpodW50ZXIy" // user:hunter2
 
-		// defaultTTL pins imagefactory's unexported default, which matches the factory's own documented
+		// defaultTTL pins imagefactory's unexported default for an image, which matches the factory's own documented
 		// default. Omni sends it explicitly so that the expiry it reports back is knowable.
 		defaultTTL = 5 * time.Minute
 	)
@@ -985,22 +1049,6 @@ func TestResolveInstallationMediaDownloadToken(t *testing.T) {
 
 		require.Equal(t, primaryURL+mediaPath+"?token="+url.QueryEscape(token), media.URL)
 		require.Empty(t, media.Headers, "a token in the URL leaves nothing for the headers to carry")
-	})
-
-	t.Run("PXE keeps its credentials and never asks for a token", func(t *testing.T) {
-		t.Parallel()
-
-		st := authenticatedState(ctx, t)
-		issuer := newIssuer(token, nil)
-
-		// The factory reads ?token= only under /image/, and its iPXE script propagates basic auth alone, so
-		// a token would authenticate neither the script nor what it boots.
-		media, err := imagefactory.ResolveInstallationMedia(ctx, st, "1.13.0", pxeSpec(), schematicID, false, withIssuer(t, st, issuer, 0))
-		require.NoError(t, err)
-
-		require.Equal(t, "https://user:hunter2@pxe.factory.example.org/pxe/"+schematicID+"/v1.13.0/metal-amd64", media.URL)
-		require.Empty(t, issuer.calls(), "a token that cannot be used must not be requested")
-		require.Zero(t, media.ExpiresAt)
 	})
 
 	t.Run("an anonymous factory never asks for a token", func(t *testing.T) {

--- a/client/pkg/infra/infra_test.go
+++ b/client/pkg/infra/infra_test.go
@@ -574,7 +574,8 @@ func TestProvisionStepImageFactory(t *testing.T) {
 		media.disk.Headers.Get("Authorization"))
 	require.NotContains(t, media.disk.URL, testFactoryPassword)
 
-	// PXE firmware cannot send headers, so those credentials have to ride in the URL instead.
+	// No factory client is wired here, so no download token is requested, and PXE firmware cannot send
+	// headers, so the credentials ride in the URL instead.
 	require.Contains(t, media.pxe.URL,
 		"https://"+testFactoryUsername+":"+testFactoryPassword+"@pxe.factory.example.org/pxe/")
 	require.Contains(t, media.pxe.URL, "/v1.13.0/metal-amd64")

--- a/client/pkg/omnictl/internal/download/download.go
+++ b/client/pkg/omnictl/internal/download/download.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/cosi-project/runtime/pkg/safe"
@@ -626,11 +627,17 @@ func resolveInstallationMedia(
 		headers.Set(name, value)
 	}
 
-	return imagefactory.InstallationMedia{
+	media := imagefactory.InstallationMedia{
 		URL:              resp.Url,
 		Headers:          headers,
 		ImageFactoryHost: resp.ImageFactoryHost,
-	}, nil
+	}
+
+	if resp.ExpiresAt != nil {
+		media.ExpiresAt = resp.ExpiresAt.AsTime()
+	}
+
+	return media, nil
 }
 
 // DownloadImageTo downloads an installation media image and saves it to the output path.
@@ -661,6 +668,11 @@ func DownloadImageTo(ctx context.Context, client *client.Client, image ImageInfo
 	fmt.Fprintf(os.Stderr, "Using image factory at %q\n", media.ImageFactoryHost)
 
 	if params.PXE {
+		if !media.ExpiresAt.IsZero() {
+			fmt.Fprintf(os.Stderr, "This URL is authenticated with a token expiring at %s. Run this again for a fresh one.\n",
+				media.ExpiresAt.Format(time.RFC3339))
+		}
+
 		fmt.Println(media.URL)
 
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/siderolabs/go-retry v0.3.3
 	github.com/siderolabs/go-talos-support v0.3.1
 	github.com/siderolabs/grpc-proxy v0.5.2
-	github.com/siderolabs/image-factory v1.5.1
+	github.com/siderolabs/image-factory v1.6.0
 	github.com/siderolabs/kms-client v0.2.0
 	github.com/siderolabs/omni/client v1.9.3
 	github.com/siderolabs/proto-codec v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,8 @@ github.com/siderolabs/go-talos-support v0.3.1 h1:2cIct5nxGby8B7NNALO5WL3WbCe9S1s
 github.com/siderolabs/go-talos-support v0.3.1/go.mod h1:3fljgD3YQGB2+nJfWLLt482/C8epdqge70fWH+VtuiU=
 github.com/siderolabs/grpc-proxy v0.5.2 h1:o34tS02IxbX3qeXe0MM99zE2XhfWHuvdBtSWWRD9HNI=
 github.com/siderolabs/grpc-proxy v0.5.2/go.mod h1:ygf+gqFxWdymAXuP4qMHTa+j6SvasdcFg3XkhpvUvDw=
-github.com/siderolabs/image-factory v1.5.1 h1:VYz9CQcFuzD2of6tw1YCIiNdchPawKFVptT1q4skD/Y=
-github.com/siderolabs/image-factory v1.5.1/go.mod h1:usi+gZen80PnprOrlF9S85wwpqehG48fsWSDjMverMs=
+github.com/siderolabs/image-factory v1.6.0 h1:nzx28i+g24kTUiD8O6MfSYahQRYuuaunqJZNHdln3Rg=
+github.com/siderolabs/image-factory v1.6.0/go.mod h1:EA4pVNZOH8BvtvywCYcfOtItWd1adXPUuk3d/rUALpQ=
 github.com/siderolabs/kms-client v0.2.0 h1:8RniCStUI75RTZO8qkhHOSVOnEU1AvvsKqJ7FqW/8NA=
 github.com/siderolabs/kms-client v0.2.0/go.mod h1:qq6dwcLPO0gaUyfkrhWi/37g/ZyZJzOHzvHrilLz48E=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -11,19 +11,19 @@ previous = "v1.9.0"
 [notes.infra-provider-installation-media]
 title = "Infrastructure Providers Use the Image Factory Omni Is Configured With"
 description = """\
-Infrastructure providers used to reach the image factory themselves, at the hardcoded public URL, so an on-prem or authenticated factory was out of \
-reach, and every provider carried its own copy of the factory's URL layout and file naming. A provision step now states which medium it wants by kind, \
-platform, architecture and format through Context.EnsureInstallationMedia. Omni creates the schematic, picks the factory that serves the machine's \
-Talos version, works out the filename including the secure boot variant, and answers with a URL and whatever headers the fetch has to carry. A provider \
-that cannot attach a header, because PXE firmware or a hypervisor download API performs the fetch, asks for a self-contained URL instead. Carrying this \
-through the Omni client library for infrastructure providers meant breaking changes, so a provider has to be updated to the new API, and once it is, it \
-needs Omni 1.8 or newer.
+Every infrastructure provider reached the image factory itself, so an on-prem or authenticated one had to be configured provider by provider, each \
+with its own copy of the factory's URL layout. A provision step now states which medium it wants through Context.EnsureInstallationMedia, and Omni \
+creates the schematic, picks the factory for that Talos version, works out the filename, and answers with a URL and any headers.
 
-Image downloads are now authenticated with a short-lived download token issued by the factory rather than with the factory credentials, so a provider \
-receives something that expires and that only downloads, instead of a credential valid on every factory route until someone rotates it. A provision \
-step that hands the URL to something else, such as a hypervisor import queue that starts later, asks for the lifetime it needs and is told when the \
-URL stops working. A factory that does not issue tokens keeps working unchanged, and so does PXE: the factory accepts a token only on image downloads, \
-and the iPXE script it serves passes on the credentials it was fetched with, so a PXE script still carries them. Two things change for provider authors. \
-A URL is no longer stable for a given medium, since each one carries a fresh token, so compare the storage key rather than the URL when deciding \
-whether something has already been fetched. And a URL now expires, so fetch it promptly or ask for a lifetime that covers the delay.
+A provider on the new API needs at least Omni 1.8, where schematic creation moved into Omni, and locates the medium itself if the server cannot.
+"""
+
+[notes.installation-media-download-tokens]
+title = "Installation Media Downloads Use Short-Lived Tokens"
+description = """\
+Starting with version 1.6, an Image Factory Enterprise with authentication enabled can issue download tokens, which Omni now uses for every \
+installation media download, PXE included, so the URL it hands out is short-lived. A community or unauthenticated factory is unaffected.
+
+Each URL also carries a fresh token, so it is never the same twice. Infrastructure providers should compare the storage key rather than the URL when \
+deciding whether something has already been fetched, and ask for a lifetime covering any delay.
 """

--- a/internal/backend/grpc/schematics_test.go
+++ b/internal/backend/grpc/schematics_test.go
@@ -621,8 +621,11 @@ func (suite *GrpcSuite) TestMediaToken() {
 		schematicID = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
 	)
 
+	const pxeBaseURL = "https://pxe.factory.example.org"
+
 	features := omni.NewFeaturesConfig(omni.FeaturesConfigID)
 	features.TypedSpec().Value.ImageFactoryBaseUrl = suite.imageFactory.address
+	features.TypedSpec().Value.ImageFactoryPxeBaseUrl = pxeBaseURL
 
 	suite.Require().NoError(suite.state.Create(ctx, features))
 
@@ -699,6 +702,48 @@ func (suite *GrpcSuite) TestMediaToken() {
 
 		suite.Require().Equal(suite.imageFactory.address+assetPath+"?token="+url.QueryEscape(token), resp.Url)
 		suite.Require().NotContains(resp.Url, "hunter2", "the credential must not travel alongside the token")
+	})
+
+	suite.Run("a PXE script carries the token too", func() {
+		// The factory forwards it into the kernel and initramfs URLs of the script it serves, so the token
+		// authenticates the whole boot and the credentials never leave Omni.
+		suite.imageFactory.setDownloadToken(issuesToken)
+
+		request := newRequest()
+		request.InstallationMediaKind = management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_PXE
+		request.Platform = "metal"
+		request.Format = ""
+
+		resp, err := client.GetInstallationMediaURL(ctx, request)
+		suite.Require().NoError(err)
+
+		suite.Require().Equal(pxeBaseURL+"/pxe/"+schematicID+"/v1.13.0/metal-amd64?token="+url.QueryEscape(token), resp.Url)
+		suite.Require().Empty(resp.Headers, "PXE firmware cannot send a header")
+		suite.Require().NotContains(resp.Url, testFactoryPassword, "the credential must not travel alongside the token")
+
+		// A PXE URL is written into a boot configuration before anything boots from it, so its default
+		// lifetime is longer than the one an image download gets.
+		suite.Require().Equal([]string{"2h0m0s"}, suite.imageFactory.downloadTokenTTLs())
+		suite.Require().NotNil(resp.ExpiresAt)
+	})
+
+	suite.Run("a PXE script falls back to credentials when the factory issues no token", func() {
+		// An image factory below 1.6.0 rejects a token on /pxe/, and one below 1.5.0 or with its own
+		// authentication disabled issues none at all. Both answer 404 here.
+		suite.imageFactory.setDownloadToken(nil)
+
+		request := newRequest()
+		request.InstallationMediaKind = management.InstallationMediaURLRequest_INSTALLATION_MEDIA_KIND_PXE
+		request.Platform = "metal"
+		request.Format = ""
+
+		resp, err := client.GetInstallationMediaURL(ctx, request)
+		suite.Require().NoError(err)
+
+		suite.Require().Equal("https://"+testFactoryUsername+":"+testFactoryPassword+"@pxe.factory.example.org/pxe/"+
+			schematicID+"/v1.13.0/metal-amd64", resp.Url)
+		suite.Require().Empty(resp.Headers)
+		suite.Require().Nil(resp.ExpiresAt)
 	})
 
 	suite.Run("a refused lifetime is InvalidArgument", func() {


### PR DESCRIPTION
Omni had to embed its image factory credentials in every PXE URL, because the factory accepted a download token only on image downloads and the iPXE script it served copied whatever basic auth fetched it into the kernel and initramfs URLs. Image factory 1.6.0 forwards a token into those URLs instead, so the credential stays inside Omni.

PXE gets a two hour default token lifetime rather than the five minutes an image download gets, since someone has to write the URL into a boot configuration before anything boots from it. There is deliberately no factory version check, so an authenticated factory below 1.6.0 rejects a token on its PXE endpoint and has to be upgraded.

Related: #3109
