### PR TITLE
fix: read the node unique token uncached in the cleanup controller

### DIFF
--- a/internal/backend/runtime/omni/controllers/omni/node_unique_token_cleanup.go
+++ b/internal/backend/runtime/omni/controllers/omni/node_unique_token_cleanup.go
@@ -83,7 +83,8 @@ func (ctrl *NodeUniqueTokenCleanupController) MapInput(ctx context.Context, _ *z
 func (ctrl *NodeUniqueTokenCleanupController) Reconcile(ctx context.Context,
 	logger *zap.Logger, r controller.QRuntime, ptr resource.Pointer,
 ) error {
-	nodeUniqueToken, err := safe.ReaderGet[*siderolink.NodeUniqueToken](ctx, r, siderolink.NewNodeUniqueToken(ptr.ID()).Metadata())
+	// uncached: a stale tearing-down phase would destroy a token recreated under the same ID
+	nodeUniqueToken, err := safe.ReaderGetByID[*siderolink.NodeUniqueToken](ctx, uncached.Reader(r), ptr.ID())
 	if err != nil {
 		if state.IsNotFoundError(err) {
 			return nil


### PR DESCRIPTION
The cleanup controller read the token through the resource cache and destroyed it by ID when the cached copy was tearing down. The cache can lag behind the state, so a token destroyed and recreated under the same ID can still be served as tearing down, and the controller then destroys the recreated one. This is how `TestNodeUniqueTokenCleanup` failed sporadically.

Read the token uncached, like the link already is.
