### PR TITLE
fix: handle the META keys Talos 1.14 does not allow to write via the API

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -1191,19 +1191,6 @@ func (ctrl *StatusController) reset(
 
 	defer logClose(c, logger, "reset")
 
-	err = c.MetaDelete(ctx, meta.StateEncryptionConfig)
-	if err != nil {
-		//nolint:exhaustive
-		switch status.Code(err) {
-		case
-			codes.NotFound,
-			codes.Unimplemented,
-			codes.FailedPrecondition:
-		default:
-			return fmt.Errorf("failed resetting node '%s': %w", machineID, err)
-		}
-	}
-
 	// if is control plane first leave etcd
 	if isControlPlane && ctrl.ongoingResets.shouldLeaveEtcd(machineID) {
 		ctrl.ongoingResets.handleEtcdLeave(machineID)
@@ -1652,6 +1639,13 @@ func (ctrl *StatusController) deleteUpgradeMetaKey(
 
 		if status.Code(err) == codes.Unimplemented {
 			logger.Debug("upgrade meta key is not removed, unimplemented in the Talos version", zap.String("machine", rc.ID()))
+
+			return nil
+		}
+
+		// Talos 1.14 and later own the key and do not allow deleting it via the API, they drop it themselves once the machine is running and ready
+		if status.Code(err) == codes.PermissionDenied {
+			logger.Debug("upgrade meta key is not removed, not writeable via the API in the Talos version", zap.String("machine", rc.ID()))
 
 			return nil
 		}


### PR DESCRIPTION
Two fixes about the META keys, due to the protection Talos added for the keys it owns in siderolabs/talos#14192. It was merged on 2026-08-31 and released in v1.14.0, so the release candidates were not affected. Writing those keys via the API is rejected now, and Omni was writing two of them:

1. The state encryption config key was deleted before every reset. The rejection made the reset fail, so the machines of a cluster being destroyed were stuck in the destroying state. Remove the deletion, Talos removes the key itself when the STATE partition is wiped, which Omni always requests.

2. The upgrade key is deleted on every reconcile of a booted machine to prevent Talos from rolling an upgrade back on its own. The rejection failed the reconcile before the machine config was applied, so no config change reached a running machine. Tolerate the rejection like a missing key. Talos 1.14 drops the key itself once the machine is running and ready, so Omni can no more prevent the automatic rollback there.