### PR TITLE
fix: ensure the schematic on the target factory before an install

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/schematic/configuration.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic/configuration.go
@@ -254,8 +254,11 @@ func (ctrl *ConfigurationController) transform(ctx context.Context, r controller
 	// The published ID is deliberately left alone in that case rather than reset to the machine's own
 	// Schematic.FullId: an Enterprise factory stamps an owner into the schematic, so its ID for the
 	// same content differs from the ID the machine reports, and overwriting would lose it.
+	installPending := ms.TypedSpec().Value.Maintenance && cluster != nil // the install re-images anyway, use the factory serving the target version
+
 	if !bytes.Equal([]byte(ms.TypedSpec().Value.Schematic.Raw), patchedRaw) ||
 		versionOutdated ||
+		installPending ||
 		schematicConfiguration.TypedSpec().Value.SchematicId == "" {
 		factoryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 

--- a/internal/backend/runtime/omni/controllers/omni/schematic/configuration_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/schematic/configuration_test.go
@@ -731,3 +731,84 @@ func TestSchematicConfigurationRepublishesAfterInvalid(t *testing.T) {
 		},
 	)
 }
+
+// TestSchematicConfigurationEnsuresOnInstall covers the install of a machine in maintenance mode: the
+// schematic is ensured again on the factory serving the target version even though nothing changed.
+func TestSchematicConfigurationEnsuresOnInstall(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	factory := &testutils.ImageFactoryClientMock{}
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{},
+		func(_ context.Context, testContext testutils.TestContext) {
+			require.NoError(t, testContext.Runtime.RegisterQController(schematicctrl.NewConfigurationController(testutils.NewFactoryClientSet(factory))))
+			require.NoError(t, testContext.Runtime.RegisterQController(omnictrl.NewMachineExtensionsController()))
+		},
+		func(ctx context.Context, testContext testutils.TestContext) {
+			st := testContext.State
+			r := require.New(t)
+
+			const (
+				machineName  = "install-machine"
+				clusterName  = "install-cluster"
+				talosVersion = "1.10.0"
+			)
+
+			rawSchematic := schematic.Schematic{
+				Customization: schematic.Customization{
+					ExtraKernelArgs: []string{"console=ttyS0"},
+				},
+			}
+
+			rawYAML, err := rawSchematic.Marshal()
+			r.NoError(err)
+
+			rawSchematicID, err := rawSchematic.ID()
+			r.NoError(err)
+
+			machineStatus := omni.NewMachineStatus(machineName)
+			machineStatus.Metadata().Annotations().Set(omni.KernelArgsInitialized, "")
+			machineStatus.TypedSpec().Value.TalosVersion = talosVersion
+			machineStatus.TypedSpec().Value.InitialTalosVersion = talosVersion
+			machineStatus.TypedSpec().Value.Maintenance = true
+			machineStatus.TypedSpec().Value.Schematic = &specs.MachineStatusSpec_Schematic{
+				FullId:           rawSchematicID,
+				Raw:              string(rawYAML),
+				KernelArgs:       []string{"console=ttyS0"},
+				InitialSchematic: rawSchematicID,
+				InitialState:     &specs.MachineStatusSpec_Schematic_InitialState{},
+			}
+			machineStatus.TypedSpec().Value.SecurityState = &specs.SecurityState{}
+			machineStatus.TypedSpec().Value.PlatformMetadata = &specs.MachineStatusSpec_PlatformMetadata{
+				Platform: talosconstants.PlatformMetal,
+			}
+			r.NoError(st.Create(ctx, machineStatus))
+
+			// the first reconcile ensures the schematic, as nothing is published yet
+			rtestutils.AssertResources(ctx, t, st, []string{machineName}, func(schematicConfiguration *omni.SchematicConfiguration, assertion *assert.Assertions) {
+				assertion.Equal(rawSchematicID, schematicConfiguration.TypedSpec().Value.SchematicId)
+			})
+
+			r.EqualValues(1, factory.EnsureCalls.Load())
+
+			cluster := omni.NewCluster(clusterName)
+			cluster.TypedSpec().Value.TalosVersion = talosVersion
+			r.NoError(st.Create(ctx, cluster))
+
+			clusterMachine := omni.NewClusterMachine(machineName)
+			clusterMachine.Metadata().Labels().Set(omni.LabelCluster, clusterName)
+			r.NoError(st.Create(ctx, clusterMachine))
+
+			// the machine is about to be installed, the schematic is ensured again although its content is the same
+			r.Eventually(func() bool { return factory.EnsureCalls.Load() >= 2 }, 10*time.Second, 50*time.Millisecond)
+
+			rtestutils.AssertResources(ctx, t, st, []string{machineName}, func(schematicConfiguration *omni.SchematicConfiguration, assertion *assert.Assertions) {
+				assertion.Equal(rawSchematicID, schematicConfiguration.TypedSpec().Value.SchematicId)
+			})
+		},
+	)
+}

--- a/internal/backend/runtime/omni/controllers/testutils/factory.go
+++ b/internal/backend/runtime/omni/controllers/testutils/factory.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/state"
@@ -47,9 +48,14 @@ type ImageFactoryClientMock struct {
 	schematics map[string]schematic.Schematic
 	Owner      string
 	mu         sync.Mutex
+
+	// EnsureCalls counts the EnsureSchematic calls.
+	EnsureCalls atomic.Int64
 }
 
 func (i *ImageFactoryClientMock) EnsureSchematic(_ context.Context, inputSchematic schematic.Schematic) (string, *schematic.Schematic, error) {
+	i.EnsureCalls.Add(1)
+
 	if i.Owner != "" {
 		inputSchematic.Owner = i.Owner
 	}


### PR DESCRIPTION
Install images are built with the factory serving the target Talos version (the primary) and the schematic ID published for the machine. The schematic controller only re-ensures the schematic when its content or the Talos version changes. After a factory switch, a machine in maintenance mode that is added to a cluster keeps its ID from the old factory, so its install image names the new factory with an ID it does not know. The installer pull fails with 404.

Upgrades and customization changes do not have this problem, as they re-ensure the schematic on the factory serving the target version. The install was the only re-image that skipped this. The schematic controller now also ensures the schematic when the machine is in maintenance mode and allocated to a cluster.

This way, a machine moves to the new primary factory with its next re-image: a fresh machine on its first install, a running machine on its first upgrade or customization change. A running machine that does not change is left alone.

Part of siderolabs/omni#3346.
