### PR TITLE
test: increase the node label timeout and poll for Vault readiness

### DIFF
--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -202,15 +202,27 @@ function prepare_vault() {
   # Start Vault.
   docker run --rm -d --cap-add=IPC_LOCK -p 8200:8200 -e VAULT_DEV_ROOT_TOKEN_ID="${VAULT_TOKEN}" --name "${VAULT_CONTAINER_NAME}" "${VAULT_DOCKER_IMAGE}"
 
-  sleep 10
+  local i
+  for i in $(seq 1 30); do
+    if curl -sf "${VAULT_ADDR}/v1/sys/health" >/dev/null; then
+      break
+    fi
+
+    if [[ "$i" -eq 30 ]]; then
+      echo "Error: Vault did not become ready in time" >&2
+      docker logs "${VAULT_CONTAINER_NAME}" >&2 || true
+
+      return 1
+    fi
+
+    sleep 1
+  done
 
   # Load key into Vault.
   docker cp ./internal/backend/runtime/omni/testdata/pgp/old_key.private "${VAULT_CONTAINER_NAME}":/tmp/old_key.private
   docker exec -e VAULT_ADDR="${VAULT_ADDR}" -e VAULT_TOKEN="${VAULT_TOKEN}" "${VAULT_CONTAINER_NAME}" \
     vault kv put -mount=secret omni-private-key \
     private-key=@/tmp/old_key.private
-
-  sleep 5
 }
 
 function vault_cleanup() {

--- a/internal/integration/kubernetes_test.go
+++ b/internal/integration/kubernetes_test.go
@@ -109,7 +109,7 @@ func AssertKubernetesAPIAccessViaOmni(testCtx context.Context, omniClient *clien
 					ok    bool
 				)
 
-				assert.NoError(t, retry.Constant(time.Second*30).RetryWithContext(ctx, func(ctx context.Context) error {
+				assert.NoError(t, retry.Constant(3*time.Minute, retry.WithUnits(5*time.Second)).RetryWithContext(ctx, func(ctx context.Context) error {
 					label, ok = k8sNode.Labels[nodeLabel]
 					if !ok {
 						var n *corev1.Node


### PR DESCRIPTION
### test: increase the timeout of the node label check

The check waited 30 seconds for the label to show up on the nodes, which was not always enough. The node list check right before it waits up to 3 minutes. Use the same timeout.

### test: poll for Vault readiness instead of sleeping in the tests

The Vault setup slept for 10 seconds before loading the key and for another 5 seconds after it. Poll the health endpoint until the dev server is unsealed instead, like the Dex, Keycloak and MinIO setups do. The sleep after the key write goes away, the write is synchronous.

