### PR TITLE
chore(frontend): remove factory urls from csp

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -75,7 +75,7 @@ export default defineConfig(({ command }) => {
       `script-src 'self' 'nonce-${cspNonce}' https://*.userpilot.io https://*.posthog.com`,
       "media-src 'self' https://js.userpilot.io",
       'img-src * data:',
-      "connect-src 'self' https://factory.stage-pnap.managed.siderolabs.io/ https://factory.talos.dev https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io https://*.posthog.com",
+      "connect-src 'self' https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io https://*.posthog.com",
       "font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.userpilot.io",
       "style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com",
       'frame-src https://www.youtube.com/embed/ https://*.auth0.com',

--- a/internal/backend/server.go
+++ b/internal/backend/server.go
@@ -870,10 +870,8 @@ func makeMux(
 		))
 	}
 
-	primaryFactory := cfg.Registries.GetPrimaryFactory()
-
 	frontendHandler := compress.Handler(
-		frontend.NewStaticHandler(7200, primaryFactory.GetUrl()),
+		frontend.NewStaticHandler(7200),
 		gzip.BestCompression,
 	)
 

--- a/internal/frontend/handler.go
+++ b/internal/frontend/handler.go
@@ -27,17 +27,15 @@ const index = "/index.html"
 
 // StaticHandler serves embedded frontend files.
 type StaticHandler struct {
-	modTime             time.Time
-	imageFactoryBaseURL string
-	maxAgeSec           int
+	modTime   time.Time
+	maxAgeSec int
 }
 
 // NewStaticHandler creates new static handler.
-func NewStaticHandler(maxAgeSec int, imageFactoryBaseURL string) *StaticHandler {
+func NewStaticHandler(maxAgeSec int) *StaticHandler {
 	return &StaticHandler{
-		modTime:             time.Now(),
-		imageFactoryBaseURL: imageFactoryBaseURL,
-		maxAgeSec:           maxAgeSec,
+		modTime:   time.Now(),
+		maxAgeSec: maxAgeSec,
 	}
 }
 
@@ -140,7 +138,7 @@ func (handler *StaticHandler) serveFile(w http.ResponseWriter, r *http.Request, 
 					fmt.Sprintf(";script-src 'self' 'nonce-%s' https://*.userpilot.io https://*.posthog.com", nonce)+
 					";media-src 'self' https://js.userpilot.io"+
 					";img-src * data:"+
-					fmt.Sprintf(";connect-src 'self' %s https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io https://*.posthog.com", handler.imageFactoryBaseURL)+
+					";connect-src 'self' https://*.auth0.com https://*.userpilot.io wss://*.userpilot.io https://*.posthog.com"+
 					";font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com https://fonts.userpilot.io"+
 					// We are forced to use unsafe-inline for style-src due to monaco-editor https://github.com/microsoft/monaco-editor/issues/271
 					";style-src 'self' 'unsafe-inline' data: https://fonts.googleapis.com"+


### PR DESCRIPTION
Remove the factory URLs from the connect-src CSP as it is no longer needed. Frontend never communicates with factory and only presents links to the user.