### PR TITLE
test: retry the maintenance upgrade right after the install reboot

### DIFF
--- a/internal/integration/talos_test.go
+++ b/internal/integration/talos_test.go
@@ -1239,6 +1239,8 @@ func AssertMachineShouldBeInstalledInMaintenanceMode(testCtx context.Context, op
 		})
 
 		rtestutils.AssertResource[*omni.MachineStatusSnapshot](ctx, t, omniState, machineID, func(snapshot *omni.MachineStatusSnapshot, assertion *assert.Assertions) {
+			// An empty boot ID means the collect task could not read it yet, so it does not prove a reboot.
+			assertion.NotEmpty(snapshot.TypedSpec().Value.BootId, "machine %q has no boot ID after the maintenance install", machineID)
 			assertion.NotEqual(bootID, snapshot.TypedSpec().Value.BootId, "machine %q has not rebooted after the maintenance install", machineID)
 		})
 
@@ -1291,21 +1293,33 @@ func AssertMachineShouldBeUpgradedViaMaintenanceLifecycle(
 
 		t.Logf("upgrading Talos on maintenance machine %q from %q to %q", *machineID, currentVersion, target)
 
-		lifecycle := omniClient.Management().MaintenanceLifecycle(
-			ctx,
-			*machineID,
-			management.MaintenanceLifecycleRequest_OPERATION_UPGRADE,
-			target,
-			"",
-		)
+		// The machine has just rebooted into the installed Talos. Its API and its DNS resolver come up a few
+		// seconds after Omni first sees the new boot, so the first attempts can fail with a refused connection.
+		// The budget also has to cover a successful attempt, which includes the image factory building the installer image.
+		err = retry.Constant(10*time.Minute, retry.WithUnits(5*time.Second)).RetryWithContext(ctx, func(ctx context.Context) error {
+			lifecycle := omniClient.Management().MaintenanceLifecycle(
+				ctx,
+				*machineID,
+				management.MaintenanceLifecycleRequest_OPERATION_UPGRADE,
+				target,
+				"",
+			)
 
-		for resp, upgradeErr := range lifecycle {
-			require.NoError(t, upgradeErr, "upgrade failed on machine %q", *machineID)
+			for resp, upgradeErr := range lifecycle {
+				if upgradeErr != nil {
+					t.Logf("upgrade attempt failed on machine %q, retrying: %v", *machineID, upgradeErr)
 
-			if msg := resp.GetMessage(); msg != "" {
-				t.Logf("upgrade progress (%s): %s", *machineID, msg)
+					return retry.ExpectedError(upgradeErr)
+				}
+
+				if msg := resp.GetMessage(); msg != "" {
+					t.Logf("upgrade progress (%s): %s", *machineID, msg)
+				}
 			}
-		}
+
+			return nil
+		})
+		require.NoError(t, err, "upgrade failed on machine %q", *machineID)
 
 		rtestutils.AssertResource[*omni.MachineStatus](ctx, t, omniState, *machineID, func(ms *omni.MachineStatus, assertion *assert.Assertions) {
 			got := strings.TrimPrefix(ms.TypedSpec().Value.TalosVersion, "v")


### PR DESCRIPTION
The maintenance lifecycle test upgrades the machine as soon as Omni sees its new boot after the install. On Talos 1.14 the machine API and its DNS resolver come up a few seconds later than that, so the first upgrade attempt can fail with a refused connection. Retry the upgrade call for a bounded time instead of failing on the first attempt.