### PR TITLE
fix: restore the extra parameters of the sqlite connection string

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -320,7 +320,6 @@ func defineStorageFlags(rootCmd *cobra.Command, b *FlagBinder, flagConfig *confi
 	b.StringVar("storage.sqlite.path", &flagConfig.Storage.Sqlite.Path)
 	//nolint:staticcheck
 	b.StringVar("storage.sqlite.experimentalBaseParams", &flagConfig.Storage.Sqlite.ExperimentalBaseParams)
-	//nolint:staticcheck
 	b.StringVar("storage.sqlite.extraParams", &flagConfig.Storage.Sqlite.ExtraParams)
 	b.DurationVar("storage.sqlite.metrics.refreshInterval", &flagConfig.Storage.Sqlite.Metrics.RefreshInterval)
 	b.DurationVar("storage.sqlite.metrics.refreshTimeout", &flagConfig.Storage.Sqlite.Metrics.RefreshTimeout)

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -467,9 +467,9 @@ config:
       #
       # Deprecated: unused, has no effect.
       #experimentalBaseParams: ""
-      # ExtraParams contains the extra parameters to be used when opening the SQLite database connection.
-      #
-      # Deprecated: unused, has no effect.
+      # ExtraParams contains the extra SQLite URI parameters to be used when opening the SQLite database connection,
+      # e.g., vfs=unix-excl. This can cause data corruption if set incorrectly, modify at your own risk. It must not
+      # start with a question mark (?) or an ampersand (&).
       #extraParams: ""
       # CachedPoolSize controls the number of cached connections in the SQLite connection pool. The overall number of
       # connections is limited by poolSize. CachedPoolSize should be less or equal to poolSize.

--- a/internal/backend/runtime/omni/sqlite/sqlite.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite.go
@@ -28,6 +28,9 @@ func OpenDB(config config.SQLite) (*sqlitexx.Pool, error) {
 	}
 
 	dsn := "file:" + configPath
+	if extraParams := config.GetExtraParams(); extraParams != "" {
+		dsn += "?" + extraParams
+	}
 
 	db, err := sqlitexx.NewPool(
 		dsn,

--- a/internal/backend/runtime/omni/sqlite/sqlite_test.go
+++ b/internal/backend/runtime/omni/sqlite/sqlite_test.go
@@ -6,6 +6,7 @@
 package sqlite_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -50,6 +51,38 @@ func TestOpenDBSetsSynchronousNormal(t *testing.T) {
 
 		db.Put(conn)
 	}
+}
+
+// TestOpenDBExtraParams checks that the extra params reach SQLite as URI parameters.
+func TestOpenDBExtraParams(t *testing.T) {
+	t.Parallel()
+
+	conf := config.Default().Storage.Sqlite
+	conf.SetPath(filepath.Join(t.TempDir(), "test.db"))
+	conf.SetCachedPoolSize(16)
+	conf.SetPoolSize(16)
+	conf.SetExtraParams("vfs=unix-excl")
+
+	db, err := sqlite.OpenDB(conf)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, sqlite.CloseDB(db, 5*time.Second))
+	})
+
+	conn, err := db.Take(t.Context())
+	require.NoError(t, err)
+
+	require.NoError(t, sqlitex.ExecuteTransient(conn, "CREATE TABLE test (id INTEGER)", nil))
+
+	db.Put(conn)
+
+	// the unix-excl VFS keeps the WAL index in heap memory instead of the shm file
+	_, err = os.Stat(conf.GetPath() + "-wal")
+	require.NoError(t, err)
+
+	_, err = os.Stat(conf.GetPath() + "-shm")
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func readPragma(t *testing.T, conn *zombiesqlite.Conn, name string) string {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -296,7 +296,14 @@ func TestValidateConfig(t *testing.T) {
 			config: []byte(`storage:
   sqlite:
     extraParams: "&bad"`),
-			validateErr: `config value ".storage.sqlite.extraParams" or flag "--sqlite-storage-extra-params": must not start with '&'`,
+			validateErr: `config value ".storage.sqlite.extraParams" or flag "--sqlite-storage-extra-params": must not start with '?' or '&'`,
+		},
+		{
+			name: "pattern: sqlite extra params starts with ?",
+			config: []byte(`storage:
+  sqlite:
+    extraParams: "?bad"`),
+			validateErr: `config value ".storage.sqlite.extraParams" or flag "--sqlite-storage-extra-params": must not start with '?' or '&'`,
 		},
 
 		// --- if/then/else + not (kept as-is for now, TODO: move to Go validation) ---

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -1598,12 +1598,11 @@
           }
         },
         "extraParams": {
-          "description": "ExtraParams contains the extra parameters to be used when opening the SQLite database connection.\n\nDeprecated: unused, has no effect.",
+          "description": "ExtraParams contains the extra SQLite URI parameters to be used when opening the SQLite database connection, e.g., vfs=unix-excl. This can cause data corruption if set incorrectly, modify at your own risk. It must not start with a question mark (?) or an ampersand (&).",
           "x-cli-flag": "sqlite-storage-extra-params",
-          "deprecated": true,
           "type": "string",
-          "pattern": "^(?:$|[^&].*)",
-          "x-pattern-message": "must not start with '&'"
+          "pattern": "^(?:$|[^?&].*)",
+          "x-pattern-message": "must not start with '?' or '&'"
         },
         "cachedPoolSize" : {
           "description": "CachedPoolSize controls the number of cached connections in the SQLite connection pool. The overall number of connections is limited by poolSize. CachedPoolSize should be less or equal to poolSize.",

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -724,10 +724,10 @@ type SQLite struct {
 	// Deprecated: unused, has no effect.
 	ExperimentalBaseParams *string `json:"experimentalBaseParams,omitempty,omitzero" yaml:"experimentalBaseParams,omitempty"`
 
-	// ExtraParams contains the extra parameters to be used when opening the SQLite
-	// database connection.
-	//
-	// Deprecated: unused, has no effect.
+	// ExtraParams contains the extra SQLite URI parameters to be used when opening
+	// the SQLite database connection, e.g., vfs=unix-excl. This can cause data
+	// corruption if set incorrectly, modify at your own risk. It must not start with
+	// a question mark (?) or an ampersand (&).
 	ExtraParams *string `json:"extraParams,omitempty,omitzero" yaml:"extraParams,omitempty"`
 
 	// Metrics corresponds to the JSON schema field "metrics".


### PR DESCRIPTION
The extra parameters were deprecated and dropped from the connection string together with the base parameters, on the assumption that neither had any effect since the driver switch. That was only true for the base parameters, whose syntax belonged to the previous driver. The extra parameters carry native SQLite URI options and always reached the database, and they are the way to select a different VFS, such as unix-excl for a database on a network filesystem.

Pass the extra parameters to the connection again and remove the deprecation. Reject a leading question mark as well as a leading ampersand, as either makes SQLite ignore the parameters. The base parameters stay deprecated, as their syntax has no effect with the current driver.