### PR TITLE
test: reduce the IO load of the e2e test scripts

### DIFF
--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -131,7 +131,30 @@ export RUN_DIR
 LOCAL_IP=$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
 export LOCAL_IP
 
+# Print the host IO and CPU pressure, the disk counters and the disk usage, so that a slow runner shows up in the job log.
+function print_host_pressure() {
+  # the trace output would interleave with the snapshot, so it is turned off for the duration of the function
+  local -
+  set +x
+
+  echo "--- host pressure snapshot: $1 ($(date -u +%FT%TZ)) ---"
+  {
+    local f
+    for f in io cpu memory; do
+      echo "pressure/${f}:"
+      cat "/proc/pressure/${f}"
+    done
+    echo "diskstats:"
+    awk '$3 ~ /^(nvme[0-9]+n[0-9]+|sd[a-z]+|vd[a-z]+)$/' /proc/diskstats
+    df -h "${TEST_OUTPUTS_DIR}" "${HOME}" "${ARTIFACTS}" 2>/dev/null
+    docker system df
+  } 2>&1 || true
+  echo "--- end of host pressure snapshot ---"
+}
+
 mkdir -p "$TEST_OUTPUTS_DIR"
+
+print_host_pressure "start"
 
 export ENABLE_TALOS_PRERELEASE_VERSIONS=true
 VAULT_DOCKER_IMAGE=hashicorp/vault:1.18
@@ -173,6 +196,8 @@ function configure_registry_mirrors() {
 
 function common_cleanup() {
   cd "${RUN_DIR}"
+
+  print_host_pressure "end"
   rm -rf "${ARTIFACTS}/omni.db" "${ARTIFACTS}/etcd/"
 
   if [[ $PARTIAL_CONFIG_SERVER_PID -ne 0 ]]; then

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -202,15 +202,28 @@ function prepare_vault() {
   # Start Vault.
   docker run --rm -d --cap-add=IPC_LOCK -p 8200:8200 -e VAULT_DEV_ROOT_TOKEN_ID="${VAULT_TOKEN}" --name "${VAULT_CONTAINER_NAME}" "${VAULT_DOCKER_IMAGE}"
 
-  sleep 10
+  # Wait for the dev server to be initialized and unsealed instead of sleeping a fixed time.
+  local i
+  for i in $(seq 1 30); do
+    if curl -sf "${VAULT_ADDR}/v1/sys/health" >/dev/null; then
+      break
+    fi
+
+    if [[ "$i" -eq 30 ]]; then
+      echo "Error: Vault did not become ready in time" >&2
+      docker logs "${VAULT_CONTAINER_NAME}" >&2 || true
+
+      return 1
+    fi
+
+    sleep 1
+  done
 
   # Load key into Vault.
   docker cp ./internal/backend/runtime/omni/testdata/pgp/old_key.private "${VAULT_CONTAINER_NAME}":/tmp/old_key.private
   docker exec -e VAULT_ADDR="${VAULT_ADDR}" -e VAULT_TOKEN="${VAULT_TOKEN}" "${VAULT_CONTAINER_NAME}" \
     vault kv put -mount=secret omni-private-key \
     private-key=@/tmp/old_key.private
-
-  sleep 5
 }
 
 function vault_cleanup() {

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -485,6 +485,8 @@ function create_machines() {
     "--skip-injecting-config"
     "--skip-injecting-extra-cmdline"
     "--wait=false"
+    # The disks are throwaway, so do not reserve their full size up front on the runner disk.
+    "--disk-preallocate=false"
   )
 
   if [[ "${uki}" == "false" ]]; then
@@ -560,6 +562,8 @@ function create_talos_cluster { # args: name, cp_count, wk_count, cidr, talos_ve
     "--talos-version=${talos_version}"
     "--install-image=factory.talos.dev/metal-installer/${schematic_id}:v${talos_version}"
     "--iso-path=https://factory.talos.dev/image/${schematic_id}/v${talos_version}/metal-amd64.iso"
+    # The disks are throwaway, so do not reserve their full size up front on the runner disk.
+    "--disk-preallocate=false"
   )
 
   if [[ "${allow_scheduling_on_control_planes}" == "true" ]]; then

--- a/hack/test/e2e-auth0.sh
+++ b/hack/test/e2e-auth0.sh
@@ -39,7 +39,7 @@ export MAX_SERVICE_ACCOUNTS=5
 prepare_omni_config
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
-  nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
+  "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \
   "${REGISTRY_MIRROR_FLAGS[@]}" >"${TEST_OUTPUTS_DIR}/omni-e2e.log" 2>&1 &

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -74,7 +74,7 @@ if [[ "${CREATE_QEMU_MACHINES:-true}" == "true" ]]; then
 fi
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
-  nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
+  "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \
   "${REGISTRY_MIRROR_FLAGS[@]}" >"${TEST_OUTPUTS_DIR}/omni-e2e.log" 2>&1 &

--- a/hack/test/e2e-saml.sh
+++ b/hack/test/e2e-saml.sh
@@ -43,7 +43,7 @@ export MAX_SERVICE_ACCOUNTS=5
 prepare_omni_config
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
-  nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
+  "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \
   "${REGISTRY_MIRROR_FLAGS[@]}" >"${TEST_OUTPUTS_DIR}/omni-e2e.log" 2>&1 &

--- a/hack/test/e2e-talemu.sh
+++ b/hack/test/e2e-talemu.sh
@@ -55,7 +55,7 @@ docker run --name "${TALEMU_CONTAINER_NAME}" \
   --omni-api-endpoint="https://${LOCAL_IP}:8099"
 
 SIDEROLINK_DEV_JOIN_TOKEN="${JOIN_TOKEN}" \
-  nice -n 10 "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
+  "${ARTIFACTS}"/omni-linux-amd64 --config-path "${OMNI_CONFIG}" \
   --etcd-embedded-unsafe-fsync=true \
   --etcd-backup-s3 \
   "${REGISTRY_MIRROR_FLAGS[@]}" >"${TEST_OUTPUTS_DIR}/omni-e2e.log" 2>&1 &

--- a/hack/test/helm/templates/omni-values.yaml
+++ b/hack/test/helm/templates/omni-values.yaml
@@ -55,6 +55,11 @@ config:
       - ${AUTH_USERNAME}
   registries:
     mirrors: ${REGISTRY_MIRRORS_JSON}
+  storage:
+    default:
+      etcd:
+        # The embedded etcd phase is a throwaway, skip the fsyncs like the other e2e suites do.
+        embeddedUnsafeFsync: true
   services:
     api:
       advertisedURL: https://omni.example.org

--- a/internal/integration/kubernetes_test.go
+++ b/internal/integration/kubernetes_test.go
@@ -109,7 +109,9 @@ func AssertKubernetesAPIAccessViaOmni(testCtx context.Context, omniClient *clien
 					ok    bool
 				)
 
-				assert.NoError(t, retry.Constant(time.Second*30).RetryWithContext(ctx, func(ctx context.Context) error {
+				// The label is applied by the node's own controller through its local apiserver, which takes minutes on a starved runner.
+				// Give it the same budget as the node list check above.
+				assert.NoError(t, retry.Constant(3*time.Minute, retry.WithUnits(5*time.Second)).RetryWithContext(ctx, func(ctx context.Context) error {
 					label, ok = k8sNode.Labels[nodeLabel]
 					if !ok {
 						var n *corev1.Node


### PR DESCRIPTION
### test: do not preallocate the QEMU disks in the integration tests

`talosctl` preallocates every VM disk by default. Because of this, a QEMU integration job reserved 60 GiB on the runner disk before a single machine booted, and the cluster import job another 36 GiB. The runners keep the VM disks on the node disk next to the container images, so the jobs were getting evicted on disk pressure.

The disks are throwaway. Let them grow with what the machines actually write.

### test: wait for Vault readiness instead of sleeping in the tests

Previously, the Vault setup slept for a fixed 10 seconds before loading the key, and for another 5 seconds after it. This happened in all but one of the integration and e2e jobs.

Poll the health endpoint until the dev server is unsealed instead, like the Dex, Keycloak and MinIO setups already do. Also drop the sleep after the key write, as the write is synchronous anyway.

### test: print the host pressure and disk usage in the test logs

The self-hosted runners share their disk and CPUs with other jobs. When a run fails, there is nothing in the log to tell a slow runner from a real failure.

Print the following when a test script starts and again in its cleanup, so that every job log carries the numbers:
- the kernel pressure stall information for IO, CPU and memory
- the disk counters
- the disk usage of the test directories
- the Docker disk usage

### test: run the Omni server with normal priority in the e2e tests

The e2e scripts started the Omni server under `nice -n 10` since the initial commit. On the CPU starved runners, this gives Omni a tenth of the scheduler weight of the browser, Docker and the QEMU machines it competes with. At the same time, Omni is the process the UI tests are waiting on.

Run it with the normal priority.

### test: skip the etcd fsync in the Helm e2e embedded etcd phase

All other e2e suites run the embedded etcd of the Omni under test without fsync, because the state is throwaway. The Helm suite did not. Its embedded etcd phase runs with persistence disabled inside the QEMU node, so every fsync went through the virtual disk to the runner disk.

Enable the unsafe fsync setting in the test values.

### test: give the node label check the same budget as the node list check

The Kubernetes API test waits 30 seconds for every ready node to carry the label the test injects through a config patch. The label is applied by the node's own controller through its local apiserver. On an IO starved runner, this took minutes twice, once on the enterprise backports run and once on the IO wins draft, while the node list check right before it already waits up to 3 minutes.

Give the label check the same budget.

