### PR TITLE
fix: generate the registry auth document by the running Talos version

### DIFF
--- a/client/api/omni/specs/omni.pb.go
+++ b/client/api/omni/specs/omni.pb.go
@@ -6205,7 +6205,9 @@ func (x *MachineClassSpec) GetAutoProvision() *MachineClassSpec_Provision {
 type MachineConfigGenOptionsSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// InstallImage contains the information needed to build the install image URL of a machine to be used by the Talos installer.
-	InstallImage  *MachineConfigGenOptionsSpec_InstallImage `protobuf:"bytes,2,opt,name=install_image,json=installImage,proto3" json:"install_image,omitempty"`
+	InstallImage *MachineConfigGenOptionsSpec_InstallImage `protobuf:"bytes,2,opt,name=install_image,json=installImage,proto3" json:"install_image,omitempty"`
+	// TalosVersion is the Talos version the machine runs.
+	TalosVersion  string `protobuf:"bytes,3,opt,name=talos_version,json=talosVersion,proto3" json:"talos_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6245,6 +6247,13 @@ func (x *MachineConfigGenOptionsSpec) GetInstallImage() *MachineConfigGenOptions
 		return x.InstallImage
 	}
 	return nil
+}
+
+func (x *MachineConfigGenOptionsSpec) GetTalosVersion() string {
+	if x != nil {
+		return x.TalosVersion
+	}
+	return ""
 }
 
 // EtcdAuditResult is updated when the etcd audit removes a member.
@@ -12664,9 +12673,10 @@ const file_omni_specs_omni_proto_rawDesc = "" +
 	"metaValues\x12#\n" +
 	"\rprovider_data\x18\x04 \x01(\tR\fproviderData\x126\n" +
 	"\vgrpc_tunnel\x18\x05 \x01(\x0e2\x15.specs.GrpcTunnelModeR\n" +
-	"grpcTunnel\"\xc1\x03\n" +
+	"grpcTunnel\"\xe6\x03\n" +
 	"\x1bMachineConfigGenOptionsSpec\x12T\n" +
-	"\rinstall_image\x18\x02 \x01(\v2/.specs.MachineConfigGenOptionsSpec.InstallImageR\finstallImage\x1a\xc5\x02\n" +
+	"\rinstall_image\x18\x02 \x01(\v2/.specs.MachineConfigGenOptionsSpec.InstallImageR\finstallImage\x12#\n" +
+	"\rtalos_version\x18\x03 \x01(\tR\ftalosVersion\x1a\xc5\x02\n" +
 	"\fInstallImage\x12#\n" +
 	"\rtalos_version\x18\x01 \x01(\tR\ftalosVersion\x12!\n" +
 	"\fschematic_id\x18\x02 \x01(\tR\vschematicId\x123\n" +

--- a/client/api/omni/specs/omni.proto
+++ b/client/api/omni/specs/omni.proto
@@ -1325,6 +1325,9 @@ message MachineConfigGenOptionsSpec {
 
   // InstallImage contains the information needed to build the install image URL of a machine to be used by the Talos installer.
   InstallImage install_image = 2;
+
+  // TalosVersion is the Talos version the machine runs.
+  string talos_version = 3;
 }
 
 // EtcdAuditResult is updated when the etcd audit removes a member.

--- a/client/api/omni/specs/omni_vtproto.pb.go
+++ b/client/api/omni/specs/omni_vtproto.pb.go
@@ -2086,6 +2086,7 @@ func (m *MachineConfigGenOptionsSpec) CloneVT() *MachineConfigGenOptionsSpec {
 	}
 	r := new(MachineConfigGenOptionsSpec)
 	r.InstallImage = m.InstallImage.CloneVT()
+	r.TalosVersion = m.TalosVersion
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -6369,6 +6370,9 @@ func (this *MachineConfigGenOptionsSpec) EqualVT(that *MachineConfigGenOptionsSp
 		return false
 	}
 	if !this.InstallImage.EqualVT(that.InstallImage) {
+		return false
+	}
+	if this.TalosVersion != that.TalosVersion {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -14148,6 +14152,13 @@ func (m *MachineConfigGenOptionsSpec) MarshalToSizedBufferVT(dAtA []byte) (int, 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.TalosVersion) > 0 {
+		i -= len(m.TalosVersion)
+		copy(dAtA[i:], m.TalosVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TalosVersion)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if m.InstallImage != nil {
 		size, err := m.InstallImage.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -20016,6 +20027,10 @@ func (m *MachineConfigGenOptionsSpec) SizeVT() (n int) {
 	_ = l
 	if m.InstallImage != nil {
 		l = m.InstallImage.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.TalosVersion)
+	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -36600,6 +36615,38 @@ func (m *MachineConfigGenOptionsSpec) UnmarshalVT(dAtA []byte) error {
 			if err := m.InstallImage.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TalosVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TalosVersion = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config.go
@@ -285,24 +285,9 @@ func reconcileClusterMachineConfig(
 		installDiskStatus,
 	}
 
-	var imageFactories safe.List[*omni.ImageFactoryAuth]
-
-	initialTalosVersion := clusterConfigVersion.TypedSpec().Value.Version
-
-	if quirks.New(initialTalosVersion).SupportsMultidoc() {
-		var vc *config.VersionContract
-
-		vc, err = config.ParseContractFromVersion(initialTalosVersion)
-		if err != nil {
-			return fmt.Errorf("failed to parse contract from version: %w", err)
-		}
-
-		if vc.MultidocNetworkConfigSupported() {
-			imageFactories, err = safe.ReaderListAll[*omni.ImageFactoryAuth](ctx, r)
-			if err != nil {
-				return err
-			}
-		}
+	imageFactories, err := safe.ReaderListAll[*omni.ImageFactoryAuth](ctx, r)
+	if err != nil {
+		return err
 	}
 
 	for imageFactory := range imageFactories.All() {
@@ -384,7 +369,7 @@ func reconcileClusterMachineConfig(
 		machineConfig.TypedSpec().Value.WithoutComments = true
 	}
 
-	useUKICmdline, err := grubUseUKICmdline(conf, initialTalosVersion)
+	useUKICmdline, err := grubUseUKICmdline(conf, clusterConfigVersion.TypedSpec().Value.Version)
 	if err != nil {
 		return err
 	}
@@ -418,9 +403,25 @@ type clusterMachineConfigControllerHelper struct {
 	talosRegistry string
 }
 
-func (helper clusterMachineConfigControllerHelper) buildRegistryAuthPatch(creds safe.List[*omni.ImageFactoryAuth]) (string, error) {
+// buildRegistryAuthPatch builds the registry auth documents for the image factories, if all the given Talos versions support them.
+func (helper clusterMachineConfigControllerHelper) buildRegistryAuthPatch(creds safe.List[*omni.ImageFactoryAuth], talosVersions ...string) (string, error) {
 	if creds.Len() == 0 {
 		return "", nil
+	}
+
+	for _, talosVersion := range talosVersions {
+		if talosVersion == "" { // not known yet
+			continue
+		}
+
+		vc, err := config.ParseContractFromVersion(talosVersion)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse contract from version %q: %w", talosVersion, err)
+		}
+
+		if !vc.MultidocNetworkConfigSupported() {
+			return "", nil
+		}
 	}
 
 	authDocs, err := imagefactoryauth.BuildDocs(slices.Collect(creds.All()))
@@ -612,7 +613,8 @@ func (helper clusterMachineConfigControllerHelper) generateConfig(clusterMachine
 		patchList = append(patchList, machineJoinConfig.TypedSpec().Value.Config.Config)
 	}
 
-	authPatch, authErr := helper.buildRegistryAuthPatch(imageFactories)
+	// the version the machine runs, when known, and the one it installs must both know the document
+	authPatch, authErr := helper.buildRegistryAuthPatch(imageFactories, configGenOptions.TypedSpec().Value.TalosVersion, installImageSpec.TalosVersion)
 	if authErr != nil {
 		return nil, authErr
 	}

--- a/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/cluster_machine_config_test.go
@@ -796,3 +796,76 @@ func TestClusterMachineConfigInstallDiskOverride(t *testing.T) {
 		})
 	}
 }
+
+// TestClusterMachineConfigRegistryAuthFollowsRunningVersion checks that the image factory registry auth
+// document is generated when both the Talos version the machine runs and the one it installs support it,
+// regardless of the version the cluster was created with.
+func TestClusterMachineConfigRegistryAuthFollowsRunningVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	testutils.WithRuntime(
+		ctx, t, testutils.TestOptions{}, registerClusterMachineConfigControllers(t),
+		func(ctx context.Context, tc testutils.TestContext) {
+			const factoryHost = "factory.example.com"
+
+			auth := omni.NewImageFactoryAuth("https://" + factoryHost)
+			auth.TypedSpec().Value.Username = "omni"
+			auth.TypedSpec().Value.Password = "secret"
+			require.NoError(t, tc.State.Create(ctx, auth))
+
+			// created at 1.11, which does not know the registry auth document
+			_, machines := createConfigTestCluster(ctx, t, tc.State, "registry-auth", 0, "1.11.0")
+			machineID := machines[0].Metadata().ID()
+
+			setVersions := func(running, target string) {
+				rmock.Mock[*omni.MachineConfigGenOptions](ctx, t, tc.State, options.WithID(machineID), options.Modify(func(res *omni.MachineConfigGenOptions) error {
+					res.TypedSpec().Value.TalosVersion = running
+					res.TypedSpec().Value.InstallImage.TalosVersion = target
+
+					return nil
+				}))
+			}
+
+			assertRegistryAuth := func(installVersion string, expectDocument bool) {
+				rtestutils.AssertResource(ctx, t, tc.State, machineID, func(res *omni.ClusterMachineConfig, assertions *assert.Assertions) {
+					cfg := machineConfigOf(t, res)
+
+					assertions.Contains(cfg.Machine().Install().Image(), ":v"+installVersion)
+
+					registryAuth, ok := cfg.RegistryAuthConfigs()[factoryHost]
+					if !expectDocument {
+						assertions.False(ok, "unexpected registry auth for %q", factoryHost)
+
+						return
+					}
+
+					if assertions.True(ok, "no registry auth for %q", factoryHost) {
+						assertions.Equal("omni", registryAuth.Username())
+						assertions.Equal("secret", registryAuth.Password())
+					}
+				})
+			}
+
+			assertRegistryAuth("1.11.0", false)
+
+			// not installed yet, the target version decides
+			setVersions("", "1.12.0")
+			assertRegistryAuth("1.12.0", true)
+
+			// upgrade to 1.12: the machine still runs 1.11, no document yet
+			setVersions("1.11.0", "1.12.0")
+			assertRegistryAuth("1.12.0", false)
+
+			// the machine runs 1.12 now, the document is added although the cluster was created at 1.11
+			setVersions("1.12.0", "1.12.0")
+			assertRegistryAuth("1.12.0", true)
+
+			// downgrade back to 1.11: the document must not reach the 1.11 install
+			setVersions("1.12.0", "1.11.0")
+			assertRegistryAuth("1.11.0", false)
+		},
+	)
+}

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options.go
@@ -7,6 +7,7 @@ package omni
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/controller/generic/qtransform"
@@ -65,6 +66,8 @@ func NewMachineConfigGenOptionsController(imageFactoryClients ImageFactoryClient
 						options.TypedSpec().Value.InstallImage.SchematicId == schematicID) {
 					imageFactoryHost = options.TypedSpec().Value.InstallImage.ImageFactoryHost
 				}
+
+				options.TypedSpec().Value.TalosVersion = strings.TrimPrefix(machineStatus.TypedSpec().Value.TalosVersion, "v")
 
 				if clusterMachineTalosVersion == nil {
 					backfillImageFactoryHost(options.TypedSpec().Value.InstallImage, imageFactoryClients, imageFactoryHost)

--- a/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/machine_config_gen_options_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/imagefactory"
 	"github.com/siderolabs/omni/client/pkg/omni/resources/omni"
 	omnictrl "github.com/siderolabs/omni/internal/backend/runtime/omni/controllers/omni"
@@ -204,6 +205,7 @@ func TestMachineConfigGenOptionsFactoryHost(t *testing.T) {
 
 					rtestutils.AssertResource(ctx, t, tc.State, machineID, func(res *omni.MachineConfigGenOptions, assertions *assert.Assertions) {
 						assertions.Equal(tt.expectedFactoryHost, res.TypedSpec().Value.InstallImage.GetImageFactoryHost())
+						assertions.Equal(constants.DefaultTalosVersion, res.TypedSpec().Value.TalosVersion)
 					})
 				},
 			)


### PR DESCRIPTION
The image factory registry auth document was only generated for clusters created at Talos 1.12 or later, as the check read the version the cluster was created with, which never changes. A cluster created at 1.11 never got the document, at any later version. After the switch to an authenticated image factory, such a cluster could not pull the installer image on the upgrade that moved it to a version served by that factory.

The document is now generated when both the version the machine runs, which the machine config generation options now carry, and the version it installs support it. A machine gets the document as soon as it runs a version that knows it, and every upgrade after that pulls with the credentials. A downgrade to a version that does not know the document removes it first.

This way, a cluster created at 1.11 is upgraded one minor at a time: the upgrade to 1.12 goes through the factory that needs no credentials, the upgrade to 1.13 already has them.

Part of siderolabs/omni#3346.
