### PR TITLE
fix: apply the registry mirrors to machines in maintenance mode

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_status.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/config/container"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/cri"
+	"github.com/siderolabs/talos/pkg/machinery/config/types/meta"
 	siderolinkmachinery "github.com/siderolabs/talos/pkg/machinery/config/types/siderolink"
 	"github.com/siderolabs/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/siderolabs/talos/pkg/machinery/imager/quirks"
@@ -94,9 +96,9 @@ type MaintenanceConfigStatusController = qtransform.QController[*siderolinkres.L
 // NewMaintenanceConfigStatusController initializes MaintenanceConfigStatusController.
 func NewMaintenanceConfigStatusController(
 	maintenanceClientFactory MaintenanceClientFactory, eventSinkPort, logServerPort int,
-	state state.State,
+	state state.State, registryMirrors []string,
 ) *MaintenanceConfigStatusController {
-	helper := newMaintenanceConfigStatusControllerHelper(maintenanceClientFactory, eventSinkPort, logServerPort, state)
+	helper := newMaintenanceConfigStatusControllerHelper(maintenanceClientFactory, eventSinkPort, logServerPort, state, registryMirrors)
 
 	return qtransform.NewQController(
 		qtransform.Settings[*siderolinkres.Link, *omni.MaintenanceConfigStatus]{
@@ -142,7 +144,7 @@ type maintenanceConfigStatusControllerHelper struct {
 }
 
 func newMaintenanceConfigStatusControllerHelper(maintenanceClientFactory MaintenanceClientFactory, eventSinkPort, logServerPort int,
-	state state.State,
+	state state.State, registryMirrors []string,
 ) *maintenanceConfigStatusControllerHelper {
 	buildPatch := func(extraDocs ...talosconfig.Document) (maintenanceBasePatch, error) {
 		cfg, err := siderolink.NewJoinOptions(
@@ -168,9 +170,6 @@ func newMaintenanceConfigStatusControllerHelper(maintenanceClientFactory Mainten
 	}
 
 	var (
-		patchWithRegistryAuth   *maintenanceBasePatch
-		patchWithRegistryAuthMu sync.Mutex
-
 		basePatch   *maintenanceBasePatch
 		basePatchMu sync.Mutex
 	)
@@ -193,12 +192,13 @@ func newMaintenanceConfigStatusControllerHelper(maintenanceClientFactory Mainten
 		return p, nil
 	}
 
-	getPatchWithRegistryAuth := func(ctx context.Context) (maintenanceBasePatch, error) {
-		patchWithRegistryAuthMu.Lock()
-		defer patchWithRegistryAuthMu.Unlock()
-
-		if patchWithRegistryAuth != nil {
-			return *patchWithRegistryAuth, nil
+	// getPatchWithRegistryDocs returns the base patch extended with the registry mirror and registry auth documents,
+	// so that the installer image is pulled through the same mirrors and with the same credentials as on cluster machines.
+	// It is rebuilt on every call, as the image factory credentials can appear after the first reconcile.
+	getPatchWithRegistryDocs := func(ctx context.Context) (maintenanceBasePatch, error) {
+		docs, err := registryMirrorDocs(registryMirrors)
+		if err != nil {
+			return maintenanceBasePatch{}, err
 		}
 
 		auths, err := safe.ReaderListAll[*omni.ImageFactoryAuth](ctx, state)
@@ -206,21 +206,21 @@ func newMaintenanceConfigStatusControllerHelper(maintenanceClientFactory Mainten
 			return maintenanceBasePatch{}, fmt.Errorf("error listing ImageFactoryAuth resources: %w", err)
 		}
 
-		if auths.Len() == 0 {
-			return getBasePatch()
-		}
-
-		authDoc, err := imagefactoryauth.BuildDocs(slices.Collect(auths.All()))
+		authDocs, err := imagefactoryauth.BuildDocs(slices.Collect(auths.All()))
 		if err != nil {
 			return maintenanceBasePatch{}, fmt.Errorf("error building registry auth doc: %w", err)
 		}
 
-		p, err := buildPatch(xslices.Map(authDoc, func(doc *cri.RegistryAuthConfigV1Alpha1) talosconfig.Document { return doc })...)
-		if err != nil {
-			return maintenanceBasePatch{}, fmt.Errorf("error building patch with registry auth: %w", err)
+		docs = append(docs, xslices.Map(authDocs, func(doc *cri.RegistryAuthConfigV1Alpha1) talosconfig.Document { return doc })...)
+
+		if len(docs) == 0 {
+			return getBasePatch()
 		}
 
-		patchWithRegistryAuth = &p
+		p, err := buildPatch(docs...)
+		if err != nil {
+			return maintenanceBasePatch{}, fmt.Errorf("error building patch with registry docs: %w", err)
+		}
 
 		return p, nil
 	}
@@ -234,12 +234,47 @@ func newMaintenanceConfigStatusControllerHelper(maintenanceClientFactory Mainten
 			}
 
 			if vc.MultidocNetworkConfigSupported() {
-				return getPatchWithRegistryAuth(ctx)
+				return getPatchWithRegistryDocs(ctx)
 			}
 
 			return getBasePatch()
 		},
 	}
+}
+
+// registryMirrorDocs builds the RegistryMirrorConfig documents for the registry mirrors configured in Omni ("<registry host>=<mirror URL>").
+// Several mirrors for the same registry host end up as endpoints of a single document, in the order they are configured.
+func registryMirrorDocs(registryMirrors []string) ([]talosconfig.Document, error) {
+	docs := make([]talosconfig.Document, 0, len(registryMirrors))
+	docsByHost := make(map[string]*cri.RegistryMirrorConfigV1Alpha1, len(registryMirrors))
+
+	for _, registryMirror := range registryMirrors {
+		hostname, endpoint, ok := strings.Cut(registryMirror, "=")
+		if !ok || hostname == "" {
+			return nil, fmt.Errorf("invalid registry mirror spec: %q", registryMirror)
+		}
+
+		endpointURL, err := url.Parse(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("invalid registry mirror endpoint %q: %w", endpoint, err)
+		}
+
+		if endpointURL.Scheme != "http" && endpointURL.Scheme != "https" {
+			return nil, fmt.Errorf("invalid registry mirror endpoint %q: the scheme must be http or https", endpoint)
+		}
+
+		doc, ok := docsByHost[hostname]
+		if !ok {
+			doc = cri.NewRegistryMirrorConfigV1Alpha1(hostname)
+			docsByHost[hostname] = doc
+
+			docs = append(docs, doc)
+		}
+
+		doc.RegistryEndpoints = append(doc.RegistryEndpoints, cri.RegistryEndpoint{EndpointURL: meta.URL{URL: endpointURL}})
+	}
+
+	return docs, nil
 }
 
 //nolint:gocyclo,cyclop
@@ -334,7 +369,7 @@ func (helper *maintenanceConfigStatusControllerHelper) transform(ctx context.Con
 		return fmt.Errorf("error loading machine config patches: %w", err)
 	}
 
-	// the Omni-managed connection documents are applied last, so they always win over anything in the user patches.
+	// the Omni-managed documents are applied last, so their settings win over anything in the user patches (list fields, e.g., the mirror endpoints, are merged).
 	patches = append(patches, baseConfig.patch)
 
 	patched, err := configpatcher.Apply(configpatcher.WithConfig(machineConfig), patches)

--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_status_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"net"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/cosi-project/runtime/pkg/safe"
@@ -60,7 +61,7 @@ func (suite *MachineStatusSnapshotControllerSuite) TestMaintenanceConfigStatus()
 	}
 
 	// Register the controller and start the runtime
-	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state)
+	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state, nil)
 
 	suite.Require().NoError(suite.runtime.RegisterQController(controller))
 
@@ -165,6 +166,49 @@ func (suite *MachineStatusSnapshotControllerSuite) TestMaintenanceConfigStatus()
 	suite.Contains(dataStr, u.String())
 }
 
+// reconcileMaintenanceMachine registers a connected maintenance machine and returns the config apply request the controller issues for it.
+func (suite *MaintenanceConfigStatusControllerSuite) reconcileMaintenanceMachine(
+	maintenanceClient *maintenanceClientMock, machineIDCh chan string, id, talosVersion, publicKey string,
+) *machine.ApplyConfigurationRequest {
+	suite.T().Helper()
+
+	link := siderolinkres.NewLink(id, &specs.SiderolinkSpec{})
+	link.TypedSpec().Value.Connected = true
+	link.TypedSpec().Value.NodePublicKey = publicKey
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, link))
+
+	machineStatus := omnires.NewMachineStatus(id)
+	machineStatus.TypedSpec().Value.Maintenance = true
+	machineStatus.TypedSpec().Value.ManagementAddress = id + "-address"
+	machineStatus.TypedSpec().Value.TalosVersion = talosVersion
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, machineStatus))
+
+	suite.markConfigExtracted(id)
+
+	select {
+	case <-machineIDCh:
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timeout waiting for maintenance client factory to be called")
+	}
+
+	select {
+	case maintenanceClient.getMachineConfigCh <- nil:
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timeout waiting for get machine config request")
+	}
+
+	select {
+	case req := <-maintenanceClient.applyConfigReqCh:
+		return req
+	case <-suite.ctx.Done():
+		suite.Require().Fail("timeout waiting for apply configuration request")
+	}
+
+	return nil
+}
+
 func (suite *MaintenanceConfigStatusControllerSuite) TestImageFactoryRegistryAuth() {
 	getMachineConfigCh := make(chan *config.MachineConfig)
 	machineIDCh := make(chan string)
@@ -191,50 +235,14 @@ func (suite *MaintenanceConfigStatusControllerSuite) TestImageFactoryRegistryAut
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, auth))
 
-	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state)
+	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state, nil)
 
 	suite.Require().NoError(suite.runtime.RegisterQController(controller))
 
 	suite.startRuntime()
 
 	reconcileMachine := func(id, talosVersion, publicKey string) *machine.ApplyConfigurationRequest {
-		suite.T().Helper()
-
-		link := siderolinkres.NewLink(id, &specs.SiderolinkSpec{})
-		link.TypedSpec().Value.Connected = true
-		link.TypedSpec().Value.NodePublicKey = publicKey
-
-		suite.Require().NoError(suite.state.Create(suite.ctx, link))
-
-		machineStatus := omnires.NewMachineStatus(id)
-		machineStatus.TypedSpec().Value.Maintenance = true
-		machineStatus.TypedSpec().Value.ManagementAddress = id + "-address"
-		machineStatus.TypedSpec().Value.TalosVersion = talosVersion
-
-		suite.Require().NoError(suite.state.Create(suite.ctx, machineStatus))
-
-		suite.markConfigExtracted(id)
-
-		select {
-		case <-machineIDCh:
-		case <-suite.ctx.Done():
-			suite.Require().Fail("timeout waiting for maintenance client factory to be called")
-		}
-
-		select {
-		case getMachineConfigCh <- nil:
-		case <-suite.ctx.Done():
-			suite.Require().Fail("timeout waiting for get machine config request")
-		}
-
-		select {
-		case req := <-maintenanceClient.applyConfigReqCh:
-			return req
-		case <-suite.ctx.Done():
-			suite.Require().Fail("timeout waiting for apply configuration request")
-		}
-
-		return nil
+		return suite.reconcileMaintenanceMachine(maintenanceClient, machineIDCh, id, talosVersion, publicKey)
 	}
 
 	// Talos version that predates RegistryAuthConfig: auth must NOT be injected.
@@ -257,6 +265,74 @@ func (suite *MaintenanceConfigStatusControllerSuite) TestImageFactoryRegistryAut
 	suite.Contains(newData, "password: factory-pass")
 }
 
+func (suite *MaintenanceConfigStatusControllerSuite) TestRegistryMirrors() {
+	getMachineConfigCh := make(chan *config.MachineConfig)
+	machineIDCh := make(chan string)
+	applyConfigReqCh := make(chan *machine.ApplyConfigurationRequest)
+
+	maintenanceClient := &maintenanceClientMock{
+		getMachineConfigCh: getMachineConfigCh,
+		applyConfigReqCh:   applyConfigReqCh,
+	}
+
+	maintenanceClientFactory := func(ctx context.Context, machineID string) (omni.MaintenanceClient, error) {
+		select {
+		case machineIDCh <- machineID:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+
+		return maintenanceClient, nil
+	}
+
+	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state,
+		[]string{"docker.io=http://mirror.example.org:5000", "factory.talos.dev=http://mirror.example.org:5004", "docker.io=http://mirror-2.example.org:5000"})
+
+	suite.Require().NoError(suite.runtime.RegisterQController(controller))
+
+	suite.startRuntime()
+
+	reconcileMachine := func(id, talosVersion, publicKey string) *machine.ApplyConfigurationRequest {
+		return suite.reconcileMaintenanceMachine(maintenanceClient, machineIDCh, id, talosVersion, publicKey)
+	}
+
+	// Talos version that predates RegistryMirrorConfig: mirrors must NOT be injected.
+	oldReq := reconcileMachine("old-machine", "1.11.0", "pk-old")
+	oldData := string(oldReq.Data)
+
+	suite.Contains(oldData, "omni-kmsg")
+	suite.NotContains(oldData, "kind: RegistryMirrorConfig")
+
+	// Talos version that supports RegistryMirrorConfig: mirrors must be injected.
+	newReq := reconcileMachine("new-machine", "1.12.0", "pk-new")
+	newData := string(newReq.Data)
+
+	suite.Contains(newData, "omni-kmsg")
+	suite.Contains(newData, "kind: RegistryMirrorConfig")
+	suite.Contains(newData, "name: docker.io")
+	suite.Contains(newData, "url: http://mirror.example.org:5000")
+	suite.Contains(newData, "name: factory.talos.dev")
+	suite.Contains(newData, "url: http://mirror.example.org:5004")
+
+	// two mirrors for the same registry are two endpoints of a single document
+	suite.Equal(1, strings.Count(newData, "name: docker.io"))
+	suite.Contains(newData, "url: http://mirror-2.example.org:5000")
+
+	// image factory credentials that appear later must still make it into the config, next to the mirrors.
+	auth := omnires.NewImageFactoryAuth("https://factory.example.org")
+	auth.TypedSpec().Value.Username = "factory-user"
+	auth.TypedSpec().Value.Password = "factory-pass"
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, auth))
+
+	authReq := reconcileMachine("auth-machine", "1.12.0", "pk-auth")
+	authData := string(authReq.Data)
+
+	suite.Contains(authData, "kind: RegistryMirrorConfig")
+	suite.Contains(authData, "kind: RegistryAuthConfig")
+	suite.Contains(authData, "username: factory-user")
+}
+
 func (suite *MaintenanceConfigStatusControllerSuite) TestMachineConfigPatchPreserved() {
 	getMachineConfigCh := make(chan *config.MachineConfig)
 	machineIDCh := make(chan string)
@@ -277,7 +353,7 @@ func (suite *MaintenanceConfigStatusControllerSuite) TestMachineConfigPatchPrese
 		return maintenanceClient, nil
 	}
 
-	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state)
+	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state, nil)
 
 	suite.Require().NoError(suite.runtime.RegisterQController(controller))
 
@@ -370,7 +446,7 @@ func (suite *MaintenanceConfigStatusControllerSuite) TestMachineConfigPatchDocum
 		return maintenanceClient, nil
 	}
 
-	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state)
+	controller := omni.NewMaintenanceConfigStatusController(maintenanceClientFactory, 123, 456, suite.state, nil)
 
 	suite.Require().NoError(suite.runtime.RegisterQController(controller))
 

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -269,6 +269,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 			cfg.Services.Siderolink.GetEventSinkPort(),
 			cfg.Services.Siderolink.GetLogServerPort(),
 			st.Default(),
+			cfg.Registries.Mirrors,
 		),
 		omnictrl.NewDiscoveryAffiliateDeleteTaskController(discoveryClientCache),
 		omnictrl.NewServiceAccountStatusController(),


### PR DESCRIPTION
Omni applies its configured registry mirrors to cluster machines, but not to machines in maintenance mode. Since Omni installs Talos through the machine API instead of the initial config apply, the installer image for a maintenance install or upgrade is pulled without the mirrors, straight from the image factory. In CI, which relies on the mirrors heavily, this made every install bypass them.

Add the registry mirrors to the maintenance config as registry mirror documents, next to the registry auth documents, for Talos versions that support them. Both maintenance installs and upgrades then pull the installer image through the mirrors, the same as cluster machines do. Machines on Talos versions before the mirror document keep pulling directly.