### PR TITLE
fix: make the omni log format of omnictl machine-logs work

### DIFF
--- a/client/pkg/omnictl/logformat/omni.go
+++ b/client/pkg/omnictl/logformat/omni.go
@@ -13,6 +13,9 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/siderolabs/omni/client/internal/safeout"
 )
 
 // NewOmniOutput returns a new OmniOutput.
@@ -31,9 +34,11 @@ type OmniOutput struct {
 func (o *OmniOutput) Run(ctx context.Context) error {
 	var msg talosLogMessage
 
-	var logger zap.Logger
-
-	logger.WithOptions(zap.AddStacktrace(zap.FatalLevel))
+	logger := zap.New(zapcore.NewCore(
+		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+		zapcore.Lock(zapcore.AddSync(safeout.Stdout())),
+		zapcore.DebugLevel,
+	))
 
 	for {
 		if ctx.Err() != nil {
@@ -56,12 +61,14 @@ func (o *OmniOutput) Run(ctx context.Context) error {
 
 		logMsg := logger.Check(level.Level(), msg.Message)
 		if logMsg != nil {
+			// the entry is stamped with the time the machine logged it, not the time it is printed
+			logMsg.Time = msg.TalosTime
+
 			logMsg.Write(
 				zap.Int("clock", msg.Clock),
 				zap.String("facility", msg.Facility),
 				zap.String("priority", msg.Priority),
 				zap.Int("seq", msg.Seq),
-				zap.Time("talos-time", msg.TalosTime),
 			)
 		}
 	}


### PR DESCRIPTION
The omni log format printed the machine logs through a zero-value zap logger, which has no core, so the first line made omnictl panic with a nil pointer dereference. Build a proper console logger instead, and stamp each entry with the time the machine logged it rather than the time it is printed.