### PR TITLE
fix: retry the installer image pull in the maintenance lifecycle API

### DIFF
--- a/internal/backend/talos/lifecycle/client.go
+++ b/internal/backend/talos/lifecycle/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/siderolabs/go-retry/retry"
 	machineapi "github.com/siderolabs/talos/pkg/machinery/api/machine"
 	talosclient "github.com/siderolabs/talos/pkg/machinery/client"
 	"github.com/siderolabs/talos/pkg/machinery/constants"
@@ -79,6 +80,9 @@ func (m *Manager) buildInstallImage(ctx context.Context, machineID string, ms *o
 }
 
 // pullInstallerImage pulls the installer image into the machine's containerd and returns the resolved image name, as required by LifecycleService.{Install,Upgrade}'s InstallArtifactsSource.
+//
+// Since Talos 1.14 the image pull API does not retry or time out on its own, so both are done here. The pull can fail
+// for transient reasons, e.g., when it is requested right after the machine rebooted and the machine is not fully up yet.
 func (m *Manager) pullInstallerImage(
 	ctx context.Context,
 	talosClient *talosclient.Client,
@@ -90,10 +94,55 @@ func (m *Manager) pullInstallerImage(
 
 	emitf(cfg.progress, "[omni] pulling installer image %s", imageRef)
 
-	if err := cfg.audit(ctx, machineapi.ImageService_Pull_FullMethodName, machineID); err != nil {
+	var (
+		resolved       string
+		notFoundErrors int
+	)
+
+	err := retry.Exponential(PullTimeout, retry.WithUnits(pullRetryInterval)).RetryWithContext(ctx, func(ctx context.Context) error {
+		if auditErr := cfg.audit(ctx, machineapi.ImageService_Pull_FullMethodName, machineID); auditErr != nil {
+			return auditErr
+		}
+
+		var pullErr error
+
+		resolved, pullErr = m.pullImage(ctx, talosClient, imageRef)
+		if pullErr == nil {
+			return nil
+		}
+
+		switch status.Code(pullErr) { //nolint:exhaustive
+		case codes.PermissionDenied, codes.InvalidArgument:
+			return pullErr
+		case codes.NotFound:
+			// With several registry mirrors, a transient failure on one of them and a real miss on the next one also
+			// surface as not found, so give up on it only after a few attempts.
+			notFoundErrors++
+
+			if notFoundErrors > pullMaxNotFoundRetries {
+				return pullErr
+			}
+		}
+
+		emitf(cfg.progress, "[omni] pulling installer image failed, retrying: %v", pullErr)
+
+		return retry.ExpectedError(pullErr)
+	})
+	if err != nil {
 		return "", err
 	}
 
+	if resolved == "" {
+		resolved = imageRef
+	}
+
+	emitf(cfg.progress, "[omni] installer image pulled: %s", resolved)
+
+	return resolved, nil
+}
+
+// pullImage runs a single image pull and returns the resolved image reference reported by the machine.
+func (m *Manager) pullImage(ctx context.Context, talosClient *talosclient.Client, imageRef string) (string, error) {
 	pullClient, err := talosClient.ImageClient.Pull(ctx, &machineapi.ImageServicePullRequest{
 		Containerd: m.containerdInstance,
 		ImageRef:   imageRef,
@@ -112,7 +161,7 @@ func (m *Manager) pullInstallerImage(
 		msg, recvErr := pullClient.Recv()
 		if recvErr != nil {
 			if errors.Is(recvErr, io.EOF) {
-				break
+				return resolved, nil
 			}
 
 			return "", recvErr
@@ -122,14 +171,6 @@ func (m *Manager) pullInstallerImage(
 			resolved = name
 		}
 	}
-
-	if resolved == "" {
-		resolved = imageRef
-	}
-
-	emitf(cfg.progress, "[omni] installer image pulled: %s", resolved)
-
-	return resolved, nil
 }
 
 // install runs LifecycleService.Install and relays installer progress.

--- a/internal/backend/talos/lifecycle/lifecycle.go
+++ b/internal/backend/talos/lifecycle/lifecycle.go
@@ -17,8 +17,14 @@ import (
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
-// PullTimeout bounds pulling the installer image into containerd.
+// PullTimeout bounds pulling the installer image into containerd, including the retries.
 const PullTimeout = 5 * time.Minute
+
+// pullRetryInterval is the base interval between installer image pull attempts.
+const pullRetryInterval = 5 * time.Second
+
+// pullMaxNotFoundRetries is how many times a not found error is retried before it is treated as final.
+const pullMaxNotFoundRetries = 5
 
 // InstallTimeout bounds writing the image to disk (LifecycleService install or upgrade).
 const InstallTimeout = 5 * time.Minute

--- a/internal/integration/talos_test.go
+++ b/internal/integration/talos_test.go
@@ -1293,33 +1293,21 @@ func AssertMachineShouldBeUpgradedViaMaintenanceLifecycle(
 
 		t.Logf("upgrading Talos on maintenance machine %q from %q to %q", *machineID, currentVersion, target)
 
-		// The machine has just rebooted into the installed Talos. Its API and its DNS resolver come up a few
-		// seconds after Omni first sees the new boot, so the first attempts can fail with a refused connection.
-		// The budget also has to cover a successful attempt, which includes the image factory building the installer image.
-		err = retry.Constant(10*time.Minute, retry.WithUnits(5*time.Second)).RetryWithContext(ctx, func(ctx context.Context) error {
-			lifecycle := omniClient.Management().MaintenanceLifecycle(
-				ctx,
-				*machineID,
-				management.MaintenanceLifecycleRequest_OPERATION_UPGRADE,
-				target,
-				"",
-			)
+		lifecycle := omniClient.Management().MaintenanceLifecycle(
+			ctx,
+			*machineID,
+			management.MaintenanceLifecycleRequest_OPERATION_UPGRADE,
+			target,
+			"",
+		)
 
-			for resp, upgradeErr := range lifecycle {
-				if upgradeErr != nil {
-					t.Logf("upgrade attempt failed on machine %q, retrying: %v", *machineID, upgradeErr)
+		for resp, upgradeErr := range lifecycle {
+			require.NoError(t, upgradeErr, "upgrade failed on machine %q", *machineID)
 
-					return retry.ExpectedError(upgradeErr)
-				}
-
-				if msg := resp.GetMessage(); msg != "" {
-					t.Logf("upgrade progress (%s): %s", *machineID, msg)
-				}
+			if msg := resp.GetMessage(); msg != "" {
+				t.Logf("upgrade progress (%s): %s", *machineID, msg)
 			}
-
-			return nil
-		})
-		require.NoError(t, err, "upgrade failed on machine %q", *machineID)
+		}
 
 		rtestutils.AssertResource[*omni.MachineStatus](ctx, t, omniState, *machineID, func(ms *omni.MachineStatus, assertion *assert.Assertions) {
 			got := strings.TrimPrefix(ms.TypedSpec().Value.TalosVersion, "v")


### PR DESCRIPTION
Since Talos 1.14, the image pull API does not retry or time out on its own anymore and leaves both to the caller. Omni pulls the installer image through this API when it installs or upgrades Talos on a machine in maintenance mode, and the pull can fail for transient reasons, e.g., when it is requested right after the machine rebooted and the machine is not fully up yet. This made the maintenance lifecycle integration test fail on Talos 1.14.

Retry the pull for a bounded time, as Talos did internally before. The workaround of retrying the whole maintenance lifecycle call in the integration test is removed, only the check for a non-empty boot ID after the install reboot stays.