### PR TITLE
feat: make the lifetime of the image factory machine tokens configurable

### DIFF
--- a/cmd/omni/cmd/cmd.go
+++ b/cmd/omni/cmd/cmd.go
@@ -359,6 +359,7 @@ func defineRegistriesFlags(b *FlagBinder, flagConfig *config.Params) {
 	b.StringVar("registries.factories.primary.username", &primary.Username)
 	b.StringVar("registries.factories.primary.password", &primary.Password)
 	b.StringVar("registries.factories.primary.tokenFile", &primary.TokenFile)
+	b.DurationVar("registries.factories.primary.machineTokenTTL", &primary.MachineTokenTTL)
 
 	secondary := &flagConfig.Registries.Factories.Secondary
 	b.StringVar("registries.factories.secondary.url", &secondary.Url)
@@ -366,6 +367,7 @@ func defineRegistriesFlags(b *FlagBinder, flagConfig *config.Params) {
 	b.StringVar("registries.factories.secondary.username", &secondary.Username)
 	b.StringVar("registries.factories.secondary.password", &secondary.Password)
 	b.StringVar("registries.factories.secondary.tokenFile", &secondary.TokenFile)
+	b.DurationVar("registries.factories.secondary.machineTokenTTL", &secondary.MachineTokenTTL)
 
 	b.StringSliceVar("registries.mirrors", &flagConfig.Registries.Mirrors, flagConfig.Registries.Mirrors)
 }

--- a/deploy/helm/omni/values.yaml
+++ b/deploy/helm/omni/values.yaml
@@ -588,6 +588,11 @@ config:
         # Enterprise service. It is an alternative to the username and password. The file is re-read when it changes, so
         # the token can be rotated without a restart.
         #tokenFile: ""
+        # MachineTokenTTL is the lifetime of the tokens Omni creates for the machines to pull images from the Image
+        # Factory Enterprise service. When it is not set, the factory records the token, gives it the default lifetime
+        # and counts it against the token limit of the organization. When it is set, the token is short-lived and the
+        # factory does not record it. This is meant for test setups where Omni instances come and go.
+        #machineTokenTTL: ""
       # Secondary is the secondary Image Factory configuration.
       secondary:
         # URL is the base URL of the Image Factory service used to build custom machine images.
@@ -602,6 +607,11 @@ config:
         # Enterprise service. It is an alternative to the username and password. The file is re-read when it changes, so
         # the token can be rotated without a restart.
         #tokenFile: ""
+        # MachineTokenTTL is the lifetime of the tokens Omni creates for the machines to pull images from the Image
+        # Factory Enterprise service. When it is not set, the factory records the token, gives it the default lifetime
+        # and counts it against the token limit of the organization. When it is set, the token is short-lived and the
+        # factory does not record it. This is meant for test setups where Omni instances come and go.
+        #machineTokenTTL: ""
     # Mirrors is the list of container image registry mirrors. Used mainly for the development purposes. It must be
     # in the format: <registry host>=<mirror URL>
     #mirrors: []

--- a/internal/backend/runtime/omni/controllers/omni/imagefactory/auth.go
+++ b/internal/backend/runtime/omni/controllers/omni/imagefactory/auth.go
@@ -57,8 +57,9 @@ const (
 // Omni's own credentials come from its configuration (the basic auth pair as values, the API token
 // from a file that is followed as it changes) and are copied into the ImageFactoryAuth resource. For
 // a factory Omni authenticates to with an API token, the controller also creates the machine token
-// on the factory: a stored, pull-only token that goes into the machine configs, and that the
-// controller replaces before it expires.
+// on the factory: a pull-only token that goes into the machine configs, and that the controller
+// replaces before it expires. The factory records it. With a configured lifetime, the token is
+// short-lived instead and the factory does not record it.
 //
 // The set of factories comes from Omni's configuration rather than from a resource, so the
 // controller has no inputs: it reconciles once, and comes back for a pending removal, a rotated
@@ -236,7 +237,7 @@ func (ctrl *AuthController) reconcileFactory(
 	if apiToken != "" {
 		// On a failure the current machine token is kept, which is none on a cold start. The resource
 		// is written either way, the error is returned after that.
-		machineToken, renewIn, ensureErr = ctrl.ensureMachineToken(ctx, logger, factoryURL, machineToken)
+		machineToken, renewIn, ensureErr = ctrl.ensureMachineToken(ctx, logger, factoryURL, machineToken, factory.GetMachineTokenTTL())
 	} else {
 		// Basic auth: the machines use the same credentials as Omni, no machine token is needed.
 		machineToken = ""
@@ -264,7 +265,9 @@ func (ctrl *AuthController) reconcileFactory(
 //
 // A failed request is an error, and the current token is returned with it: the machines keep it,
 // it works until it expires, and the runtime retries with its backoff.
-func (ctrl *AuthController) ensureMachineToken(ctx context.Context, logger *zap.Logger, factoryURL, current string) (string, time.Duration, error) {
+func (ctrl *AuthController) ensureMachineToken(
+	ctx context.Context, logger *zap.Logger, factoryURL, current string, ttl time.Duration,
+) (string, time.Duration, error) {
 	now := time.Now()
 
 	if current != "" {
@@ -281,7 +284,7 @@ func (ctrl *AuthController) ensureMachineToken(ctx context.Context, logger *zap.
 		return current, 0, fmt.Errorf("no image factory client is configured for %q", factoryURL)
 	}
 
-	token, err := ctrl.createMachineToken(ctx, factoryClient, now)
+	token, err := ctrl.createMachineToken(ctx, factoryClient, now, ttl)
 	if err != nil {
 		return current, 0, fmt.Errorf("failed to create the machine token: %w", err)
 	}
@@ -296,17 +299,20 @@ func (ctrl *AuthController) ensureMachineToken(ctx context.Context, logger *zap.
 	// A token that is already due when it arrives (the factory's clock behind Omni's by most of the
 	// token's lifetime) schedules nothing, so the renewal waits for the next restart. Creating another
 	// token right away would only produce another one already due, and burn the per-org cap.
-	return token, lifetime.renewIn(now), nil
+	return token, lifetime.renewIn(time.Now()), nil
 }
 
-// createMachineToken creates the stored, pull-only token the machines authenticate with.
-func (ctrl *AuthController) createMachineToken(ctx context.Context, factoryClient imagefactory.FactoryClient, now time.Time) (string, error) {
+// createMachineToken creates the pull-only token the machines authenticate with. With a lifetime
+// configured, the token is short-lived and the factory does not record it.
+func (ctrl *AuthController) createMachineToken(ctx context.Context, factoryClient imagefactory.FactoryClient, now time.Time, ttl time.Duration) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, machineTokenRequestTimeout)
 	defer cancel()
 
 	_, token, err := factoryClient.TokenCreate(ctx, client.TokenCreateOptions{
-		Name:   fmt.Sprintf("omni-machines-%s-%s", ctrl.accountName, now.UTC().Format(time.DateOnly)),
-		Scopes: []string{machineTokenScope},
+		Name:      fmt.Sprintf("omni-machines-%s-%s", ctrl.accountName, now.UTC().Format(time.DateOnly)),
+		Scopes:    []string{machineTokenScope},
+		TTL:       ttl,
+		Ephemeral: ttl != 0,
 	})
 	if err != nil {
 		return "", err

--- a/internal/backend/runtime/omni/controllers/omni/imagefactory/auth_test.go
+++ b/internal/backend/runtime/omni/controllers/omni/imagefactory/auth_test.go
@@ -215,8 +215,41 @@ func TestImageFactoryAuthToken(t *testing.T) {
 			request := factory.last.Load()
 			require.NotNil(t, request)
 			assert.Equal(t, []string{"image:read"}, request.Scopes, "the machine token pulls images and nothing else")
-			assert.False(t, request.Ephemeral, "the machine token must be stored: an ephemeral one lives hours, a stored one a year")
+			assert.False(t, request.Ephemeral, "without a configured lifetime the machine token is stored: an ephemeral one lives hours, a stored one a year")
+			assert.Zero(t, request.TTL, "without a configured lifetime the factory's default applies")
 			assert.Equal(t, "omni-machines-my-omni-"+time.Now().UTC().Format(time.DateOnly), request.Name)
+		},
+	)
+}
+
+// TestImageFactoryAuthMachineTokenTTL covers a configured machine token lifetime: the token is
+// requested short-lived, so the factory does not record it and it does not count against the
+// token limit of the organization.
+func TestImageFactoryAuthMachineTokenTTL(t *testing.T) {
+	t.Parallel()
+
+	factory := newTokenFactory(t, nil)
+
+	testutils.WithRuntime(
+		t.Context(), t, testutils.TestOptions{},
+		func(_ context.Context, tc testutils.TestContext) {
+			registries, tokens := testTokenRegistries(t, testOmniToken)
+			registries.Factories.Primary.SetMachineTokenTTL(2 * time.Hour)
+
+			registerImageFactoryAuthControllerWithFactory(t, tc, registries, tokens, factory.ImageFactoryClientMock)
+		},
+		func(ctx context.Context, tc testutils.TestContext) {
+			rtestutils.AssertResources(
+				ctx, t, tc.State, []string{testFactoryURL},
+				func(res *omni.ImageFactoryAuth, assert *assert.Assertions) {
+					assert.NotEmpty(res.TypedSpec().Value.GetMachineToken())
+				},
+			)
+
+			request := factory.last.Load()
+			require.NotNil(t, request)
+			assert.True(t, request.Ephemeral)
+			assert.Equal(t, 2*time.Hour, request.TTL)
 		},
 	)
 }

--- a/internal/pkg/config/accessors.generated.go
+++ b/internal/pkg/config/accessors.generated.go
@@ -490,6 +490,17 @@ func (s *EulaAccept) SetName(v string) {
 	s.Name = &v
 }
 
+func (s *Factory) GetMachineTokenTTL() time.Duration {
+	if s == nil || s.MachineTokenTTL == nil {
+		return *new(time.Duration)
+	}
+	return *s.MachineTokenTTL
+}
+
+func (s *Factory) SetMachineTokenTTL(v time.Duration) {
+	s.MachineTokenTTL = &v
+}
+
 func (s *Factory) GetPassword() string {
 	if s == nil || s.Password == nil {
 		return *new(string)

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -711,6 +711,23 @@ registries:
 		assert.False(t, hasSecondary)
 	})
 
+	t.Run("machine token lifetime with the deprecated URL", func(t *testing.T) {
+		p, err := config.FromBytes([]byte(`
+registries:
+  imageFactoryBaseURL: https://old.example.com
+  factories:
+    primary:
+      tokenFile: /run/secrets/factory-token
+      machineTokenTTL: 4h
+`))
+		require.NoError(t, err)
+
+		primary := p.Registries.GetPrimaryFactory()
+		assert.Equal(t, "https://old.example.com", primary.GetUrl())
+		assert.Equal(t, "/run/secrets/factory-token", primary.GetTokenFile())
+		assert.Equal(t, 4*time.Hour, primary.GetMachineTokenTTL())
+	})
+
 	t.Run("primary wins over deprecated", func(t *testing.T) {
 		p, err := config.FromBytes([]byte(`
 registries:

--- a/internal/pkg/config/factories.go
+++ b/internal/pkg/config/factories.go
@@ -32,6 +32,7 @@ func (s *Registries) GetPrimaryFactory() Factory {
 
 	resolved.SetUrl(s.GetImageFactoryBaseURL())
 	resolved.SetPxeURL(firstNonEmpty(primary.GetPxeURL(), s.GetImageFactoryPXEBaseURL()))
+	resolved.MachineTokenTTL = primary.MachineTokenTTL
 
 	// A token file and a basic auth pair never go together.
 	if tokenFile := primary.GetTokenFile(); tokenFile != "" {

--- a/internal/pkg/config/schema.json
+++ b/internal/pkg/config/schema.json
@@ -237,7 +237,8 @@
             "pxeURL": { "x-cli-flag": "primary-factory-pxe-url" },
             "username": { "x-cli-flag": "primary-factory-username" },
             "password": { "x-cli-flag": "primary-factory-password" },
-            "tokenFile": { "x-cli-flag": "primary-factory-token-file" }
+            "tokenFile": { "x-cli-flag": "primary-factory-token-file" },
+            "machineTokenTTL": { "x-cli-flag": "primary-factory-machine-token-ttl" }
           }
         },
         "secondary": {
@@ -248,7 +249,8 @@
             "pxeURL": { "x-cli-flag": "secondary-factory-pxe-url" },
             "username": { "x-cli-flag": "secondary-factory-username" },
             "password": { "x-cli-flag": "secondary-factory-password" },
-            "tokenFile": { "x-cli-flag": "secondary-factory-token-file" }
+            "tokenFile": { "x-cli-flag": "secondary-factory-token-file" },
+            "machineTokenTTL": { "x-cli-flag": "secondary-factory-machine-token-ttl" }
           }
         }
       }
@@ -289,6 +291,16 @@
         "tokenFile": {
           "description": "TokenFile is the path of a file holding the API token used to authenticate against the Image Factory Enterprise service. It is an alternative to the username and password. The file is re-read when it changes, so the token can be rotated without a restart.",
           "type": "string"
+        },
+        "machineTokenTTL": {
+          "description": "MachineTokenTTL is the lifetime of the tokens Omni creates for the machines to pull images from the Image Factory Enterprise service. When it is not set, the factory records the token, gives it the default lifetime and counts it against the token limit of the organization. When it is set, the token is short-lived and the factory does not record it. This is meant for test setups where Omni instances come and go.",
+          "type": "string",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+          "x-pattern-message": "must be a valid Go duration (e.g., '10s', '1h30m')",
+          "goJSONSchema": {
+            "type": "time.Duration",
+            "pointer": true
+          }
         }
       }
     },

--- a/internal/pkg/config/types.generated.go
+++ b/internal/pkg/config/types.generated.go
@@ -288,6 +288,14 @@ type Factories struct {
 }
 
 type Factory struct {
+	// MachineTokenTTL is the lifetime of the tokens Omni creates for the machines to
+	// pull images from the Image Factory Enterprise service. When it is not set, the
+	// factory records the token, gives it the default lifetime and counts it against
+	// the token limit of the organization. When it is set, the token is short-lived
+	// and the factory does not record it. This is meant for test setups where Omni
+	// instances come and go.
+	MachineTokenTTL *time.Duration `json:"machineTokenTTL,omitempty,omitzero" yaml:"machineTokenTTL,omitempty"`
+
 	// Password is the password used to authenticate against the Image Factory
 	// Enterprise service with basic auth.
 	Password *string `json:"password,omitempty,omitzero" yaml:"password,omitempty"`


### PR DESCRIPTION
Omni creates a token on the image factory for the machines to pull images with. The factory records it, gives it the default lifetime of a year, and counts it against the token limit of the organization.

Every Omni instance that starts from an empty state creates one, and nothing removes them before they expire. Test setups where instances come and go, like the CI runs of Omni and of the infra providers, reach the limit within days. From then on, Omni cannot generate machine configs anymore.

The factory configuration now takes an optional lifetime for the machine tokens. When it is set, Omni requests short-lived tokens that the factory does not record, so they do not count against the limit and leave nothing behind when they expire. When it is not set, nothing changes.
