### PR TITLE
fix: remove documents dropped from config patches in maintenance mode

### DIFF
--- a/client/pkg/siderolink/siderolink.go
+++ b/client/pkg/siderolink/siderolink.go
@@ -275,7 +275,7 @@ func (opts *JoinOptions) JoinConfigDocuments() ([]config.Document, error) {
 
 	if opts.logServerURL != nil {
 		kmsgLogConfig := runtime.NewKmsgLogV1Alpha1()
-		kmsgLogConfig.MetaName = "omni-kmsg"
+		kmsgLogConfig.MetaName = kmsgLogConfigName
 		kmsgLogConfig.KmsgLogURL = meta.URL{
 			URL: opts.logServerURL,
 		}
@@ -284,6 +284,24 @@ func (opts *JoinOptions) JoinConfigDocuments() ([]config.Document, error) {
 	}
 
 	return docs, nil
+}
+
+// kmsgLogConfigName is the name of the kmsg log document Omni generates, Talos supports multiple kmsg log destinations.
+const kmsgLogConfigName = "omni-kmsg"
+
+// IsJoinConfigDocument reports whether the document is one of the connection documents Omni manages for a machine:
+// the ones JoinConfigDocuments generates, and the SideroLink document which Omni leaves to the machine in maintenance mode.
+func IsJoinConfigDocument(document config.Document) bool {
+	switch document.Kind() {
+	case siderolinkmachinery.Kind, runtime.EventSinkKind:
+		return true
+	case runtime.KmsgLogKind:
+		named, ok := document.(config.NamedDocument)
+
+		return ok && named.Name() == kmsgLogConfigName
+	default:
+		return false
+	}
 }
 
 func encodeToken(options JoinConfigOptions) (string, error) {

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/extraction.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/extraction.go
@@ -19,13 +19,12 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
-	runtimecfg "github.com/siderolabs/talos/pkg/machinery/config/types/runtime"
-	talossiderolink "github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
 	configres "github.com/siderolabs/talos/pkg/machinery/resources/config"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	"github.com/siderolabs/omni/client/pkg/siderolink"
 	"github.com/siderolabs/omni/internal/backend/runtime/talos"
 )
 
@@ -170,7 +169,7 @@ func (ctrl *ExtractionController) BuildConfigPatch(machineID string, observedCon
 	kept := make([]documentconfig.Document, 0, len(documents))
 
 	for _, document := range documents {
-		if ctrl.isConnectionDocument(document) {
+		if siderolink.IsJoinConfigDocument(document) {
 			continue
 		}
 
@@ -206,16 +205,6 @@ func (ctrl *ExtractionController) BuildConfigPatch(machineID string, observedCon
 	configPatch.Metadata().Annotations().Set(omni.ConfigPatchDescription, configPatchDescription)
 
 	return configPatch, "", nil
-}
-
-// isConnectionDocument reports whether the document is one of the Omni-managed connection documents that Omni regenerates itself.
-func (ctrl *ExtractionController) isConnectionDocument(document documentconfig.Document) bool {
-	switch document.Kind() {
-	case talossiderolink.Kind, runtimecfg.EventSinkKind, runtimecfg.KmsgLogKind:
-		return true
-	default:
-		return false
-	}
 }
 
 // NewReader returns a Reader backed by the cached Talos client factory.

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/extraction_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/extraction_test.go
@@ -252,6 +252,44 @@ func TestBuildConfigPatchKeepsNonConnectionDocuments(t *testing.T) {
 	require.NotContains(t, data, "EventSinkConfig")
 }
 
+func TestBuildConfigPatchKeepsMachineKmsgLogDocuments(t *testing.T) {
+	t.Parallel()
+
+	omniKmsg := runtimecfg.NewKmsgLogV1Alpha1()
+	omniKmsg.MetaName = "omni-kmsg"
+	omniKmsg.KmsgLogURL.URL = mustParseURL(t, "tcp://[fdae::1]:8092")
+
+	// Talos supports multiple kmsg log destinations, only the one Omni generates is Omni's
+	machineKmsg := runtimecfg.NewKmsgLogV1Alpha1()
+	machineKmsg.MetaName = "remote-siem"
+	machineKmsg.KmsgLogURL.URL = mustParseURL(t, "tcp://logs.example.org:5000")
+
+	observed := encodeDocuments(t, omniKmsg, machineKmsg)
+
+	patch, reason, err := (&machineconfig.ExtractionController{}).BuildConfigPatch("machine-1", observed)
+	require.NoError(t, err)
+	require.Empty(t, reason)
+	require.NotNil(t, patch)
+
+	buffer, err := patch.TypedSpec().Value.GetUncompressedData()
+	require.NoError(t, err)
+
+	data := string(buffer.Data())
+	buffer.Free()
+
+	require.Contains(t, data, "remote-siem")
+	require.NotContains(t, data, "omni-kmsg")
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return u
+}
+
 // TestBuildConfigPatchKeepsEmbeddedRuntimeDocuments mirrors the config the integration test bakes into a machine's
 // embedded configuration: the three SideroLink connection documents plus an EnvironmentConfig and a StaticHostConfig.
 // It locks in that the connection documents are dropped while the two carrying user data survive into a valid patch,

--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_status.go
@@ -29,6 +29,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
+	siderolinkmachinery "github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
 	configres "github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -320,12 +321,12 @@ func (helper *maintenanceConfigStatusControllerHelper) transform(ctx context.Con
 		return fmt.Errorf("error getting maintenance config: %w", err)
 	}
 
-	var machineConfig config.Provider
-
-	if maintenanceConfig != nil {
-		machineConfig = maintenanceConfig.Provider()
-	} else if machineConfig, err = container.New(); err != nil {
-		return fmt.Errorf("error creating new config container: %w", err)
+	// build the config from scratch instead of patching the machine's current config, so that documents dropped from the patches are removed from the machine.
+	// the machine's own SideroLink document (if any) is the only thing carried over, as Omni does not generate one for the machine in maintenance mode:
+	// the machine is already connected, and its join token and tunnel settings are left as they are.
+	machineConfig, err := container.New(siderolinkDocuments(maintenanceConfig)...)
+	if err != nil {
+		return fmt.Errorf("error creating config container: %w", err)
 	}
 
 	patches, err := configpatcher.LoadPatches(machinePatches)
@@ -334,7 +335,6 @@ func (helper *maintenanceConfigStatusControllerHelper) transform(ctx context.Con
 	}
 
 	// the Omni-managed connection documents are applied last, so they always win over anything in the user patches.
-	// the machine's own SideroLink document (if any) is preserved as-is by the merge, so its connection is never overwritten or broken.
 	patches = append(patches, baseConfig.patch)
 
 	patched, err := configpatcher.Apply(configpatcher.WithConfig(machineConfig), patches)
@@ -429,6 +429,17 @@ func desiredConfigHash(machinePatches []string, baseConfig []byte) string {
 	hash.Write(baseConfig)
 
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// siderolinkDocuments returns the SideroLink documents of the machine's current maintenance config, if any.
+func siderolinkDocuments(maintenanceConfig *configres.MachineConfig) []talosconfig.Document {
+	if maintenanceConfig == nil {
+		return nil
+	}
+
+	return xslices.Filter(maintenanceConfig.Provider().Documents(), func(document talosconfig.Document) bool {
+		return document.Kind() == siderolinkmachinery.Kind
+	})
 }
 
 // stripV1Alpha1 removes the v1alpha1 document (if any) from the config, leaving the partial config documents intact.

--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_status_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/siderolabs/talos/pkg/machinery/api/machine"
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
 	"github.com/siderolabs/talos/pkg/machinery/resources/config"
@@ -347,6 +348,152 @@ certificates: |
 
 	// the v1alpha1 document is stripped
 	suite.NotContains(dataStr, "hostDNS:")
+}
+
+func (suite *MaintenanceConfigStatusControllerSuite) TestMachineConfigPatchDocumentRemoval() {
+	getMachineConfigCh := make(chan *config.MachineConfig)
+	machineIDCh := make(chan string)
+	applyConfigReqCh := make(chan *machine.ApplyConfigurationRequest)
+
+	maintenanceClient := &maintenanceClientMock{
+		getMachineConfigCh: getMachineConfigCh,
+		applyConfigReqCh:   applyConfigReqCh,
+	}
+
+	maintenanceClientFactory := func(ctx context.Context, machineID string) (omni.MaintenanceClient, error) {
+		select {
+		case machineIDCh <- machineID:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+
+		return maintenanceClient, nil
+	}
+
+	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state)
+
+	suite.Require().NoError(suite.runtime.RegisterQController(controller))
+
+	suite.startRuntime()
+
+	const (
+		docA = `apiVersion: v1alpha1
+kind: TrustedRootsConfig
+name: doc-a
+certificates: |
+  -----BEGIN CERTIFICATE-----
+  MIIA
+  -----END CERTIFICATE-----
+`
+		docB = `apiVersion: v1alpha1
+kind: TrustedRootsConfig
+name: doc-b
+certificates: |
+  -----BEGIN CERTIFICATE-----
+  MIIB
+  -----END CERTIFICATE-----
+`
+	)
+
+	patch := omnires.NewConfigPatch("removal-machine-patch")
+	patch.Metadata().Labels().Set(omnires.LabelMachine, "removal-machine")
+	suite.Require().NoError(patch.TypedSpec().Value.SetUncompressedData([]byte(docA + "---\n" + docB)))
+	suite.Require().NoError(suite.state.Create(suite.ctx, patch))
+
+	link := siderolinkres.NewLink("removal-machine", &specs.SiderolinkSpec{})
+	link.TypedSpec().Value.Connected = true
+	link.TypedSpec().Value.NodePublicKey = "removal-machine-key"
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, link))
+
+	machineStatus := omnires.NewMachineStatus("removal-machine")
+	machineStatus.TypedSpec().Value.Maintenance = true
+	machineStatus.TypedSpec().Value.ManagementAddress = "removal-address"
+	machineStatus.TypedSpec().Value.TalosVersion = "1.5.0"
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, machineStatus))
+
+	suite.markConfigExtracted("removal-machine")
+
+	// the machine's own SideroLink document: it is never part of a patch and must survive every reapply
+	u, err := url.Parse("http://example.org")
+	suite.Require().NoError(err)
+
+	siderolinkDoc := siderolink.NewConfigV1Alpha1()
+	siderolinkDoc.APIUrlConfig.URL = u
+
+	// the config the machine currently runs: initially only its SideroLink document, afterwards whatever Omni applied last
+	var applied []byte
+
+	currentMachineConfig := func() *config.MachineConfig {
+		if applied == nil {
+			configContainer, containerErr := container.New(siderolinkDoc)
+			suite.Require().NoError(containerErr)
+
+			return config.NewMachineConfig(configContainer)
+		}
+
+		provider, loadErr := configloader.NewFromBytes(applied)
+		suite.Require().NoError(loadErr)
+
+		return config.NewMachineConfig(provider)
+	}
+
+	reconcile := func() string {
+		select {
+		case <-machineIDCh:
+		case <-suite.ctx.Done():
+			suite.Require().Fail("timeout waiting for maintenance client factory to be called")
+		}
+
+		select {
+		case getMachineConfigCh <- currentMachineConfig():
+		case <-suite.ctx.Done():
+			suite.Require().Fail("timeout waiting for get machine config request")
+		}
+
+		select {
+		case applyConfigReq := <-applyConfigReqCh:
+			applied = applyConfigReq.Data
+		case <-suite.ctx.Done():
+			suite.Require().Fail("timeout waiting for apply configuration request")
+		}
+
+		return string(applied)
+	}
+
+	dataStr := reconcile()
+
+	suite.Contains(dataStr, "name: doc-a")
+	suite.Contains(dataStr, "name: doc-b")
+	suite.Contains(dataStr, "kind: SideroLinkConfig")
+	suite.Contains(dataStr, "http://example.org")
+	suite.Contains(dataStr, "omni-kmsg")
+
+	// drop a document from the patch: it must leave the machine
+	_, err = safe.StateUpdateWithConflicts(suite.ctx, suite.state, patch.Metadata(), func(res *omnires.ConfigPatch) error {
+		return res.TypedSpec().Value.SetUncompressedData([]byte(docA))
+	})
+	suite.Require().NoError(err)
+
+	dataStr = reconcile()
+
+	suite.Contains(dataStr, "name: doc-a")
+	suite.NotContains(dataStr, "name: doc-b")
+	suite.Contains(dataStr, "kind: SideroLinkConfig")
+	suite.Contains(dataStr, "http://example.org")
+	suite.Contains(dataStr, "omni-kmsg")
+
+	// delete the patch: only the machine's SideroLink document and the Omni-managed connection documents remain
+	suite.Require().NoError(suite.state.Destroy(suite.ctx, patch.Metadata()))
+
+	dataStr = reconcile()
+
+	suite.NotContains(dataStr, "name: doc-a")
+	suite.NotContains(dataStr, "name: doc-b")
+	suite.Contains(dataStr, "kind: SideroLinkConfig")
+	suite.Contains(dataStr, "http://example.org")
+	suite.Contains(dataStr, "omni-kmsg")
 }
 
 func TestMaintenanceConfigStatusControllerSuite(t *testing.T) {


### PR DESCRIPTION
In maintenance mode, Omni applied the machine config patches on top of the config already running on the machine. A strategic merge only adds and updates documents. Because of this, a document removed from a patch, or a deleted patch, stayed on the machine until its next reboot, while Omni recorded the new config as applied.

We now build the maintenance config from scratch: the machine config patches and the Omni-managed connection documents are applied on an empty config. This way, a document that is no more in the patches is removed from the machine.

The only document carried over from the machine's current config is its own SideroLink document. Omni does not generate this document for the machine in maintenance mode, as the machine is already connected with its own join token and tunnel settings.

Patching on top of the current config used to be the only way to keep the config a machine arrived with. This config is now preserved as a user-owned config patch, so a patch the user edits or deletes has to actually take effect.

Additionally, move the check for the Omni-managed connection documents next to the code that generates them, so that the two cannot drift apart. While at it, only the kmsg log document Omni generates counts as Omni-managed. Talos supports multiple kmsg log destinations, and the ones a machine arrives with are now preserved like any other document instead of being dropped.