### PR TITLE
test: run the enterprise image factory tests against the staging factory

### DIFF
--- a/.secrets.yaml
+++ b/.secrets.yaml
@@ -4,8 +4,7 @@ secrets:
     AUTH0_CLIENT_ID: ENC[AES256_GCM,data:HevA8uFKCOPF8W/FRjSo/pyUFN66eXwvAxaqT5LdnT0=,iv:qpWNjsRSZ28lWQJGfMoGQvLY8KRKWv1dhR07vCgIvIU=,tag:x5BS26iacdBMv2ZkdCdr3A==,type:str]
     AUTH0_DOMAIN: ENC[AES256_GCM,data:2vv9ay+hC1kN46MG8E0v1Z3G7Dm0hMmLx1/AWg==,iv:9thZflFQ1yhf0jH3u6Om7RV7Y/qYzrTf82hoYrDvyG0=,tag:BUNuHJobt/NoR5FFQBIbIQ==,type:str]
     CHROMATIC_PROJECT_TOKEN: ENC[AES256_GCM,data:VJ3yKBbNB4pvOOZf2lW0vTq8AnU=,iv:/CGREI+uWZRYhRci49MT4LbeLc4PeX1zVbgBFssgf9I=,tag:1fRu1a81ni4niRkjzqpqUg==,type:str]
-    IMAGE_FACTORY_ENTERPRISE_USERNAME: ENC[AES256_GCM,data:graHep5AA4pWp53U8w==,iv:WCwOLu8Wu+iWTvMsOu540FEYndhgdeLjGwETBaRcQ/M=,tag:Q6/G/rCPyZvct1ezNdblIA==,type:str]
-    IMAGE_FACTORY_ENTERPRISE_PASSWORD: ENC[AES256_GCM,data:bLpKq4J9cZJEJ8tegklZeg2M6EG04FJvKX52DAkxBUI=,iv:gOm54kbsTwG82E1Lsb/+tLr0Ta94ZDvTzKFBh1NG7kw=,tag:Tv+PbwFIlUAMm7VpqQtvkg==,type:str]
+    IMAGE_FACTORY_ENTERPRISE_STAGING_TOKEN: ENC[AES256_GCM,data:saXqWbSxok3TOz7BdO5ScxUIjNEQWAsIyPEzMgU2e93tuufSG992twmkDsMJgQlMBFSUT0RP+BkecN0urRUDLhuSzIbakDO+oL/hG2BruGI6ysSz8+ZsmUpnl+oG4XmM5csJUihWjXUwy6DS40IApWIt1tnI4fHxHfnwE6toyhkqPBCZ/pFqeT4HhtDd+d6HQv1m7/aP9c1PHaJE8fkhBZYiDEl5uvNiQTJid4UTLeJvnJ4H5yhN38UDW7HaJie9vUPkhukiabr6o1cUgfAuCUecbM5x2GekDzAwl3O+tbBo7s7+vSbsoYOC5I7lia0sRf5xcawN1FeWQkJRDcSCj41MzmItbjWaLiIT0k4Hm3swLaMzJbE1Y25Sk1ogLyBiV1EYKpWrrQHs+INkc6AMqaunKl9Se7/H1VRbLvSBoToIPldVX1qAEnqOpNT+4V8hj0g1PR/TphfEe+eE5ntc+bq6iBWFuxrbxy5saE7Xh9EBppDCD4WvjU+iuhn5g64igTpq2rS3goWJGuV24cdZ/hP2R/Uffn6zjStyQrU4ozfCHQpYQPSp2HNVkhyIf7g8zwSK1YMOfQ1ocksKb4QsyvkxQ+DP/kh4VAhtfQCYVErpHmmZ6dZPMdOnYFGmorQkx0ZT+ecBpSkikqY6vGehky3BHzorEJivOGAQa9YZF+WzkT9tkarooPW+drnRzC1jyaXRXGPpNFD5DuyYVYwUNwCe+iFuTX8ssKGjANbBzq2eL/YRzsO5jNmN0p/FnOGn9ol7gUIdgVPB0Kv9VS7xdSVFf8pKryBl/i0ZQGJR,iv:pDA7XQJtYhXgUkPdNurM4yHCZRYzMewSWC83UyfjX5Y=,tag:VeQFY235Sfp5ykJ4ET68UA==,type:str]
 sops:
     age:
         - enc: |
@@ -17,8 +16,8 @@ sops:
             jC2kZtoM9b+m+CpZAp2NVDWOvYv1YycZr78PDELncsTqDkGgQaW21A==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1xrpa9ujxxcj2u2gzfrzv8mxak4rts94a6y60ypurv6rs5cpr4e4sg95f0k
-    lastmodified: "2026-06-19T07:35:28Z"
-    mac: ENC[AES256_GCM,data:fdjtf5OMTGsWf1xvDbD7VFpi0cheqn8Ab+cVpovfSRhM/tYMObtBqchQXbh3x2frjGL9QtJovHpPPYEXjNiYf/SwkK0fpBtCVO5Fh+9NZnrNAgrVNTdgMwgmiYEw36FQC5WAt+fbUUs88TFRK7lGdW58kjVrcD45l71KxWKr1TI=,iv:rQWxLQIGeEqUJGvV4BEsWXSjXUv0Bgh83/l+Q0qphjI=,tag:3C+yn3VehpgBLF1AHG6NAQ==,type:str]
+    lastmodified: "2026-09-10T19:02:47Z"
+    mac: ENC[AES256_GCM,data:lvIoeCZXlRpU1oI3F0JpBZRhgYlI4g+Z9oYSsOAUekLqgi4rata3x+E6z+bI/JixVIjakxZbiUdKyCMeVlLULGouzkYQ6drWKmeV4fUUlYF1r4kXUWeZP/qRcTcoMtAzOOfeNmB+YrN42hsHxGyp5yWJZRVoEg9kIzHm8ijZuFs=,iv:bh4B8GDTjI2hHvRf+csqr4iW8LmI0cc9vv/DF7pkjIk=,tag:tzr7XDvZAstF3E1MIyB4HA==,type:str]
     pgp:
         - created_at: "2026-06-17T10:01:17Z"
           enc: |-

--- a/hack/test/common.sh
+++ b/hack/test/common.sh
@@ -115,11 +115,10 @@ export REGISTRY_MIRROR_CONFIG=""
 export REGISTRY_MIRRORS_BODY=""
 export IMPORTED_CLUSTER_ARGS=()
 export IMAGE_FACTORY_PUBLIC_URL="https://factory.talos.dev"
-export IMAGE_FACTORY_ENTERPRISE_URL="https://factory.siderolabs.com"
 export WITH_IMAGE_FACTORY_ENTERPRISE="${WITH_IMAGE_FACTORY_ENTERPRISE:-false}"
+export IMAGE_FACTORY_ENTERPRISE_ENV="${IMAGE_FACTORY_ENTERPRISE_ENV:-staging}" # staging or prod, selects the enterprise factory URL and its token
 export OMNI_IMAGE_FACTORY_BASE_URL="${IMAGE_FACTORY_PUBLIC_URL}"
 export FACTORY_API_URL="${OMNI_IMAGE_FACTORY_BASE_URL}"
-export FACTORY_IMAGE_URL="${OMNI_IMAGE_FACTORY_BASE_URL}"
 export FACTORY_CURL_AUTH="${FACTORY_CURL_AUTH:-}"
 # Basic-auth args for curl calls against the factory schematic API. Empty for the public factory, so it expands to nothing when unset.
 FACTORY_CURL_ARGS=()
@@ -174,6 +173,7 @@ function configure_registry_mirrors() {
 function common_cleanup() {
   cd "${RUN_DIR}"
   rm -rf "${ARTIFACTS}/omni.db" "${ARTIFACTS}/etcd/"
+  [[ -z "${OMNI_IMAGE_FACTORY_TOKEN_DIR:-}" ]] || rm -rf "${OMNI_IMAGE_FACTORY_TOKEN_DIR}"
 
   if [[ $PARTIAL_CONFIG_SERVER_PID -ne 0 ]]; then
     kill -9 "$PARTIAL_CONFIG_SERVER_PID" || true
@@ -359,11 +359,16 @@ function minio_cleanup() {
 }
 
 function prepare_omni_config() {
-  # Credentials are passed to Omni via OMNI_IMAGE_FACTORY_USERNAME/PASSWORD so they stay out of the config.yaml that is uploaded as a CI artifact.
+  # The config.yaml is uploaded as a CI artifact, so the factory token stays in a file outside the uploaded directories.
   local registries_body=""
 
-  if [[ -n "${OMNI_IMAGE_FACTORY_BASE_URL:-}" ]]; then
-    registries_body+="  imageFactoryBaseURL: ${OMNI_IMAGE_FACTORY_BASE_URL}"$'\n'
+  registries_body+="  factories:"$'\n'
+  registries_body+="    primary:"$'\n'
+  registries_body+="      url: ${OMNI_IMAGE_FACTORY_BASE_URL}"$'\n'
+
+  if [[ -n "${OMNI_IMAGE_FACTORY_TOKEN_FILE:-}" ]]; then
+    registries_body+="      tokenFile: ${OMNI_IMAGE_FACTORY_TOKEN_FILE}"$'\n'
+    registries_body+="      machineTokenTTL: 8h"$'\n' # short-lived machine tokens, so that the test runs do not fill the factory's token limit
   fi
 
   registries_body+="${REGISTRY_MIRRORS_BODY}"
@@ -507,10 +512,10 @@ function create_machines() {
     cluster_create_args+=(
       "--with-tpm2"
       "--disk-encryption-key-types=tpm"
-      "--iso-path=${FACTORY_IMAGE_URL}/image/${schematic_id}/v${talos_version}/metal-amd64-secureboot.iso"
+      "--iso-path=$(download_factory_image "${schematic_id}" "${talos_version}" metal-amd64-secureboot.iso)"
     )
   else
-    cluster_create_args+=("--iso-path=${FACTORY_IMAGE_URL}/image/${schematic_id}/v${talos_version}/metal-amd64.iso")
+    cluster_create_args+=("--iso-path=$(download_factory_image "${schematic_id}" "${talos_version}" metal-amd64.iso)")
   fi
 
   "${ARTIFACTS}/talosctl" cluster create dev \
@@ -598,24 +603,48 @@ function set_factory_curl_args() {
   fi
 }
 
+# Downloads an image from the factory once and prints its path, so that the factory credentials stay out of the
+# URLs given to talosctl, which names its cache files after them.
+function download_factory_image() { # args: schematic_id, talos_version, file_name
+  local path="${ARTIFACTS}/images/$1-v$2-$3"
+
+  if [[ ! -f "${path}" ]]; then
+    mkdir -p "${ARTIFACTS}/images"
+    set_factory_curl_args
+    curl -fsSL "${FACTORY_CURL_ARGS[@]}" -o "${path}.tmp" "${FACTORY_API_URL}/image/$1/v$2/$3" || return 1
+    mv "${path}.tmp" "${path}"
+  fi
+
+  echo "${path}"
+}
+
 function configure_image_factory() {
   if [[ "${WITH_IMAGE_FACTORY_ENTERPRISE}" != "true" ]]; then
     return
   fi
 
-  # Configure env vars for Image Factory Enterprise
-  : "${IMAGE_FACTORY_ENTERPRISE_USERNAME:?IMAGE_FACTORY_ENTERPRISE_USERNAME must be set when WITH_IMAGE_FACTORY_ENTERPRISE=true}"
-  : "${IMAGE_FACTORY_ENTERPRISE_PASSWORD:?IMAGE_FACTORY_ENTERPRISE_PASSWORD must be set when WITH_IMAGE_FACTORY_ENTERPRISE=true}"
-  export OMNI_IMAGE_FACTORY_BASE_URL="${IMAGE_FACTORY_ENTERPRISE_URL}"
-  export OMNI_IMAGE_FACTORY_USERNAME="${IMAGE_FACTORY_ENTERPRISE_USERNAME}"
-  export OMNI_IMAGE_FACTORY_PASSWORD="${IMAGE_FACTORY_ENTERPRISE_PASSWORD}"
+  case "${IMAGE_FACTORY_ENTERPRISE_ENV}" in
+    staging) export OMNI_IMAGE_FACTORY_BASE_URL="https://factory-enterprise.staging.talos.dev" ;;
+    prod) export OMNI_IMAGE_FACTORY_BASE_URL="https://factory.siderolabs.com" ;;
+    *)
+      echo "unknown image factory enterprise environment: ${IMAGE_FACTORY_ENTERPRISE_ENV}" >&2
+      return 1
+      ;;
+  esac
 
+  local token_var="IMAGE_FACTORY_ENTERPRISE_${IMAGE_FACTORY_ENTERPRISE_ENV^^}_TOKEN"
+  local token="${!token_var:?${token_var} must be set when WITH_IMAGE_FACTORY_ENTERPRISE=true}"
+
+  # Omni reads the token from a file and watches its directory, so the file gets a directory of its own, outside the
+  # directories uploaded as CI artifacts.
+  OMNI_IMAGE_FACTORY_TOKEN_DIR=$(mktemp -d)
+  export OMNI_IMAGE_FACTORY_TOKEN_DIR
+  export OMNI_IMAGE_FACTORY_TOKEN_FILE="${OMNI_IMAGE_FACTORY_TOKEN_DIR}/token"
+  printf '%s' "${token}" >"${OMNI_IMAGE_FACTORY_TOKEN_FILE}"
+
+  # The factory accepts the token as the basic auth password, the username is ignored.
   export FACTORY_API_URL="${OMNI_IMAGE_FACTORY_BASE_URL}"
-  export FACTORY_CURL_AUTH="${OMNI_IMAGE_FACTORY_USERNAME}:${OMNI_IMAGE_FACTORY_PASSWORD}"
-
-  local proto="${OMNI_IMAGE_FACTORY_BASE_URL%%://*}"
-  local host="${OMNI_IMAGE_FACTORY_BASE_URL#*://}"
-  export FACTORY_IMAGE_URL="${proto}://${OMNI_IMAGE_FACTORY_USERNAME}:${OMNI_IMAGE_FACTORY_PASSWORD}@${host}"
+  export FACTORY_CURL_AUTH="token:${token}"
 }
 
 # No cleanup here, as it runs in the CI as a container in a pod.


### PR DESCRIPTION
The production enterprise factory runs an old version without the download token API, so the tests fail. The staging factory runs the current one.

The tests now run against the staging factory and authenticate with an API token read from a file. The environment is selected in one place, so that switching back to production is a one line change. The machine tokens are requested as ephemeral ones, so that the test runs do not fill the token limit of the organization.

Additionally, the images are downloaded by the test itself, so that the token stays out of the URLs given to talosctl. The unused basic auth credentials are removed from the secrets.
