### PR TITLE
fix: run the sqlite database with the NORMAL synchronous mode

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -318,7 +318,9 @@ func defineStorageFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *confi
 
 	b.StringSliceVar("storage.default.etcd.publicKeyFiles", &flagConfig.Storage.Default.Etcd.PublicKeyFiles, flagConfig.Storage.Default.Etcd.PublicKeyFiles)
 	b.StringVar("storage.sqlite.path", &flagConfig.Storage.Sqlite.Path)
+	//nolint:staticcheck
 	b.StringVar("storage.sqlite.experimentalBaseParams", &flagConfig.Storage.Sqlite.ExperimentalBaseParams)
+	//nolint:staticcheck
 	b.StringVar("storage.sqlite.extraParams", &flagConfig.Storage.Sqlite.ExtraParams)
 	b.DurationVar("storage.sqlite.metrics.refreshInterval", &flagConfig.Storage.Sqlite.Metrics.RefreshInterval)
 	b.DurationVar("storage.sqlite.metrics.refreshTimeout", &flagConfig.Storage.Sqlite.Metrics.RefreshTimeout)

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -464,11 +464,12 @@ config:
       # This path is mounted from the persistent volume by default.
       path: /data/secondary-storage/sqlite.db
       # ExperimentalBaseParams contains the base parameters to be used when opening the SQLite database connection.
-      # This can cause data corruption if set incorrectly, modify at your own risk. This flag is experimental and may
-      # be removed in future versions. It must not start with a question mark (?).
-      #experimentalBaseParams: _txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)
-      # ExtraParams contains the extra parameters to be used when opening the SQLite database connection. This can
-      # cause data corruption if set incorrectly, modify at your own risk. It must not start with an ampersand (&).
+      #
+      # Deprecated: unused, has no effect.
+      #experimentalBaseParams: ""
+      # ExtraParams contains the extra parameters to be used when opening the SQLite database connection.
+      #
+      # Deprecated: unused, has no effect.
       #extraParams: ""
       # CachedPoolSize controls the number of cached connections in the SQLite connection pool. The overall number of
       # connections is limited by poolSize. CachedPoolSize should be less or equal to poolSize.

--- a/internal/backend/runtime/omni/sqlite/sqlite.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosi-project/state-sqlite/pkg/sqlitexx"
 	"github.com/siderolabs/gen/panicsafe"
 	zombiesqlite "zombiezen.com/go/sqlite"
+	"zombiezen.com/go/sqlite/sqlitex"
 
 	"github.com/siderolabs/omni/internal/pkg/config"
 )
@@ -26,17 +27,7 @@ func OpenDB(config config.SQLite) (*sqlitexx.Pool, error) {
 		return nil, fmt.Errorf("failed to create directory for sqlite database %q: %w", configPath, err)
 	}
 
-	allParams := config.GetExperimentalBaseParams()
-
-	extraParams := config.GetExtraParams()
-	if extraParams != "" {
-		allParams += "&" + extraParams
-	}
-
 	dsn := "file:" + configPath
-	if allParams != "" {
-		dsn += "?" + allParams
-	}
 
 	db, err := sqlitexx.NewPool(
 		dsn,
@@ -44,6 +35,10 @@ func OpenDB(config config.SQLite) (*sqlitexx.Pool, error) {
 			Flags:         zombiesqlite.OpenReadWrite | zombiesqlite.OpenCreate | zombiesqlite.OpenWAL | zombiesqlite.OpenURI,
 			LowWatermark:  config.GetCachedPoolSize(),
 			HighWatermark: config.GetPoolSize(),
+			// the synchronous mode is per connection, NORMAL skips the fsync on every commit in WAL mode
+			PrepareConn: func(conn *zombiesqlite.Conn) error {
+				return sqlitex.ExecuteTransient(conn, "PRAGMA synchronous=NORMAL", nil)
+			},
 		},
 	)
 	if err != nil {

--- a/internal/backend/runtime/omni/sqlite/sqlite_test.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package sqlite_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	zombiesqlite "zombiezen.com/go/sqlite"
+	"zombiezen.com/go/sqlite/sqlitex"
+
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/sqlite"
+	"github.com/siderolabs/omni/internal/pkg/config"
+)
+
+// TestOpenDBSetsSynchronousNormal checks that every connection of the pool runs with the NORMAL synchronous mode.
+func TestOpenDBSetsSynchronousNormal(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Default().Storage.Sqlite
+	conf.SetPath(filepath.Join(t.TempDir(), "test.db"))
+	conf.SetCachedPoolSize(2)
+	conf.SetPoolSize(2)
+
+	db, err := sqlite.OpenDB(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, sqlite.CloseDB(db, 5*time.Second))
+	})
+
+	ctx := t.Context()
+
+	// take both connections at once, so that both are freshly opened
+	conn1, err := db.Take(ctx)
+	require.NoError(t, err)
+
+	conn2, err := db.Take(ctx)
+	require.NoError(t, err)
+
+	for _, conn := range []*zombiesqlite.Conn{conn1, conn2} {
+		assert.Equal(t, "wal", readPragma(t, conn, "journal_mode"))
+		assert.Equal(t, "1", readPragma(t, conn, "synchronous"), "synchronous should be NORMAL")
+
+		db.Put(conn)
+	}
+}
+
+func readPragma(t *testing.T, conn *zombiesqlite.Conn, name string) string {
+	t.Helper()
+
+	var value string
+
+	require.NoError(t, sqlitex.ExecuteTransient(conn, "PRAGMA "+name, &sqlitex.ExecOptions{
+		ResultFunc: func(stmt *zombiesqlite.Stmt) error {
+			value = stmt.ColumnText(0)
+
+			return nil
+		},
+	}))
+
+	return value
+}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -613,7 +613,7 @@ func TestSchemaDefaults(t *testing.T) {
 	assert.Equal(t, "_out/omni.db", p.Storage.Default.Boltdb.GetPath())
 
 	// storage.sqlite
-	assert.Equal(t, "_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)", p.Storage.Sqlite.GetExperimentalBaseParams())
+	assert.Equal(t, "", p.Storage.Sqlite.GetExperimentalBaseParams())
 	assert.Equal(t, 4, p.Storage.Sqlite.GetCachedPoolSize())
 	assert.Equal(t, 64, p.Storage.Sqlite.GetPoolSize())
 	assert.Equal(t, 2*time.Minute, p.Storage.Sqlite.Metrics.GetRefreshInterval())

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -1570,19 +1570,21 @@
           }
         },
         "experimentalBaseParams": {
-          "description": "ExperimentalBaseParams contains the base parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. This flag is experimental and may be removed in future versions. It must not start with a question mark (?).",
+          "description": "ExperimentalBaseParams contains the base parameters to be used when opening the SQLite database connection.\n\nDeprecated: unused, has no effect.",
           "x-cli-flag": "sqlite-storage-experimental-base-params",
+          "deprecated": true,
           "type": "string",
           "pattern": "^(?:$|[^?].*)",
           "x-pattern-message": "must not start with '?'",
-          "default": "_txlock=immediate&_pragma=busy_timeout(50000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)",
+          "default": "",
           "goJSONSchema": {
             "pointer": true
           }
         },
         "extraParams": {
-          "description": "ExtraParams contains the extra parameters to be used when opening the SQLite database connection. This can cause data corruption if set incorrectly, modify at your own risk. It must not start with an ampersand (&).",
+          "description": "ExtraParams contains the extra parameters to be used when opening the SQLite database connection.\n\nDeprecated: unused, has no effect.",
           "x-cli-flag": "sqlite-storage-extra-params",
+          "deprecated": true,
           "type": "string",
           "pattern": "^(?:$|[^&].*)",
           "x-pattern-message": "must not start with '&'"

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -713,14 +713,15 @@ type SQLite struct {
 	CachedPoolSize *int `json:"cachedPoolSize,omitempty,omitzero" yaml:"cachedPoolSize,omitempty"`
 
 	// ExperimentalBaseParams contains the base parameters to be used when opening the
-	// SQLite database connection. This can cause data corruption if set incorrectly,
-	// modify at your own risk. This flag is experimental and may be removed in future
-	// versions. It must not start with a question mark (?).
+	// SQLite database connection.
+	//
+	// Deprecated: unused, has no effect.
 	ExperimentalBaseParams *string `json:"experimentalBaseParams,omitempty,omitzero" yaml:"experimentalBaseParams,omitempty"`
 
 	// ExtraParams contains the extra parameters to be used when opening the SQLite
-	// database connection. This can cause data corruption if set incorrectly, modify
-	// at your own risk. It must not start with an ampersand (&).
+	// database connection.
+	//
+	// Deprecated: unused, has no effect.
 	ExtraParams *string `json:"extraParams,omitempty,omitzero" yaml:"extraParams,omitempty"`
 
 	// Metrics corresponds to the JSON schema field "metrics".


### PR DESCRIPTION
The connection string carried the synchronous mode, the busy timeout and the transaction lock mode in the syntax of the previous driver. SQLite ignores the parameters it does not know, so the database ran with the default FULL mode and fsynced the WAL on every commit. The machine logs and the audit log commit one row at a time, so every line was an fsync, and on a slow disk the writers timed out on a locked database.

Set NORMAL on every new connection of the pool. The WAL mode comes from the open flags, and the busy timeout is not needed, as the driver blocks until the context ends.

The two settings for the connection string parameters are deprecated and ignored. SQLite only understands its own URI options in that string, and the pragmas the settings were meant for cannot be set this way.

Closes siderolabs/omni#3327.
