### PR TITLE
fix: keep the machine extensions consistent across extensions configurations

### DIFF
--- a/client/pkg/omni/resources/omni/labels.go
+++ b/client/pkg/omni/resources/omni/labels.go
@@ -245,8 +245,8 @@ const (
 const (
 	// MachineExtensions labels.
 
-	// ExtensionsConfigurationLabel defines the source ExtensionConfiguration resource
-	// from which MachineExtensions resource was generated.
+	// ExtensionsConfigurationLabel names the ExtensionsConfiguration resource
+	// which currently applies to the machine of the MachineExtensions resource.
 	// tsgen:ExtensionsConfigurationLabel
 	ExtensionsConfigurationLabel = SystemLabelPrefix + "root-configuration"
 )

--- a/internal/backend/runtime/omni/controllers/omni/machine_extensions.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_extensions.go
@@ -70,7 +70,7 @@ func (ctrl *MachineExtensionsController) Settings() controller.QSettings {
 				Type: omni.MachineExtensionsType,
 			},
 		},
-		Concurrency: optional.Some[uint](4),
+		Concurrency: optional.Some[uint](1), // the configurations of a cluster write the same outputs, a parallel reconcile can overwrite a newer list with an older one
 	}
 }
 
@@ -78,25 +78,14 @@ func (ctrl *MachineExtensionsController) Settings() controller.QSettings {
 func (ctrl *MachineExtensionsController) MapInput(ctx context.Context, _ *zap.Logger,
 	r controller.QRuntime, ptr controller.ReducedResourceMetadata,
 ) ([]resource.Pointer, error) {
-	res, err := r.Get(ctx, ptr)
-	if err != nil {
-		if state.IsNotFoundError(err) {
-			return nil, nil
-		}
-
-		return nil, err
-	}
-
 	switch ptr.Type() {
 	case omni.MachineExtensionsType:
-		clusterName, ok := res.Metadata().Labels().Get(omni.LabelCluster)
+		clusterName, ok := ptr.Labels().Get(omni.LabelCluster)
 		if !ok {
 			return nil, nil
 		}
 
-		var list safe.List[*omni.ExtensionsConfiguration]
-
-		list, err = safe.ReaderListAll[*omni.ExtensionsConfiguration](ctx, r, state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, clusterName)))
+		list, err := safe.ReaderListAll[*omni.ExtensionsConfiguration](ctx, r, state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, clusterName)))
 		if err != nil {
 			return nil, err
 		}
@@ -109,19 +98,19 @@ func (ctrl *MachineExtensionsController) MapInput(ctx context.Context, _ *zap.Lo
 
 		return resources, nil
 	case omni.ClusterMachineType:
-		clusterName, ok := res.Metadata().Labels().Get(omni.LabelCluster)
+		clusterName, ok := ptr.Labels().Get(omni.LabelCluster)
 		if !ok {
-			return nil, fmt.Errorf("cluster machine %q doesn't have cluster label set", res.Metadata().ID())
+			return nil, fmt.Errorf("cluster machine %q doesn't have cluster label set", ptr.ID())
 		}
 
-		machineSet, ok := res.Metadata().Labels().Get(omni.LabelMachineSet)
+		machineSet, ok := ptr.Labels().Get(omni.LabelMachineSet)
 		if !ok {
-			return nil, fmt.Errorf("cluster machine %q doesn't have machine set label set", res.Metadata().ID())
+			return nil, fmt.Errorf("cluster machine %q doesn't have machine set label set", ptr.ID())
 		}
 
 		for _, queries := range [][]resource.LabelQueryOption{
 			{
-				resource.LabelEqual(omni.LabelClusterMachine, res.Metadata().ID()),
+				resource.LabelEqual(omni.LabelClusterMachine, ptr.ID()),
 			},
 			{
 				resource.LabelEqual(omni.LabelMachineSet, machineSet),
@@ -132,9 +121,7 @@ func (ctrl *MachineExtensionsController) MapInput(ctx context.Context, _ *zap.Lo
 				resource.LabelExists(omni.LabelMachineSet, resource.NotMatches),
 			},
 		} {
-			var matching safe.List[*omni.ExtensionsConfiguration]
-
-			matching, err = safe.ReaderListAll[*omni.ExtensionsConfiguration](ctx, r, state.WithLabelQuery(queries...))
+			matching, err := safe.ReaderListAll[*omni.ExtensionsConfiguration](ctx, r, state.WithLabelQuery(queries...))
 			if err != nil {
 				return nil, err
 			}
@@ -178,51 +165,68 @@ func (ctrl *MachineExtensionsController) Reconcile(ctx context.Context, logger *
 		return err
 	}
 
-	if configuration.Metadata().Phase() == resource.PhaseTearingDown {
-		return tracker.cleanup(ctx, withDestroyReadyCallback(func() error {
-			return r.RemoveFinalizer(ctx, configuration.Metadata(), MachineExtensionsControllerName)
-		}))
-	}
+	tearingDown := configuration.Metadata().Phase() == resource.PhaseTearingDown
 
-	if !configuration.Metadata().Finalizers().Has(MachineExtensionsControllerName) {
+	if !tearingDown && !configuration.Metadata().Finalizers().Has(MachineExtensionsControllerName) {
 		if err = r.AddFinalizer(ctx, configuration.Metadata(), MachineExtensionsControllerName); err != nil {
 			return err
 		}
 	}
 
-	cluster, ok := configuration.Metadata().Labels().Get(omni.LabelCluster)
-	if !ok {
+	var configs []*omni.ExtensionsConfiguration
+
+	if cluster, ok := configuration.Metadata().Labels().Get(omni.LabelCluster); ok {
+		var configList safe.List[*omni.ExtensionsConfiguration]
+
+		configList, err = safe.ReaderListAll[*omni.ExtensionsConfiguration](ctx, r, state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, cluster)))
+		if err != nil {
+			return err
+		}
+
+		configs = xslices.Filter(slices.Collect(configList.All()), func(cfg *omni.ExtensionsConfiguration) bool {
+			return cfg.Metadata().Phase() == resource.PhaseRunning // a configuration being deleted must not be picked
+		})
+	} else if !tearingDown {
 		logger.Warn("extensions configuration doesn't have cluster label set")
 
 		return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("extensions configuration doesn't have cluster label set")
 	}
 
-	configList, err := safe.ReaderListAll[*omni.ExtensionsConfiguration](ctx, r, state.WithLabelQuery(resource.LabelEqual(omni.LabelCluster, cluster)))
-	if err != nil {
-		return err
-	}
-
-	configs := slices.Collect(configList.All())
-
 	for _, clusterMachine := range clusterMachines {
+		config := ctrl.matchExtensionsConfiguration(clusterMachine, configs)
+		if config == nil {
+			continue // destroyed by the cleanup below
+		}
+
 		status := omni.NewMachineExtensions(clusterMachine.Metadata().ID())
 
-		tracker.keep(status)
-
 		if err = safe.WriterModify(ctx, r, status, func(r *omni.MachineExtensions) error {
+			r.Metadata().Labels().Set(omni.ExtensionsConfigurationLabel, config.Metadata().ID())
+
+			helpers.CopyLabels(clusterMachine, r, omni.LabelCluster)
+
 			if !ctrl.shouldRecalculateExtensions(r, configs) {
 				return nil
 			}
 
-			r.TypedSpec().Value.Extensions = ctrl.determineExtensions(clusterMachine, configs)
-			r.Metadata().Labels().Set(omni.ExtensionsConfigurationLabel, configuration.Metadata().ID())
-
-			helpers.CopyLabels(clusterMachine, r, omni.LabelCluster)
+			r.TypedSpec().Value.Extensions = config.TypedSpec().Value.Extensions
 
 			return nil
 		}); err != nil {
+			if state.IsPhaseConflictError(err) {
+				continue // being destroyed by the cleanup below, created again on the next reconcile
+			}
+
 			return err
 		}
+
+		tracker.keep(status)
+	}
+
+	if tearingDown {
+		return tracker.cleanup(ctx, withDestroyReadyCallback(func() error {
+			return r.RemoveFinalizer(ctx, configuration.Metadata(), MachineExtensionsControllerName)
+		}))
 	}
 
 	return tracker.cleanup(ctx)
@@ -251,14 +255,14 @@ func (ctrl *MachineExtensionsController) shouldRecalculateExtensions(me *omni.Ma
 	return false
 }
 
-// determineExtensions determines the extensions for the given cluster machine.
-// The extensions are determined in the following order:
-// 1. Extensions defined for the cluster machine itself.
-// 2. Extensions defined for the machine set the cluster machine belongs to.
-// 3. Extensions defined for the cluster the machine belongs to.
+// matchExtensionsConfiguration finds the extensions configuration which applies to the given cluster machine.
+// The levels are checked in the following order:
+// 1. The configuration defined for the cluster machine itself.
+// 2. The configuration defined for the machine set the cluster machine belongs to.
+// 3. The configuration defined for the cluster the machine belongs to.
 //
-// If there are multiple extensions defined for the same level, the one with the lexicographically highest ID is used.
-func (ctrl *MachineExtensionsController) determineExtensions(cm *omni.ClusterMachine, configs []*omni.ExtensionsConfiguration) []string {
+// If there are multiple configurations defined for the same level, the one with the lexicographically highest ID is used.
+func (ctrl *MachineExtensionsController) matchExtensionsConfiguration(cm *omni.ClusterMachine, configs []*omni.ExtensionsConfiguration) *omni.ExtensionsConfiguration {
 	cmID := cm.Metadata().ID()
 	msID, _ := cm.Metadata().Labels().Get(omni.LabelMachineSet)
 	clusterID, _ := cm.Metadata().Labels().Get(omni.LabelCluster)
@@ -271,16 +275,16 @@ func (ctrl *MachineExtensionsController) determineExtensions(cm *omni.ClusterMac
 		{omni.LabelMachineSet, msID},
 		{omni.LabelCluster, clusterID},
 	} {
-		config := matchExtensionConfigByLabel(labels.labelName, labels.labelValue, configs)
+		config := ctrl.matchExtensionConfigByLabel(labels.labelName, labels.labelValue, configs)
 		if config != nil {
-			return config.TypedSpec().Value.Extensions
+			return config
 		}
 	}
 
 	return nil
 }
 
-func matchExtensionConfigByLabel(labelName, labelValue string, configs []*omni.ExtensionsConfiguration) *omni.ExtensionsConfiguration {
+func (ctrl *MachineExtensionsController) matchExtensionConfigByLabel(labelName, labelValue string, configs []*omni.ExtensionsConfiguration) *omni.ExtensionsConfiguration {
 	configs = xslices.Filter(configs, func(cfg *omni.ExtensionsConfiguration) bool {
 		val, ok := cfg.Metadata().Labels().Get(labelName)
 

--- a/internal/backend/runtime/omni/controllers/omni/machine_extensions_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_extensions_test.go
@@ -10,12 +10,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/kvutils"
 	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
+	"github.com/siderolabs/omni/client/pkg/omni/resources"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/helpers"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
@@ -265,6 +270,178 @@ func TestPreserveLegacyOrder(t *testing.T) {
 			assertion.True(annotationOk)
 
 			assertion.Equal([]string{"cluster-level"}, res.TypedSpec().Value.Extensions)
+		})
+	})
+}
+
+func TestMachineExtensionsDeleteOverride(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*5)
+	defer cancel()
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(_ context.Context, testContext testutils.TestContext) {
+		require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewMachineExtensionsController()))
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		st := testContext.State
+		require := require.New(t)
+
+		clusterMachine := omni.NewClusterMachine("machine")
+		clusterMachine.Metadata().Labels().Set(omni.LabelCluster, "cluster")
+		clusterMachine.Metadata().Labels().Set(omni.LabelMachineSet, "machine-set")
+		require.NoError(st.Create(ctx, clusterMachine))
+
+		clusterLevel := omni.NewExtensionsConfiguration("cluster-level")
+		clusterLevel.Metadata().Labels().Set(omni.LabelCluster, "cluster")
+		clusterLevel.TypedSpec().Value.Extensions = []string{"a"}
+		require.NoError(st.Create(ctx, clusterLevel))
+
+		machineLevel := omni.NewExtensionsConfiguration("machine-level")
+		machineLevel.Metadata().Labels().Set(omni.LabelCluster, "cluster")
+		machineLevel.Metadata().Labels().Set(omni.LabelClusterMachine, "machine")
+		machineLevel.TypedSpec().Value.Extensions = []string{"b"}
+		require.NoError(st.Create(ctx, machineLevel))
+
+		rtestutils.AssertResource(ctx, t, st, machineLevel.Metadata().ID(), func(r *omni.ExtensionsConfiguration, assertion *assert.Assertions) {
+			assertion.True(r.Metadata().Finalizers().Has(omnictrl.MachineExtensionsControllerName))
+		})
+
+		_, err := safe.StateUpdateWithConflicts(ctx, st, clusterLevel.Metadata(), func(r *omni.ExtensionsConfiguration) error {
+			r.TypedSpec().Value.Extensions = []string{"a", "c"}
+
+			return nil
+		})
+		require.NoError(err)
+
+		var created time.Time
+
+		rtestutils.AssertResources(ctx, t, st, []string{"machine"}, func(r *omni.MachineExtensions, assertion *assert.Assertions) {
+			assertion.Equal([]string{"b"}, r.TypedSpec().Value.Extensions)
+
+			source, _ := r.Metadata().Labels().Get(omni.ExtensionsConfigurationLabel)
+			assertion.Equal("machine-level", source)
+
+			created = r.Metadata().Created()
+		})
+
+		rtestutils.Destroy[*omni.ExtensionsConfiguration](ctx, t, st, []string{"machine-level"})
+
+		rtestutils.AssertResources(ctx, t, st, []string{"machine"}, func(r *omni.MachineExtensions, assertion *assert.Assertions) {
+			assertion.Equal([]string{"a", "c"}, r.TypedSpec().Value.Extensions)
+
+			source, _ := r.Metadata().Labels().Get(omni.ExtensionsConfigurationLabel)
+			assertion.Equal("cluster-level", source)
+
+			assertion.Equal(created, r.Metadata().Created())
+		})
+	})
+}
+
+// machineExtensionsHolder keeps a finalizer on every MachineExtensions until released, like the schematic controller does.
+type machineExtensionsHolder struct {
+	release chan struct{}
+}
+
+func (h *machineExtensionsHolder) Name() string { return "MachineExtensionsHolder" }
+
+func (h *machineExtensionsHolder) Inputs() []controller.Input {
+	return []controller.Input{{Namespace: resources.DefaultNamespace, Type: omni.MachineExtensionsType, Kind: controller.InputStrong}}
+}
+
+func (h *machineExtensionsHolder) Outputs() []controller.Output { return nil }
+
+func (h *machineExtensionsHolder) Run(ctx context.Context, r controller.Runtime, _ *zap.Logger) error {
+	released := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		case <-h.release:
+			released = true
+		}
+
+		list, err := safe.ReaderListAll[*omni.MachineExtensions](ctx, r)
+		if err != nil {
+			return err
+		}
+
+		for me := range list.All() {
+			switch {
+			case me.Metadata().Phase() == resource.PhaseTearingDown && released:
+				err = r.RemoveFinalizer(ctx, me.Metadata(), h.Name())
+			case me.Metadata().Phase() == resource.PhaseRunning && !me.Metadata().Finalizers().Has(h.Name()):
+				err = r.AddFinalizer(ctx, me.Metadata(), h.Name())
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func TestMachineExtensionsDeleteWithHeldOutput(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*5)
+	defer cancel()
+
+	holder := &machineExtensionsHolder{release: make(chan struct{})}
+
+	testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(_ context.Context, testContext testutils.TestContext) {
+		require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewMachineExtensionsController()))
+		require.NoError(t, testContext.Runtime.RegisterController(holder))
+	}, func(ctx context.Context, testContext testutils.TestContext) {
+		st := testContext.State
+		require := require.New(t)
+
+		clusterMachine := omni.NewClusterMachine("machine")
+		clusterMachine.Metadata().Labels().Set(omni.LabelCluster, "cluster")
+		clusterMachine.Metadata().Labels().Set(omni.LabelMachineSet, "machine-set")
+		require.NoError(st.Create(ctx, clusterMachine))
+
+		machineSetLevel := omni.NewExtensionsConfiguration("machine-set-level")
+		machineSetLevel.Metadata().Labels().Set(omni.LabelCluster, "cluster")
+		machineSetLevel.Metadata().Labels().Set(omni.LabelMachineSet, "machine-set")
+		machineSetLevel.TypedSpec().Value.Extensions = []string{"a"}
+		require.NoError(st.Create(ctx, machineSetLevel))
+
+		rtestutils.AssertResources(ctx, t, st, []string{"machine"}, func(r *omni.MachineExtensions, assertion *assert.Assertions) {
+			assertion.Equal([]string{"a"}, r.TypedSpec().Value.Extensions)
+			assertion.True(r.Metadata().Finalizers().Has(holder.Name()))
+		})
+
+		rtestutils.AssertResource(ctx, t, st, machineSetLevel.Metadata().ID(), func(r *omni.ExtensionsConfiguration, assertion *assert.Assertions) {
+			assertion.True(r.Metadata().Finalizers().Has(omnictrl.MachineExtensionsControllerName))
+		})
+
+		// delete the only configuration, the output is torn down but held
+		_, err := st.Teardown(ctx, machineSetLevel.Metadata())
+		require.NoError(err)
+
+		rtestutils.AssertResources(ctx, t, st, []string{"machine"}, func(r *omni.MachineExtensions, assertion *assert.Assertions) {
+			assertion.Equal(resource.PhaseTearingDown, r.Metadata().Phase())
+		})
+
+		// a new configuration appears while the output is held
+		clusterLevel := omni.NewExtensionsConfiguration("cluster-level")
+		clusterLevel.Metadata().Labels().Set(omni.LabelCluster, "cluster")
+		clusterLevel.TypedSpec().Value.Extensions = []string{"b"}
+		require.NoError(st.Create(ctx, clusterLevel))
+
+		rtestutils.AssertResource(ctx, t, st, clusterLevel.Metadata().ID(), func(r *omni.ExtensionsConfiguration, assertion *assert.Assertions) {
+			assertion.True(r.Metadata().Finalizers().Has(omnictrl.MachineExtensionsControllerName))
+		})
+
+		close(holder.release)
+
+		rtestutils.Destroy[*omni.ExtensionsConfiguration](ctx, t, st, []string{machineSetLevel.Metadata().ID()})
+
+		rtestutils.AssertResources(ctx, t, st, []string{"machine"}, func(r *omni.MachineExtensions, assertion *assert.Assertions) {
+			assertion.Equal(resource.PhaseRunning, r.Metadata().Phase())
+			assertion.Equal([]string{"b"}, r.TypedSpec().Value.Extensions)
 		})
 	})
 }


### PR DESCRIPTION
All extensions configurations of a cluster write the same machine extensions resources. They were reconciled in parallel, so a reconcile with an older list of configurations could write after a newer one, and nothing corrected that afterwards. This happens when several configurations are created at once, e.g. by a cluster template sync, and caused sporadic failures of the schematic configuration test. Reconcile them one at a time.

Additionally:
- Point the machine extensions to the configuration which applies to the machine instead of the one which wrote last. Previously, deleting a machine level override after an edit of the cluster level configuration left the override's extensions on the machine. The UI shows the level based on the same label, so it is now correct as well.
- Switch the machines of a deleted configuration to the next applicable one in place. Previously their machine extensions were destroyed and created again, and an intermediate schematic without any explicit extensions was generated in between.
