### PR TITLE
feat: use the Linux view of CPU cores and report machines by core count

### DIFF
--- a/client/pkg/omni/resources/omni/machine_status.go
+++ b/client/pkg/omni/resources/omni/machine_status.go
@@ -148,7 +148,7 @@ func ReconcileMachineStatusLabels(machineStatus *MachineStatus) {
 		switch {
 		case strings.Contains(cpuManufacturer, "intel"):
 			return "intel"
-		case strings.Contains(cpuManufacturer, "amd"):
+		case strings.Contains(cpuManufacturer, "amd"), strings.Contains(cpuManufacturer, "advanced micro devices"):
 			return "amd"
 		default:
 			return cpuManufacturer

--- a/client/pkg/omni/resources/omni/machine_status.go
+++ b/client/pkg/omni/resources/omni/machine_status.go
@@ -146,9 +146,9 @@ func ReconcileMachineStatusLabels(machineStatus *MachineStatus) {
 		cpuManufacturer = strings.ToLower(strings.TrimSpace(cpuManufacturer))
 
 		switch {
-		case strings.HasPrefix(cpuManufacturer, "intel"):
+		case strings.Contains(cpuManufacturer, "intel"):
 			return "intel"
-		case strings.HasPrefix(cpuManufacturer, "amd"):
+		case strings.Contains(cpuManufacturer, "amd"):
 			return "amd"
 		default:
 			return cpuManufacturer

--- a/client/pkg/omni/resources/omni/machine_status_test.go
+++ b/client/pkg/omni/resources/omni/machine_status_test.go
@@ -131,6 +131,40 @@ func TestReconcileMachineStatusLabels(t *testing.T) {
 			},
 		},
 		{
+			name: "linux intel vendor",
+			spec: &specs.MachineStatusSpec{
+				Hardware: &specs.MachineStatusSpec_HardwareStatus{
+					Processors: []*specs.MachineStatusSpec_HardwareStatus_Processor{
+						{
+							Manufacturer: "GenuineIntel",
+							CoreCount:    4,
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				omni.MachineStatusLabelCores: "4",
+				omni.MachineStatusLabelCPU:   "intel",
+			},
+		},
+		{
+			name: "linux amd vendor",
+			spec: &specs.MachineStatusSpec{
+				Hardware: &specs.MachineStatusSpec_HardwareStatus{
+					Processors: []*specs.MachineStatusSpec_HardwareStatus_Processor{
+						{
+							Manufacturer: "AuthenticAMD",
+							CoreCount:    8,
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				omni.MachineStatusLabelCores: "8",
+				omni.MachineStatusLabelCPU:   "amd",
+			},
+		},
+		{
 			name: "enterprise with fips",
 			spec: &specs.MachineStatusSpec{
 				TalosVersionName: "Talos Enterprise",

--- a/client/pkg/omni/resources/omni/machine_status_test.go
+++ b/client/pkg/omni/resources/omni/machine_status_test.go
@@ -165,6 +165,23 @@ func TestReconcileMachineStatusLabels(t *testing.T) {
 			},
 		},
 		{
+			name: "smbios amd vendor",
+			spec: &specs.MachineStatusSpec{
+				Hardware: &specs.MachineStatusSpec_HardwareStatus{
+					Processors: []*specs.MachineStatusSpec_HardwareStatus_Processor{
+						{
+							Manufacturer: "Advanced Micro Devices, Inc.",
+							CoreCount:    16,
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				omni.MachineStatusLabelCores: "16",
+				omni.MachineStatusLabelCPU:   "amd",
+			},
+		},
+		{
 			name: "enterprise with fips",
 			spec: &specs.MachineStatusSpec{
 				TalosVersionName: "Talos Enterprise",

--- a/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/index.vue
+++ b/frontend/src/pages/(authenticated)/clusters/[cluster]/machine/[machine]/index.vue
@@ -161,7 +161,8 @@ const getCPUInfo = () => {
   const cpus: Record<string, number> = {}
 
   for (const processor of processors) {
-    const id = `${processor.frequency! / 1000} GHz ${processor.manufacturer}, ${processor.core_count} Cores`
+    const frequency = processor.frequency ? `${processor.frequency / 1000} GHz ` : ''
+    const id = `${frequency}${processor.manufacturer}, ${processor.core_count} Cores`
 
     cpus[id] = (cpus[id] ?? 0) + 1
   }

--- a/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
@@ -414,7 +414,7 @@ const onSavePatchConfig = (config: string) => {
         <div>
           <div v-for="(processor, index) in item?.spec?.hardware?.processors" :key="index">
             <template v-if="processor.frequency">{{ processor.frequency / 1000 }} GHz,</template>
-            {{ processor.core_count }} {{ pluralize('core', processor.core_count) }},
+            {{ pluralize('core', processor.core_count, true) }},
             {{ processor.description }}
           </div>
         </div>

--- a/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
+++ b/frontend/src/views/Clusters/Management/ClusterMachineItem.vue
@@ -413,8 +413,9 @@ const onSavePatchConfig = (config: string) => {
         <div class="mt-4 mb-2">Network Interfaces</div>
         <div>
           <div v-for="(processor, index) in item?.spec?.hardware?.processors" :key="index">
-            {{ (processor.frequency ?? 0) / 1000 }} GHz, {{ processor.core_count }}
-            {{ pluralize('core', processor.core_count) }}, {{ processor.description }}
+            <template v-if="processor.frequency">{{ processor.frequency / 1000 }} GHz,</template>
+            {{ processor.core_count }} {{ pluralize('core', processor.core_count) }},
+            {{ processor.description }}
           </div>
         </div>
         <div>

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/export_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/export_test.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package machine
+
+var PollCPUCores = pollCPUCores

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/machine.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/machine.go
@@ -244,6 +244,9 @@ func (spec CollectTaskSpec) RunTask(ctx context.Context, logger *zap.Logger, not
 		hardware.ProcessorType: {
 			namespace: hardware.NamespaceName,
 		},
+		hardware.CPUCoreType: {
+			namespace: hardware.NamespaceName,
+		},
 		hardware.MemoryModuleType: {
 			namespace: hardware.NamespaceName,
 		},
@@ -296,6 +299,11 @@ func (spec CollectTaskSpec) RunTask(ctx context.Context, logger *zap.Logger, not
 	}
 
 	skipPollers := map[string]struct{}{}
+
+	// the Linux kernel view of the CPUs is more accurate than the SMBIOS one, prefer it when Talos provides it
+	if _, ok := registeredTypes[hardware.CPUCoreType]; ok {
+		skipPollers[hardware.ProcessorType] = struct{}{}
+	}
 
 	if quirks.New(pointer.SafeDeref(info.TalosVersion)).SkipDataPartitions() {
 		skipPollers["disks"] = struct{}{}

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll.go
@@ -41,6 +41,7 @@ var resourcePollers = map[string]machinePollFunction{
 	network.NodeAddressType:      pollAddresses,
 	network.LinkStatusType:       pollNetworkLinks,
 	hardware.ProcessorType:       pollProcessors,
+	hardware.CPUCoreType:         pollCPUCores,
 	hardware.MemoryModuleType:    pollMemory,
 	runtime.PlatformMetadataType: pollPlatformMetadata,
 	runtime.MetaKeyType:          pollMeta,
@@ -272,6 +273,59 @@ func pollProcessors(ctx context.Context, c *client.Client, info *Info) error {
 			return nil
 		},
 	)
+}
+
+// pollCPUCores builds the processor list from the Linux kernel view of the CPUs, which is more accurate than SMBIOS and follows CPU hotplug.
+//
+// Talos produces one resource per physical core, so the cores are aggregated back into one entry per socket.
+// The SMBIOS data still names the populated sockets, as the kernel view has no vendor or model on arm64 and never knows the rated clock speed.
+func pollCPUCores(ctx context.Context, c *client.Client, info *Info) error {
+	if err := pollProcessors(ctx, c, info); err != nil {
+		return err
+	}
+
+	populated := xslices.Filter(info.Processors, func(p *specs.MachineStatusSpec_HardwareStatus_Processor) bool { return p.CoreCount > 0 })
+
+	info.Processors = nil
+
+	sockets := map[string]*specs.MachineStatusSpec_HardwareStatus_Processor{}
+
+	if err := forEachResource(
+		ctx,
+		c,
+		hardware.NamespaceName,
+		hardware.CPUCoreType,
+		func(r *hardware.CPUCore) error {
+			processor, ok := sockets[r.TypedSpec().Socket]
+			if !ok {
+				processor = &specs.MachineStatusSpec_HardwareStatus_Processor{
+					Manufacturer: r.TypedSpec().VendorID,
+					Description:  r.TypedSpec().ModelName,
+				}
+
+				sockets[r.TypedSpec().Socket] = processor
+
+				info.Processors = append(info.Processors, processor)
+			}
+
+			processor.CoreCount++
+			processor.ThreadCount += uint32(len(r.TypedSpec().LogicalCPUs))
+
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+
+	for i, processor := range info.Processors {
+		if i < len(populated) {
+			processor.Manufacturer = populated[i].Manufacturer
+			processor.Description = populated[i].Description
+			processor.Frequency = populated[i].Frequency
+		}
+	}
+
+	return nil
 }
 
 func pollMemory(ctx context.Context, c *client.Client, info *Info) error {

--- a/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/internal/task/machine/poll_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package machine_test
+
+import (
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/siderolabs/talos/pkg/machinery/client"
+	"github.com/siderolabs/talos/pkg/machinery/resources/hardware"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/task/machine"
+)
+
+func cpuCore(id, socket, vendor, model string, logicalCPUs ...uint32) *hardware.CPUCore {
+	core := hardware.NewCPUCore(id)
+	core.TypedSpec().Socket = socket
+	core.TypedSpec().VendorID = vendor
+	core.TypedSpec().ModelName = model
+	core.TypedSpec().LogicalCPUs = logicalCPUs
+
+	return core
+}
+
+func smbiosProcessor(id, manufacturer, product string, cores, threads, speed uint32) *hardware.Processor {
+	processor := hardware.NewProcessorInfo(id)
+	processor.TypedSpec().Manufacturer = manufacturer
+	processor.TypedSpec().ProductName = product
+	processor.TypedSpec().CoreCount = cores
+	processor.TypedSpec().ThreadCount = threads
+	processor.TypedSpec().MaxSpeed = speed
+
+	return processor
+}
+
+func TestPollCPUCores(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		resources []resource.Resource
+		want      []*specs.MachineStatusSpec_HardwareStatus_Processor
+	}{
+		{
+			name: "single socket named by smbios",
+			resources: []resource.Resource{
+				cpuCore("0-0", "0", "GenuineIntel", "Intel(R) Xeon(R) CPU", 0, 2),
+				cpuCore("0-1", "0", "GenuineIntel", "Intel(R) Xeon(R) CPU", 1, 3),
+				smbiosProcessor("CPU-0", "Intel", "Xeon", 2, 4, 2400),
+			},
+			want: []*specs.MachineStatusSpec_HardwareStatus_Processor{
+				{CoreCount: 2, ThreadCount: 4, Frequency: 2400, Manufacturer: "Intel", Description: "Intel Xeon"},
+			},
+		},
+		{
+			name: "two sockets",
+			resources: []resource.Resource{
+				cpuCore("0-0", "0", "AuthenticAMD", "AMD EPYC", 0),
+				cpuCore("0-1", "0", "AuthenticAMD", "AMD EPYC", 1),
+				cpuCore("1-0", "1", "AuthenticAMD", "AMD EPYC", 2),
+				smbiosProcessor("CPU-0", "AMD", "EPYC", 2, 2, 3000),
+				smbiosProcessor("CPU-1", "AMD", "EPYC", 2, 2, 3000),
+			},
+			want: []*specs.MachineStatusSpec_HardwareStatus_Processor{
+				{CoreCount: 2, ThreadCount: 2, Frequency: 3000, Manufacturer: "AMD", Description: "AMD EPYC"},
+				{CoreCount: 1, ThreadCount: 1, Frequency: 3000, Manufacturer: "AMD", Description: "AMD EPYC"},
+			},
+		},
+		{
+			name: "no smbios keeps the kernel identity",
+			resources: []resource.Resource{
+				cpuCore("0-0", "0", "GenuineIntel", "Intel(R) Xeon(R) CPU", 0, 1),
+			},
+			want: []*specs.MachineStatusSpec_HardwareStatus_Processor{
+				{CoreCount: 1, ThreadCount: 2, Manufacturer: "GenuineIntel", Description: "Intel(R) Xeon(R) CPU"},
+			},
+		},
+		{
+			name: "arm64 without socket or vendor info",
+			resources: []resource.Resource{
+				cpuCore("0", "", "", "", 0),
+				cpuCore("1", "", "", "", 1),
+				cpuCore("2", "", "", "", 2),
+				smbiosProcessor("CPU-0", "QEMU", "virt-11.1", 3, 3, 2000),
+			},
+			want: []*specs.MachineStatusSpec_HardwareStatus_Processor{
+				{CoreCount: 3, ThreadCount: 3, Frequency: 2000, Manufacturer: "QEMU", Description: "QEMU virt-11.1"},
+			},
+		},
+		{
+			name: "empty smbios socket does not name the populated one",
+			resources: []resource.Resource{
+				cpuCore("1-0", "1", "GenuineIntel", "Intel(R) Xeon(R) CPU", 0, 1),
+				smbiosProcessor("CPU-0", "", "", 0, 0, 4000),
+				smbiosProcessor("CPU-1", "Intel", "Xeon", 1, 2, 2400),
+			},
+			want: []*specs.MachineStatusSpec_HardwareStatus_Processor{
+				{CoreCount: 1, ThreadCount: 2, Frequency: 2400, Manufacturer: "Intel", Description: "Intel Xeon"},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			st := state.WrapCore(namespaced.NewState(inmem.Build))
+
+			for _, r := range test.resources {
+				require.NoError(t, st.Create(t.Context(), r))
+			}
+
+			var info machine.Info
+
+			require.NoError(t, machine.PollCPUCores(t.Context(), &client.Client{COSI: st}, &info))
+			require.Equal(t, test.want, info.Processors)
+		})
+	}
+}

--- a/internal/backend/runtime/omni/controllers/omni/metrics/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/metrics/machine_status.go
@@ -74,6 +74,7 @@ func NewMachineStatusMetricsController(maxRegisteredMachines uint32) *MachineSta
 type MachineStatusMetricsController struct {
 	versionsMu  sync.Mutex
 	versionsMap map[nodeInfo]int32
+	coresMap    map[uint32]int32
 
 	metricsOnce sync.Once
 
@@ -88,6 +89,7 @@ type MachineStatusMetricsController struct {
 	metricNumCores                                       prometheus.Gauge
 	metricNumTalosVersionEndOfSupportMachines            prometheus.Gauge
 	metricNumMachinesPerVersion                          *prometheus.Desc
+	metricNumMachinesPerCores                            *prometheus.Desc
 	metricMachinePlatforms                               *prometheus.GaugeVec
 	metricMachineSecureBootStatus                        *prometheus.GaugeVec
 	metricMachineUKIStatus                               *prometheus.GaugeVec
@@ -164,6 +166,13 @@ func (ctrl *MachineStatusMetricsController) initMetrics() {
 			"omni_machines_version",
 			"Number of machines in the instance by version.",
 			[]string{"talos_version", "cluster", "connected"},
+			nil,
+		)
+
+		ctrl.metricNumMachinesPerCores = prometheus.NewDesc(
+			"omni_machine_cores",
+			"Number of machines in the instance by CPU core count.",
+			[]string{"cores"},
 			nil,
 		)
 
@@ -372,6 +381,7 @@ func (ctrl *MachineStatusMetricsController) gatherMetrics(statuses iter.Seq[*omn
 
 	ctrl.versionsMu.Lock()
 	ctrl.versionsMap = map[nodeInfo]int32{}
+	ctrl.coresMap = map[uint32]int32{}
 
 	for ms := range statuses {
 		machines++
@@ -414,9 +424,14 @@ func (ctrl *MachineStatusMetricsController) gatherMetrics(statuses iter.Seq[*omn
 			platformMetrics[platform]++
 		}
 
+		var machineCores uint32
+
 		for _, proc := range ms.TypedSpec().Value.GetHardware().GetProcessors() {
-			cores += uint64(proc.GetCoreCount())
+			machineCores += proc.GetCoreCount()
 		}
+
+		cores += uint64(machineCores)
+		ctrl.coresMap[machineCores]++
 
 		securityState := ms.TypedSpec().Value.SecurityState
 		if securityState != nil {
@@ -480,6 +495,10 @@ func (ctrl *MachineStatusMetricsController) Collect(ch chan<- prometheus.Metric)
 
 	for info, count := range ctrl.versionsMap {
 		ch <- prometheus.MustNewConstMetric(ctrl.metricNumMachinesPerVersion, prometheus.GaugeValue, float64(count), info.talosVersion, info.cluster, strconv.FormatBool(info.connected))
+	}
+
+	for machineCores, count := range ctrl.coresMap {
+		ch <- prometheus.MustNewConstMetric(ctrl.metricNumMachinesPerCores, prometheus.GaugeValue, float64(count), strconv.FormatUint(uint64(machineCores), 10))
 	}
 
 	ctrl.versionsMu.Unlock()

--- a/internal/backend/runtime/omni/controllers/omni/metrics/machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/metrics/machine_status_test.go
@@ -213,6 +213,65 @@ func TestMachineStatusMetricsController_CollectMetrics(t *testing.T) {
 	}, names)
 }
 
+func TestMachineStatusMetricsController_MachinesByCores(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	ctrl := metrics.NewMachineStatusMetricsController(0)
+
+	// the vectors gain their label sets only as machines appear, which the pedantic registry does not allow
+	registry := prometheus.NewRegistry()
+	require.NoError(t, registry.Register(ctrl))
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			require.NoError(t, tc.Runtime.RegisterController(ctrl))
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			for id, coreCounts := range map[string][]uint32{
+				"m1": {4},
+				"m2": {2, 2},
+				"m3": {8},
+				"m4": nil,
+			} {
+				ms := omni.NewMachineStatus(id)
+				ms.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{
+					Processors: xslices.Map(coreCounts, func(cores uint32) *specs.MachineStatusSpec_HardwareStatus_Processor {
+						return &specs.MachineStatusSpec_HardwareStatus_Processor{CoreCount: cores}
+					}),
+				}
+
+				require.NoError(t, tc.State.Create(ctx, ms))
+			}
+
+			rtestutils.AssertResource(ctx, t, tc.State, omni.MachineStatusMetricsID, func(res *omni.MachineStatusMetrics, a *assert.Assertions) {
+				a.EqualValues(4, res.TypedSpec().Value.RegisteredMachinesCount)
+				a.EqualValues(16, res.TypedSpec().Value.CoresCount)
+			})
+
+			families, err := registry.Gather()
+			require.NoError(t, err)
+
+			byCores := map[string]float64{}
+
+			for _, family := range families {
+				if family.GetName() != "omni_machine_cores" {
+					continue
+				}
+
+				for _, m := range family.GetMetric() {
+					byCores[m.GetLabel()[0].GetValue()] = m.GetGauge().GetValue()
+				}
+			}
+
+			assert.Equal(t, map[string]float64{"0": 1, "4": 2, "8": 1}, byCores)
+		},
+	)
+}
+
 func TestMachineStatusMetricsController_UnsupportedTalosVersionTeardown(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Talos 1.14 reports the CPU cores the way the Linux kernel sees them, one resource per online core. This is more accurate than the SMBIOS processor table and follows CPU hotplug. Omni now takes the core and thread counts from that view when a machine provides it, and keeps using SMBIOS on older Talos. The count reflects the cores currently available to workloads rather than the installed hardware, so offlined or hot-unplugged cores lower it. The kernel does not know everything about a CPU: on arm64 it has no vendor or model name, and it never knows the rated clock speed. Those fields still come from SMBIOS, so the vendor label, the CPU description and the frequency shown in the UI stay as they were.

The total core count of an instance says nothing about how the cores are distributed across machines. A new metric counts the machines in the instance for each distinct core count, so the distribution of machine sizes can be read off directly and size classes can be derived at query time without Omni having to know their thresholds. Machines whose core count is not known yet are reported under zero cores, so the series always add up to the total number of machines.

Firmware commonly reports the processor manufacturer as "Advanced Micro Devices, Inc.", which the CPU label never mapped to amd, so AMD machines carried the raw vendor string as their label. The label now recognizes that spelling next to the short one and the kernel's vendor identifier.

Closes siderolabs/omni#3224.

The new metric, for an instance with twelve 4-core machines, three 16-core machines and one 64-core machine:

```
omni_machine_cores{cores="4"} 12
omni_machine_cores{cores="16"} 3
omni_machine_cores{cores="64"} 1
```
