### PR TITLE
fix: manage the lifetime of the cached Talos clients with explicit leases

### DIFF
--- a/internal/backend/grpc/kubernetes_manifests.go
+++ b/internal/backend/grpc/kubernetes_manifests.go
@@ -362,6 +362,8 @@ func (s *managementServer) prepareKubernetesSyncHelpers(ctx, authCtx context.Con
 		return nil, fmt.Errorf("failed to get talos client: %w", err)
 	}
 
+	defer talosClient.Close() //nolint:errcheck
+
 	bootstrapManifests, err := manifests.GetBootstrapManifests(ctx, talosClient.COSI, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get manifests: %w", err)

--- a/internal/backend/grpc/management.go
+++ b/internal/backend/grpc/management.go
@@ -76,10 +76,51 @@ type KubernetesRuntime interface {
 }
 
 // TalosRuntime provides Talos cluster access capabilities.
+//
+// The returned clients must be closed by the caller.
 type TalosRuntime interface {
 	GetTalosconfigRaw(context *commonOmni.Context, identity string) ([]byte, error)
 	GetClientForCluster(ctx context.Context, clusterName string) (*talos.Client, error)
 	GetClientForMachine(ctx context.Context, machineID string) (*talos.Client, error)
+}
+
+// talosClientGroup obtains Talos clients and closes all of them at once.
+//
+// It is for the callers which hand the clients over to a library through a callback and cannot close them one by one.
+type talosClientGroup struct {
+	talosRuntime TalosRuntime
+	clients      []*talos.Client
+	mu           sync.Mutex
+}
+
+func newTalosClientGroup(talosRuntime TalosRuntime) *talosClientGroup {
+	return &talosClientGroup{talosRuntime: talosRuntime}
+}
+
+// GetForMachine returns a Talos client for the machine, closed when the group is closed.
+func (g *talosClientGroup) GetForMachine(ctx context.Context, machineID string) (*talos.Client, error) {
+	c, err := g.talosRuntime.GetClientForMachine(ctx, machineID)
+	if err != nil {
+		return nil, err
+	}
+
+	g.mu.Lock()
+	g.clients = append(g.clients, c)
+	g.mu.Unlock()
+
+	return c, nil
+}
+
+// Close closes all the clients obtained through the group.
+func (g *talosClientGroup) Close() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for _, c := range g.clients {
+		c.Close() //nolint:errcheck
+	}
+
+	g.clients = nil
 }
 
 // TalosconfigProvider provides raw and operator Talos configurations.
@@ -521,8 +562,12 @@ func (s *managementServer) KubernetesUpgradePreChecks(ctx context.Context, req *
 
 	var logBuffer strings.Builder
 
+	// the clients are closed only after the pre-checks are done
+	talosClients := newTalosClientGroup(s.talosRuntime)
+	defer talosClients.Close()
+
 	preCheck, err := upgrade.NewChecksWithStateProvider(path, func(ctx context.Context, machineID string) (state.State, error) {
-		c, clientErr := s.talosRuntime.GetClientForMachine(ctx, machineID)
+		c, clientErr := talosClients.GetForMachine(ctx, machineID)
 		if clientErr != nil {
 			return nil, clientErr
 		}
@@ -1244,6 +1289,8 @@ func (s *managementServer) MachinePowerOff(ctx context.Context, request *managem
 	if err != nil {
 		return nil, fmt.Errorf("failed to get talos client: %w", err)
 	}
+
+	defer talosClient.Close() //nolint:errcheck
 
 	if err = s.auditTalosAccess(authCtx, machineapi.MachineService_Shutdown_FullMethodName, clusterName, request.MachineId); err != nil {
 		return nil, err

--- a/internal/backend/grpc/support.go
+++ b/internal/backend/grpc/support.go
@@ -96,11 +96,15 @@ func (s *managementServer) GetSupportBundle(req *management.GetSupportBundleRequ
 
 	progress := make(chan bundle.Progress)
 
+	// the clients are closed only after the bundle is complete
+	talosClients := newTalosClientGroup(s.talosRuntime)
+	defer talosClients.Close()
+
 	options := bundle.NewOptions(
 		bundle.WithArchiveOutput(archiveOutput),
 		bundle.WithKubernetesClient(kubernetesClient),
 		bundle.WithTalosClientProvider(func(ctx context.Context, machineID string) (context.Context, *client.Client, error) {
-			c, clientErr := s.talosRuntime.GetClientForMachine(ctx, machineID)
+			c, clientErr := talosClients.GetForMachine(ctx, machineID)
 			if clientErr != nil {
 				return ctx, nil, clientErr
 			}

--- a/internal/backend/runtime/omni/controllers/omni/etcd_backup.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcd_backup.go
@@ -373,6 +373,8 @@ func (ctrl *EtcdBackupController) doBackup(
 		return fmt.Errorf("failed to create talos client for cluster, skipping cluster backup: %w", err)
 	}
 
+	defer client.Close() //nolint:errcheck
+
 	rdr, err := client.EtcdSnapshot(ctx, &machineapi.EtcdSnapshotRequest{})
 	if err != nil {
 		return fmt.Errorf("failed to start etcd snapshot stream for cluster: %w", err)
@@ -463,9 +465,10 @@ func (ctrl *EtcdBackupController) updateBackupStatus(
 	}
 }
 
-// TalosClient is a subset of Talos client.
+// TalosClient is a subset of Talos client. It must be closed by the caller.
 type TalosClient interface {
 	EtcdSnapshot(ctx context.Context, req *machineapi.EtcdSnapshotRequest, callOptions ...grpc.CallOption) (io.ReadCloser, error)
+	Close() error
 }
 
 type countingReader struct {

--- a/internal/backend/runtime/omni/controllers/omni/etcd_backup_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/etcd_backup_test.go
@@ -929,6 +929,10 @@ func (m *mockTalosClient) EtcdSnapshot(context.Context, *machine.EtcdSnapshotReq
 	return io.NopCloser(strings.NewReader("Hello World")), nil
 }
 
+func (m *mockTalosClient) Close() error {
+	return nil
+}
+
 func startFactory(ctx context.Context, t *testing.T, factory store.Factory, st state.State, logger *zap.Logger) store.Factory {
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/internal/backend/runtime/omni/controllers/omni/image/client.go
+++ b/internal/backend/runtime/omni/controllers/omni/image/client.go
@@ -44,6 +44,8 @@ func (c *TalosImageClient) ListImagesOnNode(ctx context.Context, cluster, node s
 		return nil, fmt.Errorf("failed to get talos client for node %q: %w", node, err)
 	}
 
+	defer talosCli.Close() //nolint:errcheck
+
 	stream, err := talosCli.ImageClient.List(ctx, &machine.ImageServiceListRequest{
 		Containerd: &common.ContainerdInstance{
 			Driver:    common.ContainerDriver_CRI,
@@ -106,6 +108,8 @@ func (c *TalosImageClient) PullImageToNode(ctx context.Context, cluster, node, i
 	if err != nil {
 		return fmt.Errorf("failed to get talos client for node %q: %w", node, err)
 	}
+
+	defer talosCli.Close() //nolint:errcheck
 
 	stream, err := talosCli.ImageClient.Pull(ctx, &machine.ImageServicePullRequest{
 		ImageRef: image,

--- a/internal/backend/runtime/omni/controllers/omni/kubernetes_upgrade_manifest_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/kubernetes_upgrade_manifest_status.go
@@ -169,6 +169,8 @@ func NewKubernetesUpgradeManifestStatusController(talosClientGetter TalosClientG
 					return fmt.Errorf("failed to get talos client: %w", err)
 				}
 
+				defer talosClient.Close() //nolint:errcheck
+
 				manifestStatus.TypedSpec().Value.OutOfSync = 0
 				manifestStatus.TypedSpec().Value.LastFatalError = ""
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_set_etcd_audit.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_set_etcd_audit.go
@@ -104,6 +104,8 @@ func NewMachineSetEtcdAuditController(talosClientFactory *talos.ClientFactory, m
 					return err
 				}
 
+				defer talosCli.Close() //nolint:errcheck
+
 				orphanMemberSet, err := auditor.auditEtcd(ctx, r, talosCli, cluster, machineSet, logger)
 				if err != nil {
 					return err
@@ -480,6 +482,8 @@ func (auditor *etcdAuditor) getClient(ctx context.Context, r controller.Reader, 
 
 	connected, err := c.Connected(ctx, r)
 	if err != nil {
+		c.Close() //nolint:errcheck
+
 		if state.IsNotFoundError(err) {
 			return nil, xerrors.NewTagged[qtransform.SkipReconcileTag](err)
 		}
@@ -488,6 +492,8 @@ func (auditor *etcdAuditor) getClient(ctx context.Context, r controller.Reader, 
 	}
 
 	if !connected {
+		c.Close() //nolint:errcheck
+
 		return nil, xerrors.NewTaggedf[qtransform.SkipReconcileTag]("the cluster is not available")
 	}
 

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/extraction.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/extraction.go
@@ -224,6 +224,8 @@ func (r reader) ReadMachineConfig(ctx context.Context, machineID string) (*confi
 		return nil, err
 	}
 
+	defer client.Close() //nolint:errcheck
+
 	machineConfig, err := safe.ReaderGetByID[*configres.MachineConfig](ctx, client.COSI, configres.ActiveID)
 	if err != nil && !state.IsNotFoundError(err) {
 		return nil, err

--- a/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineconfig/status.go
@@ -597,6 +597,8 @@ func (ctrl *StatusController) legacyUpgrade(inputCtx context.Context, logger *za
 		return false, fmt.Errorf("failed to get talos client: %w", err)
 	}
 
+	defer nodeClient.Close() //nolint:errcheck
+
 	//nolint:staticcheck
 	_, err = nodeClient.UpgradeWithOptions(
 		upgradeCtx,
@@ -867,6 +869,8 @@ func (ctrl *StatusController) checkInstalledImage(
 	if err != nil {
 		return installedImage{}, fmt.Errorf("failed to get talos client: %w", err)
 	}
+
+	defer nodeClient.Close() //nolint:errcheck
 
 	actualVersion, err := getVersion(ctx, nodeClient.Client)
 	if err != nil {

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
@@ -346,6 +346,8 @@ func (ctrl *StatusController) legacyUpgrade(ctx context.Context, logger *zap.Log
 		return fmt.Errorf("failed to get talos client: %w", err)
 	}
 
+	defer talosClient.Close() //nolint:errcheck
+
 	//nolint:staticcheck
 	if _, err = talosClient.UpgradeWithOptions(ctx, client.WithUpgradeImage(installImageStr)); err != nil {
 		return fmt.Errorf("failed to do Talos upgrade: %w", err)

--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_status.go
@@ -52,9 +52,12 @@ import (
 type MaintenanceClientFactory = func(ctx context.Context, machineID string) (MaintenanceClient, error)
 
 // MaintenanceClient is a client for interacting with Talos running in maintenance mode.
+//
+// It must be closed by the caller.
 type MaintenanceClient interface {
 	GetMachineConfig(ctx context.Context) (*configres.MachineConfig, error)
 	ApplyConfiguration(ctx context.Context, req *machine.ApplyConfigurationRequest) (*machine.ApplyConfigurationResponse, error)
+	Close() error
 }
 
 // NewMaintenanceClientFactory returns a MaintenanceClientFactory backed by a Talos client factory.
@@ -86,6 +89,10 @@ func (c maintenanceClient) GetMachineConfig(ctx context.Context) (*configres.Mac
 
 func (c maintenanceClient) ApplyConfiguration(ctx context.Context, req *machine.ApplyConfigurationRequest) (*machine.ApplyConfigurationResponse, error) {
 	return c.client.ApplyConfiguration(ctx, req)
+}
+
+func (c maintenanceClient) Close() error {
+	return c.client.Close()
 }
 
 // MaintenanceConfigStatusController manages MaintenanceConfigStatus resource lifecycle.
@@ -347,6 +354,8 @@ func (helper *maintenanceConfigStatusControllerHelper) transform(ctx context.Con
 	if err != nil {
 		return fmt.Errorf("error creating maintenance client: %w", err)
 	}
+
+	defer maintenanceTalosClient.Close() //nolint:errcheck
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/internal/backend/runtime/omni/controllers/omni/maintenance_config_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/maintenance_config_status_test.go
@@ -601,3 +601,7 @@ func (m *maintenanceClientMock) ApplyConfiguration(ctx context.Context, req *mac
 
 	return &machine.ApplyConfigurationResponse{}, nil
 }
+
+func (m *maintenanceClientMock) Close() error {
+	return nil
+}

--- a/internal/backend/runtime/talos/clients.go
+++ b/internal/backend/runtime/talos/clients.go
@@ -12,18 +12,17 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/siderolabs/talos/pkg/machinery/client"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
 	"go.uber.org/zap"
-	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -58,19 +57,34 @@ func IsClientNotReadyError(e error) bool {
 	return errors.As(e, &w)
 }
 
-// NewClient creates a new Talos client.
+// NewClient wraps a Talos client which is not managed by a ClientFactory. Close closes the wrapped client.
 //
 // clusterID is optional, and can be empty for maintenance clients. If it is set, the client will check cluster status to determine connectivity in Connected() method.
 func NewClient(c *client.Client, clusterID, machineID string) *Client {
-	return &Client{Client: c, clusterID: clusterID, machineID: machineID}
+	cli := &Client{Client: c, clusterID: clusterID, machineID: machineID}
+
+	if c != nil {
+		cli.release = c.Close
+	}
+
+	return cli
 }
 
-// Client wraps Talos client.
+// Client represents a Talos client handed out by a ClientFactory.
+//
+// The clients of the same cluster or machine share one connection. It stays open as long as any of them is open or the
+// factory holds it in its cache. Therefore, the caller must close the client when it is done with it. Nothing obtained
+// through the client (e.g., a stream) must be used after that.
 type Client struct {
 	*client.Client
 
+	release func() error
+
 	clusterID string
 	machineID string
+
+	cleanup runtime.Cleanup
+	once    sync.Once
 }
 
 // ClusterID returns the cluster ID of the client. Empty for maintenance clients.
@@ -83,11 +97,23 @@ func (c *Client) MachineID() string {
 	return c.machineID
 }
 
-// Close closes the Talos client.
-//
-// Deprecated: Clients are cached, so this is no-op and must not be called.
+// Close releases the client. Only the first call has an effect.
 func (c *Client) Close() error {
-	return nil
+	var err error
+
+	c.once.Do(func() {
+		if c.release == nil {
+			return
+		}
+
+		// the client is released properly, so the leak guard is stopped. Stop requires the client to stay reachable across the call.
+		c.cleanup.Stop()
+		runtime.KeepAlive(c)
+
+		err = c.release()
+	})
+
+	return err
 }
 
 // Connected provides informational flag about cluster being reachable which is computed from the resources.
@@ -156,23 +182,38 @@ func GetSocketOptions(address string) []client.OptionFunc {
 }
 
 const (
-	// Talos client cache holds both cluster-wide and per-machine clients.
-	// Cluster-wide clients are used by controllers (e.g. etcd machine audit).
-	// Per-machine clients are created on demand for frontend resource requests.
-	// TTL is kept short to avoid holding many idle per-machine connections.
-	// Active invalidation via StartCacheManager handles state-change evictions.
+	// talosClientCacheSize is the maximum number of cached clients. The idle timeout is the primary bound, this is the
+	// ceiling for a fleet-wide burst of lookups.
+	talosClientCacheSize = 1024
 
-	talosClientLRUSize = 1024
-	talosClientTTL     = 10 * time.Minute
+	// talosClientIdleTimeout is how long a cached client without open leases is kept.
+	talosClientIdleTimeout = 10 * time.Minute
+
+	// talosClientSweepInterval is how often the idle clients are evicted.
+	talosClientSweepInterval = time.Minute
 )
 
+// entry represents a cached Talos client shared by all the leases handed out for its key.
+//
+// refs counts the open leases plus one for the cache while the entry is cached. The connection is closed when it drops
+// to zero. idleSince is set when the last lease is closed. Both are guarded by the factory mutex.
+type entry struct {
+	client    *client.Client
+	idleSince time.Time
+	key       string
+	clusterID string
+	machineID string
+	refs      int
+}
+
 // ClientFactory creates client based on the resource state.
+//
+// See Client for the lifetime of the returned clients.
 type ClientFactory struct {
 	omniState state.State
 	logger    *zap.Logger
 
-	cache *expirable.LRU[string, *Client]
-	sf    singleflight.Group
+	entries map[string]*entry
 
 	// started is closed by StartCacheManager once all its watches are registered.
 	started chan struct{}
@@ -181,6 +222,13 @@ type ClientFactory struct {
 	metricActiveClients *prometheus.GaugeVec
 	metricCacheHits     *prometheus.CounterVec
 	metricCacheMisses   *prometheus.CounterVec
+
+	mu sync.Mutex
+
+	cacheSize int
+
+	// stopped is set when the cache manager exits, no new clients are cached after that.
+	stopped bool
 }
 
 // NewClientFactory initializes a ClientFactory with a built-in cache.
@@ -188,16 +236,16 @@ type ClientFactory struct {
 func NewClientFactory(omniState state.State, logger *zap.Logger) *ClientFactory {
 	typeLabel := []string{"type"}
 
-	cacheSize := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "omni_talos_clientfactory_cache_size",
-		Help: "Number of Talos clients in the cache of Talos client factory.",
-	}, typeLabel)
-
-	f := &ClientFactory{
-		omniState:       omniState,
-		logger:          logger,
-		started:         make(chan struct{}),
-		metricCacheSize: cacheSize,
+	return &ClientFactory{
+		omniState: omniState,
+		logger:    logger,
+		entries:   map[string]*entry{},
+		cacheSize: talosClientCacheSize,
+		started:   make(chan struct{}),
+		metricCacheSize: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "omni_talos_clientfactory_cache_size",
+			Help: "Number of Talos clients in the cache of Talos client factory.",
+		}, typeLabel),
 		metricActiveClients: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "omni_talos_clientfactory_active_clients",
 			Help: "Number of active Talos clients created by Talos client factory.",
@@ -211,12 +259,6 @@ func NewClientFactory(omniState state.State, logger *zap.Logger) *ClientFactory 
 			Help: "Number of Talos client factory cache misses.",
 		}, typeLabel),
 	}
-
-	f.cache = expirable.NewLRU[string, *Client](talosClientLRUSize, func(key string, _ *Client) {
-		cacheSize.WithLabelValues(cacheKeyType(key)).Dec()
-	}, talosClientTTL)
-
-	return f
 }
 
 // connectionOptions returns client configuration generated from the TalosConfig resource.
@@ -263,88 +305,226 @@ func (factory *ClientFactory) connectionOptions(ctx context.Context, id string, 
 }
 
 // GetForCluster constructs a client from resource configuration.
-// Returned client is cached and must not be closed by the consumer.
+//
+// The returned client must be closed by the caller.
 func (factory *ClientFactory) GetForCluster(ctx context.Context, clusterID string) (*Client, error) {
 	cacheKey := buildCacheKey(clusterID, "")
-	typ := cacheKeyType(cacheKey)
 
-	if cli, ok := factory.cache.Get(cacheKey); ok {
-		factory.logger.Debug("cache hit, returning cached Talos client", zap.String("key", cacheKey))
+	factory.mu.Lock()
+	defer factory.mu.Unlock()
 
-		factory.metricCacheHits.WithLabelValues(typ).Inc()
-
+	if cli, ok := factory.leaseLocked(cacheKey); ok {
 		return cli, nil
 	}
 
-	ch := factory.sf.DoChan(cacheKey, func() (any, error) {
-		factory.logger.Debug("cache miss, creating new Talos client", zap.String("key", cacheKey))
+	c, err := factory.buildForCluster(ctx, clusterID)
+	if err != nil {
+		return nil, err
+	}
 
-		factory.metricCacheMisses.WithLabelValues(typ).Inc()
+	return factory.publishLocked(cacheKey, clusterID, "", c)
+}
 
-		cli, err := factory.buildForCluster(ctx, clusterID)
-		if err != nil {
-			return nil, err
-		}
+// leaseLocked returns a new lease on the cached client for the key, if there is one. Must be called with the factory mutex held.
+func (factory *ClientFactory) leaseLocked(cacheKey string) (*Client, bool) {
+	e, ok := factory.entries[cacheKey]
+	if !ok {
+		return nil, false
+	}
 
-		activeGauge := factory.metricActiveClients.WithLabelValues(typ)
-		activeGauge.Inc()
+	factory.logger.Debug("cache hit, returning cached Talos client", zap.String("key", cacheKey))
 
-		runtime.AddCleanup(cli, func(c *client.Client) {
-			factory.logger.Debug("finalizing Talos client", zap.String("key", cacheKey))
+	factory.metricCacheHits.WithLabelValues(cacheKeyType(cacheKey)).Inc()
 
-			activeGauge.Dec()
+	return factory.newLeaseLocked(e), true
+}
 
-			c.Close() //nolint:errcheck
-		}, cli.Client)
+// publishLocked caches a freshly built client and returns the first lease on it. Must be called with the factory mutex held.
+//
+// The client is built and published under the mutex on purpose. This serializes it with the cache invalidation: either
+// the state reads of the build see the change already, or the invalidation runs after the publish and evicts the client.
+// This way, a client built from a stale state never survives in the cache. Building a client does not dial, so the mutex
+// is held only for the state reads. A slow state stalls the lookups and the releases alike, we accept that.
+func (factory *ClientFactory) publishLocked(cacheKey, clusterID, machineID string, c *client.Client) (*Client, error) {
+	if factory.stopped {
+		c.Close() //nolint:errcheck
 
-		factory.cache.Add(cacheKey, cli)
+		return nil, errors.New("talos client factory is stopped")
+	}
 
-		factory.metricCacheSize.WithLabelValues(typ).Inc()
+	factory.logger.Debug("cache miss, caching new Talos client", zap.String("key", cacheKey))
 
-		return cli, nil
-	})
+	factory.evictIdleLocked()
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case res := <-ch:
-		if res.Err != nil {
-			return nil, res.Err
-		}
+	typ := cacheKeyType(cacheKey)
 
-		cli := res.Val.(*Client) //nolint:forcetypeassert,errcheck
+	factory.metricCacheMisses.WithLabelValues(typ).Inc()
+	factory.metricCacheSize.WithLabelValues(typ).Inc()
+	factory.metricActiveClients.WithLabelValues(typ).Inc()
 
-		return cli, nil
+	e := &entry{
+		client:    c,
+		key:       cacheKey,
+		clusterID: clusterID,
+		machineID: machineID,
+		refs:      1, // the reference held by the cache
+	}
+
+	factory.entries[cacheKey] = e
+
+	return factory.newLeaseLocked(e), nil
+}
+
+// newLeaseLocked adds a reference to the entry and returns a client which releases it on Close. Must be called with the
+// factory mutex held.
+func (factory *ClientFactory) newLeaseLocked(e *entry) *Client {
+	e.refs++
+	e.idleSince = time.Time{}
+
+	cli := &Client{
+		Client:    e.client,
+		clusterID: e.clusterID,
+		machineID: e.machineID,
+		release: func() error {
+			factory.release(e)
+
+			return nil
+		},
+	}
+
+	// the leak guard reports a lease which is garbage collected without being closed. It never releases the lease itself,
+	// as the connection might still be in use through a stream. Its argument must not reference the lease.
+	cli.cleanup = runtime.AddCleanup(cli, factory.reportLeak, e.key)
+
+	return cli
+}
+
+func (factory *ClientFactory) reportLeak(key string) {
+	factory.logger.Warn("Talos client was garbage collected without being closed", zap.String("key", key))
+}
+
+// release drops one reference to the entry and closes the connection when it was the last one.
+//
+// It never touches the cache map, the entry might have been evicted already.
+func (factory *ClientFactory) release(e *entry) {
+	factory.mu.Lock()
+
+	e.refs--
+	refs := e.refs
+
+	if refs == 1 {
+		// only the cache holds the entry now
+		e.idleSince = time.Now()
+	}
+
+	factory.mu.Unlock()
+
+	if refs > 0 {
+		return
+	}
+
+	factory.closeEntry(e)
+}
+
+// closeEntry closes the connection of an entry which has no references left.
+func (factory *ClientFactory) closeEntry(e *entry) {
+	factory.logger.Debug("closing Talos client", zap.String("key", e.key))
+
+	factory.metricActiveClients.WithLabelValues(cacheKeyType(e.key)).Dec()
+
+	if err := e.client.Close(); err != nil {
+		factory.logger.Warn("failed to close Talos client", zap.String("key", e.key), zap.Error(err))
 	}
 }
 
-// releaseForCluster evicts all cached clients for the given cluster (cluster-wide and per-machine).
+// evictIdleLocked makes room for a new entry when the cache is full, by evicting the entries idle for the longest.
 //
-// The cluster-wide key ("clusterID/") is removed last to avoid a window where
-// stale per-machine entries remain in the cache after the cluster key is gone.
-func (factory *ClientFactory) releaseForCluster(clusterID string) {
-	clusterKey := buildCacheKey(clusterID, "")
+// Entries with open leases are never evicted, so the cache can exceed its size while that many clients are in use, and
+// it stays above it until the next cache miss or the idle sweep trims it. The evicted entries have no leases and are out
+// of the cache, so nothing can reference them anymore and they are closed right away. Closing an undialed or a dialed
+// connection takes microseconds, so it is done under the mutex. Must be called with the factory mutex held.
+func (factory *ClientFactory) evictIdleLocked() {
+	for len(factory.entries) >= factory.cacheSize {
+		var victim *entry
 
-	for _, key := range factory.cache.Keys() {
-		if key == clusterKey {
-			continue // remove last
+		for _, e := range factory.entries {
+			if e.refs != 1 {
+				continue
+			}
+
+			if victim == nil || e.idleSince.Before(victim.idleSince) {
+				victim = e
+			}
 		}
 
-		if !strings.HasPrefix(key, clusterKey) {
+		if victim == nil {
+			return
+		}
+
+		factory.logger.Debug("cache is full, evicting the longest idle Talos client", zap.String("key", victim.key))
+
+		delete(factory.entries, victim.key)
+
+		factory.metricCacheSize.WithLabelValues(cacheKeyType(victim.key)).Dec()
+
+		factory.closeEntry(victim)
+	}
+}
+
+// evict removes the matching entries from the cache and releases the cache reference on each of them.
+// The predicate is called with the factory mutex held.
+func (factory *ClientFactory) evict(match func(e *entry) bool) {
+	var evicted []*entry
+
+	factory.mu.Lock()
+
+	for key, e := range factory.entries {
+		if !match(e) {
 			continue
 		}
 
-		if factory.cache.Remove(key) {
-			factory.logger.Debug("deleted Talos client from cache", zap.String("key", key))
-		}
+		delete(factory.entries, key)
+
+		factory.metricCacheSize.WithLabelValues(cacheKeyType(key)).Dec()
+
+		evicted = append(evicted, e)
 	}
 
-	if factory.cache.Remove(clusterKey) {
-		factory.logger.Debug("deleted Talos client from cache", zap.String("key", clusterKey))
+	factory.mu.Unlock()
+
+	for _, e := range evicted {
+		factory.logger.Debug("evicted Talos client from cache", zap.String("key", e.key))
+
+		factory.release(e)
 	}
 }
 
-func (factory *ClientFactory) buildForCluster(ctx context.Context, clusterID string) (*Client, error) {
+// sweep evicts the cached clients which had no open leases for longer than the idle timeout.
+func (factory *ClientFactory) sweep(now time.Time) {
+	factory.evict(func(e *entry) bool {
+		return e.refs == 1 && now.Sub(e.idleSince) >= talosClientIdleTimeout
+	})
+}
+
+// stop evicts all the cached clients and prevents new ones from being cached.
+func (factory *ClientFactory) stop() {
+	factory.mu.Lock()
+	factory.stopped = true
+	factory.mu.Unlock()
+
+	factory.evict(func(*entry) bool { return true })
+}
+
+// releaseForCluster evicts all cached clients for the given cluster (cluster-wide and per-machine).
+func (factory *ClientFactory) releaseForCluster(clusterID string) {
+	clusterKey := buildCacheKey(clusterID, "")
+
+	factory.evict(func(e *entry) bool {
+		return strings.HasPrefix(e.key, clusterKey)
+	})
+}
+
+func (factory *ClientFactory) buildForCluster(ctx context.Context, clusterID string) (*client.Client, error) {
 	clusterEndpoint, err := safe.StateGet[*omni.ClusterEndpoint](
 		ctx, factory.omniState,
 		omni.NewClusterEndpoint(clusterID).Metadata(),
@@ -367,18 +547,14 @@ func (factory *ClientFactory) buildForCluster(ctx context.Context, clusterID str
 		return nil, err
 	}
 
-	c, err := client.New(ctx, options...)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewClient(c, clusterID, ""), nil
+	return client.New(ctx, options...)
 }
 
 // GetForMachine constructs a Talos client connected directly to a specific node's SideroLink address.
 // It returns a maintenance (insecure) or a regular (secure) client depending on whether the machine is currently in
 // maintenance mode or not, as reported by its MachineStatus.
-// Returned client is cached and must not be closed by the consumer.
+//
+// The returned client must be closed by the caller.
 func (factory *ClientFactory) GetForMachine(ctx context.Context, machineID string) (*Client, error) {
 	return factory.getForMachine(ctx, machineID, false)
 }
@@ -390,22 +566,60 @@ func (factory *ClientFactory) GetForMachine(ctx context.Context, machineID strin
 // is not in maintenance mode, it returns an error instead of a client. This way a caller acting on a machine it believes
 // to be in maintenance mode (based on a possibly stale view) can never accidentally reconfigure an allocated machine that
 // has already left maintenance.
-// Returned client is cached and must not be closed by the consumer.
+//
+// The returned client must be closed by the caller.
 func (factory *ClientFactory) GetMaintenance(ctx context.Context, machineID string) (*Client, error) {
 	return factory.getForMachine(ctx, machineID, true)
 }
 
 func (factory *ClientFactory) getForMachine(ctx context.Context, machineID string, maintenanceOnly bool) (*Client, error) {
+	_, clusterID, err := factory.resolveMachine(ctx, machineID, maintenanceOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheKey := buildCacheKey(clusterID, machineID)
+
+	factory.mu.Lock()
+	defer factory.mu.Unlock()
+
+	if cli, ok := factory.leaseLocked(cacheKey); ok {
+		return cli, nil
+	}
+
+	// cache miss: the machine status is read again under the mutex, as the one read above might be stale (see publishLocked)
+	machineStatus, clusterID, err := factory.resolveMachine(ctx, machineID, maintenanceOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheKey = buildCacheKey(clusterID, machineID)
+
+	if cli, ok := factory.leaseLocked(cacheKey); ok {
+		return cli, nil
+	}
+
+	c, err := factory.buildForMachine(ctx, clusterID, machineStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	return factory.publishLocked(cacheKey, clusterID, machineID, c)
+}
+
+// resolveMachine reads the machine status and returns the cluster the machine is reachable through: its own cluster over
+// the secure connection, or none in maintenance mode.
+func (factory *ClientFactory) resolveMachine(ctx context.Context, machineID string, maintenanceOnly bool) (*omni.MachineStatus, string, error) {
 	machineStatus, err := safe.StateGet[*omni.MachineStatus](
 		ctx, factory.omniState,
 		omni.NewMachineStatus(machineID).Metadata(),
 	)
 	if err != nil {
 		if state.IsNotFoundError(err) {
-			return nil, NewClientNotReadyError(err)
+			return nil, "", NewClientNotReadyError(err)
 		}
 
-		return nil, err
+		return nil, "", err
 	}
 
 	spec := machineStatus.TypedSpec().Value
@@ -413,71 +627,19 @@ func (factory *ClientFactory) getForMachine(ctx context.Context, machineID strin
 	// when only a maintenance client was asked for, refuse to build (or return a cached) cluster client. checked before
 	// touching the cache so a concurrently cached cluster client can never leak through either.
 	if maintenanceOnly && !spec.Maintenance {
-		return nil, fmt.Errorf("machine %q is not in maintenance mode", machineID)
+		return nil, "", fmt.Errorf("machine %q is not in maintenance mode", machineID)
 	}
 
 	// A machine in maintenance mode is reachable only over the insecure maintenance connection, even when already
 	// allocated to a cluster. Otherwise it is reachable over its cluster's secure connection. A machine that is in
 	// neither state has no reachable client, so report it as not ready rather than caching a doomed one.
-	clusterID := spec.Cluster
-
 	switch {
 	case spec.Maintenance:
-		clusterID = ""
-	case clusterID == "":
-		return nil, NewClientNotReadyError(fmt.Errorf("machine %q is neither in maintenance mode nor allocated to a cluster", machineID))
-	}
-
-	cacheKey := buildCacheKey(clusterID, machineID)
-	typ := cacheKeyType(cacheKey)
-
-	if cli, ok := factory.cache.Get(cacheKey); ok {
-		factory.logger.Debug("cache hit, returning cached Talos node client", zap.String("key", cacheKey))
-
-		factory.metricCacheHits.WithLabelValues(typ).Inc()
-
-		return cli, nil
-	}
-
-	ch := factory.sf.DoChan(cacheKey, func() (any, error) {
-		factory.logger.Debug("cache miss, creating new Talos node client", zap.String("key", cacheKey))
-
-		factory.metricCacheMisses.WithLabelValues(typ).Inc()
-
-		cli, err := factory.buildForMachine(ctx, clusterID, machineStatus)
-		if err != nil {
-			return nil, err
-		}
-
-		activeGauge := factory.metricActiveClients.WithLabelValues(typ)
-		activeGauge.Inc()
-
-		runtime.AddCleanup(cli, func(c *client.Client) {
-			factory.logger.Debug("finalizing Talos node client", zap.String("machine", machineID))
-
-			activeGauge.Dec()
-
-			c.Close() //nolint:errcheck
-		}, cli.Client)
-
-		factory.cache.Add(cacheKey, cli)
-
-		factory.metricCacheSize.WithLabelValues(typ).Inc()
-
-		return cli, nil
-	})
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case res := <-ch:
-		if res.Err != nil {
-			return nil, res.Err
-		}
-
-		cli := res.Val.(*Client) //nolint:forcetypeassert,errcheck
-
-		return cli, nil
+		return machineStatus, "", nil
+	case spec.Cluster == "":
+		return nil, "", NewClientNotReadyError(fmt.Errorf("machine %q is neither in maintenance mode nor allocated to a cluster", machineID))
+	default:
+		return machineStatus, spec.Cluster, nil
 	}
 }
 
@@ -495,7 +657,7 @@ func buildCacheKey(clusterID, machineID string) string {
 	return clusterID + "/" + machineID
 }
 
-func (factory *ClientFactory) buildForMachine(ctx context.Context, clusterID string, machineStatus *omni.MachineStatus) (*Client, error) {
+func (factory *ClientFactory) buildForMachine(ctx context.Context, clusterID string, machineStatus *omni.MachineStatus) (*client.Client, error) {
 	machineID := machineStatus.Metadata().ID()
 
 	managementAddress := machineStatus.TypedSpec().Value.ManagementAddress
@@ -509,16 +671,11 @@ func (factory *ClientFactory) buildForMachine(ctx context.Context, clusterID str
 			return nil, err
 		}
 
-		c, err := client.New(ctx, options...)
-		if err != nil {
-			return nil, err
-		}
-
-		return NewClient(c, clusterID, machineID), nil
+		return client.New(ctx, options...)
 	}
 
 	// Maintenance mode: encrypted but no certificate verification.
-	c, err := client.New(
+	return client.New(
 		ctx,
 		client.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}), //nolint:gosec
 		client.WithEndpoints(managementAddress),
@@ -526,19 +683,14 @@ func (factory *ClientFactory) buildForMachine(ctx context.Context, clusterID str
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(constants.GRPCMaxMessageSize)),
 		),
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewClient(c, "", machineID), nil
 }
 
 func (factory *ClientFactory) releaseForMachine(clusterID, machineID string) {
 	cacheKey := buildCacheKey(clusterID, machineID)
 
-	factory.logger.Debug("deleting Talos machine client from cache", zap.String("key", cacheKey))
-
-	factory.cache.Remove(cacheKey)
+	factory.evict(func(e *entry) bool {
+		return e.key == cacheKey
+	})
 }
 
 // WaitForCacheStart blocks until StartCacheManager has registered all its watches, or the context is done.
@@ -554,8 +706,11 @@ func (factory *ClientFactory) WaitForCacheStart(ctx context.Context) error {
 	}
 }
 
-// StartCacheManager starts watching the relevant resources to do the client cache invalidation.
+// StartCacheManager watches the relevant resources to invalidate the client cache and evicts the idle clients periodically.
+// When it returns, the cache is emptied and no new clients are cached.
 func (factory *ClientFactory) StartCacheManager(ctx context.Context) error {
+	defer factory.stop()
+
 	eventCh := make(chan state.Event)
 
 	clusterEndpointMd := omni.NewClusterEndpoint("").Metadata()
@@ -581,6 +736,9 @@ func (factory *ClientFactory) StartCacheManager(ctx context.Context) error {
 
 	close(factory.started)
 
+	ticker := time.NewTicker(talosClientSweepInterval)
+	defer ticker.Stop()
+
 	for {
 		var event state.Event
 
@@ -589,6 +747,10 @@ func (factory *ClientFactory) StartCacheManager(ctx context.Context) error {
 			factory.logger.Debug("stopping Talos client cache manager")
 
 			return nil
+		case now := <-ticker.C:
+			factory.sweep(now)
+
+			continue
 		case event = <-eventCh:
 		}
 
@@ -604,7 +766,7 @@ func (factory *ClientFactory) StartCacheManager(ctx context.Context) error {
 		case omni.MachineStatusType:
 			factory.handleMachineStatusEvent(event)
 		default:
-			// ClusterEndpoint or TalosConfig changed — invalidate the cluster with all its clients.
+			// ClusterEndpoint or TalosConfig changed, invalidate the cluster with all its clients.
 			clusterID := event.Resource.Metadata().ID()
 			factory.releaseForCluster(clusterID)
 		}
@@ -619,6 +781,9 @@ func (factory *ClientFactory) StartCacheManager(ctx context.Context) error {
 //
 // The previous cluster is read from the old version of the resource carried by the event, so the secure cluster client
 // can be evicted even when the machine status has already cleared its cluster field as the machine leaves the cluster.
+//
+// The management address is not watched, as it never changes for an existing machine: SideroLink keeps the address of an
+// existing link, and a machine gets a new one only after its link and status were destroyed, which evicts its clients.
 func (factory *ClientFactory) handleMachineStatusEvent(event state.Event) {
 	machineID := event.Resource.Metadata().ID()
 

--- a/internal/backend/runtime/talos/clients_test.go
+++ b/internal/backend/runtime/talos/clients_test.go
@@ -7,6 +7,7 @@ package talos_test
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/siderolabs/omni/client/pkg/constants"
@@ -68,7 +71,7 @@ func TestGetClientForCluster(t *testing.T) {
 		clusterStatus := omni.NewClusterStatus(clusterName)
 		clusterStatus.TypedSpec().Value.Available = true
 
-		require.NoError(t, testContext.State.Create(ctx, clusterStatus), state.WithCreateOwner(omnictrl.ClusterStatusControllerName))
+		require.NoError(t, testContext.State.Create(ctx, clusterStatus, state.WithCreateOwner(omnictrl.ClusterStatusControllerName)))
 
 		require.NoError(t, testContext.State.Create(ctx, talosconfig))
 
@@ -79,10 +82,16 @@ func TestGetClientForCluster(t *testing.T) {
 		c1, err := clientFactory.GetForCluster(ctx, clusterName)
 		require.NoError(t, err)
 
+		defer c1.Close() //nolint:errcheck
+
 		c2, err := clientFactory.GetForCluster(ctx, clusterName)
 		require.NoError(t, err)
 
-		assert.Same(t, c1, c2)
+		defer c2.Close() //nolint:errcheck
+
+		// two leases on the same cached connection
+		assert.Same(t, c1.Client, c2.Client)
+		assert.Equal(t, 1, clientFactory.CacheLen())
 	})
 }
 
@@ -94,9 +103,7 @@ func TestGetMaintenance(t *testing.T) {
 
 	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
 	}, func(ctx context.Context, testContext testutils.TestContext) {
-		// Use a nop logger because runtime.AddCleanup finalizers may run after the test completes,
-		// and zaptest loggers panic when logging to a finished testing.T.
-		clientFactory := talos.NewClientFactory(testContext.State, zap.NewNop())
+		clientFactory := talos.NewClientFactory(testContext.State, testContext.Logger)
 
 		// A machine in maintenance mode: it has a status with the maintenance flag set.
 		maintMachine := omni.NewMachineStatus("m-maint")
@@ -122,30 +129,45 @@ func TestGetMaintenance(t *testing.T) {
 
 		maint, err := clientFactory.GetMaintenance(ctx, "m-maint")
 		require.NoError(t, err)
+
+		defer maint.Close() //nolint:errcheck
+
 		assert.Empty(t, maint.ClusterID())
 		assert.Equal(t, "m-maint", maint.MachineID())
 
-		// Cached: a second call returns the same pointer.
+		// Cached: a second call returns a lease on the same connection.
 		maintAgain, err := clientFactory.GetMaintenance(ctx, "m-maint")
 		require.NoError(t, err)
-		assert.Same(t, maint, maintAgain)
+
+		defer maintAgain.Close() //nolint:errcheck
+
+		assert.Same(t, maint.Client, maintAgain.Client)
 
 		// GetForMachine shares the same maintenance cache entry.
 		viaForMachine, err := clientFactory.GetForMachine(ctx, "m-maint")
 		require.NoError(t, err)
-		assert.Same(t, maint, viaForMachine)
+
+		defer viaForMachine.Close() //nolint:errcheck
+
+		assert.Same(t, maint.Client, viaForMachine.Client)
 
 		// --- Allocated machine still in maintenance: maintenance client, despite the cluster being set ---
 
 		allocMaint, err := clientFactory.GetMaintenance(ctx, "m-alloc-maint")
 		require.NoError(t, err)
+
+		defer allocMaint.Close() //nolint:errcheck
+
 		assert.Empty(t, allocMaint.ClusterID())
 		assert.Equal(t, "m-alloc-maint", allocMaint.MachineID())
 
 		// GetForMachine also returns the maintenance client, not a cluster client.
 		allocMaintViaForMachine, err := clientFactory.GetForMachine(ctx, "m-alloc-maint")
 		require.NoError(t, err)
-		assert.Same(t, allocMaint, allocMaintViaForMachine)
+
+		defer allocMaintViaForMachine.Close() //nolint:errcheck
+
+		assert.Same(t, allocMaint.Client, allocMaintViaForMachine.Client)
 
 		// --- Configured machine: refuses to return a maintenance client ---
 
@@ -161,6 +183,15 @@ func TestGetMaintenance(t *testing.T) {
 	})
 }
 
+// getAndClose obtains a client for the machine and closes it. Only its connection is meant to be compared afterwards.
+func getAndClose(ctx context.Context, t *testing.T, clientFactory *talos.ClientFactory, machineID string) *talos.Client {
+	c, err := clientFactory.GetForMachine(ctx, machineID)
+	require.NoError(t, err)
+	require.NoError(t, c.Close())
+
+	return c
+}
+
 func TestClientLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -169,9 +200,7 @@ func TestClientLifecycle(t *testing.T) {
 
 	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(ctx context.Context, testContext testutils.TestContext) {
 	}, func(ctx context.Context, testContext testutils.TestContext) {
-		// Use a nop logger because runtime.AddCleanup finalizers may run after the test completes,
-		// and zaptest loggers panic when logging to a finished testing.T.
-		clientFactory := talos.NewClientFactory(testContext.State, zap.NewNop())
+		clientFactory := talos.NewClientFactory(testContext.State, testContext.Logger)
 
 		const clusterName = "alpha"
 
@@ -236,44 +265,40 @@ func TestClientLifecycle(t *testing.T) {
 
 		clusterClient, err := clientFactory.GetForCluster(ctx, clusterName)
 		require.NoError(t, err)
+		require.NoError(t, clusterClient.Close())
 		assert.Equal(t, clusterName, clusterClient.ClusterID())
 		assert.Empty(t, clusterClient.MachineID())
 
-		clientM1, err := clientFactory.GetForMachine(ctx, "m1")
-		require.NoError(t, err)
+		clientM1 := getAndClose(ctx, t, clientFactory, "m1")
 		assert.Equal(t, clusterName, clientM1.ClusterID())
 		assert.Equal(t, "m1", clientM1.MachineID())
 
-		clientM2, err := clientFactory.GetForMachine(ctx, "m2")
-		require.NoError(t, err)
+		clientM2 := getAndClose(ctx, t, clientFactory, "m2")
 		assert.Equal(t, clusterName, clientM2.ClusterID())
 		assert.Equal(t, "m2", clientM2.MachineID())
 
-		maintenanceM4, err := clientFactory.GetForMachine(ctx, "m4")
-		require.NoError(t, err)
+		maintenanceM4 := getAndClose(ctx, t, clientFactory, "m4")
 		assert.Empty(t, maintenanceM4.ClusterID())
 		assert.Equal(t, "m4", maintenanceM4.MachineID())
 
-		maintenanceM5, err := clientFactory.GetForMachine(ctx, "m5")
-		require.NoError(t, err)
+		maintenanceM5 := getAndClose(ctx, t, clientFactory, "m5")
 		assert.Empty(t, maintenanceM5.ClusterID())
 		assert.Equal(t, "m5", maintenanceM5.MachineID())
 
-		// --- Phase 2: Caching — same calls return same pointers ---
+		// --- Phase 2: Caching, the same calls return leases on the same connections ---
 
 		c, err := clientFactory.GetForCluster(ctx, clusterName)
 		require.NoError(t, err)
-		assert.Same(t, clusterClient, c)
+		require.NoError(t, c.Close())
+		assert.Same(t, clusterClient.Client, c.Client)
 
-		c, err = clientFactory.GetForMachine(ctx, "m1")
-		require.NoError(t, err)
-		assert.Same(t, clientM1, c)
+		c = getAndClose(ctx, t, clientFactory, "m1")
+		assert.Same(t, clientM1.Client, c.Client)
 
-		c, err = clientFactory.GetForMachine(ctx, "m4")
-		require.NoError(t, err)
-		assert.Same(t, maintenanceM4, c)
+		c = getAndClose(ctx, t, clientFactory, "m4")
+		assert.Same(t, maintenanceM4.Client, c.Client)
 
-		// --- Phase 3: Machine leaves maintenance (m4) — maintenance client evicted ---
+		// --- Phase 3: Machine leaves maintenance (m4), maintenance client evicted ---
 
 		ms4, err := safe.StateGet[*omni.MachineStatus](ctx, testContext.State, omni.NewMachineStatus("m4").Metadata())
 		require.NoError(t, err)
@@ -286,19 +311,22 @@ func TestClientLifecycle(t *testing.T) {
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			client, clientErr := clientFactory.GetForMachine(ctx, "m4")
-			assert.NoError(collect, clientErr)
-			assert.NotSame(collect, maintenanceM4, client, "m4 maintenance client should have been evicted")
+			if !assert.NoError(collect, clientErr) {
+				return
+			}
+
+			assert.NoError(collect, client.Close())
+			assert.NotSame(collect, maintenanceM4.Client, client.Client, "m4 maintenance client should have been evicted")
 			assert.Equal(collect, clusterName, client.ClusterID(), "m4 should now be a regular client")
 
 			newM4 = client
 		}, time.Minute, 100*time.Millisecond)
 
 		// m5 should still be cached (unaffected).
-		c, err = clientFactory.GetForMachine(ctx, "m5")
-		require.NoError(t, err)
-		assert.Same(t, maintenanceM5, c)
+		c = getAndClose(ctx, t, clientFactory, "m5")
+		assert.Same(t, maintenanceM5.Client, c.Client)
 
-		// --- Phase 4: Machine leaves cluster (m2) — client evicted ---
+		// --- Phase 4: Machine leaves cluster (m2), client evicted ---
 
 		// The machine goes back to maintenance mode and its status clears the cluster.
 		ms2, err := safe.StateGet[*omni.MachineStatus](ctx, testContext.State, omni.NewMachineStatus("m2").Metadata())
@@ -312,19 +340,22 @@ func TestClientLifecycle(t *testing.T) {
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			client, clientErr := clientFactory.GetForMachine(ctx, "m2")
-			assert.NoError(collect, clientErr)
-			assert.NotSame(collect, clientM2, client, "m2 client should have been evicted")
+			if !assert.NoError(collect, clientErr) {
+				return
+			}
+
+			assert.NoError(collect, client.Close())
+			assert.NotSame(collect, clientM2.Client, client.Client, "m2 client should have been evicted")
 			assert.Empty(collect, client.ClusterID(), "m2 should now be a maintenance client")
 
 			newM2 = client
 		}, time.Minute, 100*time.Millisecond)
 
 		// m1 should still be cached (unaffected).
-		c, err = clientFactory.GetForMachine(ctx, "m1")
-		require.NoError(t, err)
-		assert.Same(t, clientM1, c)
+		c = getAndClose(ctx, t, clientFactory, "m1")
+		assert.Same(t, clientM1.Client, c.Client)
 
-		// --- Phase 5: Cluster endpoint changes — all cluster clients evicted ---
+		// --- Phase 5: Cluster endpoint changes, all cluster clients evicted ---
 
 		currentEndpoint, err := safe.StateGet[*omni.ClusterEndpoint](ctx, testContext.State, omni.NewClusterEndpoint(clusterName).Metadata())
 		require.NoError(t, err)
@@ -335,27 +366,27 @@ func TestClientLifecycle(t *testing.T) {
 		// Cluster-wide client evicted.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			client, clientErr := clientFactory.GetForCluster(ctx, clusterName)
-			assert.NoError(collect, clientErr)
-			assert.NotSame(collect, clusterClient, client, "cluster client should have been evicted")
+			if !assert.NoError(collect, clientErr) {
+				return
+			}
+
+			assert.NoError(collect, client.Close())
+			assert.NotSame(collect, clusterClient.Client, client.Client, "cluster client should have been evicted")
 		}, time.Minute, 100*time.Millisecond)
 
 		// Per-node clients also evicted (they share the cluster prefix).
-		c, err = clientFactory.GetForMachine(ctx, "m1")
-		require.NoError(t, err)
-		assert.NotSame(t, clientM1, c, "m1 should have been evicted with the cluster")
+		c = getAndClose(ctx, t, clientFactory, "m1")
+		assert.NotSame(t, clientM1.Client, c.Client, "m1 should have been evicted with the cluster")
 
-		c, err = clientFactory.GetForMachine(ctx, "m4")
-		require.NoError(t, err)
-		assert.NotSame(t, newM4, c, "m4 should have been evicted with the cluster")
+		c = getAndClose(ctx, t, clientFactory, "m4")
+		assert.NotSame(t, newM4.Client, c.Client, "m4 should have been evicted with the cluster")
 
 		// Maintenance clients unaffected.
-		c, err = clientFactory.GetForMachine(ctx, "m5")
-		require.NoError(t, err)
-		assert.Same(t, maintenanceM5, c, "m5 maintenance client should be unaffected")
+		c = getAndClose(ctx, t, clientFactory, "m5")
+		assert.Same(t, maintenanceM5.Client, c.Client, "m5 maintenance client should be unaffected")
 
-		c, err = clientFactory.GetForMachine(ctx, "m2")
-		require.NoError(t, err)
-		assert.Same(t, newM2, c, "m2 (now maintenance) should be unaffected")
+		c = getAndClose(ctx, t, clientFactory, "m2")
+		assert.Same(t, newM2.Client, c.Client, "m2 (now maintenance) should be unaffected")
 	})
 }
 
@@ -373,9 +404,7 @@ func TestClusterClientEvictedOnClusterLeave(t *testing.T) {
 
 	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
 	}, func(ctx context.Context, testContext testutils.TestContext) {
-		// Use a nop logger because runtime.AddCleanup finalizers may run after the test completes,
-		// and zaptest loggers panic when logging to a finished testing.T.
-		clientFactory := talos.NewClientFactory(testContext.State, zap.NewNop())
+		clientFactory := talos.NewClientFactory(testContext.State, testContext.Logger)
 
 		const clusterName = "alpha"
 
@@ -421,8 +450,7 @@ func TestClusterClientEvictedOnClusterLeave(t *testing.T) {
 		require.NoError(t, clientFactory.WaitForCacheStart(ctx))
 
 		// Initial secure cluster client.
-		clusterClient, err := clientFactory.GetForMachine(ctx, "m1")
-		require.NoError(t, err)
+		clusterClient := getAndClose(ctx, t, clientFactory, "m1")
 		require.Equal(t, clusterName, clusterClient.ClusterID())
 
 		// --- Machine leaves the cluster and goes back to maintenance: cluster field is cleared in the same update ---
@@ -436,7 +464,11 @@ func TestClusterClientEvictedOnClusterLeave(t *testing.T) {
 
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			client, clientErr := clientFactory.GetForMachine(ctx, "m1")
-			assert.NoError(collect, clientErr)
+			if !assert.NoError(collect, clientErr) {
+				return
+			}
+
+			assert.NoError(collect, client.Close())
 			assert.Empty(collect, client.ClusterID(), "m1 should now be a maintenance client")
 		}, time.Minute, 100*time.Millisecond)
 
@@ -453,9 +485,424 @@ func TestClusterClientEvictedOnClusterLeave(t *testing.T) {
 		// cluster name from the update event. Otherwise the rejoined machine would be served the stale client.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			client, clientErr := clientFactory.GetForMachine(ctx, "m1")
-			assert.NoError(collect, clientErr)
+			if !assert.NoError(collect, clientErr) {
+				return
+			}
+
+			assert.NoError(collect, client.Close())
 			assert.Equal(collect, clusterName, client.ClusterID(), "m1 should be a cluster client again")
-			assert.NotSame(collect, clusterClient, client, "stale cluster client must have been evicted on cluster leave")
+			assert.NotSame(collect, clusterClient.Client, client.Client, "stale cluster client must have been evicted on cluster leave")
 		}, time.Minute, 100*time.Millisecond)
+	})
+}
+
+// createClusterMachine creates the status of a machine allocated to the cluster and reachable over the given address.
+//
+// The address must be a unix socket, as a cluster client over any other address needs the cluster credentials.
+func createClusterMachine(ctx context.Context, t *testing.T, st state.State, id, clusterName, address string) {
+	ms := omni.NewMachineStatus(id)
+	ms.TypedSpec().Value.ManagementAddress = address
+	ms.TypedSpec().Value.Cluster = clusterName
+	require.NoError(t, st.Create(ctx, ms))
+}
+
+// createMaintenanceMachine creates the status of a machine in maintenance mode. Its client needs no credentials.
+func createMaintenanceMachine(ctx context.Context, t *testing.T, st state.State, id string) {
+	ms := omni.NewMachineStatus(id)
+	ms.TypedSpec().Value.ManagementAddress = "127.0.0.1"
+	ms.TypedSpec().Value.Maintenance = true
+	require.NoError(t, st.Create(ctx, ms))
+}
+
+// TestClientLease checks that the shared connection stays open as long as any client is open, cached or not, and is
+// closed after the last one.
+func TestClientLease(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		clientFactory := talos.NewClientFactory(testContext.State, testContext.Logger)
+
+		// the machine is reachable over the unix socket of the machine mock, so the clients can do real RPCs
+		machineMock := testutils.NewMachineServiceMock(ctx, t, "m1", testContext.State)
+		createClusterMachine(ctx, t, testContext.State, "m1", "alpha", machineMock.SocketConnectionString)
+
+		c1, err := clientFactory.GetForMachine(ctx, "m1")
+		require.NoError(t, err)
+
+		c2, err := clientFactory.GetForMachine(ctx, "m1")
+		require.NoError(t, err)
+
+		assert.Same(t, c1.Client, c2.Client)
+		assert.Equal(t, 1, clientFactory.CacheLen())
+		assert.Equal(t, 1, clientFactory.ActiveClients("machine"))
+
+		// evicted from the cache while both clients are open: the connection stays open
+		clientFactory.ReleaseForMachine("alpha", "m1")
+
+		assert.Equal(t, 0, clientFactory.CacheLen())
+		assert.Equal(t, 1, clientFactory.ActiveClients("machine"))
+
+		_, err = c1.Version(ctx)
+		require.NoError(t, err)
+
+		// closing one client keeps the connection open for the other one
+		require.NoError(t, c1.Close())
+
+		_, err = c2.Version(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, clientFactory.ActiveClients("machine"))
+
+		// closing the last client closes the connection, closing it again is a no-op
+		require.NoError(t, c2.Close())
+		require.NoError(t, c2.Close())
+
+		_, err = c2.Version(ctx)
+		require.Error(t, err)
+
+		assert.Equal(t, 0, clientFactory.ActiveClients("machine"))
+
+		// a new client gets a new connection
+		c3, err := clientFactory.GetForMachine(ctx, "m1")
+		require.NoError(t, err)
+
+		assert.NotSame(t, c1.Client, c3.Client)
+
+		_, err = c3.Version(ctx)
+		require.NoError(t, err)
+
+		// closing the client before the eviction keeps the connection cached
+		require.NoError(t, c3.Close())
+
+		assert.Equal(t, 1, clientFactory.CacheLen())
+		assert.Equal(t, 1, clientFactory.ActiveClients("machine"))
+
+		c4, err := clientFactory.GetForMachine(ctx, "m1")
+		require.NoError(t, err)
+
+		assert.Same(t, c3.Client, c4.Client)
+
+		_, err = c4.Version(ctx)
+		require.NoError(t, err)
+
+		// the eviction of a cached connection without open clients closes it
+		require.NoError(t, c4.Close())
+
+		clientFactory.ReleaseForMachine("alpha", "m1")
+
+		assert.Equal(t, 0, clientFactory.CacheLen())
+		assert.Equal(t, 0, clientFactory.ActiveClients("machine"))
+	})
+}
+
+// TestClientSweep checks that the idle connections are closed after the idle timeout, and the ones with open clients are
+// not counted as idle.
+func TestClientSweep(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		clientFactory := talos.NewClientFactory(testContext.State, testContext.Logger)
+
+		createMaintenanceMachine(ctx, t, testContext.State, "m1")
+		createMaintenanceMachine(ctx, t, testContext.State, "m2")
+
+		getAndClose(ctx, t, clientFactory, "m1")
+
+		c2, err := clientFactory.GetForMachine(ctx, "m2")
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, clientFactory.CacheLen())
+
+		// nothing is idle for long enough yet
+		clientFactory.Sweep(time.Now())
+
+		assert.Equal(t, 2, clientFactory.CacheLen())
+
+		// m1 has no open clients and is idle for longer than the timeout, m2 has an open client
+		clientFactory.Sweep(time.Now().Add(talos.IdleTimeout))
+
+		assert.Equal(t, 1, clientFactory.CacheLen())
+		assert.Equal(t, 1, clientFactory.ActiveClients("maintenance"))
+
+		// the idle time of m2 starts when its last client is closed
+		require.NoError(t, c2.Close())
+
+		clientFactory.Sweep(time.Now())
+
+		assert.Equal(t, 1, clientFactory.CacheLen())
+
+		clientFactory.Sweep(time.Now().Add(talos.IdleTimeout))
+
+		assert.Equal(t, 0, clientFactory.CacheLen())
+		assert.Equal(t, 0, clientFactory.ActiveClients("maintenance"))
+	})
+}
+
+// TestClientCacheSize checks that a full cache evicts the clients idle for the longest, and never a client with open leases.
+func TestClientCacheSize(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		clientFactory := talos.NewClientFactory(testContext.State, testContext.Logger)
+		clientFactory.SetCacheSize(4)
+
+		for _, id := range []string{"m1", "m2", "m3", "m4", "m5", "m6", "m7"} {
+			createMaintenanceMachine(ctx, t, testContext.State, id)
+		}
+
+		// m1, m2 and m3 go idle in this order, m4 has an open lease
+		for _, id := range []string{"m1", "m2", "m3"} {
+			getAndClose(ctx, t, clientFactory, id)
+		}
+
+		c4, err := clientFactory.GetForMachine(ctx, "m4")
+		require.NoError(t, err)
+
+		assert.Equal(t, 4, clientFactory.CacheLen())
+
+		// the cache is full: the client idle for the longest makes room, the leased one stays
+		c5, err := clientFactory.GetForMachine(ctx, "m5")
+		require.NoError(t, err)
+
+		assert.Equal(t, 4, clientFactory.CacheLen())
+		assert.Equal(t, 4, clientFactory.CacheSizeMetric("maintenance"))
+		assert.Equal(t, 4, clientFactory.ActiveClients("maintenance"))
+		assert.False(t, clientFactory.Cached("", "m1"))
+
+		for _, id := range []string{"m2", "m3", "m4", "m5"} {
+			assert.True(t, clientFactory.Cached("", id), "%s should stay cached", id)
+		}
+
+		// only leased clients left besides m2 and m3: the cache grows past its size instead of evicting a leased client
+		c2, err := clientFactory.GetForMachine(ctx, "m2")
+		require.NoError(t, err)
+
+		c3, err := clientFactory.GetForMachine(ctx, "m3")
+		require.NoError(t, err)
+
+		c6, err := clientFactory.GetForMachine(ctx, "m6")
+		require.NoError(t, err)
+
+		assert.Equal(t, 5, clientFactory.CacheLen())
+		assert.Equal(t, 5, clientFactory.ActiveClients("maintenance"))
+
+		// once the clients are released, the next cache miss trims all the excess idle clients at once
+		for _, c := range []*talos.Client{c2, c3, c4, c5, c6} {
+			require.NoError(t, c.Close())
+		}
+
+		assert.Equal(t, 5, clientFactory.CacheLen())
+
+		getAndClose(ctx, t, clientFactory, "m7")
+
+		assert.Equal(t, 4, clientFactory.CacheLen())
+		assert.Equal(t, 4, clientFactory.CacheSizeMetric("maintenance"))
+		assert.Equal(t, 4, clientFactory.ActiveClients("maintenance"))
+
+		clientFactory.Stop()
+
+		assert.Equal(t, 0, clientFactory.CacheLen())
+		assert.Equal(t, 0, clientFactory.ActiveClients("maintenance"))
+	})
+}
+
+// TestClientFactoryStop checks that stopping the factory evicts everything, keeps the open clients working and refuses
+// to cache new clients.
+func TestClientFactoryStop(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		clientFactory := talos.NewClientFactory(testContext.State, testContext.Logger)
+
+		machineMock := testutils.NewMachineServiceMock(ctx, t, "m1", testContext.State)
+		createClusterMachine(ctx, t, testContext.State, "m1", "alpha", machineMock.SocketConnectionString)
+
+		c, err := clientFactory.GetForMachine(ctx, "m1")
+		require.NoError(t, err)
+
+		clientFactory.Stop()
+
+		assert.Equal(t, 0, clientFactory.CacheLen())
+
+		_, err = c.Version(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, c.Close())
+
+		assert.Equal(t, 0, clientFactory.ActiveClients("machine"))
+
+		_, err = clientFactory.GetForMachine(ctx, "m1")
+		require.ErrorContains(t, err, "stopped")
+	})
+}
+
+// TestClientLeakGuard checks that a client garbage collected without being closed is reported, and a closed one is not.
+func TestClientLeakGuard(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		// the leak report can be logged after the test is over, so the logger must not be bound to the test
+		core, logs := observer.New(zapcore.WarnLevel)
+		clientFactory := talos.NewClientFactory(testContext.State, zap.New(core))
+
+		createMaintenanceMachine(ctx, t, testContext.State, "m1")
+
+		leaked := func() bool {
+			return len(logs.FilterMessageSnippet("without being closed").All()) > 0
+		}
+
+		collectGarbage := func() {
+			for range 3 {
+				runtime.GC()
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+
+		// a closed client is not reported. it is obtained in a function, so no reference to it is left on the stack
+		func() {
+			getAndClose(ctx, t, clientFactory, "m1")
+		}()
+
+		collectGarbage()
+
+		assert.False(t, leaked())
+
+		// a client which is never closed is reported
+		func() {
+			_, err := clientFactory.GetForMachine(ctx, "m1")
+			require.NoError(t, err)
+		}()
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			collectGarbage()
+
+			assert.True(collect, leaked())
+		}, 10*time.Second, 50*time.Millisecond)
+
+		// the entry is still cached and still counted as leased, so the sweep never drops it
+		clientFactory.Sweep(time.Now().Add(talos.IdleTimeout))
+
+		assert.Equal(t, 1, clientFactory.CacheLen())
+
+		clientFactory.Stop()
+	})
+}
+
+// TestClientFactoryConcurrency runs lookups, closes, evictions and sweeps concurrently and checks that nothing is left open.
+func TestClientFactoryConcurrency(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		clientFactory := talos.NewClientFactory(testContext.State, zap.NewNop())
+		// a tiny cache puts the eviction on the full path under the same stress
+		clientFactory.SetCacheSize(2)
+
+		machines := []string{"m1", "m2", "m3"}
+
+		for _, id := range machines {
+			createMaintenanceMachine(ctx, t, testContext.State, id)
+		}
+
+		var eg errgroup.Group
+
+		for range 8 {
+			eg.Go(func() error {
+				for i := range 200 {
+					c, err := clientFactory.GetForMachine(ctx, machines[i%len(machines)])
+					if err != nil {
+						return err
+					}
+
+					if len(c.GetEndpoints()) == 0 {
+						return context.Canceled
+					}
+
+					if err = c.Close(); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			})
+		}
+
+		eg.Go(func() error {
+			for i := range 200 {
+				clientFactory.ReleaseForMachine("", machines[i%len(machines)])
+				clientFactory.Sweep(time.Now().Add(talos.IdleTimeout))
+			}
+
+			return nil
+		})
+
+		require.NoError(t, eg.Wait())
+
+		clientFactory.Stop()
+
+		assert.Equal(t, 0, clientFactory.CacheLen())
+		assert.Equal(t, 0, clientFactory.ActiveClients("maintenance"))
+	})
+}
+
+// TestRuntimeReleasesClientOnError checks that the runtime does not keep a client open when it fails to hand it out.
+func TestRuntimeReleasesClientOnError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(context.Context, testutils.TestContext) {
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		clientFactory := talos.NewClientFactory(testContext.State, testContext.Logger)
+		talosRuntime := talos.New(clientFactory, testContext.Logger, "omni", "https://omni.example.org")
+
+		createMaintenanceMachine(ctx, t, testContext.State, "m1")
+
+		// the machine has a status but no machine resource, so the connectivity check fails
+		_, err := talosRuntime.GetClientForMachine(ctx, "m1")
+		require.Error(t, err)
+
+		// the client was released: the cached connection has no open clients, so the sweep drops it
+		assert.Equal(t, 1, clientFactory.CacheLen())
+
+		clientFactory.Sweep(time.Now().Add(talos.IdleTimeout))
+
+		assert.Equal(t, 0, clientFactory.CacheLen())
+		assert.Equal(t, 0, clientFactory.ActiveClients("maintenance"))
+
+		// the machine is known but not connected, so the client is refused and released as well
+		require.NoError(t, testContext.State.Create(ctx, omni.NewMachine("m1")))
+
+		_, err = talosRuntime.GetClientForMachine(ctx, "m1")
+		require.ErrorContains(t, err, "not reachable")
+
+		clientFactory.Sweep(time.Now().Add(talos.IdleTimeout))
+
+		assert.Equal(t, 0, clientFactory.CacheLen())
+		assert.Equal(t, 0, clientFactory.ActiveClients("maintenance"))
 	})
 }

--- a/internal/backend/runtime/talos/export_test.go
+++ b/internal/backend/runtime/talos/export_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package talos
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// IdleTimeout is exported for testing.
+const IdleTimeout = talosClientIdleTimeout
+
+// Sweep exposes sweep to external tests.
+func (factory *ClientFactory) Sweep(now time.Time) {
+	factory.sweep(now)
+}
+
+// Stop exposes stop to external tests.
+func (factory *ClientFactory) Stop() {
+	factory.stop()
+}
+
+// ReleaseForMachine exposes releaseForMachine to external tests.
+func (factory *ClientFactory) ReleaseForMachine(clusterID, machineID string) {
+	factory.releaseForMachine(clusterID, machineID)
+}
+
+// SetCacheSize sets the maximum number of cached clients.
+func (factory *ClientFactory) SetCacheSize(size int) {
+	factory.mu.Lock()
+	defer factory.mu.Unlock()
+
+	factory.cacheSize = size
+}
+
+// Cached returns whether a client for the machine is in the cache.
+func (factory *ClientFactory) Cached(clusterID, machineID string) bool {
+	factory.mu.Lock()
+	defer factory.mu.Unlock()
+
+	_, ok := factory.entries[buildCacheKey(clusterID, machineID)]
+
+	return ok
+}
+
+// CacheSizeMetric returns the value of the cache size gauge for the given client type.
+func (factory *ClientFactory) CacheSizeMetric(typ string) int {
+	return int(testutil.ToFloat64(factory.metricCacheSize.WithLabelValues(typ)))
+}
+
+// CacheLen returns the number of cached clients.
+func (factory *ClientFactory) CacheLen() int {
+	factory.mu.Lock()
+	defer factory.mu.Unlock()
+
+	return len(factory.entries)
+}
+
+// ActiveClients returns the value of the active clients metric for the client type.
+func (factory *ClientFactory) ActiveClients(typ string) int {
+	return int(testutil.ToFloat64(factory.metricActiveClients.WithLabelValues(typ)))
+}

--- a/internal/backend/runtime/talos/talos.go
+++ b/internal/backend/runtime/talos/talos.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	goruntime "runtime"
 
 	cosiresource "github.com/cosi-project/runtime/pkg/resource"
 	clientconfig "github.com/siderolabs/talos/pkg/machinery/client/config"
@@ -84,6 +83,8 @@ func (r *Runtime) watch(ctx context.Context, events chan<- runtime.WatchResponse
 		return err
 	}
 
+	defer c.Close() //nolint:errcheck
+
 	ctx = metadata.AppendToOutgoingContext(ctx, constants.APIAuthzRoleMetadataKey, string(talosrole.Reader))
 
 	var queries []cosiresource.LabelQuery
@@ -94,8 +95,6 @@ func (r *Runtime) watch(ctx context.Context, events chan<- runtime.WatchResponse
 			return err
 		}
 	}
-
-	defer goruntime.KeepAlive(c)
 
 	return cosi.WatchLegacy(
 		ctx,
@@ -134,6 +133,8 @@ func (r *Runtime) Get(ctx context.Context, setters ...runtime.QueryOption) (any,
 		return nil, err
 	}
 
+	defer c.Close() //nolint:errcheck
+
 	ctx = metadata.AppendToOutgoingContext(ctx, constants.APIAuthzRoleMetadataKey, string(talosrole.Reader))
 
 	res, err := c.COSI.Get(ctx, cosiresource.NewMetadata(opts.Namespace, opts.Resource, opts.Name, cosiresource.VersionUndefined))
@@ -155,42 +156,58 @@ func (r *Runtime) List(ctx context.Context, setters ...runtime.QueryOption) (run
 	var res []pkgruntime.ListItem
 
 	for _, machine := range opts.Machines {
-		var (
-			c   *Client
-			err error
-		)
-
-		if machine == "" {
-			c, err = r.GetClientForCluster(ctx, opts.Context)
-		} else {
-			c, err = r.GetClientForMachine(ctx, machine)
-		}
-
+		items, err := r.list(ctx, machine, opts)
 		if err != nil {
 			return runtime.ListResult{}, err
 		}
 
-		machineCtx := metadata.AppendToOutgoingContext(ctx, constants.APIAuthzRoleMetadataKey, string(talosrole.Reader))
-
-		items, err := c.COSI.List(machineCtx, cosiresource.NewMetadata(opts.Namespace, opts.Resource, "", cosiresource.VersionUndefined))
-		if err != nil {
-			return runtime.ListResult{}, err
-		}
-
-		for _, item := range items.Items {
-			resource, err := runtime.NewResource(item)
-			if err != nil {
-				return runtime.ListResult{}, err
-			}
-
-			res = append(res, newItem(resource))
-		}
+		res = append(res, items...)
 	}
 
 	return runtime.ListResult{
 		Items: res,
 		Total: len(res),
 	}, nil
+}
+
+// list lists the resources on a single machine, or on the cluster if the machine is empty.
+func (r *Runtime) list(ctx context.Context, machine string, opts *runtime.QueryOptions) ([]pkgruntime.ListItem, error) {
+	var (
+		c   *Client
+		err error
+	)
+
+	if machine == "" {
+		c, err = r.GetClientForCluster(ctx, opts.Context)
+	} else {
+		c, err = r.GetClientForMachine(ctx, machine)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer c.Close() //nolint:errcheck
+
+	machineCtx := metadata.AppendToOutgoingContext(ctx, constants.APIAuthzRoleMetadataKey, string(talosrole.Reader))
+
+	items, err := c.COSI.List(machineCtx, cosiresource.NewMetadata(opts.Namespace, opts.Resource, "", cosiresource.VersionUndefined))
+	if err != nil {
+		return nil, err
+	}
+
+	var res []pkgruntime.ListItem
+
+	for _, item := range items.Items {
+		resource, err := runtime.NewResource(item)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, newItem(resource))
+	}
+
+	return res, nil
 }
 
 // Create implements runtime.Runtime.
@@ -246,39 +263,47 @@ func (r *Runtime) GetTalosconfigRaw(context *common.Context, identity string) ([
 }
 
 // GetClientForCluster returns talos client for the cluster name.
+//
+// The returned client must be closed by the caller.
 func (r *Runtime) GetClientForCluster(ctx context.Context, clusterName string) (*Client, error) {
 	c, err := r.clientFactory.GetForCluster(ctx, clusterName)
 	if err != nil {
 		return nil, err
 	}
 
-	connected, err := c.Connected(ctx, r.clientFactory.omniState)
-	if err != nil {
-		return nil, err
-	}
-
-	if !connected {
-		return nil, fmt.Errorf("the cluster %s is not reachable", clusterName)
-	}
-
-	return c, nil
+	return r.checkConnected(ctx, c)
 }
 
 // GetClientForMachine returns a Talos client connected directly to the given machine's SideroLink endpoint.
 //
 // Cluster membership is determined automatically from the machine's state.
+//
+// The returned client must be closed by the caller.
 func (r *Runtime) GetClientForMachine(ctx context.Context, machineID string) (*Client, error) {
 	c, err := r.clientFactory.GetForMachine(ctx, machineID)
 	if err != nil {
 		return nil, err
 	}
 
+	return r.checkConnected(ctx, c)
+}
+
+// checkConnected returns the client if its cluster or machine is reachable, otherwise it closes the client.
+func (r *Runtime) checkConnected(ctx context.Context, c *Client) (*Client, error) {
 	connected, err := c.Connected(ctx, r.clientFactory.omniState)
 	if err != nil {
+		c.Close() //nolint:errcheck
+
 		return nil, err
 	}
 
 	if !connected {
+		c.Close() //nolint:errcheck
+
+		if c.clusterID == "" {
+			return nil, fmt.Errorf("the machine %s is not reachable", c.machineID)
+		}
+
 		return nil, fmt.Errorf("the cluster %s is not reachable", c.clusterID)
 	}
 

--- a/internal/backend/talos/lifecycle/manager.go
+++ b/internal/backend/talos/lifecycle/manager.go
@@ -28,7 +28,7 @@ type KubernetesClientProvider interface {
 	GetKubernetesClientset(ctx context.Context, cluster string) (k8s.Interface, error)
 }
 
-// TalosClientFactory hands out a cached Talos client for a machine. The returned client must not be closed by the caller.
+// TalosClientFactory hands out a Talos client for a machine. The returned client must be closed by the caller.
 type TalosClientFactory interface {
 	GetForMachine(ctx context.Context, machineID string) (*talos.Client, error)
 }
@@ -174,8 +174,8 @@ func (m *Manager) SupportsLifecycleManagement(version string) error {
 	return nil
 }
 
-// GetForMachine returns the cached Talos client for a machine, selecting maintenance or cluster mode from
-// live state. The client is owned by the factory and must not be closed by the caller.
+// GetForMachine returns the Talos client for a machine, selecting maintenance or cluster mode from live state.
+// The returned client must be closed by the caller.
 func (m *Manager) GetForMachine(ctx context.Context, machineID string) (*talos.Client, error) {
 	if m.talosClientFactory == nil {
 		return nil, status.Error(codes.Internal, "talos client factory not configured")
@@ -208,11 +208,13 @@ func (m *Manager) Run(ctx context.Context, op Operation, opts ...Option) error {
 		zap.String("image", installImageStr),
 		zap.Stringer("operation", op.Kind))
 
-	// The factory owns the cached client, so we never close it.
+	// the client is kept open for the whole operation
 	nodeClient, err := m.GetForMachine(ctx, op.MachineID)
 	if err != nil {
 		return err
 	}
+
+	defer nodeClient.Close() //nolint:errcheck
 
 	talosClient := nodeClient.Client
 


### PR DESCRIPTION
The cached Talos clients were closed when their cache wrapper was garbage collected. Nothing told the callers to keep that wrapper referenced, so a caller working through the embedded client or through a stream lost its connection as soon as the cache dropped the entry. The cache expired the entries a fixed time after their creation, in use or not. This caused an installer image pull to die in the middle of an install.

Every lookup now returns a lease on the shared connection, and the caller closes it when done. The connection is closed only when the last lease and the cache have released it.

Additionally:
- The entries expire when idle instead of on a timer from their creation, so a connection in use is never torn down.
- The cache is a plain map with a periodic sweep in the cache manager loop instead of the LRU library. The client creation is serialized with the cache invalidation, so a client built from a stale state never survives in the cache.
- A lease which is garbage collected without being closed is reported in the log.
- The cache keeps a size limit. When it is full, the clients idle for the longest are closed to make room. A client with open leases is never chosen, so the cache can stay above the limit until those clients are released and the next lookup or the idle sweep trims it.
- The interfaces representing a returned Talos client gained a close method, and the callers which hand the clients over to a library keep them open until the library is done.

Related to siderolabs/omni#3364.