### PR TITLE
chore: bump delve version in compose

### DIFF
--- a/hack/compose/docker-compose.yml
+++ b/hack/compose/docker-compose.yml
@@ -77,7 +77,7 @@ services:
 
   # The launcher is needed regardless of WITH_DEBUG.
   runtime-tools-init:
-    image: golang:1.26-alpine
+    image: ${TOOLCHAIN}
     restart: on-failure
     volumes:
       - dlv-tools:/output
@@ -91,7 +91,7 @@ services:
         case '${WITH_DEBUG:-false}' in
           true|1)
             test -f /output/dlv || \
-              (CGO_ENABLED=0 go install github.com/go-delve/delve/cmd/dlv@v1.26.3 && cp /go/bin/dlv /output/)
+              (CGO_ENABLED=0 go install github.com/go-delve/delve/cmd/dlv@v1.27.1 && cp /go/bin/dlv /output/)
             ;;
         esac
 


### PR DESCRIPTION
Bump go-delve version to 1.27.1 in docker-compose.yml to support go 1.27 (version match is only a coindence). Also set the image to use TOOLCHAIN.