### PR TITLE
fix(frontend): distinguish initial log fetch failures

### DIFF
--- a/frontend/src/methods/useMachineServices.ts
+++ b/frontend/src/methods/useMachineServices.ts
@@ -90,7 +90,7 @@ export function useMachineServices(
       // Retry with backoff
       const backoff = Math.min(2 ** retryCount * 500, 10_000)
       retryCount++
-      retryTimer = setTimeout(() => serviceListVersion.value++, backoff)
+      retryTimer = window.setTimeout(() => serviceListVersion.value++, backoff)
     } finally {
       loading.value = false
     }

--- a/frontend/src/views/Machines/MachineLogsContainer.spec.ts
+++ b/frontend/src/views/Machines/MachineLogsContainer.spec.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+import { render, screen } from '@testing-library/vue'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { ref } from 'vue'
+
+const streamState = vi.hoisted(() => ({
+  logs: [] as { msg: string }[],
+}))
+
+vi.mock('@vueuse/router', () => ({ useRouteQuery: () => ref('') }))
+
+vi.mock('@/methods/useResourceWatch', () => ({
+  useResourceWatch: () => ({ data: ref(undefined) }),
+}))
+
+vi.mock('@/methods/useMachineServices', () => ({
+  supportsMaintenanceEvents: () => false,
+  useMachineServices: () => ({ data: ref([]) }),
+}))
+
+vi.mock('@/methods/logs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/methods/logs')>()
+
+  return {
+    ...actual,
+    setupLogStream: (logs: { value: { msg: string }[] }) => {
+      logs.value = [...streamState.logs]
+
+      return {
+        stream: { err: ref(new Error('machine is unreachable')) },
+        shutdown: vi.fn(),
+      }
+    },
+  }
+})
+
+import MachineLogsContainer from './MachineLogsContainer.vue'
+
+beforeEach(() => {
+  streamState.logs = []
+})
+
+function renderMachineLogs() {
+  return render(MachineLogsContainer, {
+    props: { machineId: 'offline-machine', service: 'controller-runtime' },
+    global: {
+      stubs: ['TSelectList', 'TInput', 'LogViewer'],
+    },
+  })
+}
+
+test('labels an initial log fetch error as a fetch failure', async () => {
+  renderMachineLogs()
+
+  expect(await screen.findByText('Failed to Fetch Logs')).toBeInTheDocument()
+  expect(screen.queryByText('Disconnected')).not.toBeInTheDocument()
+})
+
+test('labels an error after receiving logs as a disconnect', async () => {
+  streamState.logs = [{ msg: 'existing log' }]
+
+  renderMachineLogs()
+
+  expect(await screen.findByText('Disconnected')).toBeInTheDocument()
+  expect(screen.queryByText('Failed to Fetch Logs')).not.toBeInTheDocument()
+})

--- a/frontend/src/views/Machines/MachineLogsContainer.vue
+++ b/frontend/src/views/Machines/MachineLogsContainer.vue
@@ -210,7 +210,7 @@ watchEffect((onCleanup) => {
     </div>
     <TAlert
       v-if="stream?.err"
-      :title="logs ? 'Disconnected' : 'Failed to Fetch Logs'"
+      :title="logs.length ? 'Disconnected' : 'Failed to Fetch Logs'"
       type="error"
       class="mb-2"
     >


### PR DESCRIPTION
An initial machine log request can fail before any logs arrive, but the page still says `Disconnected`. 
Empty arrays are truthy, so `Failed to Fetch Logs` was never reached

The check now uses the log count. 
Initial errors get the fetch failure label, while a dropped active stream still says `Disconnected`

Repro:

1. Open `/machines/<machine-id>/logs/controller-runtime` for an offline machine
2. Wait for the log request to fail
3. The alert says `Disconnected` even though no logs were fetched