### PR TITLE
fix: build install images with the factory that issued the schematic

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -6628,11 +6628,15 @@ func (x *TalosExtensionsSpec) GetItems() []*TalosExtensionsSpec_Info {
 
 // SchematicConfigurationSpec is the desired Image Factory schematic for a machine, machine set or a cluster.
 type SchematicConfigurationSpec struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SchematicId   string                 `protobuf:"bytes,1,opt,name=schematic_id,json=schematicId,proto3" json:"schematic_id,omitempty"`
-	TalosVersion  string                 `protobuf:"bytes,2,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	SchematicId  string                 `protobuf:"bytes,1,opt,name=schematic_id,json=schematicId,proto3" json:"schematic_id,omitempty"`
+	TalosVersion string                 `protobuf:"bytes,2,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
+	// ImageFactoryUrl is the base URL of the image factory that issued SchematicId. An install image with this
+	// schematic has to name that factory: another factory does not know the ID, an Enterprise one stamps an owner
+	// into the schematic and issues a different ID for the same content.
+	ImageFactoryUrl string `protobuf:"bytes,4,opt,name=image_factory_url,json=imageFactoryUrl,proto3" json:"image_factory_url,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *SchematicConfigurationSpec) Reset() {
@@ -6675,6 +6679,13 @@ func (x *SchematicConfigurationSpec) GetSchematicId() string {
 func (x *SchematicConfigurationSpec) GetTalosVersion() string {
 	if x != nil {
 		return x.TalosVersion
+	}
+	return ""
+}
+
+func (x *SchematicConfigurationSpec) GetImageFactoryUrl() string {
+	if x != nil {
+		return x.ImageFactoryUrl
 	}
 	return ""
 }
@@ -11068,8 +11079,8 @@ type MachineConfigGenOptionsSpec_InstallImage struct {
 	Platform string `protobuf:"bytes,6,opt,name=platform,proto3" json:"platform,omitempty"`
 	// SecurityState is used to decide the secure boot enablement in the install image.
 	SecurityState *SecurityState `protobuf:"bytes,7,opt,name=security_state,json=securityState,proto3" json:"security_state,omitempty"`
-	// ImageFactoryHost is the host of the image factory to build the install image from.
-	// When empty, the primary factory is used as a fallback.
+	// ImageFactoryHost is the host of the image factory to build the install image from: the factory that issued
+	// SchematicId, recorded on the SchematicConfiguration. An install image with a schematic and no host is not built.
 	ImageFactoryHost string `protobuf:"bytes,8,opt,name=image_factory_host,json=imageFactoryHost,proto3" json:"image_factory_host,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -12713,10 +12724,11 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12\x10\n" +
 	"\x03ref\x18\x05 \x01(\tR\x03ref\x12\x16\n" +
-	"\x06digest\x18\x06 \x01(\tR\x06digest\"j\n" +
+	"\x06digest\x18\x06 \x01(\tR\x06digest\"\x96\x01\n" +
 	"\x1aSchematicConfigurationSpec\x12!\n" +
 	"\fschematic_id\x18\x01 \x01(\tR\vschematicId\x12#\n" +
-	"\rtalos_version\x18\x02 \x01(\tR\ftalosVersionJ\x04\b\x03\x10\x04\"=\n" +
+	"\rtalos_version\x18\x02 \x01(\tR\ftalosVersion\x12*\n" +
+	"\x11image_factory_url\x18\x04 \x01(\tR\x0fimageFactoryUrlJ\x04\b\x03\x10\x04\"=\n" +
 	"\x1bExtensionsConfigurationSpec\x12\x1e\n" +
 	"\n" +
 	"extensions\x18\x01 \x03(\tR\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1316,8 +1316,8 @@ message MachineConfigGenOptionsSpec {
     string platform = 6;
     // SecurityState is used to decide the secure boot enablement in the install image.
     SecurityState security_state = 7;
-    // ImageFactoryHost is the host of the image factory to build the install image from.
-    // When empty, the primary factory is used as a fallback.
+    // ImageFactoryHost is the host of the image factory to build the install image from: the factory that issued
+    // SchematicId, recorded on the SchematicConfiguration. An install image with a schematic and no host is not built.
     string image_factory_host = 8;
   }
 
@@ -1410,6 +1410,10 @@ message SchematicConfigurationSpec {
   string schematic_id = 1;
   string talos_version = 2;
   reserved 3;
+  // ImageFactoryUrl is the base URL of the image factory that issued SchematicId. An install image with this
+  // schematic has to name that factory: another factory does not know the ID, an Enterprise one stamps an owner
+  // into the schematic and issues a different ID for the same content.
+  string image_factory_url = 4;
 }
 
 // ExtensionsConfigurationSpec is the desired list of extensions to be installed on the machine or the set of machines.

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -2331,6 +2331,7 @@ func (m *SchematicConfigurationSpec) CloneVT() *SchematicConfigurationSpec {
 	r := new(SchematicConfigurationSpec)
 	r.SchematicId = m.SchematicId
 	r.TalosVersion = m.TalosVersion
+	r.ImageFactoryUrl = m.ImageFactoryUrl
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -6688,6 +6689,9 @@ func (this *SchematicConfigurationSpec) EqualVT(that *SchematicConfigurationSpec
 		return false
 	}
 	if this.TalosVersion != that.TalosVersion {
+		return false
+	}
+	if this.ImageFactoryUrl != that.ImageFactoryUrl {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -14769,6 +14773,13 @@ func (m *SchematicConfigurationSpec) MarshalToSizedBufferVT(dAtA []byte) (int, e
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ImageFactoryUrl) > 0 {
+		i -= len(m.ImageFactoryUrl)
+		copy(dAtA[i:], m.ImageFactoryUrl)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ImageFactoryUrl)))
+		i--
+		dAtA[i] = 0x22
+	}
 	if len(m.TalosVersion) > 0 {
 		i -= len(m.TalosVersion)
 		copy(dAtA[i:], m.TalosVersion)
@@ -20253,6 +20264,10 @@ func (m *SchematicConfigurationSpec) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.TalosVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ImageFactoryUrl)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -38091,6 +38106,38 @@ func (m *SchematicConfigurationSpec) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.TalosVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ImageFactoryUrl", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ImageFactoryUrl = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"slices"
 	"strings"
 
@@ -46,7 +45,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/imagefactoryauth"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/internal/mappers"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/uncached"
-	omnicfg "github.com/siderolabs/omni/internal/pkg/config"
 )
 
 // ClusterMachineConfigControllerName is the name of the ClusterMachineConfigController.
@@ -58,7 +56,7 @@ const ClusterMachineConfigControllerName = "ClusterMachineConfigController"
 type ClusterMachineConfigController = qtransform.QController[*omni.ClusterMachine, *omni.ClusterMachineConfig]
 
 // NewClusterMachineConfigController initializes ClusterMachineConfigController.
-func NewClusterMachineConfigController(registryMirrors []string, talosRegistry string, registries omnicfg.Registries) *ClusterMachineConfigController {
+func NewClusterMachineConfigController(registryMirrors []string, talosRegistry string) *ClusterMachineConfigController {
 	return qtransform.NewQController(
 		qtransform.Settings[*omni.ClusterMachine, *omni.ClusterMachineConfig]{
 			Name: ClusterMachineConfigControllerName,
@@ -69,7 +67,7 @@ func NewClusterMachineConfigController(registryMirrors []string, talosRegistry s
 				return omni.NewClusterMachine(machineConfig.Metadata().ID())
 			},
 			TransformFunc: func(ctx context.Context, r controller.Reader, logger *zap.Logger, clusterMachine *omni.ClusterMachine, machineConfig *omni.ClusterMachineConfig) error {
-				return reconcileClusterMachineConfig(ctx, r, logger, clusterMachine, machineConfig, registryMirrors, talosRegistry, registries)
+				return reconcileClusterMachineConfig(ctx, r, logger, clusterMachine, machineConfig, registryMirrors, talosRegistry)
 			},
 		},
 		qtransform.WithExtraMappedInput[*omni.ClusterMachineConfigPatches](
@@ -154,7 +152,6 @@ func reconcileClusterMachineConfig(
 	machineConfig *omni.ClusterMachineConfig,
 	registryMirrors []string,
 	talosRegistry string,
-	registries omnicfg.Registries,
 ) error {
 	clusterName, ok := clusterMachine.Metadata().Labels().Get(omni.LabelCluster)
 	if !ok {
@@ -337,7 +334,6 @@ func reconcileClusterMachineConfig(
 
 	helper := clusterMachineConfigControllerHelper{
 		talosRegistry: talosRegistry,
-		registries:    registries,
 	}
 
 	configGenOptions := make([]generate.Option, 0, len(registryMirrors))
@@ -414,7 +410,6 @@ func grubUseUKICmdline(cfg config.Provider, initialTalosVersion string) (bool, e
 }
 
 type clusterMachineConfigControllerHelper struct {
-	registries    omnicfg.Registries
 	talosRegistry string
 }
 
@@ -500,33 +495,6 @@ func (helper clusterMachineConfigControllerHelper) generateConfig(clusterMachine
 	}
 
 	installImageSpec := configGenOptions.TypedSpec().Value.InstallImage
-
-	// Migration code, if the factory URL is not populated yet, use the secondary factory URL if configured
-	// As the second factory should be the old one we're migrating from
-	if installImageSpec.ImageFactoryHost == "" {
-		// Resolve the primary factory rather than reading registries.factories.primary directly: a
-		// deployment still using the deprecated flat imageFactory* config leaves that block empty, and
-		// falling back to an empty URL would yield an empty host and fail the install image build.
-		primaryFactory := helper.registries.GetPrimaryFactory()
-		fallbackURL := primaryFactory.GetUrl()
-
-		if f, ok := helper.registries.GetSecondaryFactory(); ok {
-			fallbackURL = f.GetUrl()
-		}
-
-		u, err := url.Parse(fallbackURL)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse image factory URL %q: %w", fallbackURL, err)
-		}
-
-		if u.Host == "" {
-			return nil, fmt.Errorf("image factory URL %q has no host", fallbackURL)
-		}
-
-		// Clone rather than writing through the pointer into the cached MachineConfigGenOptions spec.
-		installImageSpec = installImageSpec.CloneVT()
-		installImageSpec.ImageFactoryHost = u.Host
-	}
 
 	installImage, err := installimage.Build(configGenOptions.Metadata().ID(), installImageSpec, helper.talosRegistry)
 	if err != nil {

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_test.go
@@ -48,7 +48,7 @@ var testMachineAPIURL = "http://127.0.0.1:8090"
 // config, so the real controllers have to produce it instead of a fixture.
 func registerClusterMachineConfigControllers(t *testing.T) testutils.TestFunc {
 	return func(_ context.Context, tc testutils.TestContext) {
-		require.NoError(t, tc.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", conf.Registries{})))
+		require.NoError(t, tc.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 		require.NoError(t, tc.Runtime.RegisterQController(omnictrl.NewMachineJoinConfigController()))
 		require.NoError(t, tc.Runtime.RegisterQController(omnictrl.NewSiderolinkAPIConfigController(testMachineAPIURL, testSiderolinkCfg)))
 		require.NoError(t, tc.Runtime.RegisterQController(newMockJoinTokenUsageController[*siderolink.Link]()))

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
@@ -12,9 +12,9 @@ import (
 	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
 	"github.com/cosi-project/runtime/pkg/safe"
 	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/gen/xerrors"
 	"go.uber.org/zap"
 
-	"github.com/siderolabs/omni/client/api/omni/specs"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 )
 
@@ -41,41 +41,46 @@ func NewMachineConfigGenOptionsController(imageFactoryClients ImageFactoryClient
 					return err
 				}
 
-				var (
-					talosVersion string
-					schematicID  string
-				)
-
-				if clusterMachineTalosVersion != nil {
-					talosVersion = clusterMachineTalosVersion.TypedSpec().Value.TalosVersion
-					schematicID = clusterMachineTalosVersion.TypedSpec().Value.SchematicId
-				}
-
-				imageFactoryClient, err := imageFactoryClients.ForTalosVersion(ctx, talosVersion)
-				if err != nil {
+				schematicConfiguration, err := safe.ReaderGetByID[*omni.SchematicConfiguration](ctx, r, machineStatus.Metadata().ID())
+				if err != nil && !state.IsNotFoundError(err) {
 					return err
 				}
 
-				imageFactoryHost := imageFactoryClient.Host()
-
-				// Migration code: do not change image factory URL if it was already set in the options and the Talos version and schematic ID match the cluster machine Talos version.
-				// Image factory URL will only be upgraded when the Talos version or schematic ID changes.
-				if options.TypedSpec().Value.InstallImage != nil && clusterMachineTalosVersion != nil &&
-					(options.TypedSpec().Value.InstallImage.TalosVersion == talosVersion &&
-						options.TypedSpec().Value.InstallImage.SchematicId == schematicID) {
-					imageFactoryHost = options.TypedSpec().Value.InstallImage.ImageFactoryHost
-				}
+				installImage := options.TypedSpec().Value.InstallImage
 
 				if clusterMachineTalosVersion == nil {
-					backfillImageFactoryHost(options.TypedSpec().Value.InstallImage, imageFactoryClients, imageFactoryHost)
+					// A free machine keeps its install image as the record of what it runs. A host missing from
+					// it (enrolled before the host was tracked) is filled in from the schematic's record.
+					if installImage != nil && installImage.ImageFactoryHost == "" {
+						installImage.ImageFactoryHost = schematicFactoryHost(schematicConfiguration, installImage.SchematicId, installImage.TalosVersion, imageFactoryClients)
+					}
 
 					return nil
 				}
 
+				talosVersion := clusterMachineTalosVersion.TypedSpec().Value.TalosVersion
+				schematicID := clusterMachineTalosVersion.TypedSpec().Value.SchematicId
+
+				// The host is the factory that issued the schematic in use, recorded when it was ensured for the
+				// target Talos version. While the record covers another schematic or version (an upgrade in
+				// flight, a resource from before the record existed), the install image already published for
+				// this very schematic and version keeps its host. With neither, nothing is published rather
+				// than a guess: an install image naming a factory that does not know its schematic only fails
+				// the pull.
+				imageFactoryHost := schematicFactoryHost(schematicConfiguration, schematicID, talosVersion, imageFactoryClients)
+
+				if imageFactoryHost == "" && installImage != nil && installImage.SchematicId == schematicID && installImage.TalosVersion == talosVersion {
+					imageFactoryHost = installImage.ImageFactoryHost
+				}
+
+				if imageFactoryHost == "" && schematicID != "" {
+					return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("the image factory of schematic %q is not known yet", schematicID)
+				}
+
 				options.TypedSpec().Value.InstallImage = omni.NewInstallImage(
 					machineStatus,
-					clusterMachineTalosVersion.TypedSpec().Value.TalosVersion,
-					clusterMachineTalosVersion.TypedSpec().Value.SchematicId,
+					talosVersion,
+					schematicID,
 					imageFactoryHost,
 					machineStatus.TypedSpec().Value.SchematicReady(),
 				)
@@ -86,22 +91,27 @@ func NewMachineConfigGenOptionsController(imageFactoryClients ImageFactoryClient
 		qtransform.WithExtraMappedInput[*omni.ClusterMachineTalosVersion](
 			qtransform.MapperSameID[*omni.MachineStatus](),
 		),
+		qtransform.WithExtraMappedInput[*omni.SchematicConfiguration](
+			qtransform.MapperSameID[*omni.MachineStatus](),
+		),
 		qtransform.WithIgnoreTeardownUntil(), // keep the resource until everyone else is done with Machine
 	)
 }
 
-func backfillImageFactoryHost(installImage *specs.MachineConfigGenOptionsSpec_InstallImage, imageFactoryClients ImageFactoryClientProvider, fallbackHost string) {
-	if installImage == nil || installImage.ImageFactoryHost != "" {
-		return
+// schematicFactoryHost returns the host of the factory that issued the schematic for the Talos version, as
+// recorded on the SchematicConfiguration, or empty while the record covers another schematic ID or version, or
+// names no configured factory.
+func schematicFactoryHost(schematicConfiguration *omni.SchematicConfiguration, schematicID, talosVersion string, imageFactoryClients ImageFactoryClientProvider) string {
+	if schematicConfiguration == nil ||
+		schematicConfiguration.TypedSpec().Value.SchematicId != schematicID ||
+		schematicConfiguration.TypedSpec().Value.TalosVersion != talosVersion {
+		return ""
 	}
 
-	// The secondary factory is the one Omni is migrating away from, so it is the factory the schematic of a machine
-	// enrolled before the host was tracked was created on.
-	if secondary, ok := imageFactoryClients.Secondary(); ok {
-		installImage.ImageFactoryHost = secondary.Host()
-
-		return
+	imageFactoryClient := imageFactoryClients.ForURL(schematicConfiguration.TypedSpec().Value.ImageFactoryUrl)
+	if imageFactoryClient == nil {
+		return ""
 	}
 
-	installImage.ImageFactoryHost = fallbackHost
+	return imageFactoryClient.Host()
 }

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options_test.go
@@ -31,10 +31,12 @@ import (
 // started tracking the factory host per machine have it empty, and the controller kept carrying that
 // empty value forward, so every install of such a machine failed with "has no image factory host set".
 //
-// The host of a machine that is allocated to a cluster is left alone: its install image describes what
-// the machine is running, and is only ever rewritten by the allocation itself. The empty host is
-// backfilled while the machine is free, which is the state it passes through on its way back into a
-// cluster.
+// The host is the factory that issued the schematic in use, recorded on the SchematicConfiguration for the
+// Talos version it was ensured for. While that record does not cover the schematic and version in use, the
+// install image already published for that same schematic and version keeps its host, and with neither
+// nothing is published: a guessed factory would only fail the pull.
+//
+//nolint:maintidx
 func TestMachineConfigGenOptionsFactoryHost(t *testing.T) {
 	t.Parallel()
 
@@ -60,41 +62,71 @@ func TestMachineConfigGenOptionsFactoryHost(t *testing.T) {
 		}
 	}
 
+	// schematicRecord is the SchematicConfiguration of the machine: the schematic ID, the Talos version it was
+	// ensured for, and the factory that issued it.
+	schematicRecord := func(schematicID, talosVersion, factoryHost string) *specs.SchematicConfigurationSpec {
+		return &specs.SchematicConfigurationSpec{
+			SchematicId:     schematicID,
+			TalosVersion:    talosVersion,
+			ImageFactoryUrl: "https://" + factoryHost,
+		}
+	}
+
 	for _, tt := range []struct {
 		storedInstallImage *specs.MachineConfigGenOptionsSpec_InstallImage
+		schematicRecord    *specs.SchematicConfigurationSpec
 		name               string
 		// the Talos version the machine is allocated with, empty when the machine is not allocated to a cluster
 		allocatedTalosVersion string
 		expectedFactoryHost   string
-		withSecondary         bool
+		// allocatedSchematic is the schematic ID the allocation names, defaultSchematic when empty
+		allocatedSchematic string
+		withSecondary      bool
+		// invalidSchematic allocates the machine with no schematic ID at all (a machine that bypassed the
+		// factory), which needs no factory host
+		invalidSchematic bool
+		// expectUntouched expects the stored install image to be left exactly as it was
+		expectUntouched bool
 	}{
 		{
 			// the issue: Omni 1.9.x recorded no factory host, and the machine is now back out of its cluster
-			name:                "backfills the empty factory host of a machine that is not allocated",
+			name:                "fills the empty factory host of a machine that is not allocated from the schematic's record",
 			storedInstallImage:  installImage(installedTalosVersion, ""),
-			expectedFactoryHost: primaryFactoryHost,
-		},
-		{
-			// the secondary factory is the one Omni is migrating away from, so it is the factory the
-			// schematic of a machine enrolled before the upgrade was created on
-			name:                "backfills the empty factory host of a machine that is not allocated from the secondary factory",
-			storedInstallImage:  installImage(installedTalosVersion, ""),
+			schematicRecord:     schematicRecord(defaultSchematic, installedTalosVersion, secondaryFactoryHost),
 			withSecondary:       true,
 			expectedFactoryHost: secondaryFactoryHost,
 		},
 		{
+			name:                "leaves the empty factory host of a machine that is not allocated alone without a record",
+			storedInstallImage:  installImage(installedTalosVersion, ""),
+			withSecondary:       true,
+			expectedFactoryHost: "",
+		},
+		{
 			name:                "keeps the recorded factory host of a machine that is not allocated",
 			storedInstallImage:  installImage(installedTalosVersion, recordedFactoryHost),
+			schematicRecord:     schematicRecord(defaultSchematic, installedTalosVersion, primaryFactoryHost),
 			withSecondary:       true,
 			expectedFactoryHost: recordedFactoryHost,
 		},
 		{
-			// the install image of an allocated machine is left as it is: the machine is running it, and the
-			// install/upgrade path resolves the factory on its own when the host is empty
-			name:                  "leaves the empty factory host of an allocated machine alone",
+			// neither the schematic nor the install image records a factory: nothing is published until one does,
+			// a guessed factory would only fail the pull
+			name:                  "waits for a factory when neither the schematic nor the install image records one",
 			storedInstallImage:    installImage(installedTalosVersion, ""),
 			allocatedTalosVersion: installedTalosVersion,
+			withSecondary:         true,
 			expectedFactoryHost:   "",
+		},
+		{
+			// a machine allocated after a factory switch: its schematic was issued by the factory that is the
+			// secondary now, and only that factory knows the ID
+			name:                  "names the factory that issued the schematic, not the one serving the version",
+			storedInstallImage:    installImage(installedTalosVersion, ""),
+			schematicRecord:       schematicRecord(defaultSchematic, installedTalosVersion, secondaryFactoryHost),
+			allocatedTalosVersion: installedTalosVersion,
+			withSecondary:         true,
+			expectedFactoryHost:   secondaryFactoryHost,
 		},
 		{
 			name:                  "keeps the recorded factory host of an allocated machine",
@@ -103,14 +135,72 @@ func TestMachineConfigGenOptionsFactoryHost(t *testing.T) {
 			expectedFactoryHost:   recordedFactoryHost,
 		},
 		{
-			name:                  "upgrades the factory host when the Talos version changes",
+			// the schematic was ensured on the primary for the new version before the allocation moved
+			name:                  "moves the factory host with the schematic when the Talos version changes",
 			storedInstallImage:    installImage(installedTalosVersion, recordedFactoryHost),
+			schematicRecord:       schematicRecord(defaultSchematic, upgradeTalosVersion, primaryFactoryHost),
 			allocatedTalosVersion: upgradeTalosVersion,
+			withSecondary:         true,
 			expectedFactoryHost:   primaryFactoryHost,
 		},
 		{
-			name:                  "uses the primary factory for a machine that never had an install image",
+			// the record covers another schematic ID: the allocation has not caught up with it yet
+			name:                  "keeps the recorded factory host while the schematic record covers another ID",
+			storedInstallImage:    installImage(installedTalosVersion, recordedFactoryHost),
+			schematicRecord:       schematicRecord("other-schematic", installedTalosVersion, primaryFactoryHost),
+			allocatedTalosVersion: installedTalosVersion,
+			withSecondary:         true,
+			expectedFactoryHost:   recordedFactoryHost,
+		},
+		{
+			// the record is for the version the machine runs, the allocation moved on to the next one: the
+			// install image published for the old version is left as it is until the record catches up
+			name:                  "waits while the schematic record covers another Talos version",
+			storedInstallImage:    installImage(installedTalosVersion, recordedFactoryHost),
+			schematicRecord:       schematicRecord(defaultSchematic, installedTalosVersion, primaryFactoryHost),
+			allocatedTalosVersion: upgradeTalosVersion,
+			withSecondary:         true,
+			expectedFactoryHost:   recordedFactoryHost,
+			expectUntouched:       true,
+		},
+		{
+			// the allocation already names a new schematic the record does not cover yet: the host of the
+			// old schematic must not be paired with the new ID
+			name:                  "waits while the allocation names a schematic the record does not cover",
+			storedInstallImage:    installImage(installedTalosVersion, recordedFactoryHost),
+			schematicRecord:       schematicRecord(defaultSchematic, installedTalosVersion, primaryFactoryHost),
+			allocatedTalosVersion: installedTalosVersion,
+			allocatedSchematic:    "new-schematic",
+			withSecondary:         true,
+			expectedFactoryHost:   recordedFactoryHost,
+			expectUntouched:       true,
+		},
+		{
+			name:                  "keeps the recorded factory host when the record names a factory that is not configured",
+			storedInstallImage:    installImage(installedTalosVersion, recordedFactoryHost),
+			schematicRecord:       schematicRecord(defaultSchematic, installedTalosVersion, "gone.factory.test"),
+			allocatedTalosVersion: installedTalosVersion,
+			expectedFactoryHost:   recordedFactoryHost,
+		},
+		{
+			name:                  "publishes the install image of a machine without a schematic with no factory host",
 			storedInstallImage:    nil,
+			allocatedTalosVersion: installedTalosVersion,
+			invalidSchematic:      true,
+			withSecondary:         true,
+			expectedFactoryHost:   "",
+		},
+		{
+			name:                  "waits for a factory for a machine that never had an install image",
+			storedInstallImage:    nil,
+			allocatedTalosVersion: installedTalosVersion,
+			withSecondary:         true,
+			expectedFactoryHost:   "",
+		},
+		{
+			name:                  "publishes the install image of a machine that never had one from the schematic's record",
+			storedInstallImage:    nil,
+			schematicRecord:       schematicRecord(defaultSchematic, installedTalosVersion, primaryFactoryHost),
 			allocatedTalosVersion: installedTalosVersion,
 			withSecondary:         true,
 			expectedFactoryHost:   primaryFactoryHost,
@@ -166,7 +256,14 @@ func TestMachineConfigGenOptionsFactoryHost(t *testing.T) {
 							ctx, t, tc.State, options.WithID(machineID),
 							options.Modify(func(res *omni.ClusterMachineTalosVersion) error {
 								res.TypedSpec().Value.TalosVersion = tt.allocatedTalosVersion
-								res.TypedSpec().Value.SchematicId = defaultSchematic
+
+								switch {
+								case tt.invalidSchematic:
+								case tt.allocatedSchematic != "":
+									res.TypedSpec().Value.SchematicId = tt.allocatedSchematic
+								default:
+									res.TypedSpec().Value.SchematicId = defaultSchematic
+								}
 
 								return nil
 							}),
@@ -182,6 +279,18 @@ func TestMachineConfigGenOptionsFactoryHost(t *testing.T) {
 						}),
 					)
 
+					if tt.schematicRecord != nil {
+						rmock.Mock[*omni.SchematicConfiguration](
+							ctx, t, tc.State, options.WithID(machineID),
+							options.Modify(func(res *omni.SchematicConfiguration) error {
+								res.TypedSpec().Value = tt.schematicRecord.CloneVT()
+
+								return nil
+							}),
+						)
+					}
+
+					// The fence machine's schematic record names the primary, so its empty host gets filled.
 					rmock.Mock[*omni.MachineStatus](ctx, t, tc.State, options.WithID(fenceMachineID))
 					rmock.Mock[*omni.MachineConfigGenOptions](
 						ctx, t, tc.State, options.WithID(fenceMachineID),
@@ -191,19 +300,30 @@ func TestMachineConfigGenOptionsFactoryHost(t *testing.T) {
 							return nil
 						}),
 					)
+					rmock.Mock[*omni.SchematicConfiguration](
+						ctx, t, tc.State, options.WithID(fenceMachineID),
+						options.Modify(func(res *omni.SchematicConfiguration) error {
+							res.TypedSpec().Value = schematicRecord(defaultSchematic, installedTalosVersion, primaryFactoryHost)
+
+							return nil
+						}),
+					)
 				},
 				func(ctx context.Context, tc testutils.TestContext) {
-					fenceFactoryHost := primaryFactoryHost
-					if tt.withSecondary {
-						fenceFactoryHost = secondaryFactoryHost
-					}
-
 					rtestutils.AssertResource(ctx, t, tc.State, fenceMachineID, func(res *omni.MachineConfigGenOptions, assertions *assert.Assertions) {
-						assertions.Equal(fenceFactoryHost, res.TypedSpec().Value.InstallImage.GetImageFactoryHost())
+						assertions.Equal(primaryFactoryHost, res.TypedSpec().Value.InstallImage.GetImageFactoryHost())
 					})
 
 					rtestutils.AssertResource(ctx, t, tc.State, machineID, func(res *omni.MachineConfigGenOptions, assertions *assert.Assertions) {
 						assertions.Equal(tt.expectedFactoryHost, res.TypedSpec().Value.InstallImage.GetImageFactoryHost())
+
+						if tt.invalidSchematic {
+							assertions.NotNil(res.TypedSpec().Value.InstallImage, "a machine without a schematic needs no factory host to get its install image")
+						}
+
+						if tt.expectUntouched {
+							assertions.True(tt.storedInstallImage.EqualVT(res.TypedSpec().Value.InstallImage), "the stored install image must be left as it is: %v", res.TypedSpec().Value.InstallImage)
+						}
 					})
 				},
 			)

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status.go
@@ -209,9 +209,13 @@ func (ctrl *StatusController) transform(ctx context.Context, r controller.Reader
 		return nil
 	}
 
-	imageFactoryClient, err := ctrl.imageFactoryClients.ForTalosVersion(ctx, talosVersion)
-	if err != nil {
-		return fmt.Errorf("failed to get image factory client for Talos version %q: %w", talosVersion, err)
+	// The install image names the factory that issued the schematic.
+	imageFactoryClient := ctrl.imageFactoryClients.ForURL(schematicConfiguration.TypedSpec().Value.ImageFactoryUrl)
+	if imageFactoryClient == nil {
+		status.TypedSpec().Value.Status = "waiting for the image factory of the schematic to be known"
+		status.TypedSpec().Value.Error = ""
+
+		return nil
 	}
 
 	installImage := &specs.MachineConfigGenOptionsSpec_InstallImage{

--- a/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machineupgrade/status_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/imagefactory"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/machineupgrade"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
@@ -82,6 +83,7 @@ func TestReconcile(t *testing.T) {
 		schematicConfiguration := omni.NewSchematicConfiguration(id)
 		schematicConfiguration.TypedSpec().Value.SchematicId = currentSchematicID
 		schematicConfiguration.TypedSpec().Value.TalosVersion = talosVersion
+		schematicConfiguration.TypedSpec().Value.ImageFactoryUrl = "https://factory-test.talos.dev"
 		require.NoError(t, st.Create(ctx, schematicConfiguration))
 
 		currentSchematicRaw, err := initialSchematic.Marshal()
@@ -225,6 +227,7 @@ func TestReconcileLifecycleUpgrade(t *testing.T) {
 		schematicConfiguration := omni.NewSchematicConfiguration(id)
 		schematicConfiguration.TypedSpec().Value.SchematicId = currentSchematicID
 		schematicConfiguration.TypedSpec().Value.TalosVersion = talosVersion
+		schematicConfiguration.TypedSpec().Value.ImageFactoryUrl = "https://factory-test.talos.dev"
 		require.NoError(t, st.Create(ctx, schematicConfiguration))
 
 		updatedSchematic := updateKernelArgs(ctx, t, st, initialSchematic, id, []string{"updated-arg"})
@@ -232,32 +235,7 @@ func TestReconcileLifecycleUpgrade(t *testing.T) {
 		updatedSchematicID, err := updatedSchematic.ID()
 		require.NoError(t, err)
 
-		_, err = safe.StateUpdateWithConflicts(ctx, st, ms.Metadata(), func(res *omni.MachineStatus) error {
-			res.Metadata().Annotations().Set(omni.KernelArgsInitialized, "")
-
-			res.TypedSpec().Value.Maintenance = true
-			res.TypedSpec().Value.TalosVersion = talosVersion
-
-			res.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{
-				Blockdevices: []*specs.MachineStatusSpec_HardwareStatus_BlockDevice{{LinuxName: "/dev/sda", SystemDisk: true}},
-			}
-
-			res.TypedSpec().Value.SecurityState = &specs.SecurityState{BootedWithUki: true}
-
-			res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
-				Platform: talosconstants.PlatformMetal,
-			}
-
-			res.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
-				InitialSchematic: currentSchematicID,
-				KernelArgs:       initialSchematic.Customization.ExtraKernelArgs,
-				FullId:           currentSchematicID,
-				Raw:              string(currentSchematicRaw),
-			}
-
-			return nil
-		})
-		require.NoError(t, err)
+		markMaintenanceMachine(ctx, t, st, ms, talosVersion, initialSchematic, currentSchematicID, string(currentSchematicRaw))
 
 		rtestutils.AssertResource(ctx, t, st, id, func(res *omni.MachineUpgradeStatus, assertion *assert.Assertions) {
 			assertion.Equal(specs.MachineUpgradeStatusSpec_Upgrading, res.TypedSpec().Value.Phase)
@@ -308,4 +286,130 @@ func updateKernelArgs(ctx context.Context, t *testing.T, st state.State, schemat
 	require.NoError(t, err)
 
 	return updatedSchematic
+}
+
+// TestReconcileInstallImageFactory covers where the install image's factory host comes from: the factory
+// recorded as having issued the schematic, not the one serving the Talos version, and nothing happens until
+// that record exists.
+func TestReconcileInstallImageFactory(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		recordedURL  string
+		expectedHost string
+	}{
+		{name: "the recorded factory", recordedURL: "https://issuing.factory.test", expectedHost: "issuing.factory.test"},
+		{name: "no record yet"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+
+			testutils.WithRuntime(ctx, t, testutils.TestOptions{}, func(ctx context.Context, testContext testutils.TestContext) {
+				clients := testutils.NewImageFactoryClients(t, testContext.State)
+
+				secondary, err := imagefactory.NewClient("https://issuing.factory.test", "", "")
+				require.NoError(t, err)
+
+				clients.SetSecondary(secondary)
+
+				ctrl := machineupgrade.NewStatusController(clients, testutils.NewLifecycleManager(t, testContext.State, nil))
+
+				require.NoError(t, testContext.Runtime.RegisterQController(ctrl))
+			}, func(ctx context.Context, testContext testutils.TestContext) {
+				const id = "test-factory"
+
+				st := testContext.State
+
+				machineServices := testutils.NewMachineServices(t, st)
+				machineService := machineServices.Create(ctx, id)
+
+				ms := omni.NewMachineStatus(id)
+				ms.TypedSpec().Value.ManagementAddress = machineService.SocketConnectionString
+
+				require.NoError(t, st.Create(ctx, ms))
+
+				initialSchematic := schematic.Schematic{
+					Customization: schematic.Customization{
+						ExtraKernelArgs: []string{"arg1"},
+					},
+				}
+
+				currentSchematicID, err := initialSchematic.ID()
+				require.NoError(t, err)
+
+				currentSchematicRaw, err := initialSchematic.Marshal()
+				require.NoError(t, err)
+
+				const talosVersion = "1.13.4"
+
+				schematicConfiguration := omni.NewSchematicConfiguration(id)
+				schematicConfiguration.TypedSpec().Value.SchematicId = currentSchematicID
+				schematicConfiguration.TypedSpec().Value.TalosVersion = talosVersion
+				schematicConfiguration.TypedSpec().Value.ImageFactoryUrl = tt.recordedURL
+
+				require.NoError(t, st.Create(ctx, schematicConfiguration))
+
+				updatedSchematic := updateKernelArgs(ctx, t, st, initialSchematic, id, []string{"updated-arg"})
+
+				updatedSchematicID, err := updatedSchematic.ID()
+				require.NoError(t, err)
+
+				markMaintenanceMachine(ctx, t, st, ms, talosVersion, initialSchematic, currentSchematicID, string(currentSchematicRaw))
+
+				if tt.recordedURL == "" {
+					rtestutils.AssertResource(ctx, t, st, id, func(res *omni.MachineUpgradeStatus, assertion *assert.Assertions) {
+						assertion.Equal("waiting for the image factory of the schematic to be known", res.TypedSpec().Value.Status)
+					})
+
+					assert.Empty(t, machineService.GetLifecycleUpgradeRequests())
+
+					return
+				}
+
+				rtestutils.AssertResource(ctx, t, st, id, func(res *omni.MachineUpgradeStatus, assertion *assert.Assertions) {
+					assertion.Equal(specs.MachineUpgradeStatusSpec_Upgrading, res.TypedSpec().Value.Phase)
+				})
+
+				lifecycleUpgradeRequests := machineService.GetLifecycleUpgradeRequests()
+				require.Len(t, lifecycleUpgradeRequests, 1)
+
+				assert.Equal(t, fmt.Sprintf("%s/metal-installer/%s:v%s", tt.expectedHost, updatedSchematicID, talosVersion), lifecycleUpgradeRequests[0].GetSource().GetImageName())
+			})
+		})
+	}
+}
+
+// markMaintenanceMachine turns the machine status into a maintenance mode machine running the given schematic on
+// the given Talos version, ready for a schematic upgrade.
+func markMaintenanceMachine(
+	ctx context.Context, t *testing.T, st state.State, ms *omni.MachineStatus, talosVersion string, sch schematic.Schematic, schematicID, schematicRaw string,
+) {
+	t.Helper()
+
+	_, err := safe.StateUpdateWithConflicts(ctx, st, ms.Metadata(), func(res *omni.MachineStatus) error {
+		res.Metadata().Annotations().Set(omni.KernelArgsInitialized, "")
+
+		res.TypedSpec().Value.Maintenance = true
+		res.TypedSpec().Value.TalosVersion = talosVersion
+
+		res.TypedSpec().Value.Hardware = &specs.MachineStatusSpec_HardwareStatus{
+			Blockdevices: []*specs.MachineStatusSpec_HardwareStatus_BlockDevice{{LinuxName: "/dev/sda", SystemDisk: true}},
+		}
+
+		res.TypedSpec().Value.SecurityState = &specs.SecurityState{BootedWithUki: true}
+
+		res.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
+			Platform: talosconstants.PlatformMetal,
+		}
+
+		res.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+			InitialSchematic: schematicID,
+			KernelArgs:       sch.Customization.ExtraKernelArgs,
+			FullId:           schematicID,
+			Raw:              schematicRaw,
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
 }

--- a/internal/backend/runtime/omni/controllers/omni/omni.go
+++ b/internal/backend/runtime/omni/controllers/omni/omni.go
@@ -26,6 +26,7 @@ type ImageFactoryClientProvider interface {
 	Secondary() (imagefactory.FactoryClient, bool)
 	ForTalosVersion(ctx context.Context, version string) (imagefactory.FactoryClient, error)
 	ForHost(host string) imagefactory.FactoryClient
+	ForURL(url string) imagefactory.FactoryClient
 }
 
 type cleanupOptions struct {

--- a/internal/backend/runtime/omni/controllers/omni/schematic/configuration.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic/configuration.go
@@ -10,8 +10,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -22,6 +24,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/siderolabs/gen/xerrors"
 	"github.com/siderolabs/gen/xslices"
+	ifclient "github.com/siderolabs/image-factory/pkg/client"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
@@ -39,8 +42,12 @@ import (
 const ConfigurationControllerName = "SchematicConfigurationController"
 
 // imageFactoryClientProvider resolves the image factory client that serves a given Talos version.
+// imageFactoryClientProvider resolves the factory a schematic is ensured on, and lists the configured factories
+// for finding the one that issued a schematic recorded without it.
 type imageFactoryClientProvider interface {
 	ForTalosVersion(ctx context.Context, version string) (factoryclient.FactoryClient, error)
+	Primary() factoryclient.FactoryClient
+	Secondary() (factoryclient.FactoryClient, bool)
 }
 
 // ConfigurationController combines MachineExtensions resource, MachineStatus overlay into SchematicConfiguration for each existing MachineStatus.
@@ -48,12 +55,18 @@ type imageFactoryClientProvider interface {
 type ConfigurationController struct {
 	*qtransform.QController[*omni.MachineStatus, *omni.SchematicConfiguration]
 	imageFactoryClients imageFactoryClientProvider
+
+	// lookups memoizes the factories found by lookupSchematicFactory, by schematic ID: many machines share
+	// an ID, and the answer does not change.
+	lookups   map[string]string
+	lookupsMu sync.Mutex
 }
 
 // NewConfigurationController initializes SchematicConfigurationController.
 func NewConfigurationController(imageFactoryClients imageFactoryClientProvider) *ConfigurationController {
 	ctrl := &ConfigurationController{
 		imageFactoryClients: imageFactoryClients,
+		lookups:             map[string]string{},
 	}
 
 	ctrl.QController = qtransform.NewQController(
@@ -203,6 +216,7 @@ func (ctrl *ConfigurationController) transform(ctx context.Context, r controller
 	if ms.TypedSpec().Value.Schematic.Invalid {
 		schematicConfiguration.TypedSpec().Value.TalosVersion = talosVersion
 		schematicConfiguration.TypedSpec().Value.SchematicId = ""
+		schematicConfiguration.TypedSpec().Value.ImageFactoryUrl = ""
 
 		return ctrl.saveMachineExtensionStatus(ctx, r, machineExtensionsStatus)
 	}
@@ -254,9 +268,14 @@ func (ctrl *ConfigurationController) transform(ctx context.Context, r controller
 	// The published ID is deliberately left alone in that case rather than reset to the machine's own
 	// Schematic.FullId: an Enterprise factory stamps an owner into the schematic, so its ID for the
 	// same content differs from the ID the machine reports, and overwriting would lose it.
+	//
+	// The factory that issued the ID is recorded next to it: an install image with the ID has to name
+	// that factory, whichever one serves the Talos version by now.
+	spec := schematicConfiguration.TypedSpec().Value
+
 	if !bytes.Equal([]byte(ms.TypedSpec().Value.Schematic.Raw), patchedRaw) ||
 		versionOutdated ||
-		schematicConfiguration.TypedSpec().Value.SchematicId == "" {
+		spec.SchematicId == "" {
 		factoryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 
 		id, _, err := factoryClient.EnsureSchematic(factoryCtx, patched)
@@ -275,12 +294,67 @@ func (ctrl *ConfigurationController) transform(ctx context.Context, r controller
 			zap.String("schematic_id", id),
 		)
 
-		schematicConfiguration.TypedSpec().Value.SchematicId = id
+		spec.SchematicId = id
+		spec.ImageFactoryUrl = factoryClient.URL()
+	} else if spec.ImageFactoryUrl == "" {
+		// Written before the factory was recorded: find the one that knows the ID, the ID itself stays.
+		spec.ImageFactoryUrl = ctrl.lookupSchematicFactory(ctx, logger.With(zap.String("machine", ms.Metadata().ID())), spec.SchematicId)
 	}
 
 	machineExtensionsStatus.TypedSpec().Value.Extensions = computeMachineExtensionsStatus(ms, &customization)
 
 	return ctrl.saveMachineExtensionStatus(ctx, r, machineExtensionsStatus)
+}
+
+// lookupSchematicFactory returns the URL of the configured factory that knows the schematic, empty when
+// none does or none could be asked. A factory that cannot be asked is skipped: a schematic both factories
+// know is served by either. An empty answer is not kept, the next reconcile asks again.
+func (ctrl *ConfigurationController) lookupSchematicFactory(ctx context.Context, logger *zap.Logger, id string) string {
+	ctrl.lookupsMu.Lock()
+	url, known := ctrl.lookups[id]
+	ctrl.lookupsMu.Unlock()
+
+	if known {
+		return url
+	}
+
+	candidates := []factoryclient.FactoryClient{ctrl.imageFactoryClients.Primary()}
+
+	if secondary, ok := ctrl.imageFactoryClients.Secondary(); ok {
+		candidates = append(candidates, secondary)
+	}
+
+	for _, candidate := range candidates {
+		factoryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+		_, err := candidate.SchematicGet(factoryCtx, id)
+
+		cancel()
+
+		switch {
+		case err == nil:
+			url = candidate.URL()
+		case ifclient.IsHTTPErrorCode(err, http.StatusNotFound):
+			continue
+		default:
+			logger.Warn("failed to look up the schematic on the image factory", zap.String("image_factory", candidate.Host()), zap.String("schematic_id", id), zap.Error(err))
+
+			continue
+		}
+
+		break
+	}
+
+	if url == "" {
+		logger.Warn("no configured image factory knows the schematic", zap.String("schematic_id", id))
+
+		return ""
+	}
+
+	ctrl.lookupsMu.Lock()
+	ctrl.lookups[id] = url
+	ctrl.lookupsMu.Unlock()
+
+	return url
 }
 
 func (ctrl *ConfigurationController) finalizerRemoval(ctx context.Context, r controller.ReaderWriter, _ *zap.Logger, machineStatus *omni.MachineStatus) error {

--- a/internal/backend/runtime/omni/controllers/omni/schematic/configuration_factory_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic/configuration_factory_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Sidero Labs, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+package schematic_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource/rtestutils"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/siderolabs/image-factory/pkg/schematic"
+	talosconstants "github.com/siderolabs/talos/pkg/machinery/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
+	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
+	schematicctrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni/schematic"
+	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
+)
+
+// TestSchematicConfigurationFactoryRecord covers the factory recorded next to the schematic ID: the one that
+// issued it, which an install image with that ID has to name. A factory switch makes the primary a factory
+// that does not know the IDs issued before, so the record is what keeps the two together.
+func TestSchematicConfigurationFactoryRecord(t *testing.T) {
+	t.Parallel()
+
+	const (
+		primaryURL   = "https://primary.factory.test"
+		secondaryURL = "https://secondary.factory.test"
+		talosVersion = "1.10.0"
+	)
+
+	// The schematic the machine booted with, unchanged by the controller: the machine reports the same
+	// extensions and kernel args, so the controller has no reason to go to the factory.
+	raw := schematic.Schematic{
+		Customization: schematic.Customization{
+			ExtraKernelArgs: []string{"console=ttyS0"},
+			SystemExtensions: schematic.SystemExtensions{
+				OfficialExtensions: []string{"siderolabs/hello-world-service"},
+			},
+		},
+	}
+
+	rawYAML, err := raw.Marshal()
+	require.NoError(t, err)
+
+	rawID, err := raw.ID()
+	require.NoError(t, err)
+
+	newMachineStatus := func(name string) *omni.MachineStatus {
+		machineStatus := omni.NewMachineStatus(name)
+		machineStatus.Metadata().Annotations().Set(omni.KernelArgsInitialized, "")
+		machineStatus.TypedSpec().Value.TalosVersion = talosVersion
+		machineStatus.TypedSpec().Value.InitialTalosVersion = talosVersion
+		machineStatus.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+			FullId:           rawID,
+			Raw:              string(rawYAML),
+			Extensions:       []string{"siderolabs/hello-world-service"},
+			KernelArgs:       []string{"console=ttyS0"},
+			InitialSchematic: rawID,
+			InitialState: &specs.MachineStatusSpec_Schematic_InitialState{
+				Extensions: []string{"siderolabs/hello-world-service"},
+			},
+		}
+		machineStatus.TypedSpec().Value.SecurityState = &specs.SecurityState{}
+		machineStatus.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
+			Platform: talosconstants.PlatformMetal,
+		}
+
+		return machineStatus
+	}
+
+	for _, tt := range []struct {
+		name string
+		// recordedID is the schematic ID seeded into the SchematicConfiguration, without a factory, empty for
+		// a machine without one
+		recordedID  string
+		expectedID  string
+		expectedURL string
+		// secondaryKnows makes the secondary factory the one that issued the recorded ID
+		secondaryKnows bool
+	}{
+		{
+			name:        "records the factory that issued the schematic",
+			expectedID:  rawID,
+			expectedURL: primaryURL,
+		},
+		{
+			name:           "finds the factory of a schematic recorded without one",
+			recordedID:     rawID,
+			secondaryKnows: true,
+			expectedID:     rawID,
+			expectedURL:    secondaryURL,
+		},
+		{
+			name:        "keeps the schematic when no factory knows it",
+			recordedID:  rawID,
+			expectedID:  rawID,
+			expectedURL: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+
+			primary := &testutils.ImageFactoryClientMock{FactoryURL: primaryURL}
+			secondary := &testutils.ImageFactoryClientMock{FactoryURL: secondaryURL}
+
+			if tt.secondaryKnows {
+				_, _, err = secondary.EnsureSchematic(ctx, raw)
+				require.NoError(t, err)
+			}
+
+			const machineName = "machine"
+
+			testutils.WithRuntime(
+				ctx, t, testutils.TestOptions{},
+				func(ctx context.Context, testContext testutils.TestContext) {
+					require.NoError(t, testContext.Runtime.RegisterQController(schematicctrl.NewConfigurationController(testutils.NewFactoryClientSet(primary, secondary))))
+					require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewMachineExtensionsController()))
+
+					require.NoError(t, testContext.State.Create(ctx, newMachineStatus(machineName)))
+
+					if tt.recordedID != "" {
+						schematicConfiguration := omni.NewSchematicConfiguration(machineName)
+						schematicConfiguration.TypedSpec().Value.SchematicId = tt.recordedID
+						schematicConfiguration.TypedSpec().Value.TalosVersion = talosVersion
+
+						require.NoError(t, testContext.State.Create(ctx, schematicConfiguration, state.WithCreateOwner(schematicctrl.ConfigurationControllerName)))
+					}
+				},
+				func(ctx context.Context, testContext testutils.TestContext) {
+					// The extensions status is written at the end of every reconcile, so its presence means the
+					// schematic configuration above has been looked at.
+					rtestutils.AssertResources(ctx, t, testContext.State, []string{machineName}, func(*omni.MachineExtensionsStatus, *assert.Assertions) {})
+
+					rtestutils.AssertResources(ctx, t, testContext.State, []string{machineName}, func(res *omni.SchematicConfiguration, assertion *assert.Assertions) {
+						assertion.Equal(tt.expectedID, res.TypedSpec().Value.SchematicId)
+						assertion.Equal(tt.expectedURL, res.TypedSpec().Value.ImageFactoryUrl)
+					})
+
+					if tt.recordedID != "" {
+						_, ensuredOnPrimary := primary.Get(rawID)
+						assert.False(t, ensuredOnPrimary, "a recorded schematic must not be re-ensured on the primary")
+					}
+				},
+			)
+		})
+	}
+}

--- a/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/secrets/rotation_status_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock"
 	"github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/testutils/rmock/options"
-	omnicfg "github.com/siderolabs/omni/internal/pkg/config"
 	"github.com/siderolabs/omni/internal/pkg/constants"
 )
 
@@ -67,7 +66,7 @@ func Test_TalosCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -128,7 +127,7 @@ func Test_TalosCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretsController(nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -226,7 +225,7 @@ func Test_TalosCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -292,7 +291,7 @@ func Test_TalosCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -362,7 +361,7 @@ func Test_TalosCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -436,7 +435,7 @@ func Test_TalosCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -510,7 +509,7 @@ func Test_TalosCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -642,7 +641,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -703,7 +702,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 					),
 				))
 				require.NoError(t, testContext.Runtime.RegisterQController(secretsctrl.NewSecretsController(nil)))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -810,7 +809,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -885,7 +884,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -964,7 +963,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -1047,7 +1046,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -1130,7 +1129,7 @@ func Test_KubernetesCARotation(t *testing.T) {
 						&fakeKubernetesClientFactory{},
 					),
 				))
-				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+				require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 				require.NoError(t, testContext.Runtime.RegisterQController(
 					machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 				))
@@ -1195,7 +1194,7 @@ func Test_ConcurrentRotationRejection(t *testing.T) {
 					&fakeKubernetesClientFactory{},
 				),
 			))
-			require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+			require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 			require.NoError(t, testContext.Runtime.RegisterQController(
 				machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 			))
@@ -1244,7 +1243,7 @@ func Test_ComponentIsolationDuringRotation(t *testing.T) {
 					&fakeKubernetesClientFactory{},
 				),
 			))
-			require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer", omnicfg.Registries{})))
+			require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewClusterMachineConfigController(nil, "ghcr.io/siderolabs/installer")))
 			require.NoError(t, testContext.Runtime.RegisterQController(
 				machineconfig.NewStatusController(testutils.NewLifecycleManager(t, testContext.State, nil)),
 			))

--- a/internal/backend/runtime/omni/controllers/testutils/factory.go
+++ b/internal/backend/runtime/omni/controllers/testutils/factory.go
@@ -8,6 +8,7 @@ package testutils
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -27,7 +28,7 @@ func NewFactoryClientSet(clients ...imagefactory.FactoryClient) *imagefactory.Cl
 
 	var primaryClient imagefactory.FactoryClient
 
-	if len(clients) == 1 {
+	if len(clients) >= 1 {
 		primaryClient = clients[0]
 	} else {
 		primaryClient = &ImageFactoryClientMock{}
@@ -45,8 +46,11 @@ func NewFactoryClientSet(clients ...imagefactory.FactoryClient) *imagefactory.Cl
 // ImageFactoryClientMock is a mock implementation of the ImageFactoryClient interface for testing purposes.
 type ImageFactoryClientMock struct {
 	schematics map[string]schematic.Schematic
-	Owner      string
-	mu         sync.Mutex
+	// FactoryURL is what URL and Host answer, https://image.factory.test when unset.
+	FactoryURL string
+
+	Owner string
+	mu    sync.Mutex
 }
 
 func (i *ImageFactoryClientMock) EnsureSchematic(_ context.Context, inputSchematic schematic.Schematic) (string, *schematic.Schematic, error) {
@@ -85,10 +89,19 @@ func (i *ImageFactoryClientMock) SchematicGet(_ context.Context, id string) (*sc
 }
 
 func (i *ImageFactoryClientMock) Host() string {
-	return "image.factory.test"
+	u, err := url.Parse(i.URL())
+	if err != nil {
+		panic(err)
+	}
+
+	return u.Host
 }
 
 func (i *ImageFactoryClientMock) URL() string {
+	if i.FactoryURL != "" {
+		return i.FactoryURL
+	}
+
 	return "https://image.factory.test"
 }
 

--- a/internal/backend/runtime/omni/omni.go
+++ b/internal/backend/runtime/omni/omni.go
@@ -217,11 +217,7 @@ func NewRuntime(cfg *config.Params, talosClientFactory *talos.ClientFactory, dns
 		omnictrl.NewMachineSetDestroyStatusController(),
 		omnictrl.NewClusterEndpointController(),
 		omnictrl.NewClusterKubernetesNodesController(),
-		omnictrl.NewClusterMachineConfigController(
-			cfg.Registries.Mirrors,
-			cfg.Registries.GetTalos(),
-			cfg.Registries,
-		),
+		omnictrl.NewClusterMachineConfigController(cfg.Registries.Mirrors, cfg.Registries.GetTalos()),
 		omnictrl.NewClusterMachineTeardownController(omnictrl.NewGetKubernetesClientFunc(kubernetesRuntime)),
 		omnictrl.NewMachineConfigGenOptionsController(imageFactoryClients),
 		omnictrl.NewMachineStatusController(imageFactoryClients, exraKernelArgsInitializer),

--- a/internal/backend/talos/lifecycle/client.go
+++ b/internal/backend/talos/lifecycle/client.go
@@ -31,7 +31,7 @@ type AuditFunc func(ctx context.Context, fullMethodName, machineID string) error
 func NoAudit(_ context.Context, _, _ string) error { return nil }
 
 // buildInstallImage constructs the installer image reference.
-func (m *Manager) buildInstallImage(ctx context.Context, machineID string, ms *omni.MachineStatus, version string, target *specs.MachineConfigGenOptionsSpec_InstallImage) (string, error) {
+func (m *Manager) buildInstallImage(machineID string, ms *omni.MachineStatus, version string, target *specs.MachineConfigGenOptionsSpec_InstallImage) (string, error) {
 	spec := ms.TypedSpec().Value
 
 	if spec.GetPlatformMetadata().GetPlatform() == "" {
@@ -46,37 +46,22 @@ func (m *Manager) buildInstallImage(ctx context.Context, machineID string, ms *o
 		version = strings.TrimPrefix(spec.TalosVersion, "v")
 	}
 
-	if target != nil {
-		// The target is the spec of a cached resource, so patch a copy of it instead of writing through into the cache.
-		target = target.CloneVT()
-
-		if target.TalosVersion == "" {
-			target.TalosVersion = version
-		}
-
-		// A machine enrolled before Omni started tracking the image factory host per machine may still have none:
-		// resolve it the same way as for a machine without a target install image instead of failing the install.
-		// See https://github.com/siderolabs/omni/issues/3247.
-		if target.ImageFactoryHost == "" {
-			imageFactoryClient, err := m.imageFactoryClients.ForTalosVersion(ctx, target.TalosVersion)
-			if err != nil {
-				return "", fmt.Errorf("failed to get image factory client for Talos version %q: %w", target.TalosVersion, err)
-			}
-
-			target.ImageFactoryHost = imageFactoryClient.Host()
-		}
-
-		return installimage.Build(machineID, target, m.talosRegistry)
+	if target == nil {
+		// Every caller passes the install image it wants: it names the factory that issued its schematic,
+		// which is not something to guess from the machine's own schematic and the Talos version.
+		return "", status.Error(codes.InvalidArgument, "install image target is required")
 	}
 
-	imageFactoryClient, err := m.imageFactoryClients.ForTalosVersion(ctx, version)
-	if err != nil {
-		return "", fmt.Errorf("failed to get image factory client for Talos version %q: %w", version, err)
+	// The target is the spec of a cached resource, so patch a copy of it instead of writing through into the cache.
+	target = target.CloneVT()
+
+	if target.TalosVersion == "" {
+		target.TalosVersion = version
 	}
 
-	installImage := omni.NewInstallImage(ms, version, spec.Schematic.FullId, imageFactoryClient.Host(), true)
-
-	return installimage.Build(machineID, installImage, m.talosRegistry)
+	// The target names the factory that issued its schematic, or has no host yet: the build fails on
+	// that rather than guessing a factory that does not know the schematic.
+	return installimage.Build(machineID, target, m.talosRegistry)
 }
 
 // pullInstallerImage pulls the installer image into the machine's containerd and returns the resolved image name, as required by LifecycleService.{Install,Upgrade}'s InstallArtifactsSource.

--- a/internal/backend/talos/lifecycle/client_test.go
+++ b/internal/backend/talos/lifecycle/client_test.go
@@ -44,7 +44,7 @@ func TestBuildInstallImage(t *testing.T) {
 	t.Run("target install image takes precedence over the machine's current schematic", func(t *testing.T) {
 		t.Parallel()
 
-		image, err := m.BuildInstallImageForTest(t.Context(), "machine-1", ms, "1.13.1", &specs.MachineConfigGenOptionsSpec_InstallImage{
+		image, err := m.BuildInstallImageForTest("machine-1", ms, "1.13.1", &specs.MachineConfigGenOptionsSpec_InstallImage{
 			TalosVersion:         "1.14.0",
 			SchematicId:          "target-schematic",
 			SchematicInitialized: true,
@@ -57,22 +57,19 @@ func TestBuildInstallImage(t *testing.T) {
 		assert.Equal(t, "factory.talos.dev/metal-installer/target-schematic:v1.14.0", image)
 	})
 
-	// Regression test for https://github.com/siderolabs/omni/issues/3247: a machine enrolled before Omni
-	// started tracking the factory host per machine reaches this path with an empty host in its
-	// MachineConfigGenOptions, and the install fails with "has no image factory host set".
-	t.Run("a target with no factory host falls back to the configured factory", func(t *testing.T) {
+	// A target without a factory host is refused rather than pointed at a guessed factory: only the
+	// factory that issued the schematic knows it, and the host is recorded next to the schematic.
+	t.Run("a target with no factory host is refused", func(t *testing.T) {
 		t.Parallel()
 
-		image, err := m.BuildInstallImageForTest(t.Context(), "machine-1", ms, "1.13.1", &specs.MachineConfigGenOptionsSpec_InstallImage{
+		_, err := m.BuildInstallImageForTest("machine-1", ms, "1.13.1", &specs.MachineConfigGenOptionsSpec_InstallImage{
 			TalosVersion:         "1.14.0",
 			SchematicId:          "target-schematic",
 			SchematicInitialized: true,
 			Platform:             "metal",
 			SecurityState:        &specs.SecurityState{},
 		})
-		require.NoError(t, err)
-
-		assert.Equal(t, "factory.talos.dev/metal-installer/target-schematic:v1.14.0", image)
+		require.ErrorContains(t, err, "no image factory host")
 	})
 
 	t.Run("the target install image is not modified", func(t *testing.T) {
@@ -87,29 +84,18 @@ func TestBuildInstallImage(t *testing.T) {
 			ImageFactoryHost:     "factory.talos.dev",
 		}
 
-		image, err := m.BuildInstallImageForTest(t.Context(), "machine-1", ms, "1.13.1", target)
+		image, err := m.BuildInstallImageForTest("machine-1", ms, "1.13.1", target)
 		require.NoError(t, err)
 
 		assert.Equal(t, "factory.talos.dev/metal-installer/target-schematic:v1.13.1", image)
 		assert.Empty(t, target.TalosVersion)
 	})
 
-	t.Run("nil target falls back to the machine's current schematic", func(t *testing.T) {
+	t.Run("nil target is refused", func(t *testing.T) {
 		t.Parallel()
 
-		image, err := m.BuildInstallImageForTest(t.Context(), "machine-1", ms, "1.14.0", nil)
-		require.NoError(t, err)
-
-		assert.Equal(t, "factory.talos.dev/metal-installer/current-schematic:v1.14.0", image)
-	})
-
-	t.Run("nil target and empty version reuses the machine's running version", func(t *testing.T) {
-		t.Parallel()
-
-		image, err := m.BuildInstallImageForTest(t.Context(), "machine-1", ms, "", nil)
-		require.NoError(t, err)
-
-		assert.Equal(t, "factory.talos.dev/metal-installer/current-schematic:v1.13.1", image)
+		_, err := m.BuildInstallImageForTest("machine-1", ms, "1.14.0", nil)
+		require.ErrorContains(t, err, "install image target is required")
 	})
 
 	t.Run("missing platform metadata fails fast", func(t *testing.T) {
@@ -118,7 +104,7 @@ func TestBuildInstallImage(t *testing.T) {
 		bare := omni.NewMachineStatus("machine-bare")
 		bare.TypedSpec().Value.TalosVersion = "1.13.1"
 
-		_, err := m.BuildInstallImageForTest(t.Context(), "machine-bare", bare, "", nil)
+		_, err := m.BuildInstallImageForTest("machine-bare", bare, "", nil)
 		require.Error(t, err)
 	})
 }

--- a/internal/backend/talos/lifecycle/export_test.go
+++ b/internal/backend/talos/lifecycle/export_test.go
@@ -21,13 +21,12 @@ func RelayProgressForTest(progress *machineapi.LifecycleServiceInstallProgress, 
 
 // BuildInstallImageForTest exposes buildInstallImage to external tests.
 func (m *Manager) BuildInstallImageForTest(
-	ctx context.Context,
 	machineID string,
 	ms *omni.MachineStatus,
 	version string,
 	target *specs.MachineConfigGenOptionsSpec_InstallImage,
 ) (string, error) {
-	return m.buildInstallImage(ctx, machineID, ms, version, target)
+	return m.buildInstallImage(machineID, ms, version, target)
 }
 
 // AcquireForTest exposes acquire to external tests.

--- a/internal/backend/talos/lifecycle/manager.go
+++ b/internal/backend/talos/lifecycle/manager.go
@@ -198,7 +198,7 @@ func (m *Manager) Run(ctx context.Context, op Operation, opts ...Option) error {
 
 	defer m.release(op.MachineID)
 
-	installImageStr, err := m.buildInstallImage(ctx, op.MachineID, op.MachineStatus, op.Version, op.InstallImage)
+	installImageStr, err := m.buildInstallImage(op.MachineID, op.MachineStatus, op.Version, op.InstallImage)
 	if err != nil {
 		return WrapErr(err, "failed to build install image")
 	}


### PR DESCRIPTION
A schematic ID is only meaningful together with the factory that issued it: another factory does not know the ID, and an Enterprise factory stamps an owner into the schematic and issues a different ID for the same content. Install images were built with the factory serving the target Talos version instead, which is the primary. After a factory switch (an Enterprise factory becomes the primary, the public one the secondary), a machine in maintenance mode that is added to a cluster keeps its public schematic ID, because nothing about it changed, and gets an install image naming the Enterprise host. The installer pull fails with 404 and the machine never joins.

`SchematicConfiguration` now records the base URL of the factory that issued its schematic ID, in the same write. Resources written before the field existed get it backfilled by asking the configured factories which one knows the ID, without changing the ID. `MachineConfigGenOptionsController` takes the install image host from that record when it covers the schematic ID being published, keeps the host already recorded in the install image otherwise, and publishes nothing rather than a guess when it has neither. The maintenance schematic upgrade takes the host from the record as well and waits when it is not known. The guessing fallbacks in the cluster machine config generation and in the lifecycle client are gone: an install image with a schematic and no host is not built.

A running machine that does not change keeps its schematic ID and its factory host. When its extensions, kernel args or Talos version change, Omni ensures the schematic on the factory that serves the target Talos version. That factory issues the new ID, so the ID and the host move together.

This way, a machine enrolled before the switch keeps installing from the public factory until something on it changes. Because of this, the public factory has to stay configured as the secondary until no schematic names it.

Part of siderolabs/omni#3346.
