### PR TITLE
fix: retry a rejected bootstrap request at the next check

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/cluster/bootstrap_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster/bootstrap_status.go
@@ -283,6 +283,17 @@ func (ctrl *BootstrapStatusController) bootstrapCluster(
 	if err = talosCli.Bootstrap(ctx, &machine.BootstrapRequest{
 		RecoverEtcd: recoverEtcd,
 	}); err != nil {
+		// The node rejected the request without starting anything, e.g. because it is still coming up. A rejected
+		// request leaves nothing running on the node, so there is nothing to protect: forget the attempt and send
+		// another one at the next check instead of waiting out the retry interval.
+		if status.Code(err) == codes.FailedPrecondition {
+			logger.Info("the node is not ready to be bootstrapped yet", zap.String("cluster_id", clusterID), zap.Error(err))
+
+			bootstrapStatus.TypedSpec().Value.LastBootstrapAttempt = lastAttempt
+
+			return controller.NewRequeueInterval(bootstrapCheckInterval)
+		}
+
 		// The node already has etcd data, e.g. from a bootstrap that was not confirmed yet: there is nothing to
 		// send, keep checking etcd instead.
 		if status.Code(err) == codes.AlreadyExists {

--- a/internal/backend/runtime/omni/controllers/omni/cluster/bootstrap_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster/bootstrap_status_test.go
@@ -184,6 +184,45 @@ func TestBootstrapAlreadyExists(t *testing.T) {
 	})
 }
 
+// TestBootstrapRejectedRetriesSoon checks that a request the node rejected without starting anything is retried at
+// the next check, instead of being held back by the retry interval which only protects a request that might still be
+// running on the node. A node rejects a bootstrap this way while it is still coming up, which is an ordinary race
+// during cluster creation.
+func TestBootstrapRejectedRetriesSoon(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	withBootstrapController(ctx, t, func(ctx context.Context, tc testutils.TestContext, ms *testutils.MachineServiceMock) {
+		ms.SetEtcdRunning(false)
+
+		ms.SetBootstrapHandler(func(context.Context, *machine.BootstrapRequest) (*machine.BootstrapResponse, error) {
+			// the node is not ready to be bootstrapped when the first request arrives
+			if len(ms.GetBootstrapRequests()) == 1 {
+				return nil, status.Error(codes.FailedPrecondition, "bootstrap is not available yet")
+			}
+
+			return &machine.BootstrapResponse{}, nil
+		})
+
+		clusterName := createCluster(ctx, t, tc.State, ms.SocketConnectionString)
+
+		// a rejected request is not recorded as an attempt, so the attempt time showing up means the retry landed
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.NotNil(r.TypedSpec().Value.LastBootstrapAttempt)
+		})
+
+		require.Len(t, ms.GetBootstrapRequests(), 2, "the rejected request must be retried")
+
+		ms.SetEtcdRunning(true)
+
+		rtestutils.AssertResources(ctx, t, tc.State, []string{clusterName}, func(r *omni.ClusterBootstrapStatus, assertion *assert.Assertions) {
+			assertion.True(r.TypedSpec().Value.Bootstrapped)
+		})
+	})
+}
+
 // TestBootstrapErrorSavesAttempt checks that a bootstrap request which fails with an error is still counted as sent,
 // as the node might have accepted it, so it is not re-sent right away.
 func TestBootstrapErrorSavesAttempt(t *testing.T) {


### PR DESCRIPTION
Omni records the time of a bootstrap request before sending it, and does not send another one for several minutes, so that a request which might still be running on the node, such as one whose call timed out, is not interrupted. That wait was also applied to requests the node rejected outright. A node rejects a bootstrap while it is still coming up, which is an ordinary race during cluster creation, and nothing is started on the node when that happens. Cluster creation then appeared stuck until the wait was over.

Send another request at the next check when the node rejected the previous one, as there is nothing running on the node to protect in that case. Requests that might have been accepted despite a failed call keep the longer wait.

Related to siderolabs/omni#3300.