### PR TITLE
DRAFT / DO NOT MERGE: e2e suite IO and CPU wins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,6 +249,7 @@ jobs:
       - name: run-e2e-auth0
         if: github.event_name == 'pull_request'
         env:
+          GO_DEBUG_GCFLAGS: ""
           TEST_CLASS: e2e-auth0
           WITH_DEBUG: "true"
           WITH_RACE: "true"
@@ -327,6 +328,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|EtcdBackupAndRestore)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -402,6 +404,7 @@ jobs:
         env:
           CREATE_QEMU_MACHINES: "false"
           CREATE_TALOS_CLUSTER: "true"
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/ClusterImport
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -475,6 +478,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|DrainTerminationGracePeriod)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -548,6 +552,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosImageGeneration|TalosUpgrades|KernelArgsUpdate)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -622,6 +627,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|ForcedMachineRemoval|ReplaceControlPlanes|ConfigPatching|KubernetesNodeAudit)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -691,6 +697,7 @@ jobs:
       - name: run-e2e-helm
         if: github.event_name == 'pull_request'
         env:
+          GO_DEBUG_GCFLAGS: ""
           TEMP_REGISTRY: registry.dev.siderolabs.io
           TEST_CLASS: e2e-helm
           WITH_DEBUG: "true"
@@ -762,6 +769,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosUpgradesMinor)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -837,6 +845,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|KernelArgsUpdate|MaintenanceUpgrade|MaintenanceLifecycle)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -910,6 +919,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_PREPARE_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|OmniUpgradePrepare)$
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(OmniUpgradeVerify)$
           TEST_CLASS: integration-qemu
@@ -981,6 +991,7 @@ jobs:
       - name: run-e2e-qemu
         if: github.event_name == 'pull_request'
         env:
+          GO_DEBUG_GCFLAGS: ""
           TEST_CLASS: e2e-qemu
           WITH_DEBUG: "true"
           WITH_RACE: "true"
@@ -1052,6 +1063,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|RotateCA)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -1121,6 +1133,7 @@ jobs:
       - name: run-e2e-saml
         if: github.event_name == 'pull_request'
         env:
+          GO_DEBUG_GCFLAGS: ""
           TEST_CLASS: e2e-saml
           WITH_DEBUG: "true"
           WITH_RACE: "true"
@@ -1192,6 +1205,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|ScaleUpAndDown|ScaleUpAndDownMachineClassBasedMachineSets|RollingUpdateParallelism)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -1265,6 +1279,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosImageGeneration|ImmediateClusterDestruction|DefaultCluster|EncryptedCluster|SingleNodeCluster|Auth)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -1338,6 +1353,7 @@ jobs:
       - name: run-integration-qemu
         env:
           ENABLE_SECUREBOOT: "true"
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosImageGeneration|ImmediateClusterDestruction|DefaultCluster|EncryptedCluster|SingleNodeCluster|Auth)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -1407,6 +1423,7 @@ jobs:
       - name: run-e2e-talemu
         if: github.event_name == 'pull_request'
         env:
+          GO_DEBUG_GCFLAGS: ""
           TEST_CLASS: e2e-talemu
           WITH_DEBUG: "true"
           WITH_RACE: "true"
@@ -1485,6 +1502,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|ClusterTemplate)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -1558,6 +1576,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosUpgrades|KubernetesUpgrades)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -1631,6 +1650,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|WorkloadProxy)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -1700,6 +1720,7 @@ jobs:
       - name: run-integration-qemu
         if: github.event_name == 'pull_request'
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|Auth|DefaultCluster|CLICommands)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"
@@ -1787,6 +1808,7 @@ jobs:
       - name: run-integration-talemu
         if: github.event_name == 'pull_request'
         env:
+          GO_DEBUG_GCFLAGS: ""
           TALEMU_TEST_ARGS: --test.run TestIntegration/Suites/(ImmediateClusterDestruction|EncryptedCluster|SingleNodeCluster|ScaleUpAndDown|ScaleUpAndDownMachineClassBasedMachineSets|TalosUpgrades|KubernetesUpgrades|MaintenanceUpgrade|ClusterTemplate|ScaleUpAndDownAutoProvisionMachineSets|AccountLimits)$
           TEST_CLASS: integration-talemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-backups-cron.yaml
+++ b/.github/workflows/e2e-backups-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|EtcdBackupAndRestore)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-cluster-import-cron.yaml
+++ b/.github/workflows/e2e-cluster-import-cron.yaml
@@ -61,6 +61,7 @@ jobs:
         env:
           CREATE_QEMU_MACHINES: "false"
           CREATE_TALOS_CLUSTER: "true"
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/ClusterImport
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-drain-grace-period-cron.yaml
+++ b/.github/workflows/e2e-drain-grace-period-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|DrainTerminationGracePeriod)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-enterprise-cron.yaml
+++ b/.github/workflows/e2e-enterprise-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosImageGeneration|TalosUpgrades|KernelArgsUpdate)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-forced-removal-cron.yaml
+++ b/.github/workflows/e2e-forced-removal-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|ForcedMachineRemoval|ReplaceControlPlanes|ConfigPatching|KubernetesNodeAudit)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-minor-talos-upgrade-cron.yaml
+++ b/.github/workflows/e2e-minor-talos-upgrade-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosUpgradesMinor)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-misc-upgrades-cron.yaml
+++ b/.github/workflows/e2e-misc-upgrades-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|KernelArgsUpdate|MaintenanceUpgrade|MaintenanceLifecycle)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-omni-upgrade-cron.yaml
+++ b/.github/workflows/e2e-omni-upgrade-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_PREPARE_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|OmniUpgradePrepare)$
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(OmniUpgradeVerify)$
           TEST_CLASS: integration-qemu

--- a/.github/workflows/e2e-rotate-ca-cron.yaml
+++ b/.github/workflows/e2e-rotate-ca-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|RotateCA)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-scaling-cron.yaml
+++ b/.github/workflows/e2e-scaling-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|ScaleUpAndDown|ScaleUpAndDownMachineClassBasedMachineSets|RollingUpdateParallelism)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-short-cron.yaml
+++ b/.github/workflows/e2e-short-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosImageGeneration|ImmediateClusterDestruction|DefaultCluster|EncryptedCluster|SingleNodeCluster|Auth)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-short-secureboot-cron.yaml
+++ b/.github/workflows/e2e-short-secureboot-cron.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: run-integration-qemu
         env:
           ENABLE_SECUREBOOT: "true"
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosImageGeneration|ImmediateClusterDestruction|DefaultCluster|EncryptedCluster|SingleNodeCluster|Auth)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-templates-cron.yaml
+++ b/.github/workflows/e2e-templates-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|ClusterTemplate)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-upgrades-cron.yaml
+++ b/.github/workflows/e2e-upgrades-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|TalosUpgrades|KubernetesUpgrades)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.github/workflows/e2e-workload-proxy-cron.yaml
+++ b/.github/workflows/e2e-workload-proxy-cron.yaml
@@ -59,6 +59,7 @@ jobs:
           sops -d .secrets.yaml | yq -e '.secrets | to_entries[] | .key + "=" + .value' >> "$GITHUB_ENV"
       - name: run-integration-qemu
         env:
+          GO_DEBUG_GCFLAGS: ""
           INTEGRATION_TEST_ARGS: --test.run TestIntegration/Suites/(CleanState|WorkloadProxy)$
           TEST_CLASS: integration-qemu
           WITH_DEBUG: "true"

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -244,6 +244,8 @@ spec:
     environment:
       TEST_CLASS: e2e-qemu
       WITH_DEBUG: true
+      # keep the compiler optimizations, only the debug build tag is needed by the tests
+      GO_DEBUG_GCFLAGS: ""
       WITH_RACE: true
 ---
 kind: custom.Step
@@ -272,6 +274,8 @@ spec:
       TEST_CLASS: e2e-helm
       TEMP_REGISTRY: registry.dev.siderolabs.io
       WITH_DEBUG: true
+      # keep the compiler optimizations, only the debug build tag is needed by the tests
+      GO_DEBUG_GCFLAGS: ""
 ---
 kind: custom.Step
 name: run-e2e-talemu
@@ -301,6 +305,8 @@ spec:
     environment:
       TEST_CLASS: e2e-talemu
       WITH_DEBUG: true
+      # keep the compiler optimizations, only the debug build tag is needed by the tests
+      GO_DEBUG_GCFLAGS: ""
       WITH_RACE: true
 ---
 kind: custom.Step
@@ -331,6 +337,8 @@ spec:
     environment:
       TEST_CLASS: e2e-auth0
       WITH_DEBUG: true
+      # keep the compiler optimizations, only the debug build tag is needed by the tests
+      GO_DEBUG_GCFLAGS: ""
       WITH_RACE: true
 ---
 kind: custom.Step
@@ -358,6 +366,8 @@ spec:
     environment:
       TEST_CLASS: e2e-saml
       WITH_DEBUG: true
+      # keep the compiler optimizations, only the debug build tag is needed by the tests
+      GO_DEBUG_GCFLAGS: ""
       WITH_RACE: true
 ---
 kind: custom.Step
@@ -390,6 +400,8 @@ spec:
       TEST_CLASS: integration-talemu
       TALEMU_TEST_ARGS: --test.run TestIntegration/Suites/(ImmediateClusterDestruction|EncryptedCluster|SingleNodeCluster|ScaleUpAndDown|ScaleUpAndDownMachineClassBasedMachineSets|TalosUpgrades|KubernetesUpgrades|MaintenanceUpgrade|ClusterTemplate|ScaleUpAndDownAutoProvisionMachineSets|AccountLimits)$
       WITH_DEBUG: true
+      # keep the compiler optimizations, only the debug build tag is needed by the tests
+      GO_DEBUG_GCFLAGS: ""
       WITH_RACE: true
 ---
 kind: custom.Step
@@ -423,6 +435,8 @@ spec:
       TEST_CLASS: integration-qemu
       INTEGRATION_TEST_ARGS: "--test.run TestIntegration/Suites/(CleanState|Auth|DefaultCluster|CLICommands)$"
       WITH_DEBUG: true
+      # keep the compiler optimizations, only the debug build tag is needed by the tests
+      GO_DEBUG_GCFLAGS: ""
       WITH_RACE: true
     jobs:
       - name: e2e-short-secureboot

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ GO_BUILDFLAGS ?=
 GO_BUILDTAGS ?= memory.counters,libc.memexpvar,
 GO_LDFLAGS ?=
 GO_GCFLAGS ?=
+GO_DEBUG_GCFLAGS ?= -N -l
 CGO_ENABLED ?= 0
 GOTOOLCHAIN ?= local
 GOEXPERIMENT ?=
@@ -162,7 +163,7 @@ GO_LDFLAGS += -linkmode=external -extldflags '-static'
 endif
 
 ifneq (, $(filter $(WITH_DEBUG), t true TRUE y yes 1))
-GO_GCFLAGS += -N -l
+GO_GCFLAGS += $(GO_DEBUG_GCFLAGS)
 GO_BUILDTAGS := $(GO_BUILDTAGS)sidero.debug,
 else
 GO_LDFLAGS += -s

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -466,7 +466,7 @@ config:
       # ExperimentalBaseParams contains the base parameters to be used when opening the SQLite database connection.
       # This can cause data corruption if set incorrectly, modify at your own risk. This flag is experimental and may
       # be removed in future versions. It must not start with a question mark (?).
-      #experimentalBaseParams: _txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)
+      #experimentalBaseParams: ""
       # ExtraParams contains the extra parameters to be used when opening the SQLite database connection. This can
       # cause data corruption if set incorrectly, modify at your own risk. It must not start with an ampersand (&).
       #extraParams: ""

--- a/frontend/src/api/talos/containers.pb.ts
+++ b/frontend/src/api/talos/containers.pb.ts
@@ -25,6 +25,7 @@ export type ContainerSecuritySpec = {
   privileged?: boolean
   capabilitiesAdd?: string[]
   capabilitiesDrop?: string[]
+  machinedAccess?: boolean
 }
 
 export type ContainerNetworkSpec = {
@@ -61,5 +62,46 @@ export type ContainerImageStatusSpec = {
   phase?: string
   image?: string
   digest?: string
+  error?: string
+}
+
+export type ResolvedMountSpec = {
+  kind?: string
+  source?: string
+  destination?: string
+  size?: number
+  options?: string[]
+  volumeID?: string
+}
+
+export type ContainerInstanceSpecSpec = {
+  containerID?: string
+  generation?: number
+  image?: string
+  entrypoint?: string[]
+  args?: string[]
+  workingDir?: string
+  runAs?: ContainerRunAsSpec
+  environment?: string[]
+  mounts?: ResolvedMountSpec[]
+  security?: ContainerSecuritySpec
+  network?: ContainerNetworkSpec
+  resources?: ContainerResourcesSpec
+}
+
+export type ContainerInstanceStatusSpec = {
+  containerID?: string
+  generation?: number
+  phase?: string
+  pid?: number
+  exitCode?: number
+  error?: string
+  startedAt?: string
+  finishedAt?: string
+}
+
+export type ContainerMountStatusSpec = {
+  ready?: boolean
+  mounts?: ResolvedMountSpec[]
   error?: string
 }

--- a/frontend/src/api/talos/kubespan.pb.ts
+++ b/frontend/src/api/talos/kubespan.pb.ts
@@ -11,6 +11,7 @@ export type ConfigSpec = {
   advertiseKubernetesNetworks?: boolean
   mtu?: number
   endpointFilters?: string[]
+  peerEndpointFilters?: string[]
   harvestExtraEndpoints?: boolean
   extraEndpoints?: string[]
   excludeAdvertisedNetworks?: string[]

--- a/frontend/src/api/talos/network.pb.ts
+++ b/frontend/src/api/talos/network.pb.ts
@@ -186,13 +186,25 @@ export type VLANSpec = {
   vlanProtocol?: string
 }
 
+export type MacVLANSpec = {
+  mode?: string
+}
+
+export type VXLANSpec = {
+  id?: number
+  local?: string
+  group?: string
+  port?: number
+  learning?: boolean
+}
+
 export type BondMasterSpec = {
   mode?: string
   xmitHashPolicy?: string
   lacpRate?: string
   arpValidate?: string
   arpAllTargets?: string
-  primary?: number
+  primaryIndex?: number
   primaryReselect?: string
   failOverMac?: string
   adSelect?: string
@@ -215,6 +227,7 @@ export type BondMasterSpec = {
   nsIp6Targets?: string[]
   adLacpActive?: string
   missedMax?: number
+  primary?: string
 }
 
 export type STPSpec = {
@@ -287,11 +300,13 @@ export type LinkSpecSpec = {
   bridgeSlave?: BridgeSlave
   vrfSlave?: VRFSlave
   vlan?: VLANSpec
+  macvlan?: MacVLANSpec
   bondMaster?: BondMasterSpec
   bridgeMaster?: BridgeMasterSpec
   vrfMaster?: VRFMasterSpec
   wireguard?: WireguardSpec
   veth?: VethSpec
+  vxlan?: VXLANSpec
   layer?: string
   multicast?: boolean
 }
@@ -326,6 +341,8 @@ export type LinkStatusSpec = {
   port?: string
   duplex?: string
   vlan?: VLANSpec
+  macvlan?: MacVLANSpec
+  vxlan?: VXLANSpec
   bridgeMaster?: BridgeMasterSpec
   bondMaster?: BondMasterSpec
   vrfMaster?: VRFMasterSpec

--- a/frontend/src/api/talos/runtime.pb.ts
+++ b/frontend/src/api/talos/runtime.pb.ts
@@ -84,8 +84,14 @@ export type KernelParamStatusSpec = {
   unsupported?: boolean
 }
 
+export type KmsgLogDestination = {
+  endpoint?: string
+  extraTags?: {[key: string]: string}
+}
+
 export type KmsgLogConfigSpec = {
   destinations?: string[]
+  taggedDestinations?: KmsgLogDestination[]
 }
 
 export type LoadedKernelModuleSpec = {
@@ -170,6 +176,7 @@ export type SecurityStateSpec = {
   fipsState?: string
   bootedWithUKI?: boolean
   moduleSignatureEnforced?: boolean
+  lockdownState?: string
 }
 
 export type ServicePIDSpec = {

--- a/go.mod
+++ b/go.mod
@@ -320,3 +320,5 @@ require (
 )
 
 replace github.com/cosi-project/state-sqlite => github.com/utkuozdemir/cosi-state-sqlite v0.0.0-20260905093546-adc9cab50e6b
+
+replace github.com/siderolabs/talos/pkg/machinery => github.com/utkuozdemir/talos/pkg/machinery v0.15.0-alpha.1.0.20260904232447-42f563cc1006

--- a/go.mod
+++ b/go.mod
@@ -318,3 +318,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/cosi-project/state-sqlite => github.com/utkuozdemir/cosi-state-sqlite v0.0.0-20260905093546-adc9cab50e6b

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/cosi-project/runtime v1.16.3 h1:EQ1oubPjAVPnAFc5GhSGfHuiPcm8b2g2XsPnp
 github.com/cosi-project/runtime v1.16.3/go.mod h1:p3nyBuIqeipcfQHuM9uGjLkFN2gYA9GJFL4oSEEtmm0=
 github.com/cosi-project/state-etcd v0.7.0 h1:7EYGKbGClLA0h910oMWxtw4NZh9qt6GebaGxqGm7zts=
 github.com/cosi-project/state-etcd v0.7.0/go.mod h1:hplOOGHR1Rt/T8fiuFcP16thoQDvprqP/aateuCv36o=
-github.com/cosi-project/state-sqlite v0.4.0 h1:SwL5/LlAwnMomRjMM72igPA1F6W/88zbae4cFxqz5vw=
-github.com/cosi-project/state-sqlite v0.4.0/go.mod h1:V20oy2Sfxla0zZ+SJSgjV20feg2xGARlvVPL4Z4KfRo=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -528,6 +526,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/unix4ever/saml v0.0.0-20250630213700-66b137182abe h1:yEOKa5C22XlVd77FvZON16ORl6gXJ9F5mPSizYwix50=
 github.com/unix4ever/saml v0.0.0-20250630213700-66b137182abe/go.mod h1:6WchMcmyjQveGycr2BnOKa05UlR9v5z7jU2l//YKhJk=
+github.com/utkuozdemir/cosi-state-sqlite v0.0.0-20260905093546-adc9cab50e6b h1:+vwkE/iG+Tm8SvFFd9azH9VDOzRK8Obzzw1wWCdq3QA=
+github.com/utkuozdemir/cosi-state-sqlite v0.0.0-20260905093546-adc9cab50e6b/go.mod h1:V20oy2Sfxla0zZ+SJSgjV20feg2xGARlvVPL4Z4KfRo=
 github.com/valyala/fastjson v1.6.7 h1:ZE4tRy0CIkh+qDc5McjatheGX2czdn8slQjomexVpBM=
 github.com/valyala/fastjson v1.6.7/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,6 @@ github.com/siderolabs/protoenc v0.2.4 h1:D3Fpn2nQSQOhl8ZlAxijZAf7K6F8CM1uZq0afIG
 github.com/siderolabs/protoenc v0.2.4/go.mod h1:i5XLHjfv5vyi7LhQrSEo19HCA+lYtDd7CWxsoWp9XE8=
 github.com/siderolabs/siderolink v0.3.17 h1:XrHd9KTw1vecMdFw5kA+fIyH8/bGf9Yhp+IJJjbm+/Y=
 github.com/siderolabs/siderolink v0.3.17/go.mod h1:30KnTBfTrb02WAJDpXQicIZoLPjiZNSVjMP74VsIQh0=
-github.com/siderolabs/talos/pkg/machinery v1.14.0-rc.2.0.20260825161121-322de8bf2974 h1:9JEin6yanC+PFV5lbWYa2WzVw/l4XodlEl4YqbW6O3o=
-github.com/siderolabs/talos/pkg/machinery v1.14.0-rc.2.0.20260825161121-322de8bf2974/go.mod h1:oL3TmTv3RasTvMJx1kCZV9fqbUqkOdmTMfGjzQDk8F0=
 github.com/siderolabs/tcpproxy v0.1.0 h1:IbkS9vRhjMOscc1US3M5P1RnsGKFgB6U5IzUk+4WkKA=
 github.com/siderolabs/tcpproxy v0.1.0/go.mod h1:onn6CPPj/w1UNqQ0U97oRPF0CqbrgEApYCw4P9IiCW8=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -528,6 +526,8 @@ github.com/unix4ever/saml v0.0.0-20250630213700-66b137182abe h1:yEOKa5C22XlVd77F
 github.com/unix4ever/saml v0.0.0-20250630213700-66b137182abe/go.mod h1:6WchMcmyjQveGycr2BnOKa05UlR9v5z7jU2l//YKhJk=
 github.com/utkuozdemir/cosi-state-sqlite v0.0.0-20260905093546-adc9cab50e6b h1:+vwkE/iG+Tm8SvFFd9azH9VDOzRK8Obzzw1wWCdq3QA=
 github.com/utkuozdemir/cosi-state-sqlite v0.0.0-20260905093546-adc9cab50e6b/go.mod h1:V20oy2Sfxla0zZ+SJSgjV20feg2xGARlvVPL4Z4KfRo=
+github.com/utkuozdemir/talos/pkg/machinery v0.15.0-alpha.1.0.20260904232447-42f563cc1006 h1:bvgHXURAvR8jK51IV2S5j+2jnx5U++jAZewQhYGVdvE=
+github.com/utkuozdemir/talos/pkg/machinery v0.15.0-alpha.1.0.20260904232447-42f563cc1006/go.mod h1:1d5Ifhgm34wZORpFrp9ZmITG7gNT7u3yKHRKi+hlsro=
 github.com/valyala/fastjson v1.6.7 h1:ZE4tRy0CIkh+qDc5McjatheGX2czdn8slQjomexVpBM=
 github.com/valyala/fastjson v1.6.7/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -131,7 +131,30 @@ export RUN_DIR
 LOCAL_IP=$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
 export LOCAL_IP
 
+# Print the host IO and CPU pressure, the disk counters and the disk usage, so that a slow runner shows up in the job log.
+function print_host_pressure() {
+  # the trace output would interleave with the snapshot, so it is turned off for the duration of the function
+  local -
+  set +x
+
+  echo "--- host pressure snapshot: $1 ($(date -u +%FT%TZ)) ---"
+  {
+    local f
+    for f in io cpu memory; do
+      echo "pressure/${f}:"
+      cat "/proc/pressure/${f}"
+    done
+    echo "diskstats:"
+    awk '$3 ~ /^(nvme[0-9]+n[0-9]+|sd[a-z]+|vd[a-z]+)$/' /proc/diskstats
+    df -h "${TEST_OUTPUTS_DIR}" "${HOME}" "${ARTIFACTS}" 2>/dev/null
+    docker system df
+  } 2>&1 || true
+  echo "--- end of host pressure snapshot ---"
+}
+
 mkdir -p "$TEST_OUTPUTS_DIR"
+
+print_host_pressure "start"
 
 export ENABLE_TALOS_PRERELEASE_VERSIONS=true
 VAULT_DOCKER_IMAGE=hashicorp/vault:1.18
@@ -173,6 +196,8 @@ function configure_registry_mirrors() {
 
 function common_cleanup() {
   cd "${RUN_DIR}"
+
+  print_host_pressure "end"
   rm -rf "${ARTIFACTS}/omni.db" "${ARTIFACTS}/etcd/"
 
   if [[ $PARTIAL_CONFIG_SERVER_PID -ne 0 ]]; then

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -210,7 +210,8 @@ function common_cleanup() {
 }
 
 function prepare_artifacts() {
-  [[ -f "${ARTIFACTS}/talosctl" ]] || (crane export ghcr.io/siderolabs/talosctl:latest | tar x -C "${ARTIFACTS}")
+  # TEMP: a talosctl build with the disk cache mode option, until it lands in the latest talosctl image.
+  [[ -f "${ARTIFACTS}/talosctl" ]] || (crane export ghcr.io/utkuozdemir/talosctl:v1.15.0-alpha.0-omni-ci-io-wins | tar x -C "${ARTIFACTS}")
   [[ -f "${ARTIFACTS}/mc" ]] || curl -Lo "${ARTIFACTS}/mc" https://dl.min.io/client/mc/release/linux-amd64/mc
   chmod +x "${ARTIFACTS}/mc"
 
@@ -526,6 +527,8 @@ function create_machines() {
     # The disks are throwaway: no preallocation on the runner disk, and the guest writes stay in the host page cache.
     "--disk-preallocate=false"
     "--disk-cache-mode=unsafe"
+    # TEMP: the talosctl build from the fork has no release to download the CNI bundle from.
+    '--cni-bundle-url=https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-cni-bundle-${ARCH}.tar.gz'
   )
 
   if [[ "${uki}" == "false" ]]; then
@@ -604,6 +607,8 @@ function create_talos_cluster { # args: name, cp_count, wk_count, cidr, talos_ve
     # The disks are throwaway: no preallocation on the runner disk, and the guest writes stay in the host page cache.
     "--disk-preallocate=false"
     "--disk-cache-mode=unsafe"
+    # TEMP: the talosctl build from the fork has no release to download the CNI bundle from.
+    '--cni-bundle-url=https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-cni-bundle-${ARCH}.tar.gz'
   )
 
   if [[ "${allow_scheduling_on_control_planes}" == "true" ]]; then

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -523,8 +523,9 @@ function create_machines() {
     "--skip-injecting-config"
     "--skip-injecting-extra-cmdline"
     "--wait=false"
-    # The disks are throwaway, so do not reserve their full size up front on the runner disk.
+    # The disks are throwaway: no preallocation on the runner disk, and the guest writes stay in the host page cache.
     "--disk-preallocate=false"
+    "--disk-cache-mode=unsafe"
   )
 
   if [[ "${uki}" == "false" ]]; then
@@ -600,8 +601,9 @@ function create_talos_cluster { # args: name, cp_count, wk_count, cidr, talos_ve
     "--talos-version=${talos_version}"
     "--install-image=factory.talos.dev/metal-installer/${schematic_id}:v${talos_version}"
     "--iso-path=https://factory.talos.dev/image/${schematic_id}/v${talos_version}/metal-amd64.iso"
-    # The disks are throwaway, so do not reserve their full size up front on the runner disk.
+    # The disks are throwaway: no preallocation on the runner disk, and the guest writes stay in the host page cache.
     "--disk-preallocate=false"
+    "--disk-cache-mode=unsafe"
   )
 
   if [[ "${allow_scheduling_on_control_planes}" == "true" ]]; then

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -202,15 +202,28 @@ function prepare_vault() {
   # Start Vault.
   docker run --rm -d --cap-add=IPC_LOCK -p 8200:8200 -e VAULT_DEV_ROOT_TOKEN_ID="${VAULT_TOKEN}" --name "${VAULT_CONTAINER_NAME}" "${VAULT_DOCKER_IMAGE}"
 
-  sleep 10
+  # Wait for the dev server to be initialized and unsealed instead of sleeping a fixed time.
+  local i
+  for i in $(seq 1 30); do
+    if curl -sf "${VAULT_ADDR}/v1/sys/health" >/dev/null; then
+      break
+    fi
+
+    if [[ "$i" -eq 30 ]]; then
+      echo "Error: Vault did not become ready in time" >&2
+      docker logs "${VAULT_CONTAINER_NAME}" >&2 || true
+
+      return 1
+    fi
+
+    sleep 1
+  done
 
   # Load key into Vault.
   docker cp ./internal/backend/runtime/omni/testdata/pgp/old_key.private "${VAULT_CONTAINER_NAME}":/tmp/old_key.private
   docker exec -e VAULT_ADDR="${VAULT_ADDR}" -e VAULT_TOKEN="${VAULT_TOKEN}" "${VAULT_CONTAINER_NAME}" \
     vault kv put -mount=secret omni-private-key \
     private-key=@/tmp/old_key.private
-
-  sleep 5
 }
 
 function vault_cleanup() {

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -485,6 +485,8 @@ function create_machines() {
     "--skip-injecting-config"
     "--skip-injecting-extra-cmdline"
     "--wait=false"
+    # The disks are throwaway, so do not reserve their full size up front on the runner disk.
+    "--disk-preallocate=false"
   )
 
   if [[ "${uki}" == "false" ]]; then
@@ -560,6 +562,8 @@ function create_talos_cluster { # args: name, cp_count, wk_count, cidr, talos_ve
     "--talos-version=${talos_version}"
     "--install-image=factory.talos.dev/metal-installer/${schematic_id}:v${talos_version}"
     "--iso-path=https://factory.talos.dev/image/${schematic_id}/v${talos_version}/metal-amd64.iso"
+    # The disks are throwaway, so do not reserve their full size up front on the runner disk.
+    "--disk-preallocate=false"
   )
 
   if [[ "${allow_scheduling_on_control_planes}" == "true" ]]; then

--- a/hack/test/e2e-auth0.sh
+++ b/hack/test/e2e-auth0.sh
@@ -39,6 +39,7 @@ export MAX_SERVICE_ACCOUNTS=5
 prepare_omni_config
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
+  OMNI_DEV_ECDSA_SERVICE_ACCOUNT_KEY=true \
   "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \

--- a/hack/test/e2e-auth0.sh
+++ b/hack/test/e2e-auth0.sh
@@ -39,7 +39,7 @@ export MAX_SERVICE_ACCOUNTS=5
 prepare_omni_config
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
-  nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
+  "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \
   "${REGISTRY_MIRROR_FLAGS[@]}" >"${TEST_OUTPUTS_DIR}/omni-e2e.log" 2>&1 &

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -74,7 +74,7 @@ if [[ "${CREATE_QEMU_MACHINES:-true}" == "true" ]]; then
 fi
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
-  nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
+  "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \
   "${REGISTRY_MIRROR_FLAGS[@]}" >"${TEST_OUTPUTS_DIR}/omni-e2e.log" 2>&1 &

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -74,6 +74,7 @@ if [[ "${CREATE_QEMU_MACHINES:-true}" == "true" ]]; then
 fi
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
+  OMNI_DEV_ECDSA_SERVICE_ACCOUNT_KEY=true \
   "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \

--- a/hack/test/e2e-saml.sh
+++ b/hack/test/e2e-saml.sh
@@ -43,6 +43,7 @@ export MAX_SERVICE_ACCOUNTS=5
 prepare_omni_config
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
+  OMNI_DEV_ECDSA_SERVICE_ACCOUNT_KEY=true \
   "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \

--- a/hack/test/e2e-saml.sh
+++ b/hack/test/e2e-saml.sh
@@ -43,7 +43,7 @@ export MAX_SERVICE_ACCOUNTS=5
 prepare_omni_config
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
-  nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
+  "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \
   "${REGISTRY_MIRROR_FLAGS[@]}" >"${TEST_OUTPUTS_DIR}/omni-e2e.log" 2>&1 &

--- a/hack/test/e2e-talemu.sh
+++ b/hack/test/e2e-talemu.sh
@@ -55,7 +55,7 @@ docker run --name "${TALEMU_CONTAINER_NAME}" \
   --omni-api-endpoint="https://${LOCAL_IP}:8099"
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
-  nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
+  "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \
   "${REGISTRY_MIRROR_FLAGS[@]}" >"${TEST_OUTPUTS_DIR}/omni-e2e.log" 2>&1 &

--- a/hack/test/e2e-talemu.sh
+++ b/hack/test/e2e-talemu.sh
@@ -55,6 +55,7 @@ docker run --name "${TALEMU_CONTAINER_NAME}" \
   --omni-api-endpoint="https://${LOCAL_IP}:8099"
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
+  OMNI_DEV_ECDSA_SERVICE_ACCOUNT_KEY=true \
   "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \

--- a/hack/test/helm/templates/omni-values.yaml
+++ b/hack/test/helm/templates/omni-values.yaml
@@ -80,6 +80,8 @@ config:
 env:
   - name: SIDEROLINK_DEV_JOIN_TOKEN
     value: ${JOIN_TOKEN}
+  - name: OMNI_DEV_ECDSA_SERVICE_ACCOUNT_KEY
+    value: "true"
 
 service:
   main:

--- a/hack/test/helm/templates/omni-values.yaml
+++ b/hack/test/helm/templates/omni-values.yaml
@@ -55,6 +55,11 @@ config:
       - ${AUTH_USERNAME}
   registries:
     mirrors: ${REGISTRY_MIRRORS_JSON}
+  storage:
+    default:
+      etcd:
+        # The embedded etcd phase is a throwaway, skip the fsyncs like the other e2e suites do.
+        embeddedUnsafeFsync: true
   services:
     api:
       advertisedURL: https://omni.example.org

--- a/hack/test/integration-qemu.sh
+++ b/hack/test/integration-qemu.sh
@@ -154,6 +154,7 @@ fi
 
 # Run the integration test.
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
+  OMNI_DEV_ECDSA_SERVICE_ACCOUNT_KEY=true \
   SSL_CERT_DIR=hack/certs:/etc/ssl/certs \
   "${ARTIFACTS}/integration-test-linux-amd64" \
   --omni.talos-version="${TALOS_VERSION}" \

--- a/hack/test/integration-talemu.sh
+++ b/hack/test/integration-talemu.sh
@@ -69,6 +69,7 @@ docker run --name "${TALEMU_CONTAINER_NAME}" \
   --omni-api-endpoint="https://${LOCAL_IP}:8099"
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
+  OMNI_DEV_ECDSA_SERVICE_ACCOUNT_KEY=true \
   SSL_CERT_DIR=hack/certs:/etc/ssl/certs \
   "${ARTIFACTS}/integration-test-linux-amd64" \
   --omni.talos-version="${TALOS_VERSION}" \

--- a/internal/backend/runtime/omni/controllers/omni/machine_status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status.go
@@ -42,6 +42,13 @@ type KernelArgsInitializer interface {
 	Init(ctx context.Context, id resource.ID, args []string) error
 }
 
+const (
+	// notificationAttempts is the number of times a machine notification is handled before it is given up.
+	notificationAttempts = 3
+	// notificationRetryDelay is the delay between two attempts to handle a machine notification.
+	notificationRetryDelay = 200 * time.Millisecond
+)
+
 // MachineStatusControllerName is the name of the MachineStatusController.
 const MachineStatusControllerName = "MachineStatusController"
 
@@ -134,7 +141,7 @@ func (ctrl *MachineStatusController) Settings() controller.QSettings {
 				case <-ctx.Done():
 					return nil
 				case event := <-ctrl.notifyCh:
-					if err := ctrl.handleNotification(ctx, r, event, logger); err != nil {
+					if err := ctrl.handleNotificationWithRetry(ctx, r, event, logger); err != nil {
 						return err
 					}
 				}
@@ -400,6 +407,36 @@ func (ctrl *MachineStatusController) populateSchematicRaw(ctx context.Context, i
 	info.KernelArgs = parsed.Customization.ExtraKernelArgs
 
 	return nil
+}
+
+// handleNotificationWithRetry handles a notification and retries it a few times when it fails.
+//
+// A notification is consumed from the channel, and the collect task sends the next one only when the machine info changes.
+// Without the retry, a transient failure (e.g., an audit log write timing out) drops the machine info until the machine changes.
+// For a machine in maintenance mode, that is never. The attempts are few and quick, because the channel is unbuffered and
+// shared: the collect tasks of all other machines wait while this one is retried.
+func (ctrl *MachineStatusController) handleNotificationWithRetry(ctx context.Context, r controller.QRuntime, event machinetask.Info, logger *zap.Logger) error {
+	var err error
+
+	for attempt := range notificationAttempts {
+		if err = ctrl.handleNotification(ctx, r, event, logger); err == nil {
+			return nil
+		}
+
+		if attempt == notificationAttempts-1 {
+			break
+		}
+
+		logger.Warn("failed to handle machine notification, retrying", zap.Int("attempt", attempt+1), zap.Error(err))
+
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(notificationRetryDelay):
+		}
+	}
+
+	return err
 }
 
 //nolint:gocyclo,cyclop,gocognit

--- a/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_status_test.go
@@ -7,6 +7,8 @@ package omni_test
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -38,6 +40,11 @@ type MachineStatusSuite struct {
 }
 
 func (suite *MachineStatusSuite) setup() {
+	suite.setupWithKernelArgsInitializer(nil)
+}
+
+// setupWithKernelArgsInitializer sets up the suite, wrapping the kernel args initializer with the given function if it is not nil.
+func (suite *MachineStatusSuite) setupWithKernelArgsInitializer(wrap func(omnictrl.KernelArgsInitializer) omnictrl.KernelArgsInitializer) {
 	suite.startRuntime()
 
 	suite.Require().NoError(
@@ -55,10 +62,16 @@ func (suite *MachineStatusSuite) setup() {
 
 	logger := zaptest.NewLogger(suite.T())
 
-	exraKernelArgsInitializer, err := kernelargs.NewInitializer(suite.state, logger)
+	var kernelArgsInitializer omnictrl.KernelArgsInitializer
+
+	kernelArgsInitializer, err := kernelargs.NewInitializer(suite.state, logger)
 	suite.Require().NoError(err)
 
-	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineStatusController(testutils.NewFactoryClientSet(), exraKernelArgsInitializer)))
+	if wrap != nil {
+		kernelArgsInitializer = wrap(kernelArgsInitializer)
+	}
+
+	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineStatusController(testutils.NewFactoryClientSet(), kernelArgsInitializer)))
 	suite.Require().NoError(suite.runtime.RegisterQController(omnictrl.NewMachineJoinConfigController()))
 	suite.Require().NoError(suite.runtime.RegisterQController(newMockJoinTokenUsageController[*omni.Machine]()))
 }
@@ -693,6 +706,63 @@ func (suite *MachineStatusSuite) TestMachineSchematic() {
 			})
 		})
 	}
+}
+
+// failingKernelArgsInitializer runs the real initializer with an extra kernel arg, so that the KernelArgs resource is created. Then it fails the first call.
+//
+// This mimics the production failure, where the nested write is committed and the audit log write after it fails.
+// The retry then has to tolerate the conflict on the already existing resource.
+type failingKernelArgsInitializer struct {
+	inner omnictrl.KernelArgsInitializer
+	calls atomic.Int32
+}
+
+func (f *failingKernelArgsInitializer) Init(ctx context.Context, id resource.ID, args []string) error {
+	if err := f.inner.Init(ctx, id, append(args, extraKernelArg)); err != nil {
+		return err
+	}
+
+	if f.calls.Add(1) == 1 {
+		return errors.New("injected failure")
+	}
+
+	return nil
+}
+
+const extraKernelArg = "console=ttyS0"
+
+// TestNotificationRetried checks that a machine notification which fails on a nested write is retried, instead of being dropped.
+//
+// The machine info is only sent again when it changes, so a dropped notification leaves the machine without its status for good.
+func (suite *MachineStatusSuite) TestNotificationRetried() {
+	failing := &failingKernelArgsInitializer{}
+
+	suite.setupWithKernelArgsInitializer(func(inner omnictrl.KernelArgsInitializer) omnictrl.KernelArgsInitializer {
+		failing.inner = inner
+
+		return failing
+	})
+
+	ctx, cancel := context.WithTimeout(suite.ctx, time.Second*5)
+	defer cancel()
+
+	machine := omni.NewMachine(testID)
+	machine.TypedSpec().Value.Connected = true
+	machine.TypedSpec().Value.ManagementAddress = suite.socketConnectionString
+
+	suite.Require().NoError(suite.state.Create(ctx, machine))
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(status *omni.MachineStatus, assert *assert.Assertions) {
+		_, initialized := status.Metadata().Annotations().Get(omni.KernelArgsInitialized)
+		assert.True(initialized, "kernel args should be initialized after the retry")
+		assert.NotNil(status.TypedSpec().Value.Schematic)
+	})
+
+	rtestutils.AssertResources(ctx, suite.T(), suite.state, []string{testID}, func(kernelArgs *omni.KernelArgs, assert *assert.Assertions) {
+		assert.Equal([]string{extraKernelArg}, kernelArgs.TypedSpec().Value.Args)
+	})
+
+	suite.GreaterOrEqual(failing.calls.Load(), int32(2), "the failed notification should have been retried")
 }
 
 func TestMachineStatusSuite(t *testing.T) {

--- a/internal/backend/runtime/omni/controllers/omni/secrets/secrets.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/secrets.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/etcdbackup"
@@ -125,7 +127,7 @@ func NewSecretsController(etcdBackupStoreFactory store.Factory) *Controller {
 					return nil
 				}
 
-				bundle, err := talossecrets.NewBundle(talossecrets.NewFixedClock(time.Now()), versionContract)
+				bundle, err := talossecrets.NewBundle(talossecrets.NewFixedClock(time.Now()), versionContract, bundleOptions(logger)...)
 				if err != nil {
 					return fmt.Errorf("error generating secrets: %w", err)
 				}
@@ -332,4 +334,27 @@ func (s *Controller) handlePostRotate(secrets *omni.ClusterSecrets, secretRotati
 	case specs.SecretRotationSpec_NONE:
 		// nothing to do
 	}
+}
+
+// devECDSAServiceAccountKeyEnvVar switches the Kubernetes service account key of new clusters from RSA to ECDSA.
+//
+// An RSA key takes hundreds of milliseconds to generate, an ECDSA key about a millisecond. This adds up in the tests, which create many clusters.
+// RSA stays the default because some external systems (e.g., AWS IAM roles for service accounts) do not accept ECDSA signed tokens.
+// Like the dev join token, this is only honored in debug builds.
+const devECDSAServiceAccountKeyEnvVar = "OMNI_DEV_ECDSA_SERVICE_ACCOUNT_KEY"
+
+func bundleOptions(logger *zap.Logger) []talossecrets.Option {
+	if os.Getenv(devECDSAServiceAccountKeyEnvVar) == "" {
+		return nil
+	}
+
+	if !constants.IsDebugBuild {
+		logger.Sugar().Warnf("environment variable %s is set, but this is not a debug build, ignoring", devECDSAServiceAccountKeyEnvVar)
+
+		return nil
+	}
+
+	logger.Sugar().Warnf("generating an ECDSA service account key because of environment variable %s. THIS IS NOT RECOMMENDED FOR PRODUCTION USE.", devECDSAServiceAccountKeyEnvVar)
+
+	return []talossecrets.Option{talossecrets.WithECDSAServiceAccountKey()}
 }

--- a/internal/backend/runtime/omni/sqlite/sqlite.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/siderolabs/gen/panicsafe"
 	zombiesqlite "zombiezen.com/go/sqlite"
+	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
@@ -44,6 +45,12 @@ func OpenDB(config config.SQLite) (*sqlitexx.Pool, error) {
 			Flags:         zombiesqlite.OpenReadWrite | zombiesqlite.OpenCreate | zombiesqlite.OpenWAL | zombiesqlite.OpenURI,
 			LowWatermark:  config.GetCachedPoolSize(),
 			HighWatermark: config.GetPoolSize(),
+			// SQLite keeps the synchronous mode per connection and does not take it from the URI, so it is set on every new connection.
+			// NORMAL skips the fsync on every commit in WAL mode. The last commits can be lost on a power loss but the database stays
+			// consistent, which is fine for the logs, the audit log and the frequently updated data this database holds.
+			PrepareConn: func(conn *zombiesqlite.Conn) error {
+				return sqlitex.ExecuteTransient(conn, "PRAGMA synchronous=NORMAL", nil)
+			},
 		},
 	)
 	if err != nil {

--- a/internal/backend/runtime/omni/sqlite/sqlite_test.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlite_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zombiesqlite "zombiezen.com/go/sqlite"
+	"zombiezen.com/go/sqlite/sqlitex"
+
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+// TestOpenDBSetsSynchronousNormal checks that every connection of the pool runs with the NORMAL synchronous mode.
+func TestOpenDBSetsSynchronousNormal(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Default().Storage.Sqlite
+	conf.SetPath(filepath.Join(t.TempDir(), "test.db"))
+	conf.SetCachedPoolSize(2)
+	conf.SetPoolSize(2)
+
+	db, err := sqlite.OpenDB(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, sqlite.CloseDB(db, 5*time.Second))
+	})
+
+	ctx := t.Context()
+
+	// take both connections at once, so that both are freshly opened
+	conn1, err := db.Take(ctx)
+	require.NoError(t, err)
+
+	conn2, err := db.Take(ctx)
+	require.NoError(t, err)
+
+	for _, conn := range []*zombiesqlite.Conn{conn1, conn2} {
+		assert.Equal(t, "wal", readPragma(t, conn, "journal_mode"))
+		assert.Equal(t, "1", readPragma(t, conn, "synchronous"), "synchronous should be NORMAL")
+
+		db.Put(conn)
+	}
+}
+
+func readPragma(t *testing.T, conn *zombiesqlite.Conn, name string) string {
+	t.Helper()
+
+	var value string
+
+	require.NoError(t, sqlitex.ExecuteTransient(conn, "PRAGMA "+name, &sqlitex.ExecOptions{
+		ResultFunc: func(stmt *zombiesqlite.Stmt) error {
+			value = stmt.ColumnText(0)
+
+			return nil
+		},
+	}))
+
+	return value
+}

--- a/internal/integration/kubernetes_test.go
+++ b/internal/integration/kubernetes_test.go
@@ -109,7 +109,9 @@ func AssertKubernetesAPIAccessViaOmni(testCtx context.Context, omniClient *clien
 					ok    bool
 				)
 
-				assert.NoError(t, retry.Constant(time.Second*30).RetryWithContext(ctx, func(ctx context.Context) error {
+				// The label is applied by the node's own controller through its local apiserver, which takes minutes on a starved runner.
+				// Give it the same budget as the node list check above.
+				assert.NoError(t, retry.Constant(3*time.Minute, retry.WithUnits(5*time.Second)).RetryWithContext(ctx, func(ctx context.Context) error {
 					label, ok = k8sNode.Labels[nodeLabel]
 					if !ok {
 						var n *corev1.Node

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -613,7 +613,7 @@ func TestSchemaDefaults(t *testing.T) {
 	assert.Equal(t, "_out/omni.db", p.Storage.Default.Boltdb.GetPath())
 
 	// storage.sqlite
-	assert.Equal(t, "_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)", p.Storage.Sqlite.GetExperimentalBaseParams())
+	assert.Equal(t, "", p.Storage.Sqlite.GetExperimentalBaseParams())
 	assert.Equal(t, 4, p.Storage.Sqlite.GetCachedPoolSize())
 	assert.Equal(t, 64, p.Storage.Sqlite.GetPoolSize())
 	assert.Equal(t, 2*time.Minute, p.Storage.Sqlite.Metrics.GetRefreshInterval())

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -1575,7 +1575,7 @@
           "type": "string",
           "pattern": "^(?:$|[^?].*)",
           "x-pattern-message": "must not start with '?'",
-          "default": "_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)",
+          "default": "",
           "goJSONSchema": {
             "pointer": true
           }


### PR DESCRIPTION
Draft branch with the e2e suite IO and CPU wins from the CI analysis. One commit per item, to be split into separate pull requests. Opened as a draft to get a full e2e run. Do not merge.

On purpose in this draft:
- the three "temporarily" commits carry replace directives and a talosctl image from a fork
- the commits are unsigned

What the commits do:
- Do not preallocate the QEMU disks. `talosctl` preallocates every VM disk by default, so a QEMU job reserved 60 GiB on the runner disk before a single machine booted.
- Wait for Vault readiness instead of sleeping a fixed 15 seconds, like the Dex, Keycloak and MinIO setups already do.
- Print the host pressure stall information, the disk counters and the disk usage at the start and at the end of every test script, so that a slow runner shows up in the job log.
- Run the Omni server with normal priority. The e2e scripts started it under `nice -n 10` since the initial commit.
- Skip the etcd fsync in the Helm e2e embedded etcd phase, like the other suites do.
- Run the sqlite database with the NORMAL synchronous mode. The pragmas in the connection string were ignored by the current driver, so every machine log line and every audit event was an fsync. Closes siderolabs/omni#3327.
- Retry a failed machine notification instead of dropping it. A dropped notification left the machine without its hostname and hardware information for good.
- Use ECDSA service account keys for the clusters in the tests, through a development environment variable honored in debug builds only.
- Run the QEMU machine disks with the unsafe cache mode, so that the guest writes stay in the host page cache. Requires the disk cache mode option of `talosctl cluster create`.
- Keep the compiler optimizations in the debug builds of the tests. The tests need the debug build tag, not the disabled optimizations.

Related branches on the forks, to be opened as pull requests: siderolabs/talos (disk cache mode option, ECDSA bundle option), cosi-project/state-sqlite (connection prepare hook), siderolabs/kres (overridable debug gcflags).
