### PR TITLE
fix: revert stabilizing the tunnel peer address across provisions

### DIFF
--- a/internal/pkg/siderolink/provision.go
+++ b/internal/pkg/siderolink/provision.go
@@ -275,13 +275,12 @@ func updateResource[T res](ctx context.Context,
 
 		var err error
 
-		// resolve the virtual address-port before overwriting the public key: keeping it depends on the key staying the same
-		s.VirtualAddrport, err = resolveVirtualAddrPort(provisionContext, s)
+		s.NodePublicKey = provisionContext.request.NodePublicKey
+
+		s.VirtualAddrport, err = generateVirtualAddrPort(provisionContext.useWireguardOverGRPC)
 		if err != nil {
 			return err
 		}
-
-		s.NodePublicKey = provisionContext.request.NodePublicKey
 
 		updateAnnotations(link, annotationsToAdd, annotationsToRemove)
 
@@ -562,7 +561,7 @@ func generateLinkSpec(provisionContext *provisionContext) (*specs.SiderolinkSpec
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("error parsing Wireguard key: %s", err))
 	}
 
-	virtualAddrPort, err := resolveVirtualAddrPort(provisionContext, nil)
+	virtualAddrPort, err := generateVirtualAddrPort(provisionContext.useWireguardOverGRPC)
 	if err != nil {
 		return nil, err
 	}
@@ -575,45 +574,11 @@ func generateLinkSpec(provisionContext *provisionContext) (*specs.SiderolinkSpec
 	}, nil
 }
 
-// resolveVirtualAddrPort returns the virtual address-port for the machine's WireGuard peer.
-//
-// The virtual address-port belongs to the public key: it is allocated once and kept for as long as the
-// machine keeps that key and the tunnel mode stays enabled. The pending machine and its successor link
-// then share one peer and one tunnel token, and re-provisioning does not tear the peer down. A fresh
-// one is generated only on the first contact with a key, after a key rotation (Talos generates a new
-// WireGuard key on every boot), or when the tunnel mode is switched off and on.
-//
-// current is the spec being updated in place, if any. It takes precedence over the pre-provision
-// snapshots, which may be stale.
-func resolveVirtualAddrPort(provisionContext *provisionContext, current *specs.SiderolinkSpec) (string, error) {
-	if !provisionContext.useWireguardOverGRPC {
+func generateVirtualAddrPort(generate bool) (string, error) {
+	if !generate {
 		return "", nil
 	}
 
-	candidates := make([]*specs.SiderolinkSpec, 0, 3)
-
-	if current != nil {
-		candidates = append(candidates, current)
-	}
-
-	if provisionContext.link != nil {
-		candidates = append(candidates, provisionContext.link.TypedSpec().Value)
-	}
-
-	if provisionContext.pendingMachine != nil {
-		candidates = append(candidates, provisionContext.pendingMachine.TypedSpec().Value)
-	}
-
-	for _, spec := range candidates {
-		if spec.NodePublicKey == provisionContext.request.NodePublicKey && spec.VirtualAddrport != "" {
-			return spec.VirtualAddrport, nil
-		}
-	}
-
-	return generateVirtualAddrPort()
-}
-
-func generateVirtualAddrPort() (string, error) {
 	generated, err := wireguard.GenerateRandomNodeAddr(wireguard.VirtualNetworkPrefix())
 	if err != nil {
 		return "", fmt.Errorf("error generating random virtual node address: %w", err)

--- a/internal/pkg/siderolink/provision_test.go
+++ b/internal/pkg/siderolink/provision_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -987,18 +986,15 @@ func provisionFixture(
 //
 // Unlike fakeWireguardHandler it requires every spec to carry a parseable node address.
 type testDeviceHandler struct {
-	peers     map[string]*specs.SiderolinkSpec
 	ownerOf   map[netip.Addr]string
 	addrOf    map[string]netip.Addr
 	allowed   *wggrpc.AllowedPeers
-	log       []string
 	evictions []string
 	mu        sync.Mutex
 }
 
 func newTestDeviceHandler() *testDeviceHandler {
 	return &testDeviceHandler{
-		peers:   map[string]*specs.SiderolinkSpec{},
 		ownerOf: map[netip.Addr]string{},
 		addrOf:  map[string]netip.Addr{},
 		allowed: wggrpc.NewAllowedPeers(),
@@ -1034,7 +1030,6 @@ func (h *testDeviceHandler) PeerEvent(_ context.Context, spec *specs.SiderolinkS
 	defer h.mu.Unlock()
 
 	if deleted {
-		delete(h.peers, spec.NodePublicKey)
 		h.allowed.RemoveToken(pubKey)
 
 		if h.ownerOf[addr] == spec.NodePublicKey {
@@ -1043,12 +1038,8 @@ func (h *testDeviceHandler) PeerEvent(_ context.Context, spec *specs.SiderolinkS
 
 		delete(h.addrOf, spec.NodePublicKey)
 
-		h.log = append(h.log, "remove "+spec.NodePublicKey+" va="+spec.VirtualAddrport)
-
 		return nil
 	}
-
-	h.peers[spec.NodePublicKey] = spec
 
 	// ReplaceAllowedIPs on a /128 that another peer already holds moves it: the previous owner is
 	// left with no allowed IPs at all.
@@ -1070,18 +1061,7 @@ func (h *testDeviceHandler) PeerEvent(_ context.Context, spec *specs.SiderolinkS
 		h.allowed.AddToken(pubKey, addrPort.Addr().String())
 	}
 
-	h.log = append(h.log, "add "+spec.NodePublicKey+" va="+spec.VirtualAddrport)
-
 	return nil
-}
-
-func (h *testDeviceHandler) hasPeer(pubKey string) bool {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	_, ok := h.peers[pubKey]
-
-	return ok
 }
 
 // owner returns the public key that currently owns the address, or "" if nobody does.
@@ -1109,38 +1089,6 @@ func (h *testDeviceHandler) evictionLog() []string {
 	return append([]string(nil), h.evictions...)
 }
 
-func (h *testDeviceHandler) eventLog() []string {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	return append([]string(nil), h.log...)
-}
-
-// countEvents counts device events of the given kind ("add" or "remove") for the given public key.
-func (h *testDeviceHandler) countEvents(kind, pubKey string) int {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	count := 0
-
-	for _, line := range h.log {
-		if strings.HasPrefix(line, kind+" "+pubKey+" ") {
-			count++
-		}
-	}
-
-	return count
-}
-
-func tokenOf(t *testing.T, virtualAddrPort string) string {
-	t.Helper()
-
-	addrPort, err := netip.ParseAddrPort(virtualAddrPort)
-	require.NoError(t, err)
-
-	return addrPort.Addr().String()
-}
-
 func retryDestroy(ctx context.Context, st state.State, md *resource.Metadata) error {
 	for {
 		err := st.Destroy(ctx, md)
@@ -1154,193 +1102,6 @@ func retryDestroy(ctx context.Context, st state.State, md *resource.Metadata) er
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
-}
-
-// Regression test for the WireGuard-over-gRPC pending-to-link handoff.
-//
-// The pending machine and the link it hands off to share a public key, and the WireGuard device
-// tracks peers by that key alone. If the link were to get its own virtual address-port, the peers
-// pool would track two entries over one device peer, and the pending machine cleanup would delete
-// the live link's device peer and revoke its tunnel token. The test drives the full handoff with
-// the real controllers and asserts that the peer and the token survive the cleanup.
-func TestGrpcTunnelPendingHandoffKeepsLinkPeer(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
-	defer cancel()
-
-	validFingerprint := uuid.NewString()
-
-	validToken, err := jointoken.NewNodeUniqueToken(validFingerprint, "validToken").Encode()
-	require.NoError(t, err)
-
-	device := newTestDeviceHandler()
-
-	st, provisionHandler := provisionFixture(ctx, t, config.SiderolinkServiceJoinTokensModeStrict, validToken, device, func(*siderolinkres.PendingMachine) bool {
-		return true
-	})
-
-	nodeUUID := "tunnel-handoff-machine"
-	pubKey := genPublicKey(t)
-
-	// Step 1: the machine boots from tunnel-mode boot media and provisions with
-	// no node unique token yet. This creates a PendingMachine and installs its
-	// peer with a fresh virtual address-port.
-	resp1, err := provisionHandler.Provision(ctx, &pb.ProvisionRequest{
-		NodeUuid:          nodeUUID,
-		NodePublicKey:     pubKey,
-		TalosVersion:      new("v1.9.0"),
-		JoinToken:         new(validToken),
-		WireguardOverGrpc: new(true),
-	})
-	require.NoError(t, err)
-
-	pendingVA := resp1.GrpcPeerAddrPort
-	require.NotEmpty(t, pendingVA)
-
-	require.True(t, device.hasPeer(pubKey), "the pending machine's device peer must exist after the first provision")
-	require.True(t, device.allowed.CheckToken(tokenOf(t, pendingVA)), "the pending tunnel token must be allowed")
-
-	// Step 2: the unique token is delivered to the machine and it re-provisions
-	// carrying it. This creates the Link: same public key, inherited node
-	// subnet, and the SAME virtual address-port, so the pool keeps a single
-	// peer with two owners.
-	resp2, err := provisionHandler.Provision(ctx, &pb.ProvisionRequest{
-		NodeUuid:          nodeUUID,
-		NodePublicKey:     pubKey,
-		TalosVersion:      new("v1.9.0"),
-		JoinToken:         new(validToken),
-		NodeUniqueToken:   new(validToken),
-		WireguardOverGrpc: new(true),
-	})
-	require.NoError(t, err)
-
-	linkVA := resp2.GrpcPeerAddrPort
-	require.Equal(t, pendingVA, linkVA, "the link must keep the pending machine's virtual address-port")
-	require.Equal(t, resp1.NodeAddressPrefix, resp2.NodeAddressPrefix, "the link must have inherited the pending machine's node address")
-
-	// Wait for the link's LinkStatus: at that point the link's peer reference is registered.
-	linkStatusID := siderolinkres.NewLinkStatus(siderolinkres.NewLink(nodeUUID, nil)).Metadata().ID()
-	rtestutils.AssertResources(
-		ctx, t, st, []resource.ID{linkStatusID},
-		func(r *siderolinkres.LinkStatus, assertion *assert.Assertions) {
-			assertion.Equal(linkVA, r.TypedSpec().Value.VirtualAddrport)
-		},
-	)
-
-	require.True(t, device.hasPeer(pubKey))
-	require.True(t, device.allowed.CheckToken(tokenOf(t, linkVA)), "the link tunnel token must be allowed")
-
-	// Step 3: the pending machine's grace period expires and the provision
-	// handler cleans it up, exactly like removePendingMachine does: teardown,
-	// wait for the finalizers, destroy.
-	pendingMD := siderolinkres.NewPendingMachine(pubKey, nil).Metadata()
-
-	_, err = st.Teardown(ctx, pendingMD)
-	require.NoError(t, err)
-
-	require.NoError(t, retryDestroy(ctx, st, pendingMD))
-
-	// The pending machine's LinkStatus is gone: its peer reference was dropped.
-	pendingLinkStatusID := siderolinkres.NewLinkStatus(siderolinkres.NewPendingMachine(pubKey, nil)).Metadata().ID()
-	rtestutils.AssertNoResource[*siderolinkres.LinkStatus](ctx, t, st, pendingLinkStatusID)
-
-	// The link is untouched, and so are its device peer and tunnel token.
-	rtestutils.AssertResources(
-		ctx, t, st, []resource.ID{linkStatusID},
-		func(r *siderolinkres.LinkStatus, assertion *assert.Assertions) {
-			assertion.Equal(linkVA, r.TypedSpec().Value.VirtualAddrport)
-		},
-	)
-
-	assert.True(t, device.hasPeer(pubKey), "the live link's device peer must survive the pending machine cleanup")
-	assert.True(t, device.allowed.CheckToken(tokenOf(t, linkVA)), "the link's tunnel token must stay allowed")
-
-	// Step 4: a later re-provision with the same key keeps the virtual
-	// address-port, so the peer is not torn down and re-created.
-	resp3, err := provisionHandler.Provision(ctx, &pb.ProvisionRequest{
-		NodeUuid:          nodeUUID,
-		NodePublicKey:     pubKey,
-		TalosVersion:      new("v1.9.0"),
-		JoinToken:         new(validToken),
-		NodeUniqueToken:   new(validToken),
-		WireguardOverGrpc: new(true),
-	})
-	require.NoError(t, err)
-	require.Equal(t, linkVA, resp3.GrpcPeerAddrPort, "a re-provision with the same key must keep the virtual address-port")
-
-	assert.True(t, device.hasPeer(pubKey))
-	assert.True(t, device.allowed.CheckToken(tokenOf(t, linkVA)))
-
-	// Across handoff, cleanup, and same-key re-provision the device must have
-	// seen exactly ONE add and NO removal for the key: the peer is never torn
-	// down and re-created. The settle delay lets any in-flight reconcile land
-	// before the negative assertion.
-	time.Sleep(250 * time.Millisecond)
-
-	assert.Equal(t, 1, device.countEvents("add", pubKey), "exactly one device add for the key, ever")
-	assert.Zero(t, device.countEvents("remove", pubKey), "no device removal for the key through handoff, cleanup and re-provision")
-
-	// Step 5: the machine reboots. Talos generates a fresh WireGuard key on
-	// every boot, so the re-provision carries a new key: it must get a fresh
-	// virtual address-port, the peer must be re-created under the new key, the
-	// old token revoked and the new one allowed.
-	rotatedKey := genPublicKey(t)
-
-	resp4, err := provisionHandler.Provision(ctx, &pb.ProvisionRequest{
-		NodeUuid:          nodeUUID,
-		NodePublicKey:     rotatedKey,
-		TalosVersion:      new("v1.9.0"),
-		JoinToken:         new(validToken),
-		NodeUniqueToken:   new(validToken),
-		WireguardOverGrpc: new(true),
-	})
-	require.NoError(t, err)
-
-	rotatedVA := resp4.GrpcPeerAddrPort
-	require.NotEmpty(t, rotatedVA)
-	require.NotEqual(t, linkVA, rotatedVA, "a key rotation must produce a fresh virtual address-port")
-
-	rtestutils.AssertResources(
-		ctx, t, st, []resource.ID{linkStatusID},
-		func(r *siderolinkres.LinkStatus, assertion *assert.Assertions) {
-			assertion.Equal(rotatedVA, r.TypedSpec().Value.VirtualAddrport)
-			assertion.Equal(rotatedKey, r.TypedSpec().Value.NodePublicKey)
-		},
-	)
-
-	assert.True(t, device.hasPeer(rotatedKey), "the rotated key's device peer must exist")
-	assert.False(t, device.hasPeer(pubKey), "the old key's device peer must be gone")
-	assert.True(t, device.allowed.CheckToken(tokenOf(t, rotatedVA)), "the rotated key's tunnel token must be allowed")
-	assert.False(t, device.allowed.CheckToken(tokenOf(t, linkVA)), "the old tunnel token must be revoked")
-
-	// Step 6: tunnel mode switched off: the virtual address-port is cleared,
-	// not kept.
-	resp5, err := provisionHandler.Provision(ctx, &pb.ProvisionRequest{
-		NodeUuid:        nodeUUID,
-		NodePublicKey:   rotatedKey,
-		TalosVersion:    new("v1.9.0"),
-		JoinToken:       new(validToken),
-		NodeUniqueToken: new(validToken),
-	})
-	require.NoError(t, err)
-	require.Empty(t, resp5.GrpcPeerAddrPort, "disabling the tunnel must clear the virtual address-port")
-
-	// Step 7: tunnel mode switched back on: a FRESH virtual address-port is
-	// generated, the old one is not resurrected.
-	resp6, err := provisionHandler.Provision(ctx, &pb.ProvisionRequest{
-		NodeUuid:          nodeUUID,
-		NodePublicKey:     rotatedKey,
-		TalosVersion:      new("v1.9.0"),
-		JoinToken:         new(validToken),
-		NodeUniqueToken:   new(validToken),
-		WireguardOverGrpc: new(true),
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, resp6.GrpcPeerAddrPort)
-	require.NotEqual(t, rotatedVA, resp6.GrpcPeerAddrPort, "re-enabling the tunnel must generate a fresh virtual address-port")
-
-	t.Logf("device event log:\n%s", strings.Join(device.eventLog(), "\n"))
 }
 
 // Regression test for the duplicate-UUID address collision.


### PR DESCRIPTION
Commit 194c629c kept a machine's tunnel peer address stable across provisions. This turned out to leave machines on the WireGuard-over-gRPC tunnel stuck after an Omni restart, where they fail to reconnect until they reboot.

Revert it to restore the previous behavior and work around the issue for the time being.

This reverts commit 194c629cf40e468d9b52cec321ea5954fc99021e. The regression test added with it was later moved into the provisioning tests, so it is removed here as well.
